### PR TITLE
checkout: add simple check for 'git checkout -b'

### DIFF
--- a/builtin/checkout.c
+++ b/builtin/checkout.c
@@ -1713,6 +1713,15 @@ int cmd_checkout(int argc, const char **argv, const char *prefix)
 	opts.overlay_mode = -1;
 	opts.checkout_index = -2;    /* default on */
 	opts.checkout_worktree = -2; /* default on */
+	
+	if (argc == 3 && !strcmp(argv[1], "-b")) {
+		/*
+		 * User ran 'git checkout -b <branch>' and expects
+		 * the same behavior as 'git switch -c <branch>'.
+		 */
+		opts.switch_branch_doing_nothing_is_ok = 0;
+		opts.only_merge_on_switching_branches = 1;
+	}
 
 	options = parse_options_dup(checkout_options);
 	options = add_common_options(&opts, options);


### PR DESCRIPTION
This series replaces "[RFC] Revert/delay performance regression in 'git checkout -b'" [1].

The community response to that series seems to be:

1. 'git switch' is still experimental, so don't warn that users should adopt it right away.

2. 'git checkout -b <branch>' should do the fast thing, and we should check the arguments directly.

This series makes 'git checkout -b <branch>' do the same thing as 'git switch -c <branch>'.

Thanks,
-Stolee

[1] https://public-inbox.org/git/pull.317.git.gitgitgadget@gmail.com/