### PR TITLE
stash apply: be prepared to run in a worktree's subdirectory

### DIFF
--- a/builtin/stash.c
+++ b/builtin/stash.c
@@ -497,6 +497,10 @@ static int do_apply_stash(const char *prefix, struct stash_info *info,
 		 */
 		cp.git_cmd = 1;
 		cp.dir = prefix;
+		argv_array_pushf(&cp.env_array, GIT_WORK_TREE_ENVIRONMENT"=%s",
+				 absolute_path(get_git_work_tree()));
+		argv_array_pushf(&cp.env_array, GIT_DIR_ENVIRONMENT"=%s",
+				 absolute_path(get_git_dir()));
 		argv_array_push(&cp.args, "status");
 		run_command(&cp);
 	}

--- a/t/t3908-stash-in-worktree.sh
+++ b/t/t3908-stash-in-worktree.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+#
+# Copyright (c) 2019 Johannes E Schindelin
+#
+
+test_description='Test git stash in a worktree'
+
+. ./test-lib.sh
+
+test_expect_success 'setup' '
+	test_commit initial &&
+	git worktree add wt &&
+	test_commit -C wt in-worktree
+'
+
+test_expect_success 'apply in subdirectory' '
+	mkdir wt/subdir &&
+	(
+		cd wt/subdir &&
+		echo modified >../initial.t &&
+		git stash &&
+		git stash apply >out
+	) &&
+	grep "\.\.\/initial\.t" wt/subdir/out
+'
+
+test_done


### PR DESCRIPTION
I saw this issue a couple times in my setup, and always wondered why nobody else seemed to be hit by this. When I finally found/made some time to investigate, I found out that it really requires a specific setup: I have many worktrees connected to my main git.git clone, often run inside `t/` and I do stash quite often (now that `git stash`'s performance is a joy on Windows).

Changes since v1:

- We now make sure to also set `GIT_DIR`.