### PR TITLE
diff-highlight: fix a whitespace nit

### DIFF
--- a/contrib/diff-highlight/DiffHighlight.pm
+++ b/contrib/diff-highlight/DiffHighlight.pm
@@ -72,7 +72,7 @@ sub handle_line {
 	      (?:$COLOR?\|$COLOR?[ ])* # zero or more trailing "|"
 	                         [ ]*  # trailing whitespace for merges
 	    /x) {
-	        my $graph_prefix = $&;
+		my $graph_prefix = $&;
 
 		# We must flush before setting graph indent, since the
 		# new commit may be indented differently from what we


### PR DESCRIPTION
```
This changes the indent from
  "<tab><sp><sp><sp><sp><sp><sp><sp><sp>"
to
  "<tab><tab>"
so that the statement lines up with the rest of the block.

Signed-off-by: Norman Rasmussen <norman@rasmussen.co.za>
```