### PR TITLE
git-gc.txt: fix typo about gc.writeCommitGraph

### DIFF
--- a/Documentation/git-gc.txt
+++ b/Documentation/git-gc.txt
@@ -137,7 +137,7 @@ The optional configuration variable `gc.packRefs` determines if
 it within all non-bare repos or it can be set to a boolean value.
 This defaults to true.
 
-The optional configuration variable `gc.commitGraph` determines if
+The optional configuration variable `gc.writeCommitGraph` determines if
 'git gc' should run 'git commit-graph write'. This can be set to a
 boolean value. This defaults to false.
 


### PR DESCRIPTION
Thanks to Stefan Haller for sending me a private message about this typo.