### PR TITLE
trace2: fix tracing when NO_PTHREADS is defined

### DIFF
--- a/trace2/tr2_tls.c
+++ b/trace2/tr2_tls.c
@@ -61,7 +61,12 @@ struct tr2tls_thread_ctx *tr2tls_create_self(const char *thread_name,
 
 struct tr2tls_thread_ctx *tr2tls_get_self(void)
 {
-	struct tr2tls_thread_ctx *ctx = pthread_getspecific(tr2tls_key);
+	struct tr2tls_thread_ctx *ctx;
+
+	if (!HAVE_THREADS)
+		return tr2tls_thread_main;
+
+	ctx = pthread_getspecific(tr2tls_key);
 
 	/*
 	 * If the thread-proc did not call trace2_thread_start(), we won't
@@ -76,9 +81,10 @@ struct tr2tls_thread_ctx *tr2tls_get_self(void)
 
 int tr2tls_is_main_thread(void)
 {
-	struct tr2tls_thread_ctx *ctx = pthread_getspecific(tr2tls_key);
+	if (!HAVE_THREADS)
+		return 1;
 
-	return ctx == tr2tls_thread_main;
+	return pthread_getspecific(tr2tls_key) == tr2tls_thread_main;
 }
 
 void tr2tls_unset_self(void)


### PR DESCRIPTION
This commit addresses the problem reported in:
https://public-inbox.org/git/92cfdf43-8841-9c5a-7838-dda995038908@jeffhostetler.com/T/#mbaf8069f6d1bc18d5a02d3682a1f9282f5547ea9

As Duy suggested, pthread_getspecific() just returns NULL when NO_PTHREADS
is defined.  And pthread_setspecific() silently does not nothing.  So this problem was
hidden from view.

I have to wonder if we should update pthread_*specific() to call BUG() when
NO_PTHREADS is defined as a way to catch unguarded usages easier or make
this issue more clear.
