### PR TITLE
add -p: fix checkout -p with pathological context

### DIFF
--- a/git-add--interactive.perl
+++ b/git-add--interactive.perl
@@ -972,7 +972,11 @@ sub coalesce_overlapping_hunks {
 			next;
 		}
 		if ($ofs_delta) {
-			$n_ofs += $ofs_delta;
+			if ($patch_mode_flavour{IS_REVERSE}) {
+				$o_ofs -= $ofs_delta;
+			} else {
+				$n_ofs += $ofs_delta;
+			}
 			$_->{TEXT}->[0] = format_hunk_header($o_ofs, $o_cnt,
 							     $n_ofs, $n_cnt);
 		}

--- a/t/t3701-add-interactive.sh
+++ b/t/t3701-add-interactive.sh
@@ -639,4 +639,12 @@ test_expect_success 'add -p patch editing works with pathological context lines'
 	test_cmp expected-2 actual
 '
 
+test_expect_success 'checkout -p works with pathological context lines' '
+	test_write_lines a a a a a a >a &&
+	git add a &&
+	test_write_lines a b a b a b a b a b a > a&&
+	test_write_lines s n n y q | git checkout -p &&
+	test_write_lines a b a b a a b a b a >expect &&
+	test_cmp expect a
+'
 test_done


### PR DESCRIPTION
When I fixed the hunk offsets in add -p when hunks are skipped I forgot that the reverse patch case needs to be handled differently.
