### PR TITLE
git-compat-util.h: drop the `PRIuMAX` definition

### DIFF
--- a/git-compat-util.h
+++ b/git-compat-util.h
@@ -320,10 +320,6 @@ char *gitdirname(char *);
 #define PATH_MAX 4096
 #endif
 
-#ifndef PRIuMAX
-#define PRIuMAX "llu"
-#endif
-
 #ifndef SCNuMAX
 #define SCNuMAX PRIuMAX
 #endif


### PR DESCRIPTION
Git's code base already seems to be using `PRIdMAX` without any such fallback
definition for quite a while (75459410edd (json_writer: new routines to create
JSON data, 2018-07-13), to be precise, and the first Git version to include
that commit was v2.19.0).

Therefore it should be safe to drop the fallback definition for `PRIuMAX` in
`git-compat-util.h`.

This addresses https://github.com/gitgitgadget/git/issues/399