### PR TITLE
 Fix t5516 flakiness in Visual Studio builds

### DIFF
--- a/usage.c
+++ b/usage.c
@@ -9,14 +9,26 @@
 void vreportf(const char *prefix, const char *err, va_list params)
 {
 	char msg[4096];
-	char *p;
+	char *p, *pend = msg + sizeof(msg);
+	size_t prefix_len = strlen(prefix);
 
-	vsnprintf(msg, sizeof(msg), err, params);
-	for (p = msg; *p; p++) {
+	if (sizeof(msg) <= prefix_len) {
+		fprintf(stderr, "BUG!!! too long a prefix '%s'\n", prefix);
+		abort();
+	}
+	memcpy(msg, prefix, prefix_len);
+	p = msg + prefix_len;
+	if (vsnprintf(p, pend - p, err, params) < 0)
+		*p = '\0'; /* vsnprintf() failed, clip at prefix */
+
+	for (; p != pend - 1 && *p; p++) {
 		if (iscntrl(*p) && *p != '\t' && *p != '\n')
 			*p = '?';
 	}
-	fprintf(stderr, "%s%s\n", prefix, msg);
+
+	*(p++) = '\n'; /* we no longer need a NUL */
+	fflush(stderr);
+	write_in_full(2, msg, p - msg);
 }
 
 static NORETURN void usage_builtin(const char *err, va_list params)


### PR DESCRIPTION
Among the flaky tests, it seems that the Azure Pipeline suffers relatively frequently from t5516 failing with the Visual Studio builds. Essentially, we grep for an error message, but that error message is produced twice, once by a `fetch` and once by the `upload-pack` spawned from it, and those error messages are usually interleaved because of MSVC runtime `fprintf()` idiosyncracies.

As a consequence, I have to re-run about half a dozen failed builds a day, which I would like to avoid. My plan is therefore to merge this patch into Git for Windows v2.24.0-rc2.

The commit message of this patch is based, in part, on https://github.com/gitgitgadget/git/pull/407. 

This fixes https://github.com/gitgitgadget/git/issues/240.

Changes since v3:
- Reworded the part of the commit message that talks about the need for `fflush(stderr);` for accuracy, as suggested by Junio.
- Simplified the flow of the `prefix` handling as well as providing a proper `BUG` message and `abort()`ing when the `prefix` is too long. Thanks Junio!

Changes since v2:
- Using `write_in_full()` instead of `xwrite()` again (to make sure that the entire message is printed).
- When `vsnprintf()` fails, now we at least print the prefix.
- The code to check whether prefix was too long no longer tests an inequality between pointers, but between sizes.

Changes since v1:
- Changed the oneline to be more accurate (thanks Junio).
- Improved the commit message (e.g. talking about the `xwrite()` function this patch uses, rather than the `write_in_full()` function used by an earlier iteration, thanks Gábor).
- Revamped the actual code to account for insanely long prefixes (thanks for the advice, Junio).

Cc: Jeff King <peff@peff.net>, SZEDER Gábor <szeder.dev@gmail.com>, Alexandr Miloslavskiy <alexandr.miloslavskiy@syntevo.com>