### PR TITLE
diff: release all handles before running external diff

### DIFF
--- a/diff.c
+++ b/diff.c
@@ -4206,6 +4206,8 @@ static void run_external_diff(const char *pgm,
 	argv_array_pushf(&env, "GIT_DIFF_PATH_COUNTER=%d", ++o->diff_path_counter);
 	argv_array_pushf(&env, "GIT_DIFF_PATH_TOTAL=%d", q->nr);
 
+	diff_free_filespec_data(one);
+	diff_free_filespec_data(two);
 	if (run_command_v_opt_cd_env(argv.argv, RUN_USING_SHELL, NULL, env.argv))
 		die(_("external diff died, stopping at %s"), name);
 


### PR DESCRIPTION
On Windows, it is not possible to overwrite a file as long as any process holds a read handle to it. Even keeping regions memory-mapped prevents that.

When `git difftool` calls `git diff`, it might be the user's intention to write the file(s) via the diff tool, so let's make sure that they are not memory-mapped at that stage.

Changes since v1:

- Clarified in the commit message that even mapped regions block writes/deletes.
- The diff file pair is now released unconditionally, not only when it is mapped, for consistency (the CI build did not fail, and a cursory inspection of the code paths indicates that this should be safe, as from this point on only the external command accesses the file pair's contents, and they had to be written out to disk to that end).