### PR TITLE
ci: install P4 from package

### DIFF
--- a/ci/install-dependencies.sh
+++ b/ci/install-dependencies.sh
@@ -5,27 +5,23 @@
 
 . ${0%/*}/lib.sh
 
-P4WHENCE=http://filehost.perforce.com/perforce/r$LINUX_P4_VERSION
 LFSWHENCE=https://github.com/github/git-lfs/releases/download/v$LINUX_GIT_LFS_VERSION
 
 case "$jobname" in
 linux-clang|linux-gcc)
+	wget -qO - https://package.perforce.com/perforce.pubkey | sudo apt-key add -
+	echo "deb http://package.perforce.com/apt/ubuntu xenial release" >perforce.list
+	sudo mv perforce.list /etc/apt/sources.list.d/
 	sudo apt-add-repository -y "ppa:ubuntu-toolchain-r/test"
 	sudo apt-get -q update
-	sudo apt-get -q -y install language-pack-is libsvn-perl apache2
+	sudo apt-get -q -y install language-pack-is libsvn-perl apache2 \
+		helix-p4d
 	case "$jobname" in
 	linux-gcc)
 		sudo apt-get -q -y install gcc-8
 		;;
 	esac
 
-	mkdir --parents "$P4_PATH"
-	pushd "$P4_PATH"
-		wget --quiet "$P4WHENCE/bin.linux26x86_64/p4d"
-		wget --quiet "$P4WHENCE/bin.linux26x86_64/p4"
-		chmod u+x p4d
-		chmod u+x p4
-	popd
 	mkdir --parents "$GIT_LFS_PATH"
 	pushd "$GIT_LFS_PATH"
 		wget --quiet "$LFSWHENCE/git-lfs-linux-amd64-$LINUX_GIT_LFS_VERSION.tar.gz"

--- a/ci/lib.sh
+++ b/ci/lib.sh
@@ -162,17 +162,15 @@ linux-clang|linux-gcc)
 
 	export GIT_TEST_HTTPD=YesPlease
 
-	# The Linux build installs the defined dependency versions below.
-	# The OS X build installs much more recent versions, whichever
+	# The Linux build installs the defined dependency version below.
+	# The OS X build installs much more recent version, whichever
 	# were recorded in the Homebrew database upon creating the OS X
 	# image.
 	# Keep that in mind when you encounter a broken OS X build!
-	export LINUX_P4_VERSION="16.2"
 	export LINUX_GIT_LFS_VERSION="1.5.2"
 
-	P4_PATH="$HOME/custom/p4"
 	GIT_LFS_PATH="$HOME/custom/git-lfs"
-	export PATH="$GIT_LFS_PATH:$P4_PATH:$PATH"
+	export PATH="$GIT_LFS_PATH:$PATH"
 	;;
 osx-clang|osx-gcc)
 	if [ "$jobname" = osx-gcc ]


### PR DESCRIPTION
To test 'git-p4' in the Linux Clang and GCC build jobs we used to
install the 'p4' and 'p4d' binaries by directly downloading those
binaries from a Perforce filehost.  This has worked just fine ever
since we started using Travis CI [1], but during the last day or so
that filehost appeared to be gone: while its hostname still resolves,
the host doesn't seem to reply to any download request, it doesn't
even refuse the connection, and eventually our build jobs time out
[2].

Now, this might be just a temporary glitch, but I'm afraid that it
isn't.  The "Helix Core Server Administrator Guide" [3] describes two
ways to install these binaries on Linux, and none of them mentions the
filehost that we've been downloading from in the past:

  - non-package installation: open the website's download page in your
    web browser, select OS and platform, click on the download link,
    and eventually you get a .tar.gz archive containing, among other
    things, the necessary 'p4' and 'p4d' binaries.

    Now, we could use the URL of this archive to download it in our CI
    scripts with 'wget', but nobody said that that URL remains stable,
    and we would still need to extract the archive and copy the
    binaries to $PATH.

  - package installation for various distros, including Ubuntu 16.04
    (i.e. the Ubuntu version used both in our Travis CI and Azure
    Pipelines builds): add a package repository and its pubkey,
    'apt-get update && apt-get install', and ready to go.

Let's install P4 from the package repository, because this approach
seems to be simpler and more future proof.

Note that we used to install an old P4 version (16.2) in the Linux
build jobs, but with this change we'll install the most recent version
available in the Perforce package repository (currently 19.1).

[1] 522354d70f (Add Travis CI support, 2015-11-27).
[2] https://travis-ci.org/git/git/jobs/581429927#L422
[3] https://www.perforce.com/manuals/p4sag/Content/P4SAG/chapter.install.html

---

Let's see whether this works on Azure Pipelines.