### PR TITLE
gettext(windows): always use UTF-8

### DIFF
--- a/gettext.c
+++ b/gettext.c
@@ -12,7 +12,25 @@
 #ifndef NO_GETTEXT
 #	include <locale.h>
 #	include <libintl.h>
-#	ifdef HAVE_LIBCHARSET_H
+#	ifdef GIT_WINDOWS_NATIVE
+
+static const char *locale_charset(void)
+{
+	const char *env = getenv("LC_ALL"), *dot;
+
+	if (!env || !*env)
+		env = getenv("LC_CTYPE");
+	if (!env || !*env)
+		env = getenv("LANG");
+
+	if (!env)
+		return "UTF-8";
+
+	dot = strchr(env, '.');
+	return !dot ? env : dot + 1;
+}
+
+#	elif defined HAVE_LIBCHARSET_H
 #		include <libcharset.h>
 #	else
 #		include <langinfo.h>


### PR DESCRIPTION
The main issue we work around here is that Windows does not have a UTF-8 "code page".

Side note: there is actually a code page for UTF-8: 65001 (see https://docs.microsoft.com/en-us/windows/desktop/Intl/code-page-identifiers). However, when experimenting with it, we ran into a multitude of issues in the Git for Windows project, ranging from various problems with Windows' default console to miscounted file writes. While these issues may have been mitigated in recent Windows 10 versions, older ones (in particular, Windows 7) still seem to have most of them, and Git for Windows specifically still supports even Windows Vista. So from a practical point of view, there is no UTF-8 code page.

Changes since v1:

- The `LC_ALL=C` method used by `ab/no-kwset` to prevent Git from assuming UTF-8-encoded input is now supported.
- The commit message was enhanced and revamped.