### PR TITLE
Fix an off-by-one bug in the untracked cache code

### DIFF
--- a/dir.c
+++ b/dir.c
@@ -2760,7 +2760,7 @@ static int read_one_dir(struct untracked_cache_dir **untracked_,
 	next = data + len + 1;
 	if (next > rd->end)
 		return -1;
-	*untracked_ = untracked = xmalloc(st_add(sizeof(*untracked), len));
+	*untracked_ = untracked = xmalloc(st_add3(sizeof(*untracked), len, 1));
 	memcpy(untracked, &ud, sizeof(ud));
 	memcpy(untracked->name, data, len + 1);
 	data = next;


### PR DESCRIPTION
Frankly, I am surprised it took me *this* long to discover this bug, as I am running with the untracked cache for ages now.

But as of recent, I am running more and more long-running commands, mostly rebases to keep what I call "ever-green" branches up to date, where Git for Windows' patch thicket is rebased onto core Git's four integration branches, and when there are no merge conflicts to stop the rebase early, I got this really obscure crash (no error message, no nothing to indicate what it was).

It cost me two full work days to chase this one down.