### PR TITLE
commit-graph: improve error messages

### DIFF
--- a/commit-graph.c
+++ b/commit-graph.c
@@ -167,21 +167,21 @@ struct commit_graph *parse_commit_graph(void *graph_map, int fd,
 
 	graph_signature = get_be32(data);
 	if (graph_signature != GRAPH_SIGNATURE) {
-		error(_("commit-graph signature %X does not match signature %X"),
+		error(_("commit-graph signature 0x%X does not match signature 0x%X"),
 		      graph_signature, GRAPH_SIGNATURE);
 		return NULL;
 	}
 
 	graph_version = *(unsigned char*)(data + 4);
 	if (graph_version != GRAPH_VERSION) {
-		error(_("commit-graph version %X does not match version %X"),
+		error(_("commit-graph has version %d, our maximum supported version is %d"),
 		      graph_version, GRAPH_VERSION);
 		return NULL;
 	}
 
 	hash_version = *(unsigned char*)(data + 5);
 	if (hash_version != oid_version()) {
-		error(_("commit-graph hash version %X does not match version %X"),
+		error(_("commit-graph has hash version %d, our maximum supported version is %d"),
 		      hash_version, oid_version());
 		return NULL;
 	}
@@ -215,7 +215,7 @@ struct commit_graph *parse_commit_graph(void *graph_map, int fd,
 		chunk_lookup += GRAPH_CHUNKLOOKUP_WIDTH;
 
 		if (chunk_offset > graph_size - the_hash_algo->rawsz) {
-			error(_("commit-graph improper chunk offset %08x%08x"), (uint32_t)(chunk_offset >> 32),
+			error(_("commit-graph improper chunk offset 0x%08x%08x"), (uint32_t)(chunk_offset >> 32),
 			      (uint32_t)chunk_offset);
 			free(graph);
 			return NULL;
@@ -252,7 +252,7 @@ struct commit_graph *parse_commit_graph(void *graph_map, int fd,
 		}
 
 		if (chunk_repeated) {
-			error(_("commit-graph chunk id %08x appears multiple times"), chunk_id);
+			error(_("commit-graph chunk id 0x%08x appears multiple times"), chunk_id);
 			free(graph);
 			return NULL;
 		}

--- a/t/t5318-commit-graph.sh
+++ b/t/t5318-commit-graph.sh
@@ -420,17 +420,17 @@ test_expect_success 'detect too small' '
 
 test_expect_success 'detect bad signature' '
 	corrupt_graph_and_verify 0 "\0" \
-		"graph signature"
+		"commit-graph signature"
 '
 
 test_expect_success 'detect bad version' '
 	corrupt_graph_and_verify $GRAPH_BYTE_VERSION "\02" \
-		"graph version"
+		"commit-graph has version"
 '
 
 test_expect_success 'detect bad hash version' '
 	corrupt_graph_and_verify $GRAPH_BYTE_HASH "\02" \
-		"hash version"
+		"commit-graph has hash version"
 '
 
 test_expect_success 'detect low chunk count' '


### PR DESCRIPTION
Here is a small patch that revises the error messages from ab/commit-graph-fixes, as recommended by Ævar. Hopefully, it can be merged faster than the commit-graph v2 stuff, and I can update that series to include this change if we agree it is a good one.

Thanks,
-Stolee

Cc: avarab@gmail.com

In-Reply-To: <878svxrwsh.fsf@evledraar.gmail.com>