### PR TITLE
Document the stash.useBuiltin escape hatch

### DIFF
--- a/Documentation/config/stash.txt
+++ b/Documentation/config/stash.txt
@@ -1,3 +1,18 @@
+stash.useBuiltin::
+       Set to `false` to use the legacy shell script implementation of
+       linkgit:git-stash[1]. Is `true` by default, which means use
+       the built-in rewrite of it in C.
++
+The C rewrite is first included with Git version 2.22 (and Git for Windows
+version 2.19). This option serves an an escape hatch to re-enable the
+legacy version in case any bugs are found in the rewrite. This option and
+the shell script version of linkgit:git-stash[1] will be removed in some
+future release.
++
+If you find some reason to set this option to `false` other than
+one-off testing you should report the behavior difference as a bug in
+git (see https://git-scm.com/community for details).
+
 stash.showPatch::
 	If this is set to true, the `git stash show` command without an
 	option will show the stash entry in patch form.  Defaults to false.


### PR DESCRIPTION
Shamelessly copy-edited from Ævar's d8d0a546f0 (rebase doc: document rebase.useBuiltin, 2018-11-14)

:-D

Cc: Ævar Arnfjörð Bjarmason <avarab@gmail.com>