### PR TITLE
Fix regression in t9902 with NO_PERL

### DIFF
--- a/t/t9902-completion.sh
+++ b/t/t9902-completion.sh
@@ -1539,7 +1539,7 @@ test_expect_success 'complete tree filename with metacharacters' '
 	EOF
 '
 
-test_expect_success 'send-email' '
+test_expect_success PERL 'send-email' '
 	test_completion "git send-email --cov" "--cover-letter " &&
 	test_completion "git send-email ma" "master "
 '


### PR DESCRIPTION
The oneline notwithstanding, 13374987dd (completion: use __gitcomp_builtin for format-patch, 2018-11-03) changed also the way `send-email` options are completed, by asking the `git send-email` command itself what options it offers.

Necessarily, this must fail when built with `NO_PERL` because `send-email` itself is a Perl script. Which means that we need the PERL prerequisite for the `send-email` test case in t9902.

Changes since v1:

- replaced the commit message by the cover letter, as it was deemed to be more informative.