### PR TITLE
Safe-guard the Windows code a bit more against getenv() problems

### DIFF
--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -1632,7 +1632,7 @@ int mingw_kill(pid_t pid, int sig)
  */
 char *mingw_getenv(const char *name)
 {
-#define GETENV_MAX_RETAIN 30
+#define GETENV_MAX_RETAIN 64
 	static char *values[GETENV_MAX_RETAIN];
 	static int value_counter;
 	int len_key, len_value;


### PR DESCRIPTION
We saw a couple of getenv() cleanups, where we now immediately duplicate the return value of `getenv()` in order to avoid problems. However, I am really uncomfortable with the current value (30) of `GETENV_MAX_RETAIN` in `compat/mingw.c`: it strikes me as low, given that the average number of `getenv()` call per Git process in Git's test suite is already 40.

I'd really like to increase it, even if it won't help problems where `getenv()` is called in a loop whose number of iteration depends on user input (like the problem fixed in 6776a84dae (diff: ensure correct lifetime of external_diff_cmd, 2019-01-11)). It will still fend off plenty of other cases, I believe.

And yes, it's in my TODOs to look back over those getenv() issues after v2.21.0 (see https://github.com/git-for-windows/git/pull/2019 for my progress).