### PR TITLE
Docs: Add commit-graph tech docs to Makefile

### DIFF
--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -69,6 +69,8 @@ API_DOCS = $(patsubst %.txt,%,$(filter-out technical/api-index-skel.txt technica
 SP_ARTICLES += $(API_DOCS)
 
 TECH_DOCS += SubmittingPatches
+TECH_DOCS += technical/commit-graph
+TECH_DOCS += technical/commit-graph-format
 TECH_DOCS += technical/hash-function-transition
 TECH_DOCS += technical/http-protocol
 TECH_DOCS += technical/index-format


### PR DESCRIPTION
Similar to [1], add the `commit-graph` and `commit-graph-format` technical docs to Documentation/Makefile so they are automatically converted to HTML when needed.

I compiled the docs and inspected the HTML manually in the browser. Nothing looked strange, so I don't think the docs themselves need any editing for format.

[1] https://public-inbox.org/git/20180814222846.GG142615@aiede.svl.corp.google.com/
   [PATCH] partial-clone: render design doc using asciidoc