### PR TITLE
Use a more canonical method to fix the CPU reporting on Windows

### DIFF
--- a/compat/mingw.h
+++ b/compat/mingw.h
@@ -6,25 +6,6 @@ typedef _sigset_t sigset_t;
 #include <winsock2.h>
 #include <ws2tcpip.h>
 
-#ifdef __MINGW64_VERSION_MAJOR
-/*
- * In Git for Windows, we cannot rely on `uname -m` to report the correct
- * architecture: /usr/bin/uname.exe will report the architecture with which the
- * current MSYS2 runtime was built, not the architecture for which we are
- * currently compiling (both 32-bit and 64-bit `git.exe` is built in the 64-bit
- * Git for Windows SDK).
- */
-#undef GIT_HOST_CPU
-/* This was figured out by looking at `cpp -dM </dev/null`'s output */
-#if defined(__x86_64__)
-#define GIT_HOST_CPU "x86_64"
-#elif defined(__i686__)
-#define GIT_HOST_CPU "i686"
-#else
-#error "Unknown architecture"
-#endif
-#endif
-
 /* MinGW-w64 reports to have flockfile, but it does not actually have it. */
 #ifdef __MINGW64_VERSION_MAJOR
 #undef _POSIX_THREAD_SAFE_FUNCTIONS

--- a/config.mak.uname
+++ b/config.mak.uname
@@ -553,9 +553,11 @@ else
 		prefix = /usr/
 		ifeq (MINGW32,$(MSYSTEM))
 			prefix = /mingw32
+			HOST_CPU = i686
 		endif
 		ifeq (MINGW64,$(MSYSTEM))
 			prefix = /mingw64
+			HOST_CPU = x86_64
 		else
 			COMPAT_CFLAGS += -D_USE_32BIT_TIME_T
 			BASIC_LDFLAGS += -Wl,--large-address-aware


### PR DESCRIPTION
Eric Sunshine pointed out that I had completely forgotten about the HOST_CPU thing, and that is indeed the much better method of fixing the issue.

Cc: Eric Sunshine <sunshine@sunshineco.com>