### PR TITLE
mingw: support spawning programs with paths containing spacesnames

### DIFF
--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -1437,7 +1437,9 @@ static pid_t mingw_spawnve_fd(const char *cmd, const char **argv, char **deltaen
 	si.hStdOutput = winansi_get_osfhandle(fhout);
 	si.hStdError = winansi_get_osfhandle(fherr);
 
-	if (xutftowcs_path(wcmd, cmd) < 0)
+	if (*argv && !strcmp(cmd, *argv))
+		wcmd[0] = L'\0';
+	else if (xutftowcs_path(wcmd, cmd) < 0)
 		return -1;
 	if (dir && xutftowcs_path(wdir, dir) < 0)
 		return -1;
@@ -1466,8 +1468,8 @@ static pid_t mingw_spawnve_fd(const char *cmd, const char **argv, char **deltaen
 	wenvblk = make_environment_block(deltaenv);
 
 	memset(&pi, 0, sizeof(pi));
-	ret = CreateProcessW(wcmd, wargs, NULL, NULL, TRUE, flags,
-		wenvblk, dir ? wdir : NULL, &si, &pi);
+	ret = CreateProcessW(*wcmd ? wcmd : NULL, wargs, NULL, NULL, TRUE,
+		flags, wenvblk, dir ? wdir : NULL, &si, &pi);
 
 	free(wenvblk);
 	free(wargs);

--- a/t/t0061-run-command.sh
+++ b/t/t0061-run-command.sh
@@ -210,4 +210,10 @@ test_expect_success MINGW 'verify curlies are quoted properly' '
 	test_cmp expect actual
 '
 
+test_expect_success MINGW 'can spawn with argv[0] containing spaces' '
+	cp "$GIT_BUILD_DIR/t/helper/test-fake-ssh$X" ./ &&
+	test_must_fail "$PWD/test-fake-ssh$X" 2>err &&
+	grep TRASH_DIRECTORY err
+'
+
 test_done


### PR DESCRIPTION
This is a patch to support older Windows versions (e.g. Windows 7) better.

I know, I know, Windows 7's End-Of-Life is now less than half a year away, but... I am unsure just how long Git for Windows will support Windows 7 beyond its officially-supported life; We still support Windows Vista, after all, which has been "sun-set" over two years ago.