### PR TITLE
Fix multi-pack-index fsck integration

### DIFF
--- a/builtin/fsck.c
+++ b/builtin/fsck.c
@@ -49,6 +49,7 @@ static int name_objects;
 #define ERROR_PACK 04
 #define ERROR_REFS 010
 #define ERROR_COMMIT_GRAPH 020
+#define ERROR_MULTI_PACK_INDEX 040
 
 static const char *describe_object(struct object *obj)
 {
@@ -855,14 +856,14 @@ int cmd_fsck(int argc, const char **argv, const char *prefix)
 		midx_verify.argv = midx_argv;
 		midx_verify.git_cmd = 1;
 		if (run_command(&midx_verify))
-			errors_found |= ERROR_COMMIT_GRAPH;
+			errors_found |= ERROR_MULTI_PACK_INDEX;
 
 		prepare_alt_odb(the_repository);
 		for (alt =  the_repository->objects->alt_odb_list; alt; alt = alt->next) {
 			midx_argv[2] = "--object-dir";
 			midx_argv[3] = alt->path;
 			if (run_command(&midx_verify))
-				errors_found |= ERROR_COMMIT_GRAPH;
+				errors_found |= ERROR_MULTI_PACK_INDEX;
 		}
 	}
 

--- a/t/t5319-multi-pack-index.sh
+++ b/t/t5319-multi-pack-index.sh
@@ -301,7 +301,8 @@ test_expect_success 'multi-pack-index in an alternate' '
 	git multi-pack-index write &&
 	midx_read_expect 1 3 4 $objdir &&
 	git reset --hard HEAD~1 &&
-	rm -f .git/objects/pack/*
+	rm -f .git/objects/pack/* &&
+	git -c core.multiPackIndex=true fsck
 '
 
 compare_results_with_midx "with alternate (remote midx)"
@@ -313,6 +314,11 @@ corrupt_data () {
 	data="${3:-\0}"
 	printf "$data" | dd of="$file" bs=1 seek="$pos" conv=notrunc
 }
+
+test_expect_success 'fsck fails on corrupted alternate' '
+	corrupt_data alt.git/objects/pack/multi-pack-index 12 "\07" &&
+	test_must_fail git -c core.multiPackIndex=true fsck --full
+'
 
 # Force 64-bit offsets by manipulating the idx file.
 # This makes the IDX file _incorrect_ so be careful to clean up after!


### PR DESCRIPTION
As noted in the Git test report for v2.20.0-rc0 [1], we were not properly testing that 'git fsck' verifies the multi-pack-index that resides in an alternate. Further, I accidentally copied an error flag from the commit-graph integration, so fix that while we are here.

Thanks,
-Stolee

[1] https://public-inbox.org/git/6f532502-d4b6-17f6-0ec7-01079077ac90@gmail.com/