### PR TITLE
send-pack: set core.warnAmbiguousRefs=false

### DIFF
--- a/builtin/pack-objects.c
+++ b/builtin/pack-objects.c
@@ -2988,6 +2988,7 @@ static void get_object_list(int ac, const char **av)
 	struct rev_info revs;
 	char line[1000];
 	int flags = 0;
+	int save_warning;
 
 	init_revisions(&revs, NULL);
 	save_commit_buffer = 0;
@@ -2995,6 +2996,9 @@ static void get_object_list(int ac, const char **av)
 
 	/* make sure shallows are read */
 	is_repository_shallow(the_repository);
+
+	save_warning = warn_on_object_refname_ambiguity;
+	warn_on_object_refname_ambiguity = 0;
 
 	while (fgets(line, sizeof(line), stdin) != NULL) {
 		int len = strlen(line);
@@ -3021,6 +3025,8 @@ static void get_object_list(int ac, const char **av)
 		if (handle_revision_arg(line, &revs, flags, REVARG_CANNOT_BE_FILENAME))
 			die(_("bad revision '%s'"), line);
 	}
+
+	warn_on_object_refname_ambiguity = save_warning;
 
 	if (use_bitmap_index && !get_object_list_from_bitmap(&revs))
 		return;


### PR DESCRIPTION
I've been looking into the performance of `git push` for very large repos. Our users are reporting that 60-80% of `git push` time is spent during the "Enumerating objects" phase of `git pack-objects`.

A `git push` process runs several processes during its run, but one includes `git send-pack` which calls `git pack-objects` and passes the known have/wants into `stdin` using object ids. However, the default setting for `core.warnAmbiguousRefs` requires `git pack-objects` to check for ref names matching the `ref_rev_parse_rules` array in `refs.c`. This means that every object is triggering at least six "file exists?" queries.

When there are a lot of refs, this can add up significantly! My PerfView trace for a simple push measured 3 seconds spent checking these paths.

The fix is to set the global `warn_on_object_refname_ambiguity` to 0 for the section that is performing these object reads.

In addition to this patch submission, we are looking into merging it into our fork sooner [1].

[1] https://github.com/Microsoft/git/pull/67

Changes in V2: Instead of using the "-c" flag from send-pack, just set the global. I left the name of the cover letter the same to not confuse anyone viewing the message without threading.

Cc: peff@peff.net