### PR TITLE
Include `hdr-check` in the CI builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -354,7 +354,7 @@ jobs:
        test "$GITFILESHAREPWD" = '$(gitfileshare.pwd)' || ci/mount-fileshare.sh //gitfileshare.file.core.windows.net/test-cache gitfileshare "$GITFILESHAREPWD" "$HOME/test-cache" || exit 1
 
        sudo apt-get update &&
-       sudo apt-get install -y coccinelle &&
+       sudo apt-get install -y coccinelle libcurl4-openssl-dev libssl-dev libexpat-dev gettext &&
 
        export jobname=StaticAnalysis &&
 

--- a/ci/install-dependencies.sh
+++ b/ci/install-dependencies.sh
@@ -49,7 +49,8 @@ osx-clang|osx-gcc)
 	;;
 StaticAnalysis)
 	sudo apt-get -q update
-	sudo apt-get -q -y install coccinelle
+	sudo apt-get -q -y install coccinelle libcurl4-openssl-dev libssl-dev \
+		libexpat-dev gettext
 	;;
 Documentation)
 	sudo apt-get -q update

--- a/ci/run-static-analysis.sh
+++ b/ci/run-static-analysis.sh
@@ -26,4 +26,7 @@ then
 	exit 1
 fi
 
+make hdr-check ||
+exit 1
+
 save_good_tree


### PR DESCRIPTION
Our `hdr-check` target is now functional in more ways than before. Let's run it as part of the CI builds.

I [offered this idea in a review of `dl/honor-cflags-in-hdr-check`](https://public-inbox.org/git/nycvar.QRO.7.76.6.1909261452340.15067@tvgsbejvaqbjf.bet/) but it was not picked up. So I offer it as a stand-alone patch on top of that series.