### PR TITLE
t6042: fix breakage on Windows

### DIFF
--- a/t/t6042-merge-rename-corner-cases.sh
+++ b/t/t6042-merge-rename-corner-cases.sh
@@ -1175,7 +1175,7 @@ test_expect_success 'setup nested conflicts from rename/rename(2to1)' '
 
 		# Handle the left side
 		git checkout L &&
-		git mv one three &&
+		git rm one two &&
 		mv -f file_v2 three &&
 		mv -f file_v5 two &&
 		git add two three &&
@@ -1183,7 +1183,7 @@ test_expect_success 'setup nested conflicts from rename/rename(2to1)' '
 
 		# Handle the right side
 		git checkout R &&
-		git mv two three &&
+		git rm one two &&
 		mv -f file_v3 one &&
 		mv -f file_v6 three &&
 		git add one three &&


### PR DESCRIPTION
Unfortunately, Travis decided to change some things under the hood that affect the Windows build. As a consequence, `master` has not been tested in quite a while, even if the test runs pretended that it had been tested :-(

So imagine my surprise when `master` simply would refuse to pass the test suite cleanly outside Travis, always failing at t6042, despite the fact that Travis passed.

It turns out that two files are written too quickly in succession, running into the issue where Git for Windows chooses *not* to populate the inode and device numbers in the `stat` data (this is a noticeable performance optimization). As a consequence, Git thinks the file is unchanged, and fails to pick up a modification. And no, we cannot simply undo the performance optimization, it would make things prohibitively slow in particular in large worktrees, and it is not like the bug is likely to be hit in reality: for Git to be fooled into thinking that a file is unchanged, it has to be written with the same file size, and within a 100ns time bucket (it is pretty improbable that there is any real-world scenario that would run into *that*, except of course our regression test suite).

This patch works around this issue by forcing Git to recognize the new file versions as new files (which they really are: the patch simply replaces

```
git mv <old> <new> && mv <file> <new> && git add <new>`
```

by

```
git rm <old> && mv <file> <new> && git add <new>`
```

which is not shorter, but even a performance improvement (an unnoticeable one, of course).

Changes since v1:

* Clarified the change in the commit message.

Cc: Elijah Newren <newren@gmail.com>