### PR TITLE
t1308-config-set: fix a test that has a typo

### DIFF
--- a/t/t1308-config-set.sh
+++ b/t/t1308-config-set.sh
@@ -166,14 +166,14 @@ test_expect_success 'find value with highest priority from a configset' '
 '
 
 test_expect_success 'find value_list for a key from a configset' '
-	cat >except <<-\EOF &&
+	cat >expect <<-\EOF &&
+	lama
+	ball
 	sam
 	bat
 	hask
-	lama
-	ball
 	EOF
-	test-tool config configset_get_value case.baz config2 .git/config >actual &&
+	test-tool config configset_get_value_multi case.baz config2 .git/config >actual &&
 	test_cmp expect actual
 '
 


### PR DESCRIPTION
I am currently trying to whittle down the number of open PRs at https://github.com/git/git, and this is one of the patches I deem valuable enough (and complete enough) to put through to the Git mailing list even when the original contributor has gone silent.