### PR TITLE
Fix `cvsexportcommit` with CR/LF line endings

### DIFF
--- a/git-cvsexportcommit.perl
+++ b/git-cvsexportcommit.perl
@@ -431,6 +431,7 @@ END
 sub safe_pipe_capture {
     my @output;
     if (my $pid = open my $child, '-|') {
+	binmode($child, ":crlf");
 	@output = (<$child>);
 	close $child or die join(' ',@_).": $! $?";
     } else {


### PR DESCRIPTION
When using CVSNT, we need to be prepared to grok CVS output with CR/LF line endings.

While we do *not* use CVSNT in Git for Windows, this patch made its way into Git's source code via the Git for Windows project (probably because of the ease of GitHub PRs), and we had not a single complaint for over 2 years, so I would consider this patch ready to be included in core Git.