### PR TITLE
t: fix typo in test descriptions

### DIFF
--- a/t/t3060-ls-files-with-tree.sh
+++ b/t/t3060-ls-files-with-tree.sh
@@ -47,7 +47,7 @@ test_expect_success setup '
 	git add .
 '
 
-test_expect_success 'git -ls-files --with-tree should succeed from subdir' '
+test_expect_success 'git ls-files --with-tree should succeed from subdir' '
 	# We have to run from a sub-directory to trigger prune_path
 	# Then we finally get to run our --with-tree test
 	(
@@ -57,7 +57,7 @@ test_expect_success 'git -ls-files --with-tree should succeed from subdir' '
 '
 
 test_expect_success \
-    'git -ls-files --with-tree should add entries from named tree.' \
+    'git ls-files --with-tree should add entries from named tree.' \
     'test_cmp expected output'
 
 test_done


### PR DESCRIPTION
Fix two test descriptions which stated "git -ls-files" when the actual
command being tested was "git ls-files".

I based this patch off of 'maint' since the typo predates the latest release, but the patch can be applied cleanly to 'master'.

I happened to run across this while running the following quick-and-dirty command to see if it looked like there were any undocumented top-level git options that were run from inside tests.  The answer to that was unsurprisingly "no", but it did turn up this typo to fix!

```
git grep "[^./i]git -" |
    grep -v 'git -C' |
    grep -v 'git -c' |
    grep -v 'git --help' |
    grep -v 'git --exec-path' |
    grep -v 'git --version' |
    grep -v 'git --html-path' |
    grep -v 'git --man-path' |
    grep -v 'git --info-path' |
    grep -v 'git -p' |
    grep -v 'git --paginate' |
    grep -v 'git -P' |
    grep -v 'git --no-pager' |
    grep -v 'git --no-replace-objects' |
    grep -v 'git --bare' |
    grep -v 'git --git-dir' |
    grep -v 'git --work-tree' |
    grep -v 'git --namespace' |
    grep -v 'test_completion' |
    grep -v 'git-grep.*acted as if' |
    grep -v 'git --super-prefix' |
    grep -v 'git --no-replace-objects' |
    grep -v 'git --literal-pathspecs' |
    grep -v 'git --glob-pathspecs' |
    grep -v 'git --noglob-pathspecs' |
    grep -v 'git --icase-pathspecs' |
    grep -v 'git --no-optional-locks' |
    grep -v 'git --list-cmds' |
    grep -v 'git ->'
```
