### PR TITLE
git-gui (Windows): use git-bash.exe if it is available

### DIFF
--- a/git-gui.sh
+++ b/git-gui.sh
@@ -2700,10 +2700,18 @@ if {![is_bare]} {
 }
 
 if {[is_Windows]} {
+	# Use /git-bash.exe if available
+	set normalized [file normalize $::argv0]
+	regsub "/mingw../libexec/git-core/git-gui$" \
+		$normalized "/git-bash.exe" cmdLine
+	if {$cmdLine != $normalized && [file exists $cmdLine]} {
+		set cmdLine [list "Git Bash" $cmdLine &]
+	} else {
+		set cmdLine [list "Git Bash" bash --login -l &]
+	}
 	.mbar.repository add command \
 		-label [mc "Git Bash"] \
-		-command {eval exec [auto_execok start] \
-					  [list "Git Bash" bash --login -l &]}
+		-command {eval exec [auto_execok start] $cmdLine}
 }
 
 if {[is_Windows] || ![is_bare]} {


### PR DESCRIPTION
... and yet another patch that is carried in Git for Windows for quite a long time.

This commit was contributed as https://github.com/patthoyts/git/gui/pull/6 which was ignored for almost three years, and then as https://github.com/prati0100/git-gui/pull/2 which was rejected in favor of a mailing list-centric workflow.

The patch is based on Git GUI's `master` branch at https://github.com/prati0100/git-gui/.

Cc: Pratyush Yadav <me@yadavpratyush.com>