### PR TITLE
worktree: add completion for the `rev` argument in `git worktree add <path> <rev>`

### DIFF
--- a/contrib/completion/git-completion.bash
+++ b/contrib/completion/git-completion.bash
@@ -2773,6 +2773,11 @@ _git_worktree ()
 		add,--*)
 			__gitcomp_builtin worktree_add
 			;;
+		add,*)
+			if [ $(__git_count_arguments "worktree") -eq 2 ]; then
+				__git_complete_refs
+			fi
+			;;
 		list,--*)
 			__gitcomp_builtin worktree_list
 			;;


### PR DESCRIPTION
This is inspired by one of those half-finished contributions in the Git for Windows project. Fall cleaning, if you like.