### PR TITLE
bundle verify: improve the user experience when called without a .git/ directory

### DIFF
--- a/builtin/bundle.c
+++ b/builtin/bundle.c
@@ -40,6 +40,8 @@ int cmd_bundle(int argc, const char **argv, const char *prefix)
 			usage(builtin_bundle_usage);
 			return 1;
 		}
+		if (!startup_info->have_repository)
+			die(_("Need a repository to create a bundle."));
 		if (verify_bundle(the_repository, &header, 1))
 			return 1;
 		fprintf(stderr, _("%s is okay\n"), bundle_file);

--- a/t/t5607-clone-bundle.sh
+++ b/t/t5607-clone-bundle.sh
@@ -14,6 +14,12 @@ test_expect_success 'setup' '
 	git tag -d third
 '
 
+test_expect_success '"verify" needs a repository' '
+	git bundle create tip.bundle -1 master &&
+	test_must_fail nongit git bundle verify ../tip.bundle 2>err &&
+	test_i18ngrep "Need a repository" err
+'
+
 test_expect_success 'annotated tags can be excluded by rev-list options' '
 	git bundle create bundle --all --since=7.Apr.2005.15:14:00.-0700 &&
 	git ls-remote bundle > output &&


### PR DESCRIPTION
The `git bundle verify <bundle>` command really needs access to a `.git/` directory. But it did not make sure, instead erroring out with a `BUG()`, making for a terrible user experience.

This patch fixes that.

Changes since v2:

- Touched up the commit message further, to clarify why it matters that the bundle contains a thin pack.
- Moved the check from `bundle.c` to `builtin/bundle.c`.

Changes since v1:

- The commit message no longer has an incomplete sentence before a colon, instead the colon was replaced by "that".
- The title of the test case was corrected.

Cc: Konstantin Ryabitsev <konstantin@linuxfoundation.org>, SZEDER Gábor <szeder.dev@gmail.com>, brian m. carlson <sandals@crustytoothpaste.net>, Jeff King <peff@peff.net>