### PR TITLE
git gui: fix staging a second line to a 1-line file

### DIFF
--- a/lib/diff.tcl
+++ b/lib/diff.tcl
@@ -698,6 +698,7 @@ proc apply_range_or_line {x y} {
 		set hh [$ui_diff get $i_l "$i_l + 1 lines"]
 		set hh [lindex [split $hh ,] 0]
 		set hln [lindex [split $hh -] 1]
+		set hln [lindex [split $hln " "] 0]
 
 		# There is a special situation to take care of. Consider this
 		# hunk:


### PR DESCRIPTION
Yet another patch that is carried in Git for Windows for quite a long time. This fixes https://github.com/git-for-windows/git/issues/515.

This commit was contributed as https://github.com/patthoyts/git/gui/pull/7 which was ignored for almost three years, and then as https://github.com/prati0100/git-gui/pull/1 which was rejected in favor of a mailing list-centric workflow.

The patch is based on Git GUI's `master` branch at https://github.com/prati0100/git-gui/.

Cc: Pratyush Yadav <me@yadavpratyush.com>