### PR TITLE
Avoid segmentation fault in `git range-diff` when `diff.noprefix=true`

### DIFF
--- a/range-diff.c
+++ b/range-diff.c
@@ -52,6 +52,7 @@ static int read_patches(const char *range, struct string_list *list)
 
 	argv_array_pushl(&cp.args, "log", "--no-color", "-p", "--no-merges",
 			"--reverse", "--date-order", "--decorate=no",
+			"--no-prefix",
 			/*
 			 * Choose indicators that are not used anywhere
 			 * else in diffs, but still look reasonable
@@ -111,7 +112,7 @@ static int read_patches(const char *range, struct string_list *list)
 			if (!util->diff_offset)
 				util->diff_offset = buf.len;
 			line[len - 1] = '\n';
-			len = parse_git_diff_header(&root, &linenr, 1, line,
+			len = parse_git_diff_header(&root, &linenr, 0, line,
 						    len, size, &patch);
 			if (len < 0)
 				die(_("could not parse git header '%.*s'"), (int)len, line);

--- a/t/t3206-range-diff.sh
+++ b/t/t3206-range-diff.sh
@@ -461,4 +461,8 @@ test_expect_success 'format-patch --range-diff as commentary' '
 	grep "> 1: .* new message" 0001-*
 '
 
+test_expect_success 'range-diff overrides diff.noprefix internally' '
+	git -c diff.noprefix=true range-diff HEAD^...
+'
+
 test_done


### PR DESCRIPTION
This PR was inspired by this bug report: https://public-inbox.org/git/20191002141615.GB17916@kitsune.suse.cz/T/#me576615d7a151cf2ed46186c482fbd88f9959914

Changes since v1:

- Use a command-line option instead of a command-line config setting.
- Instead of forcing a prefix, force _no_ prefix (and adjust the strip level).
- Fix typo "all" -> "call" in the commit message (and adjust it to reflect the other changes since v1, too).

Cc: Eric Sunshine <sunshine@sunshineco.com>, Michal Suchánek <msuchanek@suse.de>