### PR TITLE
Fix rebase autostash

### DIFF
--- a/builtin/rebase.c
+++ b/builtin/rebase.c
@@ -1375,7 +1375,7 @@ int cmd_rebase(int argc, const char **argv, const char *prefix)
 			if (safe_create_leading_directories_const(autostash))
 				die(_("Could not create directory for '%s'"),
 				    options.state_dir);
-			write_file(autostash, "%s", buf.buf);
+			write_file(autostash, "%s", oid_to_hex(&oid));
 			printf(_("Created autostash: %s\n"), buf.buf);
 			if (reset_head(&head->object.oid, "reset --hard",
 				       NULL, 0, NULL, NULL) < 0)

--- a/builtin/rebase.c
+++ b/builtin/rebase.c
@@ -253,6 +253,8 @@ static int apply_autostash(struct rebase_options *opts)
 
 	if (read_one(path, &autostash))
 		return error(_("Could not read '%s'"), path);
+	/* Ensure that the hash is not mistake for a number */
+	strbuf_addstr(&autostash, "^0");
 	argv_array_pushl(&stash_apply.args,
 			 "stash", "apply", autostash.buf, NULL);
 	stash_apply.git_cmd = 1;

--- a/builtin/rebase.c
+++ b/builtin/rebase.c
@@ -251,7 +251,7 @@ static int apply_autostash(struct rebase_options *opts)
 	if (!file_exists(path))
 		return 0;
 
-	if (read_one(state_dir_path("autostash", opts), &autostash))
+	if (read_one(path, &autostash))
 		return error(_("Could not read '%s'"), path);
 	argv_array_pushl(&stash_apply.args,
 			 "stash", "apply", autostash.buf, NULL);


### PR DESCRIPTION
Gábor reported in https://public-inbox.org/git/20181019124625.GB30222@szeder.dev/ that `t5520-pull.sh` fails from time to time, and Alban root-caused this to a bug in the built-in rebase.

This patch series fixes that, and while at it also fixes an oversight of yours truly when helping Pratik with his GSoC project, and it also adds a change on top that makes really, really certain that `git stash apply` interprets the OID passed to it correctly (as opposed to an insanely large number for the `stash` reflog).

Please note that I based these patches on top of `next` (they might be most appropriately applied on top of `rebase-in-c-6-final`, though).

(Sorry for the v2, v1 did not send due to an UTF-8 character in the Cc: list, a bug that still needs to be fixed in GitGitGadget.)

Cc: SZEDER Gabor <szeder.dev@gmail.com>, Alban Gruin <alban.gruin@gmail.com>