### PR TITLE
Do use ALL_CFLAGS in hdr-check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2741,7 +2741,7 @@ CHK_HDRS = $(filter-out $(EXCEPT_HDRS),$(patsubst ./%,%,$(LIB_H)))
 HCO = $(patsubst %.h,%.hco,$(CHK_HDRS))
 
 $(HCO): %.hco: %.h FORCE
-	$(QUIET_HDR)$(CC) -include git-compat-util.h -I. -o /dev/null -c -xc $<
+	$(QUIET_HDR)$(CC) $(ALL_CFLAGS) -include git-compat-util.h -I. -o /dev/null -c -xc $<
 
 .PHONY: hdr-check $(HCO)
 hdr-check: $(HCO)


### PR DESCRIPTION
When I was playing with the `Makefile` target `hdr-check`, it looked as if it missed the correct `CFLAGS`. Without them, on Windows an attempt is made to include `syslog.h`, which does not make sense at all.

This patch addresses that.