### PR TITLE
ci: update caskroom/cask/perforce to new location

### DIFF
--- a/ci/install-dependencies.sh
+++ b/ci/install-dependencies.sh
@@ -40,6 +40,11 @@ osx-clang|osx-gcc)
 	test -z "$BREW_INSTALL_PACKAGES" ||
 	brew install $BREW_INSTALL_PACKAGES
 	brew link --force gettext
+	brew cask install perforce || {
+		# Update the definitions and try again
+		git -C "$(brew --repository)"/Library/Taps/homebrew/homebrew-cask pull &&
+		brew cask install perforce
+	} ||
 	brew install caskroom/cask/perforce
 	case "$jobname" in
 	osx-gcc)


### PR DESCRIPTION
Running CI on Mac OS X in Azure Pipelines is currently broken due to a moved homebrew package.

Change since v2:
- The commit message was improved (thanks Gábor).

Change since v1:
-The step is now more robust (by pulling `homebrew-cask` and trying again if the pull failed).

Thanks,
-Stolee

Cc: johannes.schindelin@gmx.de