### PR TITLE
difftool: --no-index is incompatible with --dir-diff

### DIFF
--- a/builtin/difftool.c
+++ b/builtin/difftool.c
@@ -735,7 +735,8 @@ int cmd_difftool(int argc, const char **argv, const char *prefix)
 		setup_work_tree();
 		setenv(GIT_DIR_ENVIRONMENT, absolute_path(get_git_dir()), 1);
 		setenv(GIT_WORK_TREE_ENVIRONMENT, absolute_path(get_git_work_tree()), 1);
-	}
+	} else if (dir_diff)
+		die(_("--dir-diff is incompatible with --no-index"));
 
 	if (use_gui_tool && diff_gui_tool && *diff_gui_tool)
 		setenv("GIT_DIFF_TOOL", diff_gui_tool, 1);


### PR DESCRIPTION
While debugging why a straight-forward backport of the `js/difftool-no-index` branch onto Git for Windows' `master` does not work as expected (spoiler: it's due to `git diff --no-index` now implying `--ext-diff`, a change that is not yet in Git for Windows' `master`), I ran into quite a few segmentation faults while trying to make `--no-index` work nicely with `--dir-diff`.

And this was a much bigger project than I thought it would be: the `worktree` is `NULL` and causes a segmentation fault, `make_transient_cache_entry()` returns `NULL` instead of a cache entry, while looking up replacement objects there is a crash because `git_replace_ref_base` is `NULL`, during `checkout_entry()`'s life time, the `prepare_alt_odb()` function tries to dereference `the_repository.objects->odb` (which is `NULL`, of course). I'll stop here with all the segmentation faults.

Even worse, when trying to compare `../1` to `../2` (as we do in the regression test for `difftool --no-index` outside any repository), we run afoul of `verify_path()` complaining that this is not a valid path for an index entry.

After figuring all of that out, I took a step back and guess what: it turns out that it does not even make sense to combine those two options. The `--dir-diff` option exists to enable diff'ing subdirectories of a worktree while pretending that untracked and ignored files in them do not even exist. And without a worktree, there simply are no untracked or ignored files, so `--dir-diff` is not necessary.

Still, we should address those segmentation faults. And I think we address them best by explicitly telling the user that they cannot use those two options together.