### PR TITLE
Load system libraries the recommended way on Windows

### DIFF
--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -1577,7 +1577,8 @@ static void ensure_socket_initialization(void)
 			WSAGetLastError());
 
 	for (name = libraries; *name; name++) {
-		ipv6_dll = LoadLibrary(*name);
+		ipv6_dll = LoadLibraryExA(*name, NULL,
+					  LOAD_LIBRARY_SEARCH_SYSTEM32);
 		if (!ipv6_dll)
 			continue;
 

--- a/contrib/credential/wincred/git-credential-wincred.c
+++ b/contrib/credential/wincred/git-credential-wincred.c
@@ -75,7 +75,8 @@ static CredDeleteWT CredDeleteW;
 static void load_cred_funcs(void)
 {
 	/* load DLLs */
-	advapi = LoadLibrary("advapi32.dll");
+	advapi = LoadLibraryExA("advapi32.dll", NULL,
+				LOAD_LIBRARY_SEARCH_SYSTEM32);
 	if (!advapi)
 		die("failed to load advapi32.dll");
 


### PR DESCRIPTION
The search order for DLLs on Windows is a bit funny, and for system libraries, it is recommended to use a strict search path.

In practice, this should not make a difference, as the library has been loaded into memory already, and therefore the `LoadLibrary()` call would just return the handle instead of loading the library again.