### PR TITLE
commit-graph: emit trace2 cmd_mode for each sub-command

### DIFF
--- a/builtin/commit-graph.c
+++ b/builtin/commit-graph.c
@@ -58,6 +58,8 @@ static int graph_verify(int argc, const char **argv)
 		OPT_END(),
 	};
 
+	trace2_cmd_mode("verify");
+
 	argc = parse_options(argc, argv, NULL,
 			     builtin_commit_graph_verify_options,
 			     builtin_commit_graph_verify_usage, 0);
@@ -101,6 +103,8 @@ static int graph_read(int argc, const char **argv)
 			N_("The object directory to store the graph")),
 		OPT_END(),
 	};
+
+	trace2_cmd_mode("read");
 
 	argc = parse_options(argc, argv, NULL,
 			     builtin_commit_graph_read_options,
@@ -182,6 +186,8 @@ static int graph_write(int argc, const char **argv)
 	split_opts.size_multiple = 2;
 	split_opts.max_commits = 0;
 	split_opts.expire_time = 0;
+
+	trace2_cmd_mode("write");
 
 	argc = parse_options(argc, argv, NULL,
 			     builtin_commit_graph_write_options,


### PR DESCRIPTION
Emit trace2_cmd_mode() messages for each commit-graph
sub-command.

The commit graph commands were in flux when trace2 was
making it's way to git. Now that we have enough sub-commands
in commit-graph, we can label the various modes within them.
Distinguishing between read, write and verify is a great
start.

Signed-off-by: Garima Singh <garima.singh@microsoft.com>

CC: jeffhost@microsoft.com, stolee@gmail.com, garimasigit@gmail.com, avarab@gmail.com