### PR TITLE
[v2.23.0 BUG] commit-graph: fix bug around octopus merges

### DIFF
--- a/commit-graph.c
+++ b/commit-graph.c
@@ -1629,7 +1629,7 @@ static void sort_and_scan_merged_commits(struct write_commit_graph_context *ctx)
 				num_parents++;
 
 			if (num_parents > 2)
-				ctx->num_extra_edges += num_parents - 2;
+				ctx->num_extra_edges += num_parents - 1;
 		}
 	}
 

--- a/t/t5324-split-commit-graph.sh
+++ b/t/t5324-split-commit-graph.sh
@@ -319,7 +319,9 @@ test_expect_success 'add octopus merge' '
 	git merge commits/3 commits/4 &&
 	git branch merge/octopus &&
 	git commit-graph write --reachable --split &&
-	git commit-graph verify &&
+	git commit-graph verify 2>err &&
+	test_line_count = 3 err &&
+	test_i18ngrep ! warning err &&
 	test_line_count = 3 $graphdir/commit-graph-chain
 '
 


### PR DESCRIPTION
I come, hat in hand, with a bug-fix for a bug that I wrote. I just happened to discover this issue while playing around with turning the commit-graph on by default and stumbled into this warning.

Please see the commit message for full details, but putting octopus merges in a tip commit-graph file in the incremental format [1] would cause the file to not load because Git thinks the base commit-graphs do not have the right hashes.

It is very likely that a more careful patch would allow this warning to become an error during `git commit-graph verify`, but I wanted to minimize the change for this quick bug fix.

Thanks,
-Stolee

[1] https://public-inbox.org/git/pull.184.v6.git.gitgitgadget@gmail.com/

Cc: peff@peff.net, avarab@gmail.com,  git@jeffhostetler.com, jrnieder@google.com, steadmon@google.com, johannes.schindelin@gmx.de, philipoakley@iee.org