### PR TITLE
rebase: drop the unwanted `-y` 

### DIFF
--- a/Documentation/git-rebase.txt
+++ b/Documentation/git-rebase.txt
@@ -462,12 +462,6 @@ without an explicit `--interactive`.
 +
 See also INCOMPATIBLE OPTIONS below.
 
--y <cmd>::
-	This is the same as passing `--reschedule-failed-exec` before
-	`-x <cmd>`, i.e. it appends the specified `exec` command and
-	turns on the mode where failed `exec` commands are automatically
-	rescheduled.
-
 --root::
 	Rebase all commits reachable from <branch>, instead of
 	limiting them with an <upstream>.  This allows you to rebase

--- a/builtin/rebase.c
+++ b/builtin/rebase.c
@@ -760,23 +760,6 @@ static int parse_opt_interactive(const struct option *opt, const char *arg,
 	return 0;
 }
 
-struct opt_y {
-	struct string_list *list;
-	struct rebase_options *options;
-};
-
-static int parse_opt_y(const struct option *opt, const char *arg, int unset)
-{
-	struct opt_y *o = opt->value;
-
-	if (unset || !arg)
-		return -1;
-
-	o->options->reschedule_failed_exec = 1;
-	string_list_append(o->list, arg);
-	return 0;
-}
-
 static void NORETURN error_on_missing_default_upstream(void)
 {
 	struct branch *current_branch = branch_get(NULL);
@@ -857,7 +840,6 @@ int cmd_rebase(int argc, const char **argv, const char *prefix)
 	struct string_list strategy_options = STRING_LIST_INIT_NODUP;
 	struct object_id squash_onto;
 	char *squash_onto_name = NULL;
-	struct opt_y opt_y = { .list = &exec, .options = &options };
 	struct option builtin_rebase_options[] = {
 		OPT_STRING(0, "onto", &options.onto_name,
 			   N_("revision"),
@@ -935,9 +917,6 @@ int cmd_rebase(int argc, const char **argv, const char *prefix)
 		OPT_STRING_LIST('x', "exec", &exec, N_("exec"),
 				N_("add exec lines after each commit of the "
 				   "editable list")),
-		{ OPTION_CALLBACK, 'y', NULL, &opt_y, N_("<cmd>"),
-			N_("same as --reschedule-failed-exec -x <cmd>"),
-			PARSE_OPT_NONEG, parse_opt_y },
 		OPT_BOOL(0, "allow-empty-message",
 			 &options.allow_empty_message,
 			 N_("allow rebasing commits with empty messages")),

--- a/git-legacy-rebase.sh
+++ b/git-legacy-rebase.sh
@@ -26,7 +26,6 @@ f,force-rebase!    cherry-pick all commits, even if unchanged
 m,merge!           use merging strategies to rebase
 i,interactive!     let the user edit the list of commits to rebase
 x,exec=!           add exec lines after each commit of the editable list
-y=!                same as --reschedule-failed-exec -x
 k,keep-empty	   preserve empty commits during rebase
 allow-empty-message allow rebasing commits with empty messages
 stat!              display a diffstat of what changed upstream
@@ -261,11 +260,6 @@ do
 		;;
 	--exec=*)
 		cmd="${cmd}exec ${1#--exec=}${LF}"
-		test -z "$interactive_rebase" && interactive_rebase=implied
-		;;
-	-y*)
-		reschedule_failed_exec=--reschedule-failed-exec
-		cmd="${cmd}exec ${1#-y}${LF}"
 		test -z "$interactive_rebase" && interactive_rebase=implied
 		;;
 	--interactive)

--- a/t/t3418-rebase-continue.sh
+++ b/t/t3418-rebase-continue.sh
@@ -262,9 +262,6 @@ test_expect_success '--reschedule-failed-exec' '
 	test_must_fail git -c rebase.rescheduleFailedExec=true \
 		rebase -x false HEAD^ 2>err &&
 	grep "^exec false" .git/rebase-merge/git-rebase-todo &&
-	test_i18ngrep "has been rescheduled" err &&
-	git rebase --abort &&
-	test_must_fail git rebase -y false HEAD^ 2>err &&
 	test_i18ngrep "has been rescheduled" err
 '
 


### PR DESCRIPTION
I totally missed that this patch made it into `next`, and then `master`. Sorry about that.

Changes since v1:

- Focused on the "why?" in the commit message.