### PR TITLE
Proactively fix a test issue with v3.x of the MSYS2 runtime

### DIFF
--- a/t/t6500-gc.sh
+++ b/t/t6500-gc.sh
@@ -162,7 +162,15 @@ test_expect_success 'background auto gc respects lock for all operations' '
 	# now fake a concurrent gc that holds the lock; we can use our
 	# shell pid so that it looks valid.
 	hostname=$(hostname || echo unknown) &&
-	printf "$$ %s" "$hostname" >.git/gc.pid &&
+	shell_pid=$$ &&
+	if test_have_prereq MINGW && test -f /proc/$shell_pid/winpid
+	then
+		# In Git for Windows, Bash (actually, the MSYS2 runtime) has a
+		# different idea of PIDs than git.exe (actually Windows). Use
+		# the Windows PID in this case.
+		shell_pid=$(cat /proc/$shell_pid/winpid)
+	fi &&
+	printf "%d %s" "$shell_pid" "$hostname" >.git/gc.pid &&
 
 	# our gc should exit zero without doing anything
 	run_and_wait_for_auto_gc &&


### PR DESCRIPTION
I saw this in one of my builds that followed the bleeding edge of Git for Windows' SDK: `git.exe` has a different idea of the test script's PID than the test script itself. Yet another of the quirks Git for Windows has to deal with...