### PR TITLE
Pass through the exit code of `post-checkout`

### DIFF
--- a/Documentation/githooks.txt
+++ b/Documentation/githooks.txt
@@ -193,7 +193,8 @@ worktree.  The hook is given three parameters: the ref of the previous HEAD,
 the ref of the new HEAD (which may or may not have changed), and a flag
 indicating whether the checkout was a branch checkout (changing branches,
 flag=1) or a file checkout (retrieving a file from the index, flag=0).
-This hook cannot affect the outcome of `git switch` or `git checkout`.
+If this hook exits with an exit code other than 0, it causes the calling
+`git switch` or `git checkout` command to fail with the same exit code.
 
 It is also run after linkgit:git-clone[1], unless the `--no-checkout` (`-n`) option is
 used. The first parameter given to the hook is the null-ref, the second the

--- a/t/t5403-post-checkout-hook.sh
+++ b/t/t5403-post-checkout-hook.sh
@@ -73,4 +73,13 @@ test_expect_success 'post-checkout hook is triggered by clone' '
 	test -f clone3/.git/post-checkout.args
 '
 
+test_expect_success 'exit code of post-checkout hook is passed through' '
+	mkdir -p exit-code &&
+	echo "exit 123" | write_script exit-code/post-checkout &&
+	test_expect_code 123 \
+	git -c core.hooksPath="$PWD/exit-code" switch -c trigger-exit-code &&
+	test_expect_code 123 \
+	git -c core.hooksPath="$PWD/exit-code" restore .
+'
+
 test_done


### PR DESCRIPTION
This is my attempt to revive [an old discussion](https://public-inbox.org/git/20180314003816.GE147135@aiede.svl.corp.google.com/) (related to [this StackOverflow thread](https://stackoverflow.com/questions/25561485/git-rebase-i-with-squash-cannot-detach-head)).

> [...] is this the *right* behavior for "git checkout" to have?  I.e. is it useful for "git checkout" to fail when the post-checkout hook fails, or would it be better for it to e.g. simply print a message and exit with status 0?

To answer Jonathan's question, at long last, yes, it is useful. A hook is not only an opportunity to run code at given points in Git's life cycle, but also an opportunity to stop Git in its tracks. Further, if you script the operation, it may very well be useful to discern between an exit code from Git's operation from an exit code produced by your hook.

If you don't want your `git checkout`/`git switch`/`git restore` to fail due to a `post-checkout` failure, just make sure that that hook does not fail ;-) (This could easily be achieved by `trap EXIT { exit 0; }`, I believe.

I discovered, however, that the original patch contribution missed that a `git checkout -b <branch>` will _not_ pass through the exit code, but instead return exit code 1. As part of my contribution, I fix this, and also introduce a regression test to document the now-consistent behavior.

Cc: Jonathan Nieder <jrnieder@gmail.com>, Magne Land <magne.land@gmail.com>