### PR TITLE
Prepare our git-p4 tests for running on APFS

### DIFF
--- a/config.mak.uname
+++ b/config.mak.uname
@@ -114,6 +114,8 @@ ifeq ($(uname_S),Darwin)
 	HAVE_BSD_SYSCTL = YesPlease
 	FREAD_READS_DIRECTORIES = UnfortunatelyYes
 	HAVE_NS_GET_EXECUTABLE_PATH = YesPlease
+	BASIC_CFLAGS += -I/usr/local/include
+	BASIC_LDFLAGS += -L/usr/local/lib
 endif
 ifeq ($(uname_S),SunOS)
 	NEEDS_SOCKET = YesPlease

--- a/t/t9822-git-p4-path-encoding.sh
+++ b/t/t9822-git-p4-path-encoding.sh
@@ -7,6 +7,13 @@ test_description='Clone repositories with non ASCII paths'
 UTF8_ESCAPED="a-\303\244_o-\303\266_u-\303\274.txt"
 ISO8859_ESCAPED="a-\344_o-\366_u-\374.txt"
 
+ISO8859="$(printf "$ISO8859_ESCAPED")" &&
+echo content123 >"$ISO8859" &&
+rm "$ISO8859" || {
+	skip_all="fs does not accept ISO-8859-1 filenames"
+	test_done
+}
+
 test_expect_success 'start p4d' '
 	start_p4d
 '


### PR DESCRIPTION
Azure Pipelines' macOS agents were recently upgraded to Mojave, and since that does not support HFS+ anymore, everything will be upgraded to APFS.

As I found the hard way, we have one test that fails on that filesystem (t9822, which is only run if Perforce's `p4d` is available).

The first patch adds a workaround, as I failed to find any way to finagle APFS into accepting that ISO-8859-1 encoded file name.

The second patch is a fix to make things compile on Mojave again, apparently Homebrew changed and the `/usr/local/` directories need to be added to the compiler and linker flags explicitly. Maybe this is a gcc-8 only thing, as it seems to have affected only the `osx-gcc` job, not the `osx-clang` job.

Changes since v1:

- Fix the tyop in the oneline of the first patch where it should talk about ISO-88*59*-1.

Cc: Luke Diamand <luke@diamand.org>