### PR TITLE
Deprecate `git rebase -p` even more

### DIFF
--- a/Documentation/git-pull.txt
+++ b/Documentation/git-pull.txt
@@ -112,8 +112,9 @@ When set to `merges`, rebase using `git rebase --rebase-merges` so that
 the local merge commits are included in the rebase (see
 linkgit:git-rebase[1] for details).
 +
-When set to preserve, rebase with the `--preserve-merges` option passed
-to `git rebase` so that locally created merge commits will not be flattened.
+When set to `preserve` (deprecated in favor of `merges`), rebase with the
+`--preserve-merges` option passed to `git rebase` so that locally created
+merge commits will not be flattened.
 +
 When false, merge the current branch into the upstream branch.
 +

--- a/Documentation/git-rebase.txt
+++ b/Documentation/git-rebase.txt
@@ -675,7 +675,8 @@ $ git rebase -i HEAD~5
 
 And move the first patch to the end of the list.
 
-You might want to preserve merges, if you have a history like this:
+You might want to recreate merge commits, e.g. if you have a history
+like this:
 
 ------------------
            X
@@ -689,7 +690,7 @@ Suppose you want to rebase the side branch starting at "A" to "Q". Make
 sure that the current HEAD is "B", and call
 
 -----------------------------
-$ git rebase -i -p --onto Q O
+$ git rebase -i -r --onto Q O
 -----------------------------
 
 Reordering and editing commits usually creates untested intermediate

--- a/t/t3422-rebase-incompatible-options.sh
+++ b/t/t3422-rebase-incompatible-options.sh
@@ -65,12 +65,13 @@ test_rebase_am_only --ignore-whitespace
 test_rebase_am_only --committer-date-is-author-date
 test_rebase_am_only -C4
 
-test_expect_success '--preserve-merges incompatible with --signoff' '
+test_expect_success REBASE_P '--preserve-merges incompatible with --signoff' '
 	git checkout B^0 &&
 	test_must_fail git rebase --preserve-merges --signoff A
 '
 
-test_expect_success '--preserve-merges incompatible with --rebase-merges' '
+test_expect_success REBASE_P \
+	'--preserve-merges incompatible with --rebase-merges' '
 	git checkout B^0 &&
 	test_must_fail git rebase --preserve-merges --rebase-merges A
 '

--- a/t/t3427-rebase-subtree.sh
+++ b/t/t3427-rebase-subtree.sh
@@ -38,7 +38,8 @@ test_expect_success 'setup' '
 '
 
 # FAILURE: Does not preserve master4.
-test_expect_failure 'Rebase -Xsubtree --preserve-merges --onto commit 4' '
+test_expect_failure REBASE_P \
+	'Rebase -Xsubtree --preserve-merges --onto commit 4' '
 	reset_rebase &&
 	git checkout -b rebase-preserve-merges-4 master &&
 	git filter-branch --prune-empty -f --subdirectory-filter files_subtree &&
@@ -48,7 +49,8 @@ test_expect_failure 'Rebase -Xsubtree --preserve-merges --onto commit 4' '
 '
 
 # FAILURE: Does not preserve master5.
-test_expect_failure 'Rebase -Xsubtree --preserve-merges --onto commit 5' '
+test_expect_failure REBASE_P \
+	'Rebase -Xsubtree --preserve-merges --onto commit 5' '
 	reset_rebase &&
 	git checkout -b rebase-preserve-merges-5 master &&
 	git filter-branch --prune-empty -f --subdirectory-filter files_subtree &&
@@ -58,7 +60,8 @@ test_expect_failure 'Rebase -Xsubtree --preserve-merges --onto commit 5' '
 '
 
 # FAILURE: Does not preserve master4.
-test_expect_failure 'Rebase -Xsubtree --keep-empty --preserve-merges --onto commit 4' '
+test_expect_failure REBASE_P \
+	'Rebase -Xsubtree --keep-empty --preserve-merges --onto commit 4' '
 	reset_rebase &&
 	git checkout -b rebase-keep-empty-4 master &&
 	git filter-branch --prune-empty -f --subdirectory-filter files_subtree &&
@@ -68,7 +71,8 @@ test_expect_failure 'Rebase -Xsubtree --keep-empty --preserve-merges --onto comm
 '
 
 # FAILURE: Does not preserve master5.
-test_expect_failure 'Rebase -Xsubtree --keep-empty --preserve-merges --onto commit 5' '
+test_expect_failure REBASE_P \
+	'Rebase -Xsubtree --keep-empty --preserve-merges --onto commit 5' '
 	reset_rebase &&
 	git checkout -b rebase-keep-empty-5 master &&
 	git filter-branch --prune-empty -f --subdirectory-filter files_subtree &&
@@ -78,7 +82,8 @@ test_expect_failure 'Rebase -Xsubtree --keep-empty --preserve-merges --onto comm
 '
 
 # FAILURE: Does not preserve Empty.
-test_expect_failure 'Rebase -Xsubtree --keep-empty --preserve-merges --onto empty commit' '
+test_expect_failure REBASE_P \
+	'Rebase -Xsubtree --keep-empty --preserve-merges --onto empty commit' '
 	reset_rebase &&
 	git checkout -b rebase-keep-empty-empty master &&
 	git filter-branch --prune-empty -f --subdirectory-filter files_subtree &&


### PR DESCRIPTION
Turns out that I forgot a couple of spots when I sent the patch series to deprecate `git rebase -p` earlier...