### PR TITLE
Fix stale .gitignore change, introduced via js/visual-studio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -231,7 +231,6 @@
 *.ipdb
 *.dll
 .vs/
-*.manifest
 Debug/
 Release/
 /UpgradeLog*.htm


### PR DESCRIPTION
As reported in https://public-inbox.org/git/20190825120741.GM20404@szeder.dev/, we added a line to ignore `.manifest` files, but that is a left-over from a _long_ time ago, before we added and used `compat/win32/git.manifest`.

This fixes that left-over.