### PR TITLE
Fix two grammar errors related to the word "save"

### DIFF
--- a/git-compat-util.h
+++ b/git-compat-util.h
@@ -220,7 +220,7 @@
 #endif
 #ifdef NO_INTPTR_T
 /*
- * On I16LP32, ILP32 and LP64 "long" is the save bet, however
+ * On I16LP32, ILP32 and LP64 "long" is the safe bet, however
  * on LLP86, IL33LLP64 and P64 it needs to be "long long",
  * while on IP16 and IP16L32 it is "int" (resp. "short")
  * Size needs to match (or exceed) 'sizeof(void *)'.

--- a/remote-curl.c
+++ b/remote-curl.c
@@ -714,7 +714,7 @@ retry:
 
 	} else if (use_gzip && 1024 < rpc->len) {
 		/* The client backend isn't giving us compressed data so
-		 * we can try to deflate it ourselves, this may save on.
+		 * we can try to deflate it ourselves, this may save on
 		 * the transfer time.
 		 */
 		git_zstream stream;


### PR DESCRIPTION
I stumbled over the one in `git-compat-util.h` while working on an unrelated bug fix, and then got curious whether there are other places where we use `save` instead of `safe`, too. Turns out we do not, but there was another grammar error where a spurious `.` interrupted a sentence.