### PR TITLE
mingw: enable GCC's stack smashing protector

### DIFF
--- a/config.mak.uname
+++ b/config.mak.uname
@@ -596,7 +596,8 @@ else
 			BASIC_LDFLAGS += -Wl,--large-address-aware
 		endif
 		CC = gcc
-		COMPAT_CFLAGS += -D__USE_MINGW_ANSI_STDIO=0 -DDETECT_MSYS_TTY
+		COMPAT_CFLAGS += -D__USE_MINGW_ANSI_STDIO=0 -DDETECT_MSYS_TTY \
+			-fstack-protector-strong
 		EXTLIBS += -lntdll
 		INSTALL = /bin/install
 		NO_R_TO_GCC_LINKER = YesPlease


### PR DESCRIPTION
Recently, I managed to upstream the Data Execution Prevention/Address Space Layout Randomization patches of Git for Windows. Now it is time to add to that by also enabling GCC's augmenting feature which reduces the attack surface even further.