### PR TITLE
Fix a test on NTFS (and probably HFS+)

### DIFF
--- a/t/t0001-init.sh
+++ b/t/t0001-init.sh
@@ -310,8 +310,8 @@ test_expect_success 'init prefers command line to GIT_DIR' '
 test_expect_success 'init with separate gitdir' '
 	rm -rf newdir &&
 	git init --separate-git-dir realgitdir newdir &&
-	echo "gitdir: $(pwd)/realgitdir" >expected &&
-	test_cmp expected newdir/.git &&
+	newdir_git="$(cat newdir/.git)" &&
+	test_cmp_fspath "$(pwd)/realgitdir" "${newdir_git#gitdir: }" &&
 	test_path_is_dir realgitdir/refs
 '
 
@@ -360,12 +360,9 @@ test_expect_success 're-init on .git file' '
 '
 
 test_expect_success 're-init to update git link' '
-	(
-	cd newdir &&
-	git init --separate-git-dir ../surrealgitdir
-	) &&
-	echo "gitdir: $(pwd)/surrealgitdir" >expected &&
-	test_cmp expected newdir/.git &&
+	git -C newdir init --separate-git-dir ../surrealgitdir &&
+	newdir_git="$(cat newdir/.git)" &&
+	test_cmp_fspath "$(pwd)/surrealgitdir" "${newdir_git#gitdir: }" &&
 	test_path_is_dir surrealgitdir/refs &&
 	test_path_is_missing realgitdir/refs
 '
@@ -373,12 +370,9 @@ test_expect_success 're-init to update git link' '
 test_expect_success 're-init to move gitdir' '
 	rm -rf newdir realgitdir surrealgitdir &&
 	git init newdir &&
-	(
-	cd newdir &&
-	git init --separate-git-dir ../realgitdir
-	) &&
-	echo "gitdir: $(pwd)/realgitdir" >expected &&
-	test_cmp expected newdir/.git &&
+	git -C newdir init --separate-git-dir ../realgitdir &&
+	newdir_git="$(cat newdir/.git)" &&
+	test_cmp_fspath "$(pwd)/realgitdir" "${newdir_git#gitdir: }" &&
 	test_path_is_dir realgitdir/refs
 '
 

--- a/t/test-lib-functions.sh
+++ b/t/test-lib-functions.sh
@@ -879,6 +879,21 @@ test_cmp_rev () {
 	fi
 }
 
+# Compare paths respecting core.ignoreCase
+test_cmp_fspath () {
+	if test "x$1" = "x$2"
+	then
+		return 0
+	fi
+
+	if test true != "$(git config --get --type=bool core.ignorecase)"
+	then
+		return 1
+	fi
+
+	test "x$(echo "$1" | tr A-Z a-z)" =  "x$(echo "$2" | tr A-Z a-z)"
+}
+
 # Print a sequence of integers in increasing order, either with
 # two arguments (start and end):
 #


### PR DESCRIPTION
My colleague Jameson Miller once presented me with a nice puzzle why the test suite failed on their system.

Turns out that it is possible in PowerShell to spell the directory with a different case than on disk in `cd <directory>`, and subsequent calls to get the current working directory will use that case, rather than what is recorded on disk. And since case-insensitive filesystems are frowned upon in the Linux world, Git's test suite was not prepared for such a scenario.

Changes since v2:

- Instead of writing everything into files, then editing those files, and then comparing via `test_cmp`, we now introduce `test_cmp_fspath` (as suggested by Junio).

Changes since v1:

- The `git config` call is now safe-guarded with a `--type=bool`.
- The `git config` call now actually looks at the correct config variable: `core.ignoreCase` ;-)

Cc: Martin Ågren <martin.agren@gmail.com>, brian m. carlson <sandals@crustytoothpaste.net>