### PR TITLE
legacy-rebase: fix "regression"

### DIFF
--- a/git-legacy-rebase.sh
+++ b/git-legacy-rebase.sh
@@ -337,6 +337,11 @@ do
 		fix|strip)
 			force_rebase=t
 			;;
+		warn|nowarn|error|error-all)
+			;; # okay, known whitespace option
+		*)
+			die "Invalid whitespace option: '${1%*=}'"
+			;;
 		esac
 		;;
 	--ignore-whitespace)
@@ -351,6 +356,9 @@ do
 	--committer-date-is-author-date|--ignore-date)
 		git_am_opt="$git_am_opt $1"
 		force_rebase=t
+		;;
+	-C*[!0-9]*)
+		die "switch \`C' expects a numerical value"
 		;;
 	-C*)
 		git_am_opt="$git_am_opt $1"


### PR DESCRIPTION
This is a backport, really, to accommodate a new regression test that was introduced when the built-in rebase learned to validate the `-C<n>` and `--whitespace=<option>` arguments early.