### PR TITLE
reset: parse rev as tree-ish in patch mode

### DIFF
--- a/builtin/reset.c
+++ b/builtin/reset.c
@@ -320,7 +320,7 @@ int cmd_reset(int argc, const char **argv, const char *prefix)
 	if (unborn) {
 		/* reset on unborn branch: treat as reset to empty tree */
 		oidcpy(&oid, the_hash_algo->empty_tree);
-	} else if (!pathspec.nr) {
+	} else if (!pathspec.nr && !patch_mode) {
 		struct commit *commit;
 		if (get_oid_committish(rev, &oid))
 			die(_("Failed to resolve '%s' as a valid revision."), rev);

--- a/t/t7105-reset-patch.sh
+++ b/t/t7105-reset-patch.sh
@@ -38,6 +38,27 @@ test_expect_success PERL 'git reset -p HEAD^' '
 	test_i18ngrep "Apply" output
 '
 
+test_expect_success PERL 'git reset -p HEAD^^{tree}' '
+	test_write_lines n y | git reset -p HEAD^^{tree} >output &&
+	verify_state dir/foo work parent &&
+	verify_saved_state bar &&
+	test_i18ngrep "Apply" output
+'
+
+test_expect_success PERL 'git reset -p HEAD^:dir/foo (blob fails)' '
+	set_and_save_state dir/foo work work &&
+	test_must_fail git reset -p HEAD^:dir/foo &&
+	verify_saved_state dir/foo &&
+	verify_saved_state bar
+'
+
+test_expect_success PERL 'git reset -p aaaaaaaa (unknown fails)' '
+	set_and_save_state dir/foo work work &&
+	test_must_fail git reset -p aaaaaaaa &&
+	verify_saved_state dir/foo &&
+	verify_saved_state bar
+'
+
 # The idea in the rest is that bar sorts first, so we always say 'y'
 # first and if the path limiter fails it'll apply to bar instead of
 # dir/foo.  There's always an extra 'n' to reject edits to dir/foo in


### PR DESCRIPTION
This allows passing a tree-ish `git reset -p` without specifying a pathspec. Requiring a commit in this situation appears to be an oversight, and support for a tree-ish is documented by `git-reset`'s manpage. (https://github.com/git/git/blob/d9f6f3b6195a0ca35642561e530798ad1469bd41/Documentation/git-reset.txt#L12)

An alternative implementation of this change would move the `if (patch_mode) { ... return; }` check before the `rev` parsing logic, offloading validation of the `rev` argument when in patch mode to the `git-add--interactive` logic. This would be possible as the parsed `oid` is not passed to `git-add--interactive`. (https://github.com/git/git/blob/d9f6f3b6195a0ca35642561e530798ad1469bd41/builtin/reset.c#L341-L346)