### PR TITLE
banned.h: fix vsprintf warning

### DIFF
--- a/banned.h
+++ b/banned.h
@@ -26,7 +26,7 @@
 #define vsprintf(...) BANNED(vsprintf)
 #else
 #define sprintf(buf,fmt,arg) BANNED(sprintf)
-#define vsprintf(buf,fmt,arg) BANNED(sprintf)
+#define vsprintf(buf,fmt,arg) BANNED(vsprintf)
 #endif
 
 #endif /* BANNED_H */


### PR DESCRIPTION
Previously sprintf was the argument to the BANNED macro, where vsprintf
is expected.