### PR TITLE
Fix incorrectly reported CPU in 32-bit Windows

### DIFF
--- a/compat/mingw.h
+++ b/compat/mingw.h
@@ -6,6 +6,25 @@ typedef _sigset_t sigset_t;
 #include <winsock2.h>
 #include <ws2tcpip.h>
 
+#ifdef __MINGW64_VERSION_MAJOR
+/*
+ * In Git for Windows, we cannot rely on `uname -m` to report the correct
+ * architecture: /usr/bin/uname.exe will report the architecture with which the
+ * current MSYS2 runtime was built, not the architecture for which we are
+ * currently compiling (both 32-bit and 64-bit `git.exe` is built in the 64-bit
+ * Git for Windows SDK).
+ */
+#undef GIT_HOST_CPU
+/* This was figured out by looking at `cpp -dM </dev/null`'s output */
+#if defined(__x86_64__)
+#define GIT_HOST_CPU "x86_64"
+#elif defined(__i686__)
+#define GIT_HOST_CPU "i686"
+#else
+#error "Unknown architecture"
+#endif
+#endif
+
 /* MinGW-w64 reports to have flockfile, but it does not actually have it. */
 #ifdef __MINGW64_VERSION_MAJOR
 #undef _POSIX_THREAD_SAFE_FUNCTIONS


### PR DESCRIPTION
While in review, Git for Windows' original design was changed, to use the output of `uname -m` instead of (necessarily incomplete) pre-processor magic to determine which CPU to report.

Both 32-bit and 64-bit versions of Git for Windows are built in the 64-bit Git for Windows SDK, however, whose `uname -m` always reports `x86_64`. Even for 32-bit Git for Windows.

Let's fix that by going back to the pre-processor magic, making it specific to Git for Windows' SDK (where it actually is complete).

This is yet another patch I forgot to upstream, and I hope that it will make it into v2.21.0-rc1.