### PR TITLE
Fix `git init` with `core.hidedotfiles`

### DIFF
--- a/builtin/init-db.c
+++ b/builtin/init-db.c
@@ -155,6 +155,9 @@ static int git_init_db_config(const char *k, const char *v, void *cb)
 	if (!strcmp(k, "init.templatedir"))
 		return git_config_pathname(&init_db_template_dir, k, v);
 
+	if (starts_with(k, "core."))
+		return platform_core_config(k, v, cb);
+
 	return 0;
 }
 
@@ -185,6 +188,7 @@ static int create_default_files(const char *template_path,
 	struct strbuf err = STRBUF_INIT;
 
 	/* Just look for `init.templatedir` */
+	init_db_template_dir = NULL; /* re-set in case it was set before */
 	git_config(git_init_db_config, NULL);
 
 	/*
@@ -360,6 +364,9 @@ int init_db(const char *git_dir, const char *real_git_dir,
 		git_dir = get_git_dir();
 	}
 	startup_info->have_repository = 1;
+
+	/* Just look for `core.hidedotfiles` */
+	git_config(git_init_db_config, NULL);
 
 	safe_create_dir(git_dir, 0);
 

--- a/t/t0001-init.sh
+++ b/t/t0001-init.sh
@@ -454,6 +454,17 @@ test_expect_success 're-init from a linked worktree' '
 	)
 '
 
+test_expect_success MINGW 'core.hidedotfiles = false' '
+	git config --global core.hidedotfiles false &&
+	rm -rf newdir &&
+	mkdir newdir &&
+	(
+		sane_unset GIT_DIR GIT_WORK_TREE GIT_CONFIG &&
+		git -C newdir init
+	) &&
+	! is_hidden newdir/.git
+'
+
 test_expect_success MINGW 'redirect std handles' '
 	GIT_REDIRECT_STDOUT=output.txt git rev-parse --git-dir &&
 	test .git = "$(cat output.txt)" &&


### PR DESCRIPTION
This fixes an regression that was not present in Git for Windows's original `core.hideDotFiles` patch, but in the shape of the `core.hideDotFiles` patch that made it into git.git.

We fixed it in one big hurry in Git for Windows, and I simply forgot to upstream this right away.

Changes since v1:
- Clarified in the code comment that our intention is to pick up `core.hidedotfiles` in the first `git_config()` call.
- Explained in the commit message why we cannot remove the `git_config(git_init_db_config, NULL)` call from `create_default_files()`: it would cause a change of behavior with regard to the `init.templatedir` setting.
- Simplified the test case.