### PR TITLE
Demonstrate and fix a rebase --autostash bug with dirty submodules

### DIFF
--- a/builtin/rebase.c
+++ b/builtin/rebase.c
@@ -1349,7 +1349,7 @@ int cmd_rebase(int argc, const char **argv, const char *prefix)
 			update_index_if_able(&the_index, &lock_file);
 		rollback_lock_file(&lock_file);
 
-		if (has_unstaged_changes(0) || has_uncommitted_changes(0)) {
+		if (has_unstaged_changes(1) || has_uncommitted_changes(1)) {
 			const char *autostash =
 				state_dir_path("autostash", &options);
 			struct child_process stash = CHILD_PROCESS_INIT;

--- a/t/t3420-rebase-autostash.sh
+++ b/t/t3420-rebase-autostash.sh
@@ -351,7 +351,7 @@ test_expect_success 'autostash is saved on editor failure with conflict' '
 	test_cmp expected file0
 '
 
-test_expect_failure 'autostash with dirty submodules' '
+test_expect_success 'autostash with dirty submodules' '
 	test_when_finished "git reset --hard && git checkout master" &&
 	git checkout -b with-submodule &&
 	git submodule add ./ sub &&

--- a/t/t3420-rebase-autostash.sh
+++ b/t/t3420-rebase-autostash.sh
@@ -351,4 +351,14 @@ test_expect_success 'autostash is saved on editor failure with conflict' '
 	test_cmp expected file0
 '
 
+test_expect_failure 'autostash with dirty submodules' '
+	test_when_finished "git reset --hard && git checkout master" &&
+	git checkout -b with-submodule &&
+	git submodule add ./ sub &&
+	test_tick &&
+	git commit -m add-submodule &&
+	echo changed >sub/file0 &&
+	git rebase -i --autostash HEAD
+'
+
 test_done


### PR DESCRIPTION
This bug report came in via Git for Windows (already with version 2.19.0, but I misread the reporter's enthusiasm to take matters into his own hands).

The culprit is, in a nutshell, that the built-in rebase tries to run `git stash` only when the worktree is dirty, but it includes submodules in that. However, `git stash` cannot do anything about submodules, and if the only changes are in submodules, then it won't even give us back an OID, and the built-in rebase acts surprised.

The solution is easy: simply exclude the submodules from the question whether the worktree is dirty.

What is surprisingly not simple is to get the regression test right. For that reason, and because I firmly believe that it is easier to verify a fix for a regression when the regression test is introduced separately (i.e. making it simple to verify that there *is* a regression), I really want to keep the first patch separate from the second one.

Since this bug concerns the built-in rebase, I based the patches on top of `next`.