### PR TITLE
Make t2024 NO_PERL-safe

### DIFF
--- a/t/t2024-checkout-dwim.sh
+++ b/t/t2024-checkout-dwim.sh
@@ -76,7 +76,8 @@ test_expect_success 'checkout of branch from multiple remotes fails #1' '
 	test_branch master
 '
 
-test_expect_success 'checkout of branch from multiple remotes fails with advice' '
+test_expect_success NO_PERL \
+	'checkout of branch from multiple remotes fails with advice' '
 	git checkout -B master &&
 	test_might_fail git branch -D foo &&
 	test_must_fail git checkout foo 2>stderr &&


### PR DESCRIPTION
While trying to run the build & test with NO_PERL, I noticed that t2024 had a failing test case. This patch works around that failing test case by skipping it when we know that the error message looks different than that test case would expect.

Changes since v1 (which did not make it to the list due to https://github.com/gitgitgadget/gitgitgadget/issues/29):

- reworded the commit message slightly.

Cc: AEvar Bjarmason <avarab@gmail.com>