### PR TITLE
diff-highlight: fix flushing on empty lines

### DIFF
--- a/contrib/diff-highlight/DiffHighlight.pm
+++ b/contrib/diff-highlight/DiffHighlight.pm
@@ -112,6 +112,7 @@ sub handle_line {
 	# Since we can receive arbitrary input, there's no optimal
 	# place to flush. Flushing on a blank line is a heuristic that
 	# happens to match git-log output.
+	chomp;
 	if (!length) {
 		$flush_cb->();
 	}


### PR DESCRIPTION
perl reads lines with their terminator, so they need to be removed
before checking length. This logic has not changed since initial commit
927a13fe87 ("contrib: add diff highlight script", 2011-10-18) so I
do not think that it has ever flushed as intended.

Signed-off-by: Norman Rasmussen <norman@rasmussen.co.za>