### PR TITLE
Windows: force-recompile git.res for differing architectures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2110,7 +2110,7 @@ $(SCRIPT_LIB) : % : %.sh GIT-SCRIPT-DEFINES
 	$(QUIET_GEN)$(cmd_munge_script) && \
 	mv $@+ $@
 
-git.res: git.rc GIT-VERSION-FILE
+git.res: git.rc GIT-VERSION-FILE GIT-PREFIX
 	$(QUIET_RC)$(RC) \
 	  $(join -DMAJOR= -DMINOR= -DMICRO= -DPATCHLEVEL=, $(wordlist 1, 4, \
 	    $(shell echo $(GIT_VERSION) 0 0 0 0 | tr '.a-zA-Z-' ' '))) \


### PR DESCRIPTION
This is a patch designed to help maintaining Git for Windows better: when the same source code is "cross-compiled" for i686 as well as x86_64, we want to rebuild the whole thing, *including* the resource file `git.res`.

Note: regular C files are re-compiled appropriately, as the default prefix in Git for Windows is `/mingw32` or `/mingw64` depending on the architecture, and this difference is manifested in the `CFLAGS` (which, upon change, trigger a complete rebuild).

As non-Windows platforms do not even compile these `.res` files, this patch should have exactly no effect on non-Windows builds.