### PR TITLE
Make `git rebase -r`'s label generation more resilient

### DIFF
--- a/t/t3430-rebase-merges.sh
+++ b/t/t3430-rebase-merges.sh
@@ -468,4 +468,10 @@ test_expect_success '--rebase-merges with strategies' '
 	test_cmp expect G.t
 '
 
+test_expect_success '--rebase-merges with commit that can generate bad characters for filename' '
+	git checkout -b colon-in-label E &&
+	git merge -m "colon: this should work" G &&
+	git rebase --rebase-merges --force-rebase E
+'
+
 test_done


### PR DESCRIPTION
Those labels must be valid ref names, and therefore valid file names. The initial patch came in via Git for Windows.

Change since v1:

- moved the entire sanitizing logic to `label_oid()`, as a preparatory step.

Cc: Doan Tran Cong Danh <congdanhqx@gmail.com>