### PR TITLE
fetch.c: fix typo in a warning message

### DIFF
--- a/builtin/fetch.c
+++ b/builtin/fetch.c
@@ -1411,7 +1411,7 @@ static int do_fetch(struct transport *transport,
 		for (rm = ref_map; rm; rm = rm->next) {
 			if (!rm->peer_ref) {
 				if (source_ref) {
-					warning(_("multiple branch detected, incompatible with --set-upstream"));
+					warning(_("multiple branches detected, incompatible with --set-upstream"));
 					goto skip;
 				} else {
 					source_ref = rm;


### PR DESCRIPTION
Noticed this while reviewing German translation.

Cc: Matthias Rüster <matthias.ruester@gmail.com>
Cc: Corentin BOMPARD <corentin.bompard@etu.univ-lyon1.fr>