### PR TITLE
One more fix related to `TEST_GIT_INSTALLED`

### DIFF
--- a/t/test-lib.sh
+++ b/t/test-lib.sh
@@ -1154,7 +1154,7 @@ test -d "$GIT_BUILD_DIR"/templates/blt || {
 	error "You haven't built things yet, have you?"
 }
 
-if ! test -x "$GIT_BUILD_DIR"/t/helper/test-tool
+if ! test -x "$GIT_BUILD_DIR"/t/helper/test-tool$X
 then
 	echo >&2 'You need to build test-tool:'
 	echo >&2 'Run "make t/helper/test-tool" in the source (toplevel) directory'


### PR DESCRIPTION
This fix should have gone into https://github.com/gitgitgadget/git/pull/73 (which was submitted as https://public-inbox.org/git/pull.73.v2.git.gitgitgadget@gmail.com and was integrated into `master` via 2488849c7e76 (Merge branch 'js/test-git-installed', 2018-11-19)). Ben Peart pointed out that I had forgotten to include it.

Cc: Ben Peart <benpeart@microsoft.com>