### PR TITLE
Pretty-format: Ability to add newline after non-empty string

### DIFF
--- a/Documentation/pretty-formats.txt
+++ b/Documentation/pretty-formats.txt
@@ -236,6 +236,10 @@ If you add a ` ` (space) after '%' of a placeholder, a space
 is inserted immediately before the expansion if and only if the
 placeholder expands to a non-empty string.
 
+If you add a '*' (star) after '%' of a placeholder, a line-feed
+is added immediately after the expansion if and only if the
+placeholder expands to a non-empty string.
+
 * 'tformat:'
 +
 The 'tformat:' format works exactly like 'format:', except that it

--- a/pretty.c
+++ b/pretty.c
@@ -1457,7 +1457,8 @@ static size_t format_commit_item(struct strbuf *sb, /* in UTF-8 */
 		NO_MAGIC,
 		ADD_LF_BEFORE_NON_EMPTY,
 		DEL_LF_BEFORE_EMPTY,
-		ADD_SP_BEFORE_NON_EMPTY
+		ADD_SP_BEFORE_NON_EMPTY,
+		ADD_LF_AFTER_NON_EMPTY
 	} magic = NO_MAGIC;
 
 	switch (placeholder[0]) {
@@ -1469,6 +1470,9 @@ static size_t format_commit_item(struct strbuf *sb, /* in UTF-8 */
 		break;
 	case ' ':
 		magic = ADD_SP_BEFORE_NON_EMPTY;
+		break;
+	case '*':
+		magic = ADD_LF_AFTER_NON_EMPTY;
 		break;
 	default:
 		break;
@@ -1492,6 +1496,8 @@ static size_t format_commit_item(struct strbuf *sb, /* in UTF-8 */
 			strbuf_insert(sb, orig_len, "\n", 1);
 		else if (magic == ADD_SP_BEFORE_NON_EMPTY)
 			strbuf_insert(sb, orig_len, " ", 1);
+		else if (magic == ADD_LF_AFTER_NON_EMPTY)
+			strbuf_addstr(sb, "\n");
 	}
 	return consumed + 1;
 }
@@ -1501,7 +1507,8 @@ static size_t userformat_want_item(struct strbuf *sb, const char *placeholder,
 {
 	struct userformat_want *w = context;
 
-	if (*placeholder == '+' || *placeholder == '-' || *placeholder == ' ')
+	if (*placeholder == '+' || *placeholder == '-' ||
+		*placeholder == ' ' || *placeholder == '*')
 		placeholder++;
 
 	switch (*placeholder) {

--- a/t/t6006-rev-list-format.sh
+++ b/t/t6006-rev-list-format.sh
@@ -445,6 +445,11 @@ test_expect_success 'add SP before non-empty (2)' '
 	test $(wc -w <actual) = 6
 '
 
+test_expect_success 'add LF after non-empty' '
+	git show -s --pretty=format:"%s%*sThanks" HEAD^^ >actual &&
+	test_line_count = 2 actual
+'
+
 test_expect_success '--abbrev' '
 	echo SHORT SHORT SHORT >expect2 &&
 	echo LONG LONG LONG >expect3 &&


### PR DESCRIPTION
This allows for expansion of %*x to %x followed by a LF if
and only if %x is non-empty.

Signed-off-by: Mats Nilsson <matni403@gmail.com>

There seems to be a problem with the test on travis, but can't figure out why it is failing.
https://travis-ci.org/mnil/git/builds/489470396
