### PR TITLE
blame: read diff config

### DIFF
--- a/builtin/blame.c
+++ b/builtin/blame.c
@@ -725,6 +725,8 @@ static int git_blame_config(const char *var, const char *value, void *cb)
 		return -1;
 	if (userdiff_config(var, value) < 0)
 		return -1;
+	if (git_diff_ui_config(var, value, cb))
+		return -1;
 
 	return git_default_config(var, value, cb);
 }


### PR DESCRIPTION
I had a support email where a user could not make sense of some blame output and the diff they saw when looking at the commit. When I saw the commit, the diff looked like the file was completely rewritten. However, with the "--patience" option, the output looked much cleaner and clearly that line was not modified by that commit.

I could not find a way to modify the diff algorithm used by 'git blame' using config options or command-line arguments, so I thought it would be worth reading the diff config settings in the blame builtin. If we want to start taking command-line options, then that could be handled by a later series.