### PR TITLE
t0061: fix test for argv[0] with spaces (MINGW only)

### DIFF
--- a/t/t0061-run-command.sh
+++ b/t/t0061-run-command.sh
@@ -210,10 +210,23 @@ test_expect_success MINGW 'verify curlies are quoted properly' '
 	test_cmp expect actual
 '
 
-test_expect_success MINGW 'can spawn with argv[0] containing spaces' '
-	cp "$GIT_BUILD_DIR/t/helper/test-fake-ssh$X" ./ &&
-	test_must_fail "$PWD/test-fake-ssh$X" 2>err &&
-	grep TRASH_DIRECTORY err
+test_expect_success MINGW 'can spawn .bat with argv[0] containing spaces' '
+	bat="$TRASH_DIRECTORY/bat with spaces in name.bat" &&
+	
+	# Every .bat invocation will log its arguments to file "out"
+	rm -f out &&
+	echo "echo %* >>out" >"$bat" &&
+	
+	# Ask git to invoke .bat; clone will fail due to fake SSH helper
+	test_must_fail env GIT_SSH="$bat" git clone myhost:src ssh-clone &&
+	
+	# Spawning .bat can fail if there are two quoted cmd.exe arguments.
+	# .bat itself is first (due to spaces in name), so just one more is
+	# needed to verify. GIT_SSH will invoke .bat multiple times:
+	# 1) -G myhost
+	# 2) myhost "git-upload-pack src"
+	# First invocation will always succeed. Test the second one.
+	grep "git-upload-pack" out
 '
 
 test_done


### PR DESCRIPTION
The test was originally designed for the case where user reported
that setting GIT_SSH to a .bat file with spaces in path fails on
Windows: https://github.com/git-for-windows/git/issues/692

The test has two different problems:

1. It succeeds with AND without fix eb7c7863 that addressed user's
   problem. This happens because the core problem was misunderstood,
   leading to conclusion that git is unable to start any programs with
   spaces in path on Win7. But in fact
     a) Bug only affected cmd.exe scripts, such as .bat scripts
     b) Bug only happened when cmd.exe received at least two quoted args
     c) Bug happened on any Windows (verified on Win10).
   Therefore, correct test must involve .bat script and two quoted args.
2. In Visual Studio build, it fails to run, because 'test-fake-ssh.exe'
   is copied away from its dependencies 'libiconv.dll' and 'zlib1.dll'.

Fix both problems by using .bat script instead of 'test-fake-ssh.exe'.
NOTE: With this change, the test now correctly fails without eb7c7863.

Signed-off-by: Alexandr Miloslavskiy <alexandr.miloslavskiy@syntevo.com>
