### PR TITLE
Some left-over add-on for bw/config-h

### DIFF
--- a/config.c
+++ b/config.c
@@ -1676,6 +1676,8 @@ static int do_git_config_sequence(const struct config_options *opts,
 
 	if (opts->commondir)
 		repo_config = mkpathdup("%s/config", opts->commondir);
+	else if (opts->git_dir)
+		BUG("git_dir without commondir");
 	else
 		repo_config = NULL;
 


### PR DESCRIPTION
Back when bw/config-h was developed (and backported to Git for Windows), I came up with a patch to use `git_dir` if `commondir` is `NULL`, and contributed that as v1 of this patch. However, it was deemed a bug if that happens, so let's instead detect that condition and report it.

Change since v1:

- Be loud about this bug instead of papering over it.