### PR TITLE
Run GIT_TEST_COMMIT_GRAPH and GIT_TEST_MULTI_PACK_INDEX during CI

### DIFF
--- a/ci/run-build-and-tests.sh
+++ b/ci/run-build-and-tests.sh
@@ -15,6 +15,8 @@ then
 	export GIT_TEST_FULL_IN_PACK_ARRAY=true
 	export GIT_TEST_OE_SIZE=10
 	export GIT_TEST_OE_DELTA_SIZE=5
+	export GIT_TEST_COMMIT_GRAPH=1
+	export GIT_TEST_MULTI_PACK_INDEX=1
 	make --quiet test
 fi
 


### PR DESCRIPTION
Our CI scripts include a step to run the test suite with certain optional variables enabled. Now that all branches should build and have tests succeed with GIT_TEST_COMMIT_GRAPH and GIT_TEST_MULTI_PACK_INDEX enabled, add those variables to that stage.

Note: the GIT_TEST_MULTI_PACK_INDEX variable has not merged all the way down, so will be ignored if this series is merged faster than that one. However, it is safe to make these changes orthogonally as all (known) test breaks with GIT_TEST_MULTI_PACK_INDEX=1 are fixed in the topic that introduces the variable.

I also created a build definition on Azure Pipelines that runs the test suite with different subsets of the test variables, split by the following types:

1) Index options
2) Commit-graph
3) Multi-pack-index

These builds are found at [1]. There are benefits to testing the variables all together but also separately. I didn't want to create new stages in the CI scripts to avoid consuming extra resources.

This series is based on js/vsts-ci to avoid conflicts with that series, but is not necessarily a hard dependence.

Thanks,
-Stolee

[1] https://git.visualstudio.com/git/_build?definitionId=4
    Build definition that tests Git with different arrangements of GIT_TEST_* variables.