### PR TITLE
gitk: Addressing error running on MacOS with large repos.

### DIFF
--- a/gitk-git/gitk
+++ b/gitk-git/gitk
@@ -250,8 +250,13 @@ proc parseviewargs {n arglist} {
 		set nextisval 1
 		lappend glflags $arg
 	    }
-	    "--not" - "--all" {
+	    "--not" {
 		lappend revargs $arg
+	    }
+		"--all" {
+		# we recognize this argument;
+		# no expansion needed, use it with 'git log' as-is
+		set allknown 0
 	    }
 	    "--merge" {
 		set vmergeonly($n) 1


### PR DESCRIPTION
gitk: no need to specify all refs, since `git log --all` is the same as list is all the refs/commit ids. Also Mac OS has a limit on size of the list of params for a command line