### PR TITLE
Let's use the Win32 API more precisely

### DIFF
--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -1946,13 +1946,19 @@ struct passwd *getpwuid(int uid)
 	static unsigned initialized;
 	static char user_name[100];
 	static struct passwd *p;
+	wchar_t buf[100];
 	DWORD len;
 
 	if (initialized)
 		return p;
 
-	len = sizeof(user_name);
-	if (!GetUserName(user_name, &len)) {
+	len = sizeof(buf);
+	if (!GetUserNameW(buf, &len)) {
+		initialized = 1;
+		return NULL;
+	}
+
+	if (xwcstoutf(user_name, buf, sizeof(user_name)) < 0) {
 		initialized = 1;
 		return NULL;
 	}

--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -1407,7 +1407,7 @@ static pid_t mingw_spawnve_fd(const char *cmd, const char **argv, char **deltaen
 	do_unset_environment_variables();
 
 	/* Determine whether or not we are associated to a console */
-	cons = CreateFile("CONOUT$", GENERIC_WRITE,
+	cons = CreateFileW(L"CONOUT$", GENERIC_WRITE,
 			FILE_SHARE_WRITE, NULL, OPEN_EXISTING,
 			FILE_ATTRIBUTE_NORMAL, NULL);
 	if (cons == INVALID_HANDLE_VALUE) {

--- a/compat/poll/poll.c
+++ b/compat/poll/poll.c
@@ -150,7 +150,7 @@ win32_compute_revents (HANDLE h, int *p_sought)
       if (!once_only)
 	{
 	  NtQueryInformationFile = (PNtQueryInformationFile)
-	    GetProcAddress (GetModuleHandle ("ntdll.dll"),
+	    GetProcAddress (GetModuleHandleW (L"ntdll.dll"),
 			    "NtQueryInformationFile");
 	  once_only = TRUE;
 	}


### PR DESCRIPTION
For many Win32 functions, there actually exist two variants: one that takes `const char *` ("ANSI", meaning the current code page) and `wchar_t *` ("Unicode", i.e. UTF-16, at least for all practical matters).

These functions have "A" and "W" suffixes, respectively, e.g. `GetFileAttributesW()`. The symbols without this suffix are `#define`d to the `*W()` versions if the constant `UNICODE` is defined before including the Windows headers, and to `*A()` otherwise.

Let's not rely on this constant, but explicitly say what we want: we want the Unicode versions, as they seem to be used by the ANSI flavor anyway.