### PR TITLE
Be careful about left-over files from `git add --edit` runs

### DIFF
--- a/builtin/add.c
+++ b/builtin/add.c
@@ -239,7 +239,7 @@ static int edit_patch(int argc, const char **argv, const char *prefix)
 	rev.diffopt.output_format = DIFF_FORMAT_PATCH;
 	rev.diffopt.use_color = 0;
 	rev.diffopt.flags.ignore_dirty_submodules = 1;
-	out = open(file, O_CREAT | O_WRONLY, 0666);
+	out = open(file, O_CREAT | O_WRONLY | O_TRUNC, 0666);
 	if (out < 0)
 		die(_("Could not open '%s' for writing."), file);
 	rev.diffopt.file = xfdopen(out, "w");


### PR DESCRIPTION
J Wyman reported almost a year ago (and I fixed this issue in Git for Windows around that time) that the `.git/ADD_EDIT.patch` file might still lie around at the beginning of `git add --edit` from previous runs, and if the new patch is smaller than the old one, the resulting diff is obviously corrupt.

This is yet another Git for Windows patch finally making it to the Git mailing list.