### PR TITLE
Improve instructions around how to set git-prompt preference variables.

### DIFF
--- a/contrib/completion/git-prompt.sh
+++ b/contrib/completion/git-prompt.sh
@@ -35,6 +35,11 @@
 #
 # The prompt status always includes the current branch name.
 #
+# The prompt can be customized by setting various shell variables
+# (GIT_PS1_SHOWDIRTYSTATE, GIT_PS1_SHOWSTASHSTATE, etc.), which are described
+# below. Make sure that these variables get set *before* the
+# "source ~/.git-prompt.sh" line from step 2 (above) runs.
+#
 # In addition, if you set GIT_PS1_SHOWDIRTYSTATE to a nonempty value,
 # unstaged (*) and staged (+) changes will be shown next to the branch
 # name.  You can configure this per-repository with the


### PR DESCRIPTION
When I first tried to use the `git-prompt.sh` script, I followed the instructions at the top of the file and everything worked, except for the "GIT_PS1_SHOWDIRTYSTATE" preference. Even though I had it set to true, I wasn't seeing the "(*)" and "(+)" in my shell prompt. After a few hours of poking around, I finally discovered what I had done wrong: I was setting the variable *after* the "source ~/.git-prompt.sh" line, and it has to be set *before*.

I moved the lines around my .bashrc script and got everything working, but I thought the instructions could be a bit more explicit about how to set these preference variables, especially because this is a silent failure situation; the preference doesn't work if you get the order wrong and there are no warnings or errors to guide you.

This patch started as a PR on the official Github project two years ago (https://github.com/git/git/pull/425), back when I didn't know the official process for submitting patches. Luckily, a kind user (@dscho) saw it and pointed me in the right direction to get it submitted.

This will be my first time submitting a patch, so hopefully I've figured out the process.