### PR TITLE
git-show-ref.txt: fix order of flags

### DIFF
--- a/Documentation/git-show-ref.txt
+++ b/Documentation/git-show-ref.txt
@@ -37,8 +37,8 @@ OPTIONS
 
 	Show the HEAD reference, even if it would normally be filtered out.
 
---tags::
 --heads::
+--tags::
 
 	Limit to "refs/heads" and "refs/tags", respectively.  These options
 	are not mutually exclusive; when given both, references stored in


### PR DESCRIPTION
A trivial documentation fix...and testing out gitgitgadget.  :-)