### PR TITLE
diff-highlight: add cleanups for the shebang.perl temporary file.

### DIFF
--- a/contrib/diff-highlight/Makefile
+++ b/contrib/diff-highlight/Makefile
@@ -12,12 +12,12 @@ diff-highlight: shebang.perl DiffHighlight.pm diff-highlight.perl
 
 shebang.perl: FORCE
 	@echo '#!$(PERL_PATH_SQ)' >$@+
-	@cmp $@+ $@ >/dev/null 2>/dev/null || mv $@+ $@
+	@cmp $@+ $@ >/dev/null 2>/dev/null && rm $@+ || mv $@+ $@
 
 test: all
 	$(MAKE) -C t
 
 clean:
-	$(RM) diff-highlight
+	$(RM) diff-highlight shebang.perl
 
 .PHONY: FORCE


### PR DESCRIPTION
If `shebang.perl` already exists then `shebang.perl+` should be cleaned
up. `make clean` should also delete `shebang.perl`.

Signed-off-by: Norman Rasmussen <norman@rasmussen.co.za>