### PR TITLE
commit-reach: fix first-parent heuristic

### DIFF
--- a/commit-reach.c
+++ b/commit-reach.c
@@ -593,8 +593,10 @@ int can_all_from_reach_with_flag(struct object_array *from,
 		while (stack) {
 			struct commit_list *parent;
 
-			if (stack->item->object.flags & with_flag) {
+			if (stack->item->object.flags & (with_flag | RESULT)) {
 				pop_commit(&stack);
+				if (stack)
+					stack->item->object.flags |= RESULT;
 				continue;
 			}
 


### PR DESCRIPTION
I originally reported this fix [1] after playing around with the trace2 series for measuring performance. Since trace2 isn't merging quickly, I pulled the performance fix patch out and am sending it on its own.
The only difference here is that we don't have the tracing to verify the performance fix in the test script.

See the patch message for details about the fix.

Thanks,
-Stolee

[1] https://public-inbox.org/git/20180906151309.66712-7-dstolee@microsoft.com/

    [RFC PATCH 6/6] commit-reach: fix first-parent heuristic