### PR TITLE
read-cache: update index format default to v4

### DIFF
--- a/read-cache.c
+++ b/read-cache.c
@@ -1484,7 +1484,7 @@ struct cache_entry *refresh_cache_entry(struct cache_entry *ce,
  * Index File I/O
  *****************************************************************/
 
-#define INDEX_FORMAT_DEFAULT 3
+#define INDEX_FORMAT_DEFAULT 4
 
 static unsigned int get_index_format_default(void)
 {


### PR DESCRIPTION
After discussing this with several people off-list, I thought I would open the question up to the list:

    Should we update the default index version to v4?

The .git/index file stores the list of every path tracked by Git in the working directory, including merge information, staged paths, and information about the file system contents (based on modified time). The only major update in v4 is that the paths are prefix-compressed. This compression works best in repos with a lot of paths, especially deep paths. For this reason, we set the index to v4 in VFS for Git.

Among VFS for Git contributors, we were talking about how the v4 format is not covered by the test suite by default. We are working to increase the number of CI builds that set extra `GIT_TEST_*` variables that we need. However, I thought it worth having a discussion of whether this is a good thing to recommend for all users of Git.

Personally, I'm not an expert here, but I am happy to start the conversation.

Thanks,
-Stolee

Cc: pclouds@gmail.com, peartben@gmail.com, git@jeffhostetler.com