### PR TITLE
[PoC] ci: avoid 'brew' in the OSX CI jobs

### DIFF
--- a/ci/install-dependencies.sh
+++ b/ci/install-dependencies.sh
@@ -39,7 +39,6 @@ osx-clang|osx-gcc)
 	# brew install gnu-time
 	test -z "$BREW_INSTALL_PACKAGES" ||
 	brew install $BREW_INSTALL_PACKAGES
-	brew link --force gettext
 	brew cask install perforce || {
 		# Update the definitions and try again
 		cask_repo="$(brew --repository)"/Library/Taps/homebrew/homebrew-cask &&

--- a/ci/install-dependencies.sh
+++ b/ci/install-dependencies.sh
@@ -34,26 +34,16 @@ linux-clang|linux-gcc)
 	popd
 	;;
 osx-clang|osx-gcc)
-	export HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_CLEANUP=1
 	# Uncomment this if you want to run perf tests:
 	# brew install gnu-time
-	test -z "$BREW_INSTALL_PACKAGES" ||
-	brew install $BREW_INSTALL_PACKAGES
-	brew cask install perforce || {
-		# Update the definitions and try again
-		cask_repo="$(brew --repository)"/Library/Taps/homebrew/homebrew-cask &&
-		git -C "$cask_repo" pull --no-stat &&
-		brew cask install perforce
-	} ||
-	brew install caskroom/cask/perforce
-	case "$jobname" in
-	osx-gcc)
-		brew install gcc@9
-		# Just in case the image is updated to contain gcc@9
-		# pre-installed but not linked.
-		brew link gcc@9
-		;;
-	esac
+	(
+		cd ~
+		ver=$(sw_vers | sed -n -e 's/^ProductVersion:[[:space:]]*\([0-9]*\.[0-9]*\)\..*/\1/p')
+		git clone --branch=ci-deps-osx-$ver --single-branch --depth=1 \
+			https://github.com/szeder/git deps
+		cd deps
+		./install.sh
+	)
 	;;
 StaticAnalysis)
 	sudo apt-get -q update

--- a/ci/lib.sh
+++ b/ci/lib.sh
@@ -184,6 +184,11 @@ osx-clang|osx-gcc)
 		export CC=gcc-9
 	fi
 
+	MAKEFLAGS="$MAKEFLAGS CPPFLAGS+=-I/usr/local/opt/gettext/include"
+	MAKEFLAGS="$MAKEFLAGS LDFLAGS+=-L/usr/local/opt/gettext/lib"
+
+	PATH=/usr/local/opt/gettext/bin:$PATH
+
 	# t9810 occasionally fails on Travis CI OS X
 	# t9816 occasionally fails with "TAP out of sequence errors" on
 	# Travis CI OS X

--- a/ci/lib.sh
+++ b/ci/lib.sh
@@ -106,7 +106,6 @@ then
 		echo "https://travis-ci.org/$CI_REPO_SLUG/jobs/$1"
 	}
 
-	BREW_INSTALL_PACKAGES="git-lfs gettext"
 	export GIT_PROVE_OPTS="--timer --jobs 3 --state=failed,slow,save"
 	export GIT_TEST_OPTS="--verbose-log -x --immediate"
 	MAKEFLAGS="$MAKEFLAGS --jobs=2"


### PR DESCRIPTION
Over the years we had a good couple of issues with Homebrew that
resulted in broken OSX builds.  Maybe it's worth a try to manage the
build dependencies ourselves, and see what happens.  More details in
the second commit.

This is just a proof of concept, to satisfy my curiosity; I'm not sure
whether it's a good idea or just about the dumbest idea ever.  And
would be quite surprised if it worked on Azure Pipelines...
