### PR TITLE
Fix a false negative in t3301-notes.sh

### DIFF
--- a/t/t3301-notes.sh
+++ b/t/t3301-notes.sh
@@ -1120,9 +1120,10 @@ test_expect_success 'GIT_NOTES_REWRITE_REF overrides config' '
 	test_config notes.rewriteMode overwrite &&
 	test_config notes.rewriteRef refs/notes/other &&
 	echo $(git rev-parse HEAD^) $(git rev-parse HEAD) |
-	GIT_NOTES_REWRITE_REF= git notes copy --for-rewrite=foo &&
+	GIT_NOTES_REWRITE_REF=refs/notes/commits \
+		git notes copy --for-rewrite=foo &&
 	git log -1 >actual &&
-	test_cmp expect actual
+	grep "replacement note 3" actual
 '
 
 test_expect_success 'git notes copy diagnoses too many or too few parameters' '


### PR DESCRIPTION
It is always bad when test cases fail for the wrong reasons, but it is in some ways more scary when they pass for the wrong reasons.

I stumbled over this issue while chasing down a Windows-specific issue that caused two other test cases to fail, and should have caused this one to fail, too, but didn't.