### PR TITLE
t3206-range-diff.sh: cover single-patch case

### DIFF
--- a/t/t3206-range-diff.sh
+++ b/t/t3206-range-diff.sh
@@ -154,4 +154,9 @@ do
 	'
 done
 
+test_expect_success 'format-patch --range-diff as commentary' '
+	git format-patch --stdout --range-diff=HEAD~1 HEAD~1 >actual &&
+	grep -A 1 -e "\-\-\-" actual | grep "Range-diff:"
+'
+
 test_done


### PR DESCRIPTION
The commit 40ce4160 "format-patch: allow --range-diff to apply to
a lone-patch" added the ability to see a range-diff as commentary
after the commit message of a single patch series (i.e. [PATCH]
instead of [PATCH X/N]). However, this functionality was not
covered by a test case.

Add a simple test case that checks that a range-diff is written as
commentary to the patch.