### PR TITLE
Make the includeif:onbranch feature more robust

### DIFF
--- a/config.c
+++ b/config.c
@@ -275,7 +275,8 @@ static int include_by_branch(const char *cond, size_t cond_len)
 	int flags;
 	int ret;
 	struct strbuf pattern = STRBUF_INIT;
-	const char *refname = resolve_ref_unsafe("HEAD", 0, NULL, &flags);
+	const char *refname = !the_repository || !the_repository->gitdir ?
+		NULL : resolve_ref_unsafe("HEAD", 0, NULL, &flags);
 	const char *shortname;
 
 	if (!refname || !(flags & REF_ISSYMREF)	||

--- a/t/t1309-early-config.sh
+++ b/t/t1309-early-config.sh
@@ -89,4 +89,9 @@ test_expect_failure 'ignore .git/ with invalid config' '
 	test_with_config "["
 '
 
+test_expect_success 'early config and onbranch' '
+	echo "[broken" >broken &&
+	test_with_config "[includeif \"onbranch:refs/heads/master\"]path=../broken"
+'
+
 test_done


### PR DESCRIPTION
I actually stumbled over this while rebasing the VFS for Git patches, in relation with the `pre-command` hook that we still support there (we're slowly migrating toward Trace2, of course).

Once I figured out what the problem was, I hunted for a way to trigger this bug in plain Git, and `git help -a` is the one I settled on. It had to be a command that uses the early config machinery (and `git help -a` uses it to list all aliases), and it had to be a command that does _not_ discover a `.git` directory automatically (`cmd_help` is listed without any flags in `git.c`, so: check).

Of course, part of me wants to just go and dig into the refs part of the code to introduce an equivalent to the "early config" machinery (calling it "early ref store"), but:

1. We're really in feature freeze, and I want this bug fix to go into v2.23.0.
2. It is actually a pretty obscure thing to want: a branch-dependent config that is used that early that the Git directory was not yet discovered. I _could_ imagine that some power user wants to play some games at some stage, say, with the pager depending on the name of the current branch, but even then, to run into the issue with this here patch where it simply ignores the `includeif.onbranch:` setting in the early config code path, a command has to be run that does _not_ immediately set up `the_repository->gitdir` but still wants to use the configured pager.

So yes, this patch introduces a known issue, but it does fix a `BUG()` where no bug should be reported.

Changes since v1:
- Now using my correct email address for Git contributions.