### PR TITLE
Fix two documentation typos

### DIFF
--- a/Documentation/config/transfer.txt
+++ b/Documentation/config/transfer.txt
@@ -17,7 +17,7 @@ linkgit:git-receive-pack[1]. On the fetch side, malformed objects will
 instead be left unreferenced in the repository.
 +
 Due to the non-quarantine nature of the `fetch.fsckObjects`
-implementation it can not be relied upon to leave the object store
+implementation it cannot be relied upon to leave the object store
 clean like `receive.fsckObjects` can.
 +
 As objects are unpacked they're written to the object store, so there

--- a/Documentation/git-cvsserver.txt
+++ b/Documentation/git-cvsserver.txt
@@ -232,7 +232,7 @@ write so it might not be enough to grant the users using
 'git-cvsserver' write access to the database file without granting
 them write access to the directory, too.
 
-The database can not be reliably regenerated in a
+The database cannot be reliably regenerated in a
 consistent form after the branch it is tracking has changed.
 Example: For merged branches, 'git-cvsserver' only tracks
 one branch of development, and after a 'git merge' an

--- a/Documentation/git-fetch.txt
+++ b/Documentation/git-fetch.txt
@@ -262,7 +262,7 @@ This updates (or creates, as necessary) branches `pu` and `tmp` in
 the local repository by fetching from the branches (respectively)
 `pu` and `maint` from the remote repository.
 +
-The `pu` branch will be updated even if it is does not fast-forward,
+The `pu` branch will be updated even if it does not fast-forward,
 because it is prefixed with a plus sign; `tmp` will not be.
 
 * Peek at a remote's branch, without configuring the remote in your local
@@ -285,7 +285,7 @@ BUGS
 ----
 Using --recurse-submodules can only fetch new commits in already checked
 out submodules right now. When e.g. upstream added a new submodule in the
-just fetched commits of the superproject the submodule itself can not be
+just fetched commits of the superproject the submodule itself cannot be
 fetched, making it impossible to check out that submodule later without
 having to do a fetch again. This is expected to be fixed in a future Git
 version.

--- a/Documentation/git-pull.txt
+++ b/Documentation/git-pull.txt
@@ -249,7 +249,7 @@ BUGS
 ----
 Using --recurse-submodules can only fetch new commits in already checked
 out submodules right now. When e.g. upstream added a new submodule in the
-just fetched commits of the superproject the submodule itself can not be
+just fetched commits of the superproject the submodule itself cannot be
 fetched, making it impossible to check out that submodule later without
 having to do a fetch again. This is expected to be fixed in a future Git
 version.

--- a/Documentation/glossary-content.txt
+++ b/Documentation/glossary-content.txt
@@ -255,7 +255,7 @@ This commit is referred to as a "merge commit", or sometimes just a
 [[def_object]]object::
 	The unit of storage in Git. It is uniquely identified by the
 	<<def_SHA1,SHA-1>> of its contents. Consequently, an
-	object can not be changed.
+	object cannot be changed.
 
 [[def_object_database]]object database::
 	Stores a set of "objects", and an individual <<def_object,object>> is

--- a/Documentation/technical/api-ref-iteration.txt
+++ b/Documentation/technical/api-ref-iteration.txt
@@ -54,7 +54,7 @@ this:
 do not do this you will get an error for each ref that it does not point
 to a valid object.
 
-Note: As a side-effect of this you can not safely assume that all
+Note: As a side-effect of this you cannot safely assume that all
 objects you lookup are available in superproject. All submodule objects
 will be available the same way as the superprojects objects.
 


### PR DESCRIPTION
I noticed a couple typos while reading through some manpages. 

First was "...if it is does not..." which just contained an extraneous "is".

Then I noticed a "can not" and updated that and other occurrences in Documentation to cannot. The glossary sentence with "can not" was "Consequently, an object can not be changed." To me, that reads like "it is permissible to not change an object, but it is possible that an object may be changed." Switching to "cannot" makes a stronger assertion that it is impossible to change an object.

There are also two error messages, "can not move directory into itself" and "Can not do reflog for '%s': %s\n", which I chose to not modify in this patch. I am happy to s/an not/annot/ those as a separate change if it is acceptable to change the wording on an error message like that.