### PR TITLE
doc: Document 'git submodule status --cached'

### DIFF
--- a/Documentation/git-submodule.txt
+++ b/Documentation/git-submodule.txt
@@ -80,6 +80,9 @@ status [--cached] [--recursive] [--] [<path>...]::
 	does not match the SHA-1 found in the index of the containing
 	repository and `U` if the submodule has merge conflicts.
 +
+If `--cached` is specified, this command will instead print the SHA-1
+recorded in the superproject for each submodule.
++
 If `--recursive` is specified, this command will recurse into nested
 submodules, and show their status as well.
 +


### PR DESCRIPTION
It's currently undocumented, and should be mentioned.

I previously thought that `git submodule status` was displaying the behaviors of `git submodule status --cached` and was thus incorrectly documented, but that wasn't actually the case: turns out that `git submodule status` just doesn't work when not in the root directory.