### PR TITLE
Improve unpack trees error text

### DIFF
--- a/t/t7110-reset-merge.sh
+++ b/t/t7110-reset-merge.sh
@@ -173,7 +173,7 @@ test_expect_success 'reset --merge fails with changes in file it touches' '
     sed -e "s/line 1/changed line 1/" <file1 >file3 &&
     mv file3 file1 &&
     test_must_fail git reset --merge HEAD^ 2>err.log &&
-    grep file1 err.log | grep "not uptodate"
+    grep file1 err.log | grep "not up to date"
 '
 
 # The next test will test the following:
@@ -189,7 +189,7 @@ test_expect_success 'reset --keep fails with changes in file it touches' '
     sed -e "s/line 1/changed line 1/" <file1 >file3 &&
     mv file3 file1 &&
     test_must_fail git reset --keep HEAD^ 2>err.log &&
-    grep file1 err.log | grep "not uptodate"
+    grep file1 err.log | grep "not up to date"
 '
 
 test_expect_success 'setup 3 different branches' '

--- a/unpack-trees.c
+++ b/unpack-trees.c
@@ -29,7 +29,7 @@ static const char *unpack_plumbing_errors[NB_UNPACK_TREES_ERROR_TYPES] = {
 	"Entry '%s' would be overwritten by merge. Cannot merge.",
 
 	/* ERROR_NOT_UPTODATE_FILE */
-	"Entry '%s' not uptodate. Cannot merge.",
+	"Entry '%s' is not up to date. Cannot merge.",
 
 	/* ERROR_NOT_UPTODATE_DIR */
 	"Updating '%s' would lose untracked files in it",
@@ -44,7 +44,7 @@ static const char *unpack_plumbing_errors[NB_UNPACK_TREES_ERROR_TYPES] = {
 	"Entry '%s' overlaps with '%s'.  Cannot bind.",
 
 	/* ERROR_SPARSE_NOT_UPTODATE_FILE */
-	"Entry '%s' not uptodate. Cannot update sparse checkout.",
+	"Entry '%s' is not up to date. Cannot update sparse checkout.",
 
 	/* ERROR_WOULD_LOSE_ORPHANED_OVERWRITTEN */
 	"Working tree file '%s' would be overwritten by sparse checkout update.",


### PR DESCRIPTION
Improve the following error text:
`error: Entry 'file.txt' not uptodate. Cannot merge.`
It would not appear as:
`error: Entry 'file.txt' is not up to date. Cannot merge.`