### PR TITLE
pkt-line: fix incorrect function declaration

### DIFF
--- a/parse-options.h
+++ b/parse-options.h
@@ -286,7 +286,9 @@ int parse_opt_commit(const struct option *, const char *, int);
 int parse_opt_tertiary(const struct option *, const char *, int);
 int parse_opt_string_list(const struct option *, const char *, int);
 int parse_opt_noop_cb(const struct option *, const char *, int);
-int parse_opt_unknown_cb(struct parse_opt_ctx_t *ctx, const struct option *, const char *, int);
+enum parse_opt_result parse_opt_unknown_cb(struct parse_opt_ctx_t *ctx,
+					   const struct option *,
+					   const char *, int);
 int parse_opt_passthru(const struct option *, const char *, int);
 int parse_opt_passthru_argv(const struct option *, const char *, int);
 

--- a/pkt-line.h
+++ b/pkt-line.h
@@ -25,7 +25,7 @@ void packet_delim(int fd);
 void packet_write_fmt(int fd, const char *fmt, ...) __attribute__((format (printf, 2, 3)));
 void packet_buf_flush(struct strbuf *buf);
 void packet_buf_delim(struct strbuf *buf);
-void set_packet_header(char *buf, int size);
+void set_packet_header(char *buf, const int size);
 void packet_write(int fd_out, const char *buf, size_t size);
 void packet_buf_write(struct strbuf *buf, const char *fmt, ...) __attribute__((format (printf, 2, 3)));
 void packet_buf_write_len(struct strbuf *buf, const char *data, size_t len);


### PR DESCRIPTION
MS Visual C detected a mismatch between the declaration and the definition of `set_packet_header()`: it is declared with its second parameter missing the `const` attribute.

It also detected a mismatch between the declaration and the definition of `parse_opt_unknown_cb()`.

These problems must have been introduced very recently; I do not recall seeing them before today in any of Git for Windows' ever-green branches (i.e. `master` semi-automatically rebased continously onto `pu`, `next`, `master` and `maint`).

You could not have seen it in git.git's own Azure Pipeline, as Git for Windows' version already has support to build with MSVC (I plan to submit this directly after v2.22.0 is out).