### PR TITLE
mingw: avoid a buffer overrun in `needs_hiding()`

### DIFF
--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -363,6 +363,8 @@ static inline int needs_hiding(const char *path)
 			/* ignore trailing slashes */
 			if (*path)
 				basename = path;
+			else
+				break;
 		}
 
 	if (hide_dotfiles == HIDE_DOTFILES_TRUE)


### PR DESCRIPTION
On Unix, files are hidden from the output of `ls` by default when their names start with a `.`. On Windows, there is an explicit flag that you need to set.

It is quite uncommon, though, to hide all of the "dot files" on Windows, which is why Git hides only `.git` by default, and it has a setting to override this default (`core.hideDotFiles`).

The code to determine whether that flag needs to be set for a given file had a buffer overrun, though, if the path that was passed into the function ended with a directory separator. This patch fixes this.

The original contribution by Alex is over at https://github.com/gitgitgadget/git/pull/414, and I worked with him to evolve it into the current version.

Cc: Alexandr Miloslavskiy <alexandr.miloslavskiy@syntevo.com>
