### PR TITLE
Give Git a HOME on Windows

### DIFF
--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -2299,6 +2299,30 @@ static void setup_windows_environment(void)
 	/* simulate TERM to enable auto-color (see color.c) */
 	if (!getenv("TERM"))
 		setenv("TERM", "cygwin", 1);
+
+	/* calculate HOME if not set */
+	if (!getenv("HOME")) {
+		/*
+		 * try $HOMEDRIVE$HOMEPATH - the home share may be a network
+		 * location, thus also check if the path exists (i.e. is not
+		 * disconnected)
+		 */
+		if ((tmp = getenv("HOMEDRIVE"))) {
+			struct strbuf buf = STRBUF_INIT;
+			strbuf_addstr(&buf, tmp);
+			if ((tmp = getenv("HOMEPATH"))) {
+				strbuf_addstr(&buf, tmp);
+				if (is_directory(buf.buf))
+					setenv("HOME", buf.buf, 1);
+				else
+					tmp = NULL; /* use $USERPROFILE */
+			}
+			strbuf_release(&buf);
+		}
+		/* use $USERPROFILE if the home share is not available */
+		if (!tmp && (tmp = getenv("USERPROFILE")))
+			setenv("HOME", tmp, 1);
+	}
 }
 
 /*


### PR DESCRIPTION
The environment variable `HOME` is a well-known concept on Unix/Linux, but not so much on Windows. In fact, there are competing concepts, and they fulfill separate roles.

Let's try to map the closest that we can find to `HOME` so that Git is happy.

Git for Windows carries this patch since 2015, so I think we're pretty sure that our chosen strategy works.