### PR TITLE
git-add--interactive.perl: Add progress counter in the prompt

### DIFF
--- a/git-add--interactive.perl
+++ b/git-add--interactive.perl
@@ -1541,7 +1541,7 @@ sub patch_update_file {
 		for (@{$hunk[$ix]{DISPLAY}}) {
 			print;
 		}
-		print colored $prompt_color,
+		print colored $prompt_color, "(", ($ix+1), "/$num) ",
 			sprintf(__($patch_update_prompt_modes{$patch_mode}{$hunk[$ix]{TYPE}}), $other);
 
 		my $line = prompt_single_character;

--- a/t/t3701-add-interactive.sh
+++ b/t/t3701-add-interactive.sh
@@ -314,7 +314,7 @@ test_expect_success C_LOCALE_OUTPUT 'add first line works' '
 	git commit -am "clear local changes" &&
 	git apply patch &&
 	printf "%s\n" s y y | git add -p file 2>error |
-		sed -n -e "s/^Stage this hunk[^@]*\(@@ .*\)/\1/" \
+		sed -n -e "s/^([1-2]\/[1-2]) Stage this hunk[^@]*\(@@ .*\)/\1/" \
 		       -e "/^[-+@ \\\\]"/p  >output &&
 	test_must_be_empty error &&
 	git diff --cached >diff &&


### PR DESCRIPTION
Hi git contributors!

I'm Kunal Tyagi. While I was choosing the relevant patches for a commit using the `git add -p` command, I found that there was no feedback regarding how many hunks from the current file had been processed and how many were left. So I decided to add a small change to the prompt which basically just displays `(${current-hunk-id} + 1/${total-hunks}) ` before displaying the prompt during user interaction. This patch doesn't account for all total hunks, only per file.

I don't know perl so even this one liner might have mistakes. I did test this locally and hope this works for others. Personally, this change feels helpful to me when I have to separate a long list of changes after an erroneous commit.

On the #git-devel freenode channel, I was informed that @dscho is rewriting git-add in C. If so, perhaps a similar change could be added in the rewrite. I haven't seen his patches in detail so I can't comment if it'll be as trivial as in perl.

Regards
Kunal Tyagi