### PR TITLE
commit: fix advice for empty commits during rebases

### DIFF
--- a/builtin/commit.c
+++ b/builtin/commit.c
@@ -59,6 +59,9 @@ N_("The previous cherry-pick is now empty, possibly due to conflict resolution.\
 "    git commit --allow-empty\n"
 "\n");
 
+static const char empty_rebase_advice[] =
+N_("Otherwise, please use 'git rebase --skip'\n");
+
 static const char empty_cherry_pick_advice_single[] =
 N_("Otherwise, please use 'git cherry-pick --skip'\n");
 
@@ -122,7 +125,7 @@ static enum commit_msg_cleanup_mode cleanup_mode;
 static const char *cleanup_arg;
 
 static enum commit_whence whence;
-static int sequencer_in_use;
+static int sequencer_in_use, rebase_in_progress;
 static int use_editor = 1, include_status = 1;
 static int have_option_m;
 static struct strbuf message = STRBUF_INIT;
@@ -183,6 +186,8 @@ static void determine_whence(struct wt_status *s)
 		whence = FROM_CHERRY_PICK;
 		if (file_exists(git_path_seq_dir()))
 			sequencer_in_use = 1;
+		if (file_exists(git_path_rebase_merge_dir()))
+			rebase_in_progress = 1;
 	}
 	else
 		whence = FROM_COMMIT;
@@ -453,8 +458,11 @@ static const char *prepare_index(int argc, const char **argv, const char *prefix
 	if (whence != FROM_COMMIT) {
 		if (whence == FROM_MERGE)
 			die(_("cannot do a partial commit during a merge."));
-		else if (whence == FROM_CHERRY_PICK)
+		else if (whence == FROM_CHERRY_PICK) {
+			if (rebase_in_progress && !sequencer_in_use)
+				die(_("cannot do a partial commit during a rebase."));
 			die(_("cannot do a partial commit during a cherry-pick."));
+		}
 	}
 
 	if (list_paths(&partial, !current_head ? NULL : "HEAD", &pathspec))
@@ -950,10 +958,12 @@ static int prepare_to_commit(const char *index_file, const char *prefix,
 			fputs(_(empty_amend_advice), stderr);
 		else if (whence == FROM_CHERRY_PICK) {
 			fputs(_(empty_cherry_pick_advice), stderr);
-			if (!sequencer_in_use)
-				fputs(_(empty_cherry_pick_advice_single), stderr);
-			else
+			if (sequencer_in_use)
 				fputs(_(empty_cherry_pick_advice_multi), stderr);
+			else if (rebase_in_progress)
+				fputs(_(empty_rebase_advice), stderr);
+			else
+				fputs(_(empty_cherry_pick_advice_single), stderr);
 		}
 		return 0;
 	}
@@ -1156,8 +1166,11 @@ static int parse_and_validate_options(int argc, const char *argv[],
 	if (amend && whence != FROM_COMMIT) {
 		if (whence == FROM_MERGE)
 			die(_("You are in the middle of a merge -- cannot amend."));
-		else if (whence == FROM_CHERRY_PICK)
+		else if (whence == FROM_CHERRY_PICK) {
+			if (rebase_in_progress && !sequencer_in_use)
+				die(_("You are in the middle of a rebase -- cannot amend."));
 			die(_("You are in the middle of a cherry-pick -- cannot amend."));
+		}
 	}
 	if (fixup_message && squash_message)
 		die(_("Options --squash and --fixup cannot be used together"));
@@ -1628,9 +1641,11 @@ int cmd_commit(int argc, const char **argv, const char *prefix)
 			reduce_heads_replace(&parents);
 	} else {
 		if (!reflog_msg)
-			reflog_msg = (whence == FROM_CHERRY_PICK)
-					? "commit (cherry-pick)"
-					: "commit";
+			reflog_msg = (whence != FROM_CHERRY_PICK)
+					? "commit"
+					: rebase_in_progress && !sequencer_in_use
+					? "commit (rebase)"
+					: "commit (cherry-pick)";
 		commit_list_insert(current_head, &parents);
 	}
 

--- a/sequencer.c
+++ b/sequencer.c
@@ -47,7 +47,7 @@ static GIT_PATH_FUNC(git_path_opts_file, "sequencer/opts")
 static GIT_PATH_FUNC(git_path_head_file, "sequencer/head")
 static GIT_PATH_FUNC(git_path_abort_safety_file, "sequencer/abort-safety")
 
-static GIT_PATH_FUNC(rebase_path, "rebase-merge")
+GIT_PATH_FUNC(git_path_rebase_merge_dir, "rebase-merge")
 /*
  * The file containing rebase commands, comments, and empty lines.
  * This file is created by "git rebase -i" then edited by the user. As
@@ -218,7 +218,7 @@ static inline int is_rebase_i(const struct replay_opts *opts)
 static const char *get_dir(const struct replay_opts *opts)
 {
 	if (is_rebase_i(opts))
-		return rebase_path();
+		return git_path_rebase_merge_dir();
 	return git_path_seq_dir();
 }
 

--- a/sequencer.h
+++ b/sequencer.h
@@ -9,6 +9,7 @@ struct repository;
 
 const char *git_path_commit_editmsg(void);
 const char *git_path_seq_dir(void);
+const char *git_path_rebase_merge_dir(void);
 const char *rebase_path_todo(void);
 const char *rebase_path_todo_backup(void);
 

--- a/t/t3403-rebase-skip.sh
+++ b/t/t3403-rebase-skip.sh
@@ -76,4 +76,13 @@ test_expect_success 'moved back to branch correctly' '
 
 test_debug 'gitk --all & sleep 1'
 
+test_expect_success 'correct advice upon empty commit' '
+	git checkout -b rebase-skip &&
+	test_commit a1 &&
+	test_tick &&
+	git commit --amend -m amended --no-edit &&
+	test_must_fail git rebase -m --onto a1 HEAD^ 2>err &&
+	test_i18ngrep "git rebase --skip" err
+'
+
 test_done

--- a/t/t3510-cherry-pick-sequence.sh
+++ b/t/t3510-cherry-pick-sequence.sh
@@ -123,7 +123,8 @@ test_expect_success 'revert --skip to skip commit' '
 test_expect_success 'skip "empty" commit' '
 	pristine_detach picked &&
 	test_commit dummy foo d &&
-	test_must_fail git cherry-pick anotherpick &&
+	test_must_fail git cherry-pick anotherpick 2>err &&
+	test_i18ngrep "git cherry-pick --skip" err &&
 	git cherry-pick --skip &&
 	test_cmp_rev dummy HEAD
 '


### PR DESCRIPTION
In dcb500dc16c (cherry-pick/revert: advise using --skip, 2019-07-02), we introduced a helpful message that suggests to run `git cherry-pick --skip` (instead of the previous message that talked about `git reset`) when a cherry-pick failed due to an empty patch.

However, the same message is displayed during a rebase, when the patch to-be-committed is empty. In this case, `git reset` would also have worked, but `git cherry-pick --skip` does _not_ work. This is a regression introduced in this cycle.

Let's be more careful here.

Cc: Rohit Ashiwal <rohit.ashiwal265@gmail.com>