### PR TITLE
[Outreachy] check-ref-format: parse-options

### DIFF
--- a/builtin/check-ref-format.c
+++ b/builtin/check-ref-format.c
@@ -61,10 +61,8 @@ int cmd_check_ref_format(int argc, const char **argv, const char *prefix)
 	};
 
 	int i = 0;
-	int verbose;
-	int normalize;
-	int allow_onelevel;
-	int refspec_pattern;
+	int verbose = 0;
+	int normalize = 0;
 	int flags = 0;
 	const char *refname;
 
@@ -73,12 +71,13 @@ int cmd_check_ref_format(int argc, const char **argv, const char *prefix)
 		OPT_GROUP(""),
 		OPT_CMDMODE( 0 , "branch", &check_ref_format_branch, N_("branch"), CHECK_REF_FORMAT_BRANCH),
 		OPT_BOOL( 0 , "normalize", &normalize, N_("normalize tracked files")),
-		OPT_BOOL( 0 , "allow-onelevel", &allow_onelevel, N_("allow one level")),
-		OPT_BOOL( 0 , "refspec-pattern", &refspec_pattern, N_("refspec pattern")),
+		OPT_BIT( 0 , "allow-onelevel", &flags, N_("allow one level"), REFNAME_ALLOW_ONELEVEL),
+		OPT_NEGBIT( 0, "no-allow-onelevel", &flags, N_("no allow one level"), REFNAME_ALLOW_ONELEVEL),
+		OPT_BIT( 0 , "refspec-pattern", &flags, N_("refspec pattern"), REFNAME_REFSPEC_PATTERN),
 		OPT_END(),
 	};
 
-	argc = parse_options(argc, argv, prefix, options, builtin_check_ref_format_usage, PARSE_OPT_KEEP_ARGV0);
+	argc = parse_options(argc, argv, prefix, options, builtin_check_ref_format_usage, 0);
 
 	refname = argv[i];
 	if (normalize)

--- a/builtin/merge-ours.c
+++ b/builtin/merge-ours.c
@@ -11,6 +11,11 @@
 #include "git-compat-util.h"
 #include "builtin.h"
 #include "diff.h"
+#include "parse-options.h"
+
+/* parse-options.h added to initiate replacement of manual option parsing
+ * with parse-options. 
+ */
 
 static const char builtin_merge_ours_usage[] =
 	"git merge-ours <base>... -- HEAD <remote>...";

--- a/builtin/merge-ours.c
+++ b/builtin/merge-ours.c
@@ -11,11 +11,6 @@
 #include "git-compat-util.h"
 #include "builtin.h"
 #include "diff.h"
-#include "parse-options.h"
-
-/* parse-options.h added to initiate replacement of manual option parsing
- * with parse-options. 
- */
 
 static const char builtin_merge_ours_usage[] =
 	"git merge-ours <base>... -- HEAD <remote>...";

--- a/git.c
+++ b/git.c
@@ -478,7 +478,7 @@ static struct cmd_struct commands[] = {
 	{ "check-attr", cmd_check_attr, RUN_SETUP },
 	{ "check-ignore", cmd_check_ignore, RUN_SETUP | NEED_WORK_TREE },
 	{ "check-mailmap", cmd_check_mailmap, RUN_SETUP },
-	{ "check-ref-format", cmd_check_ref_format, NO_PARSEOPT  },
+	{ "check-ref-format", cmd_check_ref_format },
 	{ "checkout", cmd_checkout, RUN_SETUP | NEED_WORK_TREE },
 	{ "checkout-index", cmd_checkout_index,
 		RUN_SETUP | NEED_WORK_TREE},


### PR DESCRIPTION
This command currently handles its own argv so by teaching it to
use parse-options instead we can standardize the way commands
handle user input across the project.

As a consequence of using OPT_BOOL data structure on --normalize &
--refspec-pattern, --no-normalize & --no-refspec-pattern has been
can now be used.

NO_PARSEOPT flag was also removed to update git.c with the
conversion of the structure in this command.

This is a rough draft and I need some advice if I'm doing this
correctly since its being built but it is failing tests.

Helped by: emily shaffer <emilyshaffer@google.com>
Helped by: johannes schindelin <johannes.schindelin@gmx.de>

Signed-off-by: george espinoza <gespinoz2019@gmail.com>