### PR TITLE
worktree: teach "add" to ignore submodule.recurse config

### DIFF
--- a/builtin/worktree.c
+++ b/builtin/worktree.c
@@ -377,7 +377,7 @@ static int add_worktree(const char *path, const char *refname,
 	if (opts->checkout) {
 		cp.argv = NULL;
 		argv_array_clear(&cp.args);
-		argv_array_pushl(&cp.args, "reset", "--hard", NULL);
+		argv_array_pushl(&cp.args, "reset", "--hard", "--no-recurse-submodules", NULL);
 		if (opts->quiet)
 			argv_array_push(&cp.args, "--quiet");
 		cp.env = child_env.argv;

--- a/t/t2400-worktree-add.sh
+++ b/t/t2400-worktree-add.sh
@@ -587,4 +587,28 @@ test_expect_success '"add" should not fail because of another bad worktree' '
 	)
 '
 
+test_expect_success '"add" with uninitialized submodule, with submodule.recurse unset' '
+	test_create_repo submodule &&
+	test_commit -C submodule first &&
+	test_create_repo project &&
+	git -C project submodule add ../submodule &&
+	git -C project add submodule &&
+	test_tick &&
+	git -C project commit -m add_sub &&
+	git clone project project-clone &&
+	git -C project-clone worktree add ../project-2
+'
+test_expect_success '"add" with uninitialized submodule, with submodule.recurse set' '
+	git -C project-clone -c submodule.recurse worktree add ../project-3
+'
+
+test_expect_success '"add" with initialized submodule, with submodule.recurse unset' '
+	git -C project-clone submodule update --init &&
+	git -C project-clone worktree add ../project-4
+'
+
+test_expect_success '"add" with initialized submodule, with submodule.recurse set' '
+	git -C project-clone -c submodule.recurse worktree add ../project-5
+'
+
 test_done


### PR DESCRIPTION
"worktree add" internally calls "reset --hard", but if submodule.recurse is set, reset tries to recurse into initialized submodules, which makes start_command try to cd into non-existing submodule paths and die.

Fix that by making sure that the call to reset in "worktree add" does not recurse.

Some remarks:
1. This patch is based on maint
2. The 2 Travis CI macOS builds fail (they also fail on maint) with the message:

    > +brew install caskroom/cask/perforce
    > Error: caskroom/cask was moved. Tap homebrew/cask-cask instead.
    > The command "ci/install-dependencies.sh" failed and exited with 1 during .

3. I'm on OS X 10.11.6 (Apple clang-800.0.42.1) and I get a warning compiling `builtin/merge.c` : 

    > ```
    >     CC builtin/merge.o
    > builtin/merge.c:831:33: warning: data argument not used by format string [-Wformat-extra-args]
    >                         no_scissors_editor_comment), comment_line_char);
    >                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~  ^
    > builtin/merge.c:809:4: note: format string is defined here
    > N_("An empty message aborts the commit.\n");
    >    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    > ./gettext.h:86:20: note: expanded from macro 'N_'
    > #define N_(msgid) (msgid)
    >                    ^~~~~
    > 1 warning generated.
    > ```
    
    This makes me unable to build with DEVELOPER=1.