### PR TITLE
Fix `make -C t chainlint` with DOS line endings

### DIFF
--- a/t/.gitattributes
+++ b/t/.gitattributes
@@ -1,4 +1,5 @@
 t[0-9][0-9][0-9][0-9]/* -whitespace
+/chainlint/*.expect eol=lf
 /diff-lib/* eol=lf
 /t0110/url-* binary
 /t3900/*.txt eol=lf


### PR DESCRIPTION
Historically, nobody paid attention to our own source code having [correct Git attributes](https://www.edwardthomson.com/blog/git_for_windows_line_endings.html) when it comes to line endings. Because historically, we had no good way to specify that ;-)

But now we do, and so we need to use it. *Especially* when it would break the build otherwise.