### PR TITLE
Support git:// with *old* MinGW

### DIFF
--- a/Documentation/config.txt
+++ b/Documentation/config.txt
@@ -406,6 +406,8 @@ include::config/reset.txt[]
 
 include::config/sendemail.txt[]
 
+include::config/sendpack.txt[]
+
 include::config/sequencer.txt[]
 
 include::config/showbranch.txt[]

--- a/Documentation/config/sendpack.txt
+++ b/Documentation/config/sendpack.txt
@@ -1,0 +1,3 @@
+sendpack.sideband::
+	Allows to disable the side-band-64k capability for send-pack even
+	when it is advertised by the server. Defaults to true.

--- a/send-pack.c
+++ b/send-pack.c
@@ -38,6 +38,16 @@ int option_parse_push_signed(const struct option *opt,
 	die("bad %s argument: %s", opt->long_name, arg);
 }
 
+static int config_use_sideband = 1;
+
+static int send_pack_config(const char *var, const char *value, void *unused)
+{
+	if (!strcmp("sendpack.sideband", var))
+		config_use_sideband = git_config_bool(var, value);
+
+	return 0;
+}
+
 static void feed_object(const struct object_id *oid, FILE *fh, int negative)
 {
 	if (negative && !has_object_file(oid))
@@ -390,6 +400,8 @@ int send_pack(struct send_pack_args *args,
 	const char *push_cert_nonce = NULL;
 	struct packet_reader reader;
 
+	git_config(send_pack_config, NULL);
+
 	/* Does the other end support the reporting? */
 	if (server_supports("report-status"))
 		status_report = 1;
@@ -397,7 +409,7 @@ int send_pack(struct send_pack_args *args,
 		allow_deleting_refs = 1;
 	if (server_supports("ofs-delta"))
 		args->use_ofs_delta = 1;
-	if (server_supports("side-band-64k"))
+	if (config_use_sideband && server_supports("side-band-64k"))
 		use_sideband = 1;
 	if (server_supports("quiet"))
 		quiet_supported = 1;


### PR DESCRIPTION
The MinGW project (which can now be considered "old", as mingw-w64 is the standard thing to use nowadays, since it also supports 64-bit builds) had some problems with our sideband feature, and in Git for Windows <2.x, we introduced a config setting to still allow using the git:// protocol by forcing off the sideband channel.

Let's contribute this patch to upstream Git, at long last.

Changes since v1:

- Fixed the typo "dump protocol" by talking specifically about the `git://` protocol.
- Dropped a reference in the documentation to a Git for Windows bug that no longer exists, for ages.

Cc: Eric Sunshine <sunshine@sunshineco.com>