### PR TITLE
win32: make it easy to start the GNU debugger at a certain source line

### DIFF
--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -13,6 +13,19 @@
 
 static const int delay[] = { 0, 1, 10, 20, 40 };
 
+void open_in_gdb(void)
+{
+	static struct child_process cp = CHILD_PROCESS_INIT;
+	extern char *_pgmptr;
+
+	argv_array_pushl(&cp.args, "mintty", "gdb", NULL);
+	argv_array_pushf(&cp.args, "--pid=%d", getpid());
+	cp.clean_on_exit = 1;
+	if (start_command(&cp) < 0)
+		die_errno("Could not start gdb");
+	sleep(1);
+}
+
 int err_win_to_posix(DWORD winerr)
 {
 	int error = ENOSYS;

--- a/compat/mingw.h
+++ b/compat/mingw.h
@@ -585,6 +585,16 @@ int main(int argc, const char **argv) \
 static int mingw_main(c,v)
 
 /*
+ * For debugging: if a problem occurs, say, in a Git process that is spawned
+ * from another Git process which in turn is spawned from yet another Git
+ * process, it can be quite daunting to figure out what is going on.
+ *
+ * Call this function to open a new MinTTY (this assumes you are in Git for
+ * Windows' SDK) with a GDB that attaches to the current process right away.
+ */
+extern void open_in_gdb(void);
+
+/*
  * Used by Pthread API implementation for Windows
  */
 extern int err_win_to_posix(DWORD winerr);


### PR DESCRIPTION
In particular when trying to debug issues in processes with redirected stdin and/or stdout, it can be quite a challenge to use an interactive debugger.

Help this, by introducing a function that is purely meant for debugging purposes: `open_in_gdb()`. It will open a new terminal window, attach gdb to the current process in it, and sleep. That way, the above-mentioned debugging problem can be solved simply by inserting the statement `open_in_gdb();` at a specific source code line, then recompiling Git and then running e.g. the regression test that failed.