### PR TITLE
gitk: Preserve window dimensions on exit when not using ttk themes

### DIFF
--- a/gitk-git/gitk
+++ b/gitk-git/gitk
@@ -2526,9 +2526,9 @@ proc makewindow {} {
             bind %W <Map> {}
             %W sashpos 0 $::geometry(botwidth)
         }
+	bind .pwbottom <Configure> {resizecdetpanes %W %w}
     }
-
-    bind .pwbottom <Configure> {resizecdetpanes %W %w}
+    
     pack .ctop -fill both -expand 1
     bindall <1> {selcanvline %W %x %y}
     #bindall <B1-Motion> {selcanvline %W %x %y}


### PR DESCRIPTION
Bug was: gitk would overwrite the botwidth setting in .gitk with
a nonsense value when not using tk themes. I'm not sure if this
is the right fix or not but it seems to work. Moving the affected
line within the conditional results in the expected behavior.

Signed-off-by: Eric Huber <echuber2@illinois.edu>