### PR TITLE
Fix a problem with PCRE2 and nedmalloc, found via Azure Pipelines

### DIFF
--- a/grep.c
+++ b/grep.c
@@ -488,7 +488,6 @@ static void compile_pcre2_pattern(struct grep_pat *p, const struct grep_opt *opt
 	PCRE2_UCHAR errbuf[256];
 	PCRE2_SIZE erroffset;
 	int options = PCRE2_MULTILINE;
-	const uint8_t *character_tables = NULL;
 	int jitret;
 	int patinforet;
 	size_t jitsizearg;
@@ -499,9 +498,10 @@ static void compile_pcre2_pattern(struct grep_pat *p, const struct grep_opt *opt
 
 	if (opt->ignore_case) {
 		if (has_non_ascii(p->pattern)) {
-			character_tables = pcre2_maketables(NULL);
+			p->pcre2_tables = pcre2_maketables(NULL);
 			p->pcre2_compile_context = pcre2_compile_context_create(NULL);
-			pcre2_set_character_tables(p->pcre2_compile_context, character_tables);
+			pcre2_set_character_tables(p->pcre2_compile_context,
+							p->pcre2_tables);
 		}
 		options |= PCRE2_CASELESS;
 	}
@@ -605,6 +605,7 @@ static void free_pcre2_pattern(struct grep_pat *p)
 	pcre2_match_data_free(p->pcre2_match_data);
 	pcre2_jit_stack_free(p->pcre2_jit_stack);
 	pcre2_match_context_free(p->pcre2_match_context);
+	free((void *)p->pcre2_tables);
 }
 #else /* !USE_LIBPCRE2 */
 static void compile_pcre2_pattern(struct grep_pat *p, const struct grep_opt *opt)

--- a/grep.h
+++ b/grep.h
@@ -96,6 +96,7 @@ struct grep_pat {
 	pcre2_compile_context *pcre2_compile_context;
 	pcre2_match_context *pcre2_match_context;
 	pcre2_jit_stack *pcre2_jit_stack;
+	const uint8_t *pcre2_tables;
 	uint32_t pcre2_jit_on;
 	kwset_t kws;
 	unsigned fixed:1;


### PR DESCRIPTION
For a couple of days, maybe even a week, `pu` fails consistently, in the Windows job where it tests t7816. The symptom is a segmentation fault.

I finally got to diagnose this, and it looked at first as if there was yet another buffer overrun that was so small that valgrind failed to detect it (see https://github.com/gitgitgadget/git/pull/178). The problem is another one, though: we ask PCRE2 to allocate a table (and it uses the system allocator for that), and then try to release it using nedmalloc's `free()` replacement.

This is squarely a problem with `cb/pcre2-chartables-leakfix` in conjunction with an overridden allocator.

Junio, for your convenience, I rebased this patch directly on top of `ab/pcre-v2` and pushed out the `let-pcre2-respect-nedmalloc` branch at https://github.com/dscho/git ready to be pulled. The rebased version is not technically a bug fix, as I do not see any way that `ab/pcre-v2` uses mismatched allocators for `malloc()`/`free()`, but just in case that you wanted to have it in v2.23.0 and not on top `cb/pcre2-chartables-leakfix`...

Cc: Carlo Marcelo Arenas Belón <carenas@gmail.com>