### PR TITLE
t5580: verify that alternates can be UNC paths

### DIFF
--- a/t/t5580-clone-push-unc.sh
+++ b/t/t5580-clone-push-unc.sh
@@ -62,4 +62,16 @@ test_expect_success MINGW 'remote nick cannot contain backslashes' '
 	test_i18ngrep ! "unable to access" err
 '
 
+test_expect_success 'unc alternates' '
+	tree="$(git rev-parse HEAD:)" &&
+	mkdir test-unc-alternate &&
+	(
+		cd test-unc-alternate &&
+		git init &&
+		test_must_fail git show $tree &&
+		echo "$UNCPATH/.git/objects" >.git/objects/info/alternates &&
+		git show $tree
+	)
+'
+
 test_done


### PR DESCRIPTION
This was fixed in git.git's `master` some time ago, unfortunately not upstreamed from Git for Windows' patch thicket (my fault, or better put: the fault of the twenty-four hour days not being longer). We carried a regression test on top of the fix, and I can at least contribute *that*.