### PR TITLE
mingw: Fix compiler warnings on MinGW64

### DIFF
--- a/compat/mingw.h
+++ b/compat/mingw.h
@@ -204,7 +204,7 @@ int pipe(int filedes[2]);
 unsigned int sleep (unsigned int seconds);
 int mkstemp(char *template);
 int gettimeofday(struct timeval *tv, void *tz);
-#ifndef __MINGW64_VERSION_MAJOR
+#if !defined(_POSIX_C_SOURCE)
 struct tm *gmtime_r(const time_t *timep, struct tm *result);
 struct tm *localtime_r(const time_t *timep, struct tm *result);
 #endif


### PR DESCRIPTION
date.c: In function local_time_tzoffset:
date.c:88:2: warning: implicit declaration of function localtime_r; did you mean localtime_s? [-Wimplicit-function-declaration]
   88 |  localtime_r(&t, tm);
      |  ^~~~~~~~~~~
      |  localtime_s
date.c: In function match_multi_number:
date.c:572:7: warning: implicit declaration of function gmtime_r; did you mean gmtime_s? [-Wimplicit-function-declaration]
  572 |   if (gmtime_r(&now, &now_tm))
      |       ^~~~~~~~
      |       gmtime_s

Signed-off-by: Orgad Shaneh <orgads@gmail.com>