### PR TITLE
Fix the speed of the CI (Visual Studio) tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -255,7 +255,7 @@ jobs:
 
         cd t &&
         PATH=\"`$PWD/helper:`$PATH\" &&
-        test-tool.exe run-command testsuite -V -x --write-junit-xml \
+        test-tool.exe run-command testsuite --jobs=10 -V -x --write-junit-xml \
                 `$(test-tool.exe path-utils slice-tests \
                         `$SYSTEM_JOBPOSITIONINPHASE `$SYSTEM_TOTALJOBSINPHASE t[0-9]*.sh)
       "@

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -157,7 +157,7 @@ jobs:
     displayName: 'Download git-sdk-64-minimal'
   - powershell: |
       & git-sdk-64-minimal\usr\bin\bash.exe -lc @"
-        make vcxproj
+        make NDEBUG=1 DEVELOPER=1 vcxproj
       "@
       if (!$?) { exit(1) }
     displayName: Generate Visual Studio Solution


### PR DESCRIPTION
I made a mistake when converting the `make`/`prove`-based test job to a `test-tool run-command testsuite` one: I lost the parallelization, resulting in way slower CI runs.

Also, I forgot to build with `DEVELOPER=1`, i.e. with stricter compile flags.

This pair of patches fixes both issues.

Changes since v1:

- Fixed typo "nore" -> "nor" in the commit message.