### PR TITLE
[v2.24.0-rc0 BUG] index.version is not parsed correctly

### DIFF
--- a/repo-settings.c
+++ b/repo-settings.c
@@ -22,7 +22,7 @@ void prepare_repo_settings(struct repository *r)
 	UPDATE_DEFAULT_BOOL(r->settings.core_commit_graph, 1);
 	UPDATE_DEFAULT_BOOL(r->settings.gc_write_commit_graph, 1);
 
-	if (!repo_config_get_bool(r, "index.version", &value))
+	if (!repo_config_get_int(r, "index.version", &value))
 		r->settings.index_version = value;
 	if (!repo_config_get_maybe_bool(r, "core.untrackedcache", &value)) {
 		if (value == 0)

--- a/t/t1600-index.sh
+++ b/t/t1600-index.sh
@@ -87,6 +87,10 @@ test_index_version () {
 }
 
 test_expect_success 'index version config precedence' '
+	test_index_version 0 false 0 2 &&
+	test_index_version 2 false 0 2 &&
+	test_index_version 3 false 0 2 &&
+	test_index_version 4 false 0 4 &&
 	test_index_version 2 false 4 4 &&
 	test_index_version 2 true 0 2 &&
 	test_index_version 0 true 0 4 &&


### PR DESCRIPTION
Here is another bug related to changes I made in this release. This time it's not due to a strange side-effect of submodules but rather that I was careless while copy-pasting some boilerplate code.

Basically, most of the config options used in repo-settings.c are boolean settings. Except that "index.version" is an int setting!

I found this while incorporating v2.24.0-rc0 into our microsoft/git fork and consuming it in VFS for Git. We really care about the index having version 4!

The tests I added around how the index version is set were not adequate to cover the case of only "index.version=4". Add a test to prevent this issue from happening again.

Thanks,
-Stolee