### PR TITLE
[guitool] feature to specify keyboard shortcuts for custom tools

### DIFF
--- a/lib/tools.tcl
+++ b/lib/tools.tcl
@@ -38,7 +38,7 @@ proc tools_create_item {parent args} {
 }
 
 proc tools_populate_one {fullname} {
-	global tools_menubar tools_menutbl tools_id
+	global tools_menubar tools_menutbl tools_id repo_config
 
 	if {![info exists tools_id]} {
 		set tools_id 0
@@ -61,9 +61,18 @@ proc tools_populate_one {fullname} {
 		}
 	}
 
-	tools_create_item $parent command \
+	if {[info exists repo_config(guitool.$fullname.gitgui-shortcut)]} {
+		set gitgui_shortcut $repo_config(guitool.$fullname.gitgui-shortcut)
+		tools_create_item $parent command \
 		-label [lindex $names end] \
-		-command [list tools_exec $fullname]
+		-command [list tools_exec $fullname] \
+		-accelerator $gitgui_shortcut
+		bind . <$gitgui_shortcut> [list tools_exec $fullname]
+	} else {
+		tools_create_item $parent command \
+			-label [lindex $names end] \
+			-command [list tools_exec $fullname]
+	}
 }
 
 proc tools_exec {fullname} {


### PR DESCRIPTION
This feature will add following introduce following optional
configuration key into gitconfig

guitool.<name>.gitgui-shortcut
	Specifies a keyboard shortcut for the custom tool in the git-gui
	application. The value must be a valid string ( without "<" , ">" wrapper )
	understood by the TCL/TK 's bind command.See https://www.tcl.tk/man/tcl8.4/TkCmd/bind.htm
	for more details about the supported values. Avoid creating shortcuts that
	conflict with existing built-in `git gui` shortcuts.
	Example:
		[guitool "Terminal"]
			cmd = gnome-terminal -e zsh
			noconsole = yes
			gitgui-shortcut = "Control-y"
		[guitool "Sync"]
			cmd = "git pull; git push"
			gitgui-shortcut = "Alt-s"


Signed-off-by: Harish.K <harish2704@gmail.com>

Thanks for taking the time to contribute to Git! Please be advised that the
Git community does not use github.com for their contributions. Instead, we use
a mailing list (git@vger.kernel.org) for code submissions, code reviews, and
bug reports. Nevertheless, you can use GitGitGadget (https://gitgitgadget.github.io/)
to conveniently send your Pull Requests commits to our mailing list.

Please read the "guidelines for contributing" linked above!
