### PR TITLE
rebase --autosquash: handle manual "final fixups"

### DIFF
--- a/sequencer.c
+++ b/sequencer.c
@@ -3578,9 +3578,20 @@ static int commit_staged_changes(struct replay_opts *opts,
 		 * the commit message and if there was a squash, let the user
 		 * edit it.
 		 */
-		if (is_clean && !oidcmp(&head, &to_amend) &&
-		    opts->current_fixup_count > 0 &&
-		    file_exists(rebase_path_stopped_sha())) {
+		if (!is_clean || !opts->current_fixup_count)
+			; /* this is not the final fixup */
+		else if (oidcmp(&head, &to_amend) ||
+			 !file_exists(rebase_path_stopped_sha())) {
+			/* was a final fixup or squash done manually? */
+			if (!is_fixup(peek_command(todo_list, 0))) {
+				unlink(rebase_path_fixup_msg());
+				unlink(rebase_path_squash_msg());
+				unlink(rebase_path_current_fixups());
+				strbuf_reset(&opts->current_fixups);
+				opts->current_fixup_count = 0;
+			}
+		} else {
+			/* we are in a fixup/squash chain */
 			const char *p = opts->current_fixups.buf;
 			int len = opts->current_fixups.len;
 

--- a/t/t3415-rebase-autosquash.sh
+++ b/t/t3415-rebase-autosquash.sh
@@ -330,4 +330,23 @@ test_expect_success 'wrapped original subject' '
 	test $base = $parent
 '
 
+test_expect_failure 'abort last squash' '
+	test_when_finished "test_might_fail git rebase --abort" &&
+	test_when_finished "git checkout master" &&
+
+	git checkout -b some-squashes &&
+	git commit --allow-empty -m first &&
+	git commit --allow-empty --squash HEAD &&
+	git commit --allow-empty -m second &&
+	git commit --allow-empty --squash HEAD &&
+
+	test_must_fail git -c core.editor="grep -q ^pick" \
+		rebase -ki --autosquash HEAD~4 &&
+	: do not finish the squash, but resolve it manually &&
+	git commit --allow-empty --amend -m edited-first &&
+	git rebase --skip &&
+	git show >actual &&
+	! grep first actual
+'
+
 test_done

--- a/t/t3415-rebase-autosquash.sh
+++ b/t/t3415-rebase-autosquash.sh
@@ -330,7 +330,7 @@ test_expect_success 'wrapped original subject' '
 	test $base = $parent
 '
 
-test_expect_failure 'abort last squash' '
+test_expect_success 'abort last squash' '
 	test_when_finished "test_might_fail git rebase --abort" &&
 	test_when_finished "git checkout master" &&
 


### PR DESCRIPTION
'tis bug fix season! I admit, though, that this bug might be a bit too off the trodden path to merit fast-tracking into v2.19.0.

While pairing with Jameson Miller to rebase Git for Windows to v2.19.0-rc1, we had to fix a couple of commits which had somehow lost their proper authorship (probably due to long fixed bugs in the interactive rebase). We did so by using empty squash! commits as reminders, so that we could interrupt the rebase by deleting the squash message, amend the commit appropriately, and then continue.

This exposed an (admittedly obscure) bug in the interactive rebase: when the last fixup or squash of a fixup/squash chain is aborted, and then the HEAD commit is amended, the rebase would not forget about the fixup/squash chain. It would hold onto the information about the current fixup count and the intermediate commit message. And upon processing another fixup/squash chain, that information would be reused!

This patch pair first introduces the test case to confirm the breakage, and then fixes it in the minimal way.