### PR TITLE
Update gpg.txt to correct gpg --verify syntax

### DIFF
--- a/Documentation/config/gpg.txt
+++ b/Documentation/config/gpg.txt
@@ -2,7 +2,7 @@ gpg.program::
 	Use this custom program instead of "`gpg`" found on `$PATH` when
 	making or verifying a PGP signature. The program must support the
 	same command-line interface as GPG, namely, to verify a detached
-	signature, "`gpg --verify $file - <$signature`" is run, and the
+	signature, "`gpg --verify $signature - <$file`" is run, and the
 	program is expected to signal a good signature by exiting with
 	code 0, and to generate an ASCII-armored detached signature, the
 	standard input of "`gpg -bsau $key`" is fed with the contents to be


### PR DESCRIPTION
The gpg --verify usage example within the 'gpg.program' variable reference provides an incorrect example of the gpg --verify command arguments.  The command argument order, when providing both a detached signature and data, should be signature first and data second: https://gnupg.org/documentation/manuals/gnupg/Operational-GPG-Commands.html#index-verify.

Signed-off-by: Robert T Morgan <robert.thomas.morgan@gmail.com>
