### PR TITLE
Enable Data Execution Protection and Address Space Layout Randomization on Windows

### DIFF
--- a/config.mak.uname
+++ b/config.mak.uname
@@ -576,10 +576,12 @@ else
 		ifeq (MINGW32,$(MSYSTEM))
 			prefix = /mingw32
 			HOST_CPU = i686
+			BASIC_LDFLAGS += -Wl,--pic-executable,-e,_mainCRTStartup
 		endif
 		ifeq (MINGW64,$(MSYSTEM))
 			prefix = /mingw64
 			HOST_CPU = x86_64
+			BASIC_LDFLAGS += -Wl,--pic-executable,-e,mainCRTStartup
 		else
 			COMPAT_CFLAGS += -D_USE_32BIT_TIME_T
 			BASIC_LDFLAGS += -Wl,--large-address-aware

--- a/config.mak.uname
+++ b/config.mak.uname
@@ -573,6 +573,12 @@ else
 	ifneq ($(shell expr "$(uname_R)" : '1\.'),2)
 		# MSys2
 		prefix = /usr/
+		# Enable DEP
+		BASIC_LDFLAGS += -Wl,--nxcompat
+		# Enable ASLR (unless debugging)
+		ifneq (,$(findstring -O,$(filter-out -O0 -Og,$(CFLAGS))))
+			BASIC_LDFLAGS += -Wl,--dynamicbase
+		endif
 		ifeq (MINGW32,$(MSYSTEM))
 			prefix = /mingw32
 			HOST_CPU = i686


### PR DESCRIPTION
These two techniques make it harder to come up with exploits, by reducing what is commonly called the "attack surface" in security circles: by making the addresses less predictable, and by making it harder to inject data that is then (mis-)interpreted as code, this hardens Git's executables on Windows.

These patches have been carried in Git for Windows for over 3 years, and should therefore be considered battle-tested.

Changes since v1:

- When determining whether we build with optimization, `-O0` and `-Og` are explicitly ignored.