### PR TITLE
add -i: close some regression test gaps

### DIFF
--- a/apply.c
+++ b/apply.c
@@ -2662,6 +2662,16 @@ static int find_pos(struct apply_state *state,
 	int backwards_lno, forwards_lno, current_lno;
 
 	/*
+	 * When running with --allow-overlap, it is possible that a hunk is
+	 * seen that pretends to start at the beginning (but no longer does),
+	 * and that *still* needs to match the end. So trust `match_end` more
+	 * than `match_beginning`.
+	 */
+	if (state->allow_overlap && match_beginning && match_end &&
+	    img->nr - preimage->nr != 0)
+		match_beginning = 0;
+
+	/*
 	 * If match_beginning or match_end is specified, there is no
 	 * point starting from a wrong line that will never match and
 	 * wander around and wait for a match at the specified end.

--- a/git-add--interactive.perl
+++ b/git-add--interactive.perl
@@ -177,7 +177,9 @@ sub run_cmd_pipe {
 	} else {
 		my $fh = undef;
 		open($fh, '-|', @_) or die;
-		return <$fh>;
+		my @out = <$fh>;
+		close $fh || die "Cannot close @_ ($!)";
+		return @out;
 	}
 }
 
@@ -224,7 +226,7 @@ my $status_head = sprintf($status_fmt, __('staged'), __('unstaged'), __('path'))
 	sub get_empty_tree {
 		return $empty_tree if defined $empty_tree;
 
-		$empty_tree = run_cmd_pipe(qw(git hash-object -t tree /dev/null));
+		($empty_tree) = run_cmd_pipe(qw(git hash-object -t tree /dev/null));
 		chomp $empty_tree;
 		return $empty_tree;
 	}
@@ -1127,7 +1129,7 @@ aborted and the hunk is left unchanged.
 EOF2
 	close $fh;
 
-	chomp(my $editor = run_cmd_pipe(qw(git var GIT_EDITOR)));
+	chomp(my ($editor) = run_cmd_pipe(qw(git var GIT_EDITOR)));
 	system('sh', '-c', $editor.' "$@"', $editor, $hunkfile);
 
 	if ($? != 0) {

--- a/t/t3701-add-interactive.sh
+++ b/t/t3701-add-interactive.sh
@@ -291,6 +291,17 @@ test_expect_success 'different prompts for mode change/deleted' '
 	test_cmp expect actual.filtered
 '
 
+test_expect_success 'correct message when there is nothing to do' '
+	git reset --hard &&
+	git add -p 2>err &&
+	test_i18ngrep "No changes" err &&
+	printf "\\0123" >binary &&
+	git add binary &&
+	printf "\\0abc" >binary &&
+	git add -p 2>err &&
+	test_i18ngrep "Only binary files changed" err
+'
+
 test_expect_success 'setup again' '
 	git reset --hard &&
 	test_chmod +x file &&

--- a/t/t3701-add-interactive.sh
+++ b/t/t3701-add-interactive.sh
@@ -105,7 +105,6 @@ test_expect_success 'revert works (commit)' '
 	grep "unchanged *+3/-0 file" output
 '
 
-
 test_expect_success 'setup expected' '
 	cat >expected <<-\EOF
 	EOF
@@ -273,6 +272,24 @@ test_expect_success FILEMODE 'stage mode and hunk' '
 '
 
 # end of tests disabled when filemode is not usable
+
+test_expect_success 'different prompts for mode change/deleted' '
+	git reset --hard &&
+	>file &&
+	>deleted &&
+	git add --chmod=+x file deleted &&
+	echo changed >file &&
+	rm deleted &&
+	test_write_lines n n n |
+	git -c core.filemode=true add -p >actual &&
+	sed -n "s/^\(([0-9/]*) Stage .*?\).*/\1/p" actual >actual.filtered &&
+	cat >expect <<-\EOF &&
+	(1/1) Stage deletion [y,n,q,a,d,?]?
+	(1/2) Stage mode change [y,n,q,a,d,j,J,g,/,?]?
+	(2/2) Stage this hunk [y,n,q,a,d,K,g,/,e,?]?
+	EOF
+	test_cmp expect actual.filtered
+'
 
 test_expect_success 'setup again' '
 	git reset --hard &&

--- a/t/t3701-add-interactive.sh
+++ b/t/t3701-add-interactive.sh
@@ -530,7 +530,7 @@ test_expect_success 'diff.algorithm is passed to `git diff-files`' '
 	>file &&
 	git add file &&
 	echo changed >file &&
-	git -c diff.algorithm=bogus add -p 2>err &&
+	test_must_fail git -c diff.algorithm=bogus add -p 2>err &&
 	test_i18ngrep "error: option diff-algorithm accepts " err
 '
 

--- a/t/t3701-add-interactive.sh
+++ b/t/t3701-add-interactive.sh
@@ -403,6 +403,28 @@ test_expect_failure 'split hunk "add -p (no, yes, edit)"' '
 	! grep "^+31" actual
 '
 
+test_expect_failure 'edit, adding lines to the first hunk' '
+	test_write_lines 10 11 20 30 40 50 51 60 >test &&
+	git reset &&
+	tr _ " " >patch <<-EOF &&
+	@@ -1,5 +1,6 @@
+	_10
+	+11
+	+12
+	_20
+	+21
+	+22
+	_30
+	EOF
+	# test sequence is s(plit), e(dit), n(o)
+	# q n q q is there to make sure we exit at the end.
+	printf "%s\n" s e n   q n q q |
+	EDITOR=./fake_editor.sh git add -p 2>error &&
+	test_must_be_empty error &&
+	git diff --cached >actual &&
+	grep "^+22" actual
+'
+
 test_expect_success 'patch mode ignores unmerged entries' '
 	git reset --hard &&
 	test_commit conflict &&

--- a/t/t3701-add-interactive.sh
+++ b/t/t3701-add-interactive.sh
@@ -23,6 +23,17 @@ diff_cmp () {
 	test_cmp "$1.filtered" "$2.filtered"
 }
 
+# This function uses a trick to manipulate the interactive add to use color:
+# the `want_color()` function special-cases the situation where a pager was
+# spawned and Git now wants to output colored text: to detect that situation,
+# the environment variable `GIT_PAGER_IN_USE` is set. However, color is
+# suppressed despite that environment variable if the `TERM` variable
+# indicates a dumb terminal, so we set that variable, too.
+
+force_color () {
+	env GIT_PAGER_IN_USE=true TERM=vt100 "$@"
+}
+
 test_expect_success 'setup (initial)' '
 	echo content >file &&
 	git add file &&
@@ -451,35 +462,38 @@ test_expect_success 'patch mode ignores unmerged entries' '
 	diff_cmp expected diff
 '
 
-test_expect_success TTY 'diffs can be colorized' '
+test_expect_success 'diffs can be colorized' '
 	git reset --hard &&
 
 	echo content >test &&
-	printf y | test_terminal git add -p >output 2>&1 &&
+	printf y >y &&
+	force_color git add -p >output 2>&1 <y &&
 
 	# We do not want to depend on the exact coloring scheme
 	# git uses for diffs, so just check that we saw some kind of color.
 	grep "$(printf "\\033")" output
 '
 
-test_expect_success TTY 'diffFilter filters diff' '
+test_expect_success 'diffFilter filters diff' '
 	git reset --hard &&
 
 	echo content >test &&
 	test_config interactive.diffFilter "sed s/^/foo:/" &&
-	printf y | test_terminal git add -p >output 2>&1 &&
+	printf y >y &&
+	force_color git add -p >output 2>&1 <y &&
 
 	# avoid depending on the exact coloring or content of the prompts,
 	# and just make sure we saw our diff prefixed
 	grep foo:.*content output
 '
 
-test_expect_success TTY 'detect bogus diffFilter output' '
+test_expect_success 'detect bogus diffFilter output' '
 	git reset --hard &&
 
 	echo content >test &&
 	test_config interactive.diffFilter "echo too-short" &&
-	printf y | test_must_fail test_terminal git add -p
+	printf y >y &&
+	test_must_fail force_color git add -p <y
 '
 
 test_expect_success 'patch-mode via -i prompts for files' '
@@ -689,7 +703,7 @@ test_expect_success 'show help from add--helper' '
 	<BOLD;BLUE>What now<RESET>>$SP
 	Bye.
 	EOF
-	test_write_lines h | GIT_PAGER_IN_USE=true TERM=vt100 git add -i >actual.colored &&
+	test_write_lines h | force_color git add -i >actual.colored &&
 	test_decode_color <actual.colored >actual &&
 	test_i18ncmp expect actual
 '

--- a/t/t3701-add-interactive.sh
+++ b/t/t3701-add-interactive.sh
@@ -524,6 +524,16 @@ test_expect_success 'detect bogus diffFilter output' '
 	test_must_fail force_color git add -p <y
 '
 
+test_expect_success 'diff.algorithm is passed to `git diff-files`' '
+	git reset --hard &&
+
+	>file &&
+	git add file &&
+	echo changed >file &&
+	git -c diff.algorithm=bogus add -p 2>err &&
+	test_i18ngrep "error: option diff-algorithm accepts " err
+'
+
 test_expect_success 'patch-mode via -i prompts for files' '
 	git reset --hard &&
 


### PR DESCRIPTION
While re-implementing `git add -i` and `git add -p` in C, I tried to make sure that there is test coverage for all of the features I convert from Perl to C, to give me some confidence in the correctness from running the test suite both with `GIT_TEST_ADD_I_USE_BUILTIN=true` and with `GIT_TEST_ADD_I_USE_BUILTIN=false`.

However, I discovered that there are a couple of gaps. This patch series intends to close them.

The first patch might actually not be considered a gap by some: it basically removes the need for the `TTY` prerequisite in the `git add -i` tests to verify that the output is colored all right. This change is rather crucial for me, though: on Windows, where the conversion to a built-in shows the most obvious benefits, there are no pseudo terminals (yet), therefore `git.exe` cannot work with them (even if the MSYS2 Perl interpreter used by Git for Windows knows about some sort of pty emulation). And I *really* wanted to make sure that the colors work on Windows, as I personally get a lot out of those color cues.

The patch series ends by addressing two issues that are not exactly covering testing gaps:

- While adding a test case, I noticed that `git add -p` exited with *success* when it could not even generate a diff. This is so obviously wrong that I had to fix it right away (I noticed, actually, because my in-progress built-in `git add -p` failed, and the Perl version did not), and I used the same test case to verify that this is fixed once and for all.

- While working on covering those test gaps, I noticed a problem in an early version of the built-in version of `git add -p` where the `git apply --allow-overlap` mode failed to work properly, for little reason, and I fixed it real quick.

  It would seem that the `--allow-overlap` function is not only purposefully under-documented, but also purposefully under-tested, probably to discourage its use. I do not quite understand the aversion to that option, but I did not feel like I should put up a battle here, so I did not accompany this fix with a new test script.

  In the end, the built-in version of `git add -p` does not use the `--allow-overlap` function at all, anyway. Which should make everybody a lot happier.

Changes since v1:
- Added a paragraph to the commit message talking about the reason why the `--allow-overlap` patch needs to loosen up only at the beginning but not at the end of the file.