### PR TITLE
upload-pack: fix race condition in t5516

### DIFF
--- a/upload-pack.c
+++ b/upload-pack.c
@@ -613,11 +613,13 @@ error:
 	for (i = 0; i < want_obj->nr; i++) {
 		struct object *o = want_obj->objects[i].item;
 		if (!is_our_ref(o)) {
+			error("git upload-pack: not our ref %s",
+			      oid_to_hex(&o->oid));
 			packet_writer_error(writer,
 					    "upload-pack: not our ref %s",
 					    oid_to_hex(&o->oid));
-			die("git upload-pack: not our ref %s",
-			    oid_to_hex(&o->oid));
+			packet_writer_flush(writer);
+			exit(1);
 		}
 	}
 }


### PR DESCRIPTION
This patch fixes a strange race condition that was hitting our PR builds on microsoft/git rather frequently. See [1] for an example.

It was only happening on the MSVC builds, so somehow that compiler/platform combination was leading to this race condition happening more often than other platforms. See the commit message for the race condition.

The thing I am worried about is that I replaced a die() statement with an error() and exit() pair. Is that OK? Or is there a preferred option?

Thanks,
-Stolee

[1] https://gvfs.visualstudio.com/ci/_build/results?buildId=16068