### PR TITLE
Multi-pack-index: Fix "too many file descriptors" bug

### DIFF
--- a/builtin/multi-pack-index.c
+++ b/builtin/multi-pack-index.c
@@ -46,7 +46,7 @@ int cmd_multi_pack_index(int argc, const char **argv,
 	if (!strcmp(argv[0], "write"))
 		return write_midx_file(opts.object_dir);
 	if (!strcmp(argv[0], "verify"))
-		return verify_midx_file(opts.object_dir);
+		return verify_midx_file(the_repository, opts.object_dir);
 
 	die(_("unrecognized verb: %s"), argv[0]);
 }

--- a/builtin/pack-objects.c
+++ b/builtin/pack-objects.c
@@ -1078,7 +1078,7 @@ static int want_object_in_pack(const struct object_id *oid,
 
 	for (m = get_multi_pack_index(the_repository); m; m = m->next) {
 		struct pack_entry e;
-		if (fill_midx_entry(oid, &e, m)) {
+		if (fill_midx_entry(the_repository, oid, &e, m)) {
 			struct packed_git *p = e.p;
 			off_t offset;
 

--- a/midx.c
+++ b/midx.c
@@ -192,10 +192,8 @@ void close_midx(struct multi_pack_index *m)
 	m->fd = -1;
 
 	for (i = 0; i < m->num_packs; i++) {
-		if (m->packs[i]) {
-			close_pack(m->packs[i]);
-			free(m->packs[i]);
-		}
+		if (m->packs[i])
+			m->packs[i]->multi_pack_index = 0;
 	}
 	FREE_AND_NULL(m->packs);
 	FREE_AND_NULL(m->pack_names);
@@ -204,6 +202,7 @@ void close_midx(struct multi_pack_index *m)
 int prepare_midx_pack(struct repository *r, struct multi_pack_index *m, uint32_t pack_int_id)
 {
 	struct strbuf pack_name = STRBUF_INIT;
+	struct packed_git *p;
 
 	if (pack_int_id >= m->num_packs)
 		die(_("bad pack-int-id: %u (%u total packs)"),
@@ -215,9 +214,18 @@ int prepare_midx_pack(struct repository *r, struct multi_pack_index *m, uint32_t
 	strbuf_addf(&pack_name, "%s/pack/%s", m->object_dir,
 		    m->pack_names[pack_int_id]);
 
-	m->packs[pack_int_id] = add_packed_git(pack_name.buf, pack_name.len, m->local);
+	p = add_packed_git(pack_name.buf, pack_name.len, m->local);
 	strbuf_release(&pack_name);
-	return !m->packs[pack_int_id];
+
+	if (!p)
+		return 1;
+
+	p->multi_pack_index = 1;
+	m->packs[pack_int_id] = p;
+	install_packed_git(r, p);
+	list_add_tail(&p->mru, &r->objects->packed_git_mru);
+
+	return 0;
 }
 
 int bsearch_midx(const struct object_id *oid, struct multi_pack_index *m, uint32_t *result)

--- a/midx.h
+++ b/midx.h
@@ -5,6 +5,7 @@
 
 struct object_id;
 struct pack_entry;
+struct repository;
 
 #define GIT_TEST_MULTI_PACK_INDEX "GIT_TEST_MULTI_PACK_INDEX"
 
@@ -37,18 +38,18 @@ struct multi_pack_index {
 };
 
 struct multi_pack_index *load_multi_pack_index(const char *object_dir, int local);
-int prepare_midx_pack(struct multi_pack_index *m, uint32_t pack_int_id);
+int prepare_midx_pack(struct repository *r, struct multi_pack_index *m, uint32_t pack_int_id);
 int bsearch_midx(const struct object_id *oid, struct multi_pack_index *m, uint32_t *result);
 struct object_id *nth_midxed_object_oid(struct object_id *oid,
 					struct multi_pack_index *m,
 					uint32_t n);
-int fill_midx_entry(const struct object_id *oid, struct pack_entry *e, struct multi_pack_index *m);
+int fill_midx_entry(struct repository *r, const struct object_id *oid, struct pack_entry *e, struct multi_pack_index *m);
 int midx_contains_pack(struct multi_pack_index *m, const char *idx_or_pack_name);
 int prepare_multi_pack_index_one(struct repository *r, const char *object_dir, int local);
 
 int write_midx_file(const char *object_dir);
 void clear_midx_file(struct repository *r);
-int verify_midx_file(const char *object_dir);
+int verify_midx_file(struct repository *r, const char *object_dir);
 
 void close_midx(struct multi_pack_index *m);
 

--- a/object-store.h
+++ b/object-store.h
@@ -76,7 +76,8 @@ struct packed_git {
 		 pack_keep_in_core:1,
 		 freshened:1,
 		 do_not_close:1,
-		 pack_promisor:1;
+		 pack_promisor:1,
+		 multi_pack_index:1;
 	unsigned char hash[GIT_MAX_RAWSZ];
 	struct revindex_entry *revindex;
 	/* something like ".git/objects/pack/xxxxx.pack" */
@@ -127,12 +128,6 @@ struct raw_object_store {
 	struct packed_git *packed_git;
 	/* A most-recently-used ordered version of the packed_git list. */
 	struct list_head packed_git_mru;
-
-	/*
-	 * A linked list containing all packfiles, starting with those
-	 * contained in the multi_pack_index.
-	 */
-	struct packed_git *all_packs;
 
 	/*
 	 * A fast, rough count of the number of objects in the repository.

--- a/packfile.c
+++ b/packfile.c
@@ -1035,7 +1035,7 @@ struct packed_git *get_all_packs(struct repository *r)
 		for (m = r->objects->multi_pack_index; m; m = m->next) {
 			uint32_t i;
 			for (i = 0; i < m->num_packs; i++) {
-				if (!prepare_midx_pack(m, i)) {
+				if (!prepare_midx_pack(r, m, i)) {
 					m->packs[i]->next = p;
 					p = m->packs[i];
 				}
@@ -1998,7 +1998,7 @@ int find_pack_entry(struct repository *r, const struct object_id *oid, struct pa
 		return 0;
 
 	for (m = r->objects->multi_pack_index; m; m = m->next) {
-		if (fill_midx_entry(oid, e, m))
+		if (fill_midx_entry(r, oid, e, m))
 			return 1;
 	}
 

--- a/packfile.c
+++ b/packfile.c
@@ -994,8 +994,6 @@ static void prepare_packed_git(struct repository *r)
 	}
 	rearrange_packed_git(r);
 
-	r->objects->all_packs = NULL;
-
 	prepare_packed_git_mru(r);
 	r->objects->packed_git_initialized = 1;
 }
@@ -1026,26 +1024,16 @@ struct multi_pack_index *get_multi_pack_index(struct repository *r)
 
 struct packed_git *get_all_packs(struct repository *r)
 {
+	struct multi_pack_index *m;
+
 	prepare_packed_git(r);
-
-	if (!r->objects->all_packs) {
-		struct packed_git *p = r->objects->packed_git;
-		struct multi_pack_index *m;
-
-		for (m = r->objects->multi_pack_index; m; m = m->next) {
-			uint32_t i;
-			for (i = 0; i < m->num_packs; i++) {
-				if (!prepare_midx_pack(r, m, i)) {
-					m->packs[i]->next = p;
-					p = m->packs[i];
-				}
-			}
-		}
-
-		r->objects->all_packs = p;
+	for (m = r->objects->multi_pack_index; m; m = m->next) {
+		uint32_t i;
+		for (i = 0; i < m->num_packs; i++)
+			prepare_midx_pack(r, m, i);
 	}
 
-	return r->objects->all_packs;
+	return r->objects->packed_git;
 }
 
 struct list_head *get_packed_git_mru(struct repository *r)
@@ -2004,7 +1992,7 @@ int find_pack_entry(struct repository *r, const struct object_id *oid, struct pa
 
 	list_for_each(pos, &r->objects->packed_git_mru) {
 		struct packed_git *p = list_entry(pos, struct packed_git, mru);
-		if (fill_pack_entry(oid, e, p)) {
+		if (!p->multi_pack_index && fill_pack_entry(oid, e, p)) {
 			list_move(&p->mru, &r->objects->packed_git_mru);
 			return 1;
 		}

--- a/sha1-name.c
+++ b/sha1-name.c
@@ -157,6 +157,9 @@ static void unique_in_pack(struct packed_git *p,
 	uint32_t num, i, first = 0;
 	const struct object_id *current = NULL;
 
+	if (p->multi_pack_index)
+		return;
+
 	if (open_pack_index(p) || !p->num_objects)
 		return;
 
@@ -588,6 +591,9 @@ static void find_abbrev_len_for_pack(struct packed_git *p,
 	uint32_t num, first = 0;
 	struct object_id oid;
 	const struct object_id *mad_oid;
+
+	if (p->multi_pack_index)
+		return;
 
 	if (open_pack_index(p) || !p->num_objects)
 		return;


### PR DESCRIPTION
Thanks to Jeff H for finding the problem with the multi-pack-index regarding many packs. Specifically: if we open too many packs, the close_one_pack() method cannot find the packs from the multi-pack-index to close.

Jeff already fixed the problem explicitly in 'git multi-pack-index verify' which would hit this issue 100% of the time we had 2000+ packs. This issue could still happen in 'git rev-list --all --objects' if there are enough packs containing commits and trees. This series fixes the issue.

The basic solution is to add packs from the multi-pack-index into the packed_git struct as they are opened. To avoid performance issues, add a `multi_pack_index` bit to the packed_git struct. Midx-aware algorithms can then ignore those packs.

There was a very subtle issue that happens during a 'git repack': we clear the multi-pack-index after possibly reading some packs from it, thus leaving some packs in the packed_git struct but having a NULL multi_pack_index in the object store. This informs the change to close_midx().

I'm based on a recent 'master' commit that contains the following three branches due to nearby changes causing conflicts if I pick only Jeff's change as a base:

jh/midx-verify-too-many-packs
jk/server-info-rabbit-hole
bc/hash-transition-16

Thanks,
-Stolee

Cc: git@jeffhostetler.com, avarab@gmail.com, peff@peff.net