### PR TITLE
Fix `git help -a` with long alias names

### DIFF
--- a/help.c
+++ b/help.c
@@ -83,8 +83,9 @@ static void print_command_list(const struct cmdname_help *cmds,
 
 	for (i = 0; cmds[i].name; i++) {
 		if (cmds[i].category & mask) {
+			size_t len = strlen(cmds[i].name);
 			printf("   %s   ", cmds[i].name);
-			mput_char(' ', longest - strlen(cmds[i].name));
+			mput_char(' ', longest > len ? longest - len : 1);
 			puts(_(cmds[i].help));
 		}
 	}
@@ -526,6 +527,13 @@ void list_all_cmds_help(void)
 
 	git_config(get_alias, &alias_list);
 	string_list_sort(&alias_list);
+
+	for (i = 0; i < alias_list.nr; i++) {
+		size_t len = strlen(alias_list.items[i].string);
+		if (longest < len)
+			longest = len;
+	}
+
 	if (alias_list.nr) {
 		printf("\n%s\n", _("Command aliases"));
 		ALLOC_ARRAY(aliases, alias_list.nr + 1);

--- a/help.h
+++ b/help.h
@@ -15,7 +15,7 @@ struct cmdnames {
 
 static inline void mput_char(char c, unsigned int num)
 {
-	while(num--)
+	while (num--)
 		putchar(c);
 }
 


### PR DESCRIPTION
The code added in 26c7d0678324 (help -a: improve and make --verbose default, 2018-09-29) that intends to print out aliases in addition to commands failed to adjust for the length of the aliases. As a consequence, if there was any alias whose name is longer than 18 characters, `git help -a` tried to print an insanely large number of spaces, one at a time, causing what appeared to be a "hang".

Let's fix this, and while at it fix a style issue that I saw on the way as well.

Original report at https://github.com/git-for-windows/git/issues/1975