### PR TITLE
2.24 release note fixups

### DIFF
--- a/Documentation/RelNotes/2.24.0.txt
+++ b/Documentation/RelNotes/2.24.0.txt
@@ -6,10 +6,9 @@ Updates since v2.23
 
 Backward compatibility note
 
- * Although it is not officially deprecated, "filter-branch" is
-   showing its age and alternatives are available.  From this release,
-   we started to discourage its uses and hint people about
-   filter-repo.
+ * "filter-branch" is showing its age and alternatives are available.
+   From this release, we started to discourage its use and hint
+   people about filter-repo.
 
 UI, Workflows & Features
 

--- a/Documentation/RelNotes/2.24.0.txt
+++ b/Documentation/RelNotes/2.24.0.txt
@@ -316,7 +316,7 @@ Fixes since v2.23
    to access the worktree correctly, which has been corrected.
    (merge dfd557c978 js/stash-apply-in-secondary-worktree later to maint).
 
- * The merge-recursive machiery is one of the most complex parts of
+ * The merge-recursive machinery is one of the most complex parts of
    the system that accumulated cruft over time.  This large series
    cleans up the implementation quite a bit.
    (merge b657047719 en/merge-recursive-cleanup later to maint).


### PR DESCRIPTION
A couple minor fixes to the 2.24 release notes.  I split into two trivial commits just in case folks don't like the second (perhaps some wording about no current plans to remove filter-branch were intended?)