### PR TITLE
p4: fix "Not a valid object name HEAD0" when unshelving

### DIFF
--- a/git-p4.py
+++ b/git-p4.py
@@ -737,7 +737,7 @@ def extractLogMessageFromGitCommit(commit):
 
     ## fixme: title is first line of commit, not 1st paragraph.
     foundTitle = False
-    for log in read_pipe_lines("git cat-file commit %s" % commit):
+    for log in read_pipe_lines(["git", "cat-file", "commit", commit]):
        if not foundTitle:
            if len(log) == 1:
                foundTitle = True


### PR DESCRIPTION
git p4 unshelve was failing with "fatal: Not a valid object name HEAD0" and "Command failed: git cat-file commit HEAD^0" on certain systems e.g. git version 2.21.0.windows.1 + python 2.7.16

It seems that certain python pOpen implementations drop the ^ character when invoked using a string instead of an array as first argument, which is what is done by extractLogMessageFromGitCommit.

Solution is to use the array format of passing the command to fOpen, which is preferred (see https://docs.python.org/2/library/subprocess.html) and is used in other parts of this code anyway.
