### PR TITLE
mingw: fix `uname -r` test

### DIFF
--- a/config.mak.uname
+++ b/config.mak.uname
@@ -569,7 +569,7 @@ ifneq (,$(wildcard ../THIS_IS_MSYSGIT))
 	NO_GETTEXT = YesPlease
 	COMPAT_CLFAGS += -D__USE_MINGW_ACCESS
 else
-	ifeq ($(shell expr "$(uname_R)" : '2\.'),2)
+	ifneq ($(shell expr "$(uname_R)" : '1\.'),2)
 		# MSys2
 		prefix = /usr/
 		ifeq (MINGW32,$(MSYSTEM))


### PR DESCRIPTION
In df5218b4c30b (config.mak.uname: support MSys2, 2016-01-13), I obviously made the assumption that calling `uname -r` in MSYS2 would always yield a version number starting with "2".

That is incorrect, though, as `uname -r` reports the version of the Cygwin runtime on which the current MSYS2 runtime is based.

This sadly breaks our build as soon as we upgrade to an MSYS2 runtime that is based on Cygwin v3.0.2.

Happily, this patch fixes that.