### PR TITLE
ci: split `linux-gcc` into `linux-gcc` and `linux-gcc-extra`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,10 @@ compiler:
 
 matrix:
   include:
+    - env: jobname=linux-gcc-extra
+      os: linux
+      compiler: gcc
+      addons:
     - env: jobname=GIT_TEST_GETTEXT_POISON
       os: linux
       compiler:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -206,6 +206,45 @@ jobs:
       PathtoPublish: t/failed-test-artifacts
       ArtifactName: failed-test-artifacts
 
+- job: linux_gcc_extra
+  displayName: linux-gcc-extra
+  condition: succeeded()
+  pool: Hosted Ubuntu 1604
+  steps:
+  - bash: |
+       test "$GITFILESHAREPWD" = '$(gitfileshare.pwd)' || ci/mount-fileshare.sh //gitfileshare.file.core.windows.net/test-cache gitfileshare "$GITFILESHAREPWD" "$HOME/test-cache" || exit 1
+
+       sudo add-apt-repository ppa:ubuntu-toolchain-r/test &&
+       sudo apt-get update &&
+       sudo apt-get -y install git gcc make libssl-dev libcurl4-openssl-dev libexpat-dev tcl tk gettext git-email zlib1g-dev apache2 language-pack-is git-svn gcc-8 || exit 1
+
+       export jobname=linux-gcc-extra &&
+
+       ci/install-dependencies.sh || exit 1
+       ci/run-build-and-tests.sh || {
+           ci/print-test-failures.sh
+           exit 1
+       }
+
+       test "$GITFILESHAREPWD" = '$(gitfileshare.pwd)' || sudo umount "$HOME/test-cache" || exit 1
+    displayName: 'ci/run-build-and-tests.sh'
+    env:
+      GITFILESHAREPWD: $(gitfileshare.pwd)
+  - task: PublishTestResults@2
+    displayName: 'Publish Test Results **/TEST-*.xml'
+    inputs:
+      mergeTestResults: true
+      testRunTitle: 'linux-gcc-extra'
+      platform: Linux
+      publishRunAttachments: false
+    condition: succeededOrFailed()
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish trash directories of failed tests'
+    condition: failed()
+    inputs:
+      PathtoPublish: t/failed-test-artifacts
+      ArtifactName: failed-test-artifacts
+
 - job: osx_clang
   displayName: osx-clang
   condition: succeeded()

--- a/ci/install-dependencies.sh
+++ b/ci/install-dependencies.sh
@@ -9,12 +9,12 @@ P4WHENCE=http://filehost.perforce.com/perforce/r$LINUX_P4_VERSION
 LFSWHENCE=https://github.com/github/git-lfs/releases/download/v$LINUX_GIT_LFS_VERSION
 
 case "$jobname" in
-linux-clang|linux-gcc)
+linux-clang|linux-gcc|linux-gcc-extra)
 	sudo apt-add-repository -y "ppa:ubuntu-toolchain-r/test"
 	sudo apt-get -q update
 	sudo apt-get -q -y install language-pack-is libsvn-perl apache2
 	case "$jobname" in
-	linux-gcc)
+	linux-gcc|linux-gcc-extra)
 		sudo apt-get -q -y install gcc-8
 		;;
 	esac

--- a/ci/lib.sh
+++ b/ci/lib.sh
@@ -154,8 +154,8 @@ export DEFAULT_TEST_TARGET=prove
 export GIT_TEST_CLONE_2GB=YesPlease
 
 case "$jobname" in
-linux-clang|linux-gcc)
-	if [ "$jobname" = linux-gcc ]
+linux-clang|linux-gcc|linux-gcc-extra)
+	if [ "$jobname" = linux-gcc -o "$jobname" = linux-gcc-extra ]
 	then
 		export CC=gcc-8
 	fi

--- a/ci/run-build-and-tests.sh
+++ b/ci/run-build-and-tests.sh
@@ -11,8 +11,7 @@ windows*) cmd //c mklink //j t\\.prove "$(cygpath -aw "$cache_dir/.prove")";;
 esac
 
 make
-make test
-if test "$jobname" = "linux-gcc"
+if test "$jobname" = "linux-gcc-extra"
 then
 	export GIT_TEST_SPLIT_INDEX=yes
 	export GIT_TEST_FULL_IN_PACK_ARRAY=true
@@ -20,8 +19,8 @@ then
 	export GIT_TEST_OE_DELTA_SIZE=5
 	export GIT_TEST_COMMIT_GRAPH=1
 	export GIT_TEST_MULTI_PACK_INDEX=1
-	make test
 fi
+make test
 
 check_unignored_build_artifacts
 


### PR DESCRIPTION
For people like me, who often look at our CI builds, it is hard to tell whether test suite failures in the `linux-gcc` job stem from the first `make test` run, or from the second one, after setting all kinds of `GIT_TEST_*` variables to non-default values.

Let's make it easier on people like me.

This also helps the problem where the CI builds often finish the other jobs waaaay before `linux-gcc` finally finishes, too: `linux-gcc` and `linux-gcc-extra` can be run in parallel, on different agents.