### PR TITLE
mingw: handle non-ASCII PATH components correctly

### DIFF
--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -1161,14 +1161,21 @@ static char *lookup_prog(const char *dir, int dirlen, const char *cmd,
 			 int isexe, int exe_only)
 {
 	char path[MAX_PATH];
+	wchar_t wpath[MAX_PATH];
 	snprintf(path, sizeof(path), "%.*s\\%s.exe", dirlen, dir, cmd);
 
-	if (!isexe && access(path, F_OK) == 0)
+	if (xutftowcs_path(wpath, path) < 0)
+		return NULL;
+
+	if (!isexe && _waccess(wpath, F_OK) == 0)
 		return xstrdup(path);
-	path[strlen(path)-4] = '\0';
-	if ((!exe_only || isexe) && access(path, F_OK) == 0)
-		if (!(GetFileAttributes(path) & FILE_ATTRIBUTE_DIRECTORY))
+	wpath[wcslen(wpath)-4] = '\0';
+	if ((!exe_only || isexe) && _waccess(wpath, F_OK) == 0) {
+		if (!(GetFileAttributesW(wpath) & FILE_ATTRIBUTE_DIRECTORY)) {
+			path[strlen(path)-4] = '\0';
 			return xstrdup(path);
+		}
+	}
 	return NULL;
 }
 


### PR DESCRIPTION
We need to be careful on Windows: there are "ANSI" versions of the API functions that take `char *`, and "Unicode" versions that take "wchar_t *` strings as parameters. The ANSI versions are subject to the current codepage, i.e. almost guaranteed to *not* handle UTF-8. Internally, we do want to use UTF-8, though, at least in `compat/mingw.c`, so we really have to use the Unicode versions of the Win32 API.