### PR TITLE
Avoid calling `find` in the Makefile, if possible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -841,7 +841,8 @@ VCSSVN_LIB = vcs-svn/lib.a
 
 GENERATED_H += command-list.h
 
-LIB_H = $(shell $(FIND) . \
+LIB_H := $(shell git ls-files '*.h' ':!t/' ':!Documentation/' 2>/dev/null || \
+	$(FIND) . \
 	-name .git -prune -o \
 	-name t -prune -o \
 	-name Documentation -prune -o \
@@ -2363,7 +2364,7 @@ else
 # should _not_ be included here, since they are necessary even when
 # building an object for the first time.
 
-$(OBJECTS): $(LIB_H)
+$(OBJECTS): $(LIB_H) $(GENERATED_H)
 endif
 
 exec-cmd.sp exec-cmd.s exec-cmd.o: GIT-PREFIX


### PR DESCRIPTION
I noticed this quite a bit of time ago, but did not get a chance to look into it in detail: all of a sudden, `make` started *really* slowly over here.

The culprit turned out to be a `find` call, which was in the `Makefile` for ages, so I was puzzled why it only caused problems recently.

After some digging, I found out that the `hdr-check` target is the culprit: before it was introduced, `$(LIB_H)` did not need to be expanded, and as a consequence the `find` call was not executed. Once `hdr-check` made it into `master`, though, `$(LIB_H)` must be expanded to define that rule.

Since I have tons of worktrees as subdirectories of my principal Git clone, and since I *also* have a `3rdparty/` directory with tons of repositories I use for various testing/contributing purposes, this `find` is quite a little slow over here.

So here is my suggested fix. It is based on similar code we already had in the Makefile, obviously also intended to avoid an expensive `find` invocation.

Changes since v1:
* Since `LIB_H`'s lazy evaluation kicks in all the time anyway, changed the `=` to `:=` to avoid evaluating it three times.
* Clarified in the commit message that the existing sites using `$(LIB_H)` are not affected by this change (or at least not affected as long as no untracked header files are included in `.c` files).