### PR TITLE
Avoid spawning `gzip` in `git archive`

### DIFF
--- a/Documentation/git-archive.txt
+++ b/Documentation/git-archive.txt
@@ -116,7 +116,8 @@ tar.<format>.command::
 	format is given.
 +
 The "tar.gz" and "tgz" formats are defined automatically and default to
-`gzip -cn`. You may override them with custom commands.
+`:internal-gzip:`, triggering an in-process gzip compression. You may
+override them with custom commands, e.g. `gzip -cn` or `pigz -cn`.
 
 tar.<format>.remote::
 	If true, enable `<format>` for use by remote clients via

--- a/archive-tar.c
+++ b/archive-tar.c
@@ -38,11 +38,16 @@ static int write_tar_filter_archive(const struct archiver *ar,
 #define USTAR_MAX_MTIME 077777777777ULL
 #endif
 
+/* writes out the whole block, or dies if fails */
+static void write_block_or_die(const char *block) {
+	write_or_die(1, block, BLOCKSIZE);
+}
+
 /* writes out the whole block, but only if it is full */
 static void write_if_needed(void)
 {
 	if (offset == BLOCKSIZE) {
-		write_or_die(1, block, BLOCKSIZE);
+		write_block_or_die(block);
 		offset = 0;
 	}
 }
@@ -66,7 +71,7 @@ static void do_write_blocked(const void *data, unsigned long size)
 		write_if_needed();
 	}
 	while (size >= BLOCKSIZE) {
-		write_or_die(1, buf, BLOCKSIZE);
+		write_block_or_die(buf);
 		size -= BLOCKSIZE;
 		buf += BLOCKSIZE;
 	}
@@ -101,10 +106,10 @@ static void write_trailer(void)
 {
 	int tail = BLOCKSIZE - offset;
 	memset(block + offset, 0, tail);
-	write_or_die(1, block, BLOCKSIZE);
+	write_block_or_die(block);
 	if (tail < 2 * RECORDSIZE) {
 		memset(block, 0, offset);
-		write_or_die(1, block, BLOCKSIZE);
+		write_block_or_die(block);
 	}
 }
 

--- a/archive-tar.c
+++ b/archive-tar.c
@@ -518,9 +518,9 @@ void init_tar_archiver(void)
 	int i;
 	register_archiver(&tar_archiver);
 
-	tar_filter_config("tar.tgz.command", "gzip -cn", NULL);
+	tar_filter_config("tar.tgz.command", ":internal-gzip:", NULL);
 	tar_filter_config("tar.tgz.remote", "true", NULL);
