### PR TITLE
t7519-status-fsmonitor: improve comments

### DIFF
--- a/t/t7519-status-fsmonitor.sh
+++ b/t/t7519-status-fsmonitor.sh
@@ -354,9 +354,11 @@ test_expect_success 'discard_index() also discards fsmonitor info' '
 	test_cmp expect actual
 '
 
-# Test staging/unstaging files that appear at the end of the index.  Test
-# file names begin with 'z' so that they are sorted to the end of the index.
-test_expect_success 'status succeeds after staging/unstaging ' '
+# Test unstaging entries that:
+#  - Are not flagged with CE_FSMONITOR_VALID
+#  - Have a position in the index >= the number of entries present in the index
+#    after unstaging.
+test_expect_success 'status succeeds after staging/unstaging' '
 	test_create_repo fsmonitor-stage-unstage &&
 	(
 		cd fsmonitor-stage-unstage &&


### PR DESCRIPTION
This patch series is based on the 'wb/fsmonitor-bitmap-fix' branch and addresses feedback on the new test that was added there.  

I've updated the comments for the new test to more accurately describe the scenario being tested.

Thanks,

William

Cc: williamtbakeremail@gmail.com, stolee@gmail.com, Johannes.Schindelin@gmx.de, jeffhost@microsoft.com