### PR TITLE
rebase: warn about the correct tree's OID

### DIFF
--- a/builtin/rebase.c
+++ b/builtin/rebase.c
@@ -582,7 +582,8 @@ static int reset_head(struct object_id *oid, const char *action,
 	}
 
 	if (!reset_hard && !fill_tree_descriptor(&desc[nr++], &head_oid)) {
-		ret = error(_("failed to find tree of %s"), oid_to_hex(oid));
+		ret = error(_("failed to find tree of %s"),
+			    oid_to_hex(&head_oid));
 		goto leave_reset_head;
 	}
 


### PR DESCRIPTION
A quick fix for a recent topic. Not overly critical, but I would deem this v2.20.0-rc1 material.