### PR TITLE
fsmonitor: skip sanity check if the index is split

### DIFF
--- a/fsmonitor.c
+++ b/fsmonitor.c
@@ -16,7 +16,7 @@ static void fsmonitor_ewah_callback(size_t pos, void *is)
 	struct index_state *istate = (struct index_state *)is;
 	struct cache_entry *ce;
 
-	if (pos >= istate->cache_nr)
+	if (!istate->split_index && pos >= istate->cache_nr)
 		BUG("fsmonitor_dirty has more entries than the index (%"PRIuMAX" >= %u)",
 		    (uintmax_t)pos, istate->cache_nr);
 
@@ -55,7 +55,7 @@ int read_fsmonitor_extension(struct index_state *istate, const void *data,
 	}
 	istate->fsmonitor_dirty = fsmonitor_dirty;
 
-	if (istate->fsmonitor_dirty->bit_size > istate->cache_nr)
+	if (!istate->split_index && istate->fsmonitor_dirty->bit_size > istate->cache_nr)
 		BUG("fsmonitor_dirty has more entries than the index (%"PRIuMAX" > %u)",
 		    (uintmax_t)istate->fsmonitor_dirty->bit_size, istate->cache_nr);
 
@@ -83,7 +83,7 @@ void write_fsmonitor_extension(struct strbuf *sb, struct index_state *istate)
 	uint32_t ewah_size = 0;
 	int fixup = 0;
 
-	if (istate->fsmonitor_dirty->bit_size > istate->cache_nr)
+	if (!istate->split_index && istate->fsmonitor_dirty->bit_size > istate->cache_nr)
 		BUG("fsmonitor_dirty has more entries than the index (%"PRIuMAX" > %u)",
 		    (uintmax_t)istate->fsmonitor_dirty->bit_size, istate->cache_nr);
 
@@ -252,7 +252,7 @@ void tweak_fsmonitor(struct index_state *istate)
 			}
 
 			/* Mark all previously saved entries as dirty */
-			if (istate->fsmonitor_dirty->bit_size > istate->cache_nr)
+			if (!istate->split_index && istate->fsmonitor_dirty->bit_size > istate->cache_nr)
 				BUG("fsmonitor_dirty has more entries than the index (%"PRIuMAX" > %u)",
 				    (uintmax_t)istate->fsmonitor_dirty->bit_size, istate->cache_nr);
 			ewah_each_bit(istate->fsmonitor_dirty, fsmonitor_ewah_callback, istate);

--- a/t/t7519-status-fsmonitor.sh
+++ b/t/t7519-status-fsmonitor.sh
@@ -371,4 +371,27 @@ test_expect_success 'status succeeds after staging/unstaging ' '
 	)
 '
 
+# Git will only split indices if we have a bunch of files created,
+# so that prep work of creating a few hundred files is required.
+# Note that this test doesn't fail determinstically without
+# its corresponding bugfix.
+test_expect_success 'update-index succeeds after staging with split index' '
+	test_create_repo fsmonitor-stage-split &&
+	(
+		cd fsmonitor-stage-split &&
+		test_commit initial &&
+		files=$(test_seq 1 100) &&
+		echo "hello world" > file &&
+		touch $files &&
+		git add -A &&
+		git commit -m "next" &&
+		git config core.fsmonitor "$TEST_DIRECTORY/t7519/fsmonitor-watchman" &&
+		echo "hello world" > file &&
+		git checkout -b new-branch &&
+		git checkout master &&
+		echo hello >> file &&
+		git update-index --split-index --untracked-cache --fsmonitor
+	)
+'
+
 test_done


### PR DESCRIPTION
The checks added in 3444ec2 to ensure
that the fsmonitor_dirty bitmap does not have more bits than the index
do not play well with the split index.

git update-index --fsmonitor --split-index calls write_locked_index
which calls write_shared_index as well as write_split_index.
The first call fills up the fsmonitor_dirty bitmap,
and the second modifies the index such that istate->cache_nr is zero and
this assert is hit.

The test written does reproduce the error, but only flakily. There is
limited difference with GIT_TEST_FSMONITOR=fsmonitor-all or
GIT_TEST_FSMONITOR=fsmonitor-watchman, so the flakiness might come from
somewhere else, which I haven't tracked down.

The test also requires checkout of a new branch, and checking out back
to master. It's clear that the index gets into some poor state through
these operations, and there is a deeper bug somewhere.

At the very least, this patch mitigates an over-eager check for split
index users while maintaining good invariants for the standard case.
Also, I haven't been able to reproduce this with "standard" user
commands, like status/checkout/stash, so the blast radius seems limited.

Helped-by: Kevin Willford <kewillf@microsoft.com>
Helped-by: Junio C Hamano <gitster@pobox.com>
Signed-off-by: Utsav Shah <utsav@dropbox.com>