### PR TITLE
doc: Add a note about ~/.zsh/_git file

### DIFF
--- a/contrib/completion/git-completion.zsh
+++ b/contrib/completion/git-completion.zsh
@@ -11,8 +11,9 @@
 #
 #  zstyle ':completion:*:*:git:*' script ~/.git-completion.zsh
 #
-# The recommended way to install this script is to copy to '~/.zsh/_git', and
-# then add the following to your ~/.zshrc file:
+# The recommended way to install this script is to make a copy of it in
+# '~/.zsh/' directory as '~/.zsh/_git' and then add the following to your
+# ~/.zshrc file:
 #
 #  fpath=(~/.zsh $fpath)
 


### PR DESCRIPTION
Hey,

Today I've spent a few hours to understand why git-completion doesn't work in my zsh shell. It was because I thought `~/.zsh/_git` should be a dictionary with `git-completion.zsh` file. 

I think this change may save some hours for someone else. 