### PR TITLE
gitignore: ignore comments on the same line as a pattern

### DIFF
--- a/Documentation/gitignore.txt
+++ b/Documentation/gitignore.txt
@@ -74,8 +74,12 @@ PATTERN FORMAT
    for readability.
 
  - A line starting with # serves as a comment.
-   Put a backslash ("`\`") in front of the first hash for patterns
-   that begin with a hash.
+   Put a backslash ("`\`") in front of each hash for patterns
+   containing a hash.
+
+ - A # after a pattern will be treated as the start of a comment.
+   Put a backslash ("`\`") in front of each hash for patterns
+   containing a hash.
 
  - Trailing spaces are ignored unless they are quoted with backslash
    ("`\`").


### PR DESCRIPTION
# Why make this change?
Add the ability to use `#` to put comments after ignore patterns. This is
useful for documenting the reason for particular ignore patterns inclusion
and structure.

Right now a common convention in `.gitignore` files is to group patterns
by similarity, using new lines beginning with one or more `#` characters
as headings to explain these groupings. This works well when clarifying
why broad classes of things are ignored, e.g. `# build artifacts` followed
by several patterns.

When leaving comments about a particular pattern it can be difficult to
distinguish comments about a single patterns from comments used for file
organization.

Comments left after a pattern are unambiguously related to that line, and
that line only.

# What should this change do?
The entirety of a string after a non-escaped `#`, including the `#`,
is removed from the pattern in a `.gitignore` file.

# Why make the change this way?
I don't normally write C, so I probably overlooked more idiomatic ways
to do this. This is done similarly to the way `trim_trailing_spaces` removes
extraneous spaces from patterns.

Potentially this change could be combined with the existing code for
`trim_trailing_spaces`, but the logic is slightly different and it seems to me
that the difference in naming aids readability by making it clear what the
responsibilities are for each function.

# How can we test this change works?
That's one area I'd like help with, please.

Test cases:
```
/pattern/to/match
# Existing comment
/pattern/with/comment # This comment is ignored
/pattern/with/\#octothorpe # \#octothorpe is ignored
```

I wasn't sure where the correct place to add these would be, I didn't see (and
potentially overlooked) any tests in `/t/*` that cover this functionality. Would
someone be willing to provide a pointer to the correct place to add these tests?

Signed-off-by: Chris Zehner <cbzehner@gmail.com>