-	tar_filter_config("tar.tar.gz.command", "gzip -cn", NULL);
+	tar_filter_config("tar.tar.gz.command", ":internal-gzip:", NULL);
 	tar_filter_config("tar.tar.gz.remote", "true", NULL);
 	git_config(git_tar_config, NULL);
 	for (i = 0; i < nr_tar_filters; i++) {

--- a/archive-tar.c
+++ b/archive-tar.c
@@ -17,6 +17,8 @@ static unsigned long offset;
 
 static int tar_umask = 002;
 
+static gzFile gzip;
+
 static int write_tar_filter_archive(const struct archiver *ar,
 				    struct archiver_args *args);
 
@@ -40,7 +42,10 @@ static int write_tar_filter_archive(const struct archiver *ar,
 
 /* writes out the whole block, or dies if fails */
 static void write_block_or_die(const char *block) {
-	write_or_die(1, block, BLOCKSIZE);
+	if (!gzip)
+		write_or_die(1, block, BLOCKSIZE);
+	else if (gzwrite(gzip, block, (unsigned) BLOCKSIZE) != BLOCKSIZE)
+		die(_("gzwrite failed"));
 }
 
 /* writes out the whole block, but only if it is full */
@@ -466,18 +471,37 @@ static int write_tar_filter_archive(const struct archiver *ar,
 	filter.use_shell = 1;
 	filter.in = -1;
 
-	if (start_command(&filter) < 0)
-		die_errno(_("unable to start '%s' filter"), argv[0]);
-	close(1);
-	if (dup2(filter.in, 1) < 0)
-		die_errno(_("unable to redirect descriptor"));
-	close(filter.in);
+	if (!strcmp(":internal-gzip:", ar->data)) {
+		gzip = gzdopen(fileno(stdout), "wb");
+		if (!gzip)
+			die(_("Could not gzdopen stdout"));
+		if (args->compression_level >= 0 &&
+		    gzsetparams(gzip, args->compression_level,
+				Z_DEFAULT_STRATEGY) != Z_OK)
+			die(_("unable to set compression level %d"),
+			    args->compression_level);
+	} else {
+		if (start_command(&filter) < 0)
+			die_errno(_("unable to start '%s' filter"), argv[0]);
+		close(1);
+		if (dup2(filter.in, 1) < 0)
+			die_errno(_("unable to redirect descriptor"));
+		close(filter.in);
+	}
 
 	r = write_tar_archive(ar, args);
 
-	close(1);
-	if (finish_command(&filter) != 0)
-		die(_("'%s' filter reported error"), argv[0]);
+	if (gzip) {
+		int ret = gzclose(gzip);
+		if (ret == Z_ERRNO)
+			die_errno(_("gzclose failed"));
+		else if (ret != Z_OK)
+			die(_("gzclose failed (%d)"), ret);
+	} else {
+		close(1);
+		if (finish_command(&filter) != 0)
+			die(_("'%s' filter reported error"), argv[0]);
+	}
 
 	strbuf_release(&cmd);
 	return r;

--- a/t/perf/p5005-archive-tgz.sh
+++ b/t/perf/p5005-archive-tgz.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+test_description='Test archive --format=tgz performance'
+
+. ./perf-lib.sh
+
+test_perf_default_repo
+
+test_perf 'archive --format=tgz' '
+	git archive --format=tgz HEAD >/dev/null
+'
+
+test_done
+

--- a/t/t5000-tar-tree.sh
+++ b/t/t5000-tar-tree.sh
@@ -215,6 +215,7 @@ test_expect_success 'git archive with --output, override inferred format' '
 
 test_expect_success GZIP 'git archive with --output and --remote creates .tgz' '
 	git archive --output=d5.tgz --remote=. HEAD &&
+	ls -l d5.tgz &&
 	gzip -d -c <d5.tgz >d5.tar &&
 	test_cmp_bin b.tar d5.tar
 '

--- a/t/t5000-tar-tree.sh
+++ b/t/t5000-tar-tree.sh
@@ -298,23 +298,29 @@ test_expect_success 'only enabled filters are available remotely' '
 	test_cmp_bin remote.bar config.bar
 '
 
-test_expect_success GZIP 'git archive --format=tgz' '
+test_expect_success 'git archive --format=tgz' '
 	git archive --format=tgz HEAD >j.tgz
 '
 
-test_expect_success GZIP 'git archive --format=tar.gz' '
+test_expect_success 'git archive --format=tar.gz' '
 	git archive --format=tar.gz HEAD >j1.tar.gz &&
 	test_cmp_bin j.tgz j1.tar.gz
 '
 
-test_expect_success GZIP 'infer tgz from .tgz filename' '
+test_expect_success 'infer tgz from .tgz filename' '
 	git archive --output=j2.tgz HEAD &&
 	test_cmp_bin j.tgz j2.tgz
 '
 
-test_expect_success GZIP 'infer tgz from .tar.gz filename' '
+test_expect_success 'infer tgz from .tar.gz filename' '
 	git archive --output=j3.tar.gz HEAD &&
 	test_cmp_bin j.tgz j3.tar.gz
+'
+
+test_expect_success 'use `archive.tgz.command=:internal-gzip:` explicitly' '
+	git -c archive.tgz.command=:internal-gzip: archive --output=j4.tgz \
+		HEAD &&
+	test_cmp_bin j.tgz j4.tgz
 '
 
 test_expect_success GZIP 'extract tgz file' '
@@ -322,12 +328,12 @@ test_expect_success GZIP 'extract tgz file' '
 	test_cmp_bin b.tar j.tar
 '
 
-test_expect_success GZIP 'remote tar.gz is allowed by default' '
+test_expect_success 'remote tar.gz is allowed by default' '
 	git archive --remote=. --format=tar.gz HEAD >remote.tar.gz &&
 	test_cmp_bin j.tgz remote.tar.gz
 '
 
-test_expect_success GZIP 'remote tar.gz can be disabled' '
+test_expect_success 'remote tar.gz can be disabled' '
 	git config tar.tar.gz.remote false &&
 	test_must_fail git archive --remote=. --format=tar.gz HEAD \
 		>remote.tar.gz


### PR DESCRIPTION
When creating `.tar.gz` archives with `git archive`, we let `gzip` handle the compression part. But that is not even necessary, as we *already* require zlib (to compress our loose objects). It is also unfortunate, as it requires `gzip` to be in the `PATH` (which is not the case e.g. with MinGit for Windows, which tries to bundle just the bare minimum of files to make Git work non-interactively, for use with 3rd-party applications requiring Git).

This patch series resolves this conundrum by teaching `git archive` the trick to gzip-compress in-process, and it is based on https://github.com/git-for-windows/git/pull/2077

Changes since v2:
- Added a perf test.
- The change to make `BLOCKSIZE` unsigned was dropped.
- The pseudo command is now called `:internal-gzip:` instead of `:zlib`.
- Integrated a patch using an extra thread for `gzip` compression, based on one of René Scharfe's patches.
- Performed some benchmarking with zlib 1.2.11 and with a zlib version with speed improvements proposed by Intel, and included the results in the added commit's message.

Changes since v1:
* The commit messages were touched up quite a bit.
* There is now a new commit that marks the `BLOCKSIZE` constant as unsigned.
* The first commit used to introduce the `gzip` variable prematurely. This part has been moved into the appropriate commit (which used to be 2/2 and now is 3/4).
* The second commit was split into two: 3/4 which introduces the new `:zlib` pseudo command, and 4/4 that switches the default.
* The `GZIP` prerequisite was dropped from a couple of tests in t5000 that no longer need it.
* The magic `"wb\0"` code was replaced by a `strbuf`-based one.
* The error message was improved when `gzclose()` failed.

Cc: Jeff King <peff@peff.net>, René Scharfe <l.s.r@web.de>, brian m. carlson <sandals@crustytoothpaste.net>