### PR TITLE
Fix perl error "unescaped left brace in regex" for paranoid update hook

### DIFF
--- a/contrib/hooks/update-paranoid
+++ b/contrib/hooks/update-paranoid
@@ -302,13 +302,13 @@ $op = 'U' if ($op eq 'R'
 
 RULE:
 	foreach (@$rules) {
-		while (/\${user\.([a-z][a-zA-Z0-9]+)}/) {
+		while (/\$\{user\.([a-z][a-zA-Z0-9]+)}/) {
 			my $k = lc $1;
 			my $v = $data{"user.$k"};
 			next RULE unless defined $v;
 			next RULE if @$v != 1;
 			next RULE unless defined $v->[0];
-			s/\${user\.$k}/$v->[0]/g;
+			s/\$\{user\.$k}/$v->[0]/g;
 		}
 
 		if (/^([AMD ]+)\s+of\s+([^\s]+)\s+for\s+([^\s]+)\s+diff\s+([^\s]+)$/) {


### PR DESCRIPTION
A literal "{" should now be escaped in a pattern starting from perl
versions >= v5.26. In perl v5.22, using a literal { in a regular
expression was deprecated, and will emit a warning if it isn't escaped: \{.
In v5.26, this won't just warn, it'll cause a syntax error.

(see https://metacpan.org/pod/release/RJBS/perl-5.22.0/pod/perldelta.pod)

Signed-off-by: Dominic Winkler <d.winkler@flexarts.at>
