### PR TITLE
Brown-bag fix on top of js/mingw-inherit-only-std-handles

### DIFF
--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -114,6 +114,7 @@ int err_win_to_posix(DWORD winerr)
 	case ERROR_SHARING_BUFFER_EXCEEDED: error = ENFILE; break;
 	case ERROR_SHARING_VIOLATION: error = EACCES; break;
 	case ERROR_STACK_OVERFLOW: error = ENOMEM; break;
+	case ERROR_SUCCESS: BUG("err_win_to_posix() called without an error!");
 	case ERROR_SWAPERROR: error = ENOENT; break;
 	case ERROR_TOO_MANY_MODULES: error = EMFILE; break;
 	case ERROR_TOO_MANY_OPEN_FILES: error = EMFILE; break;


### PR DESCRIPTION
Johannes "Hannes" Sixt pointed out that this patch series (which already made it to `next`) introduces a problem: when falling back to spawning the process without restricting the file handles, `errno` is not set accurately.

Sadly, the regression test failure observed by Hannes did not show up over here, nor in the PR builds (or, for that matter, the literally hundreds of CI builds that patch series underwent as part of Git for Windows' `master` branch). The cause was that `errno` is set to the expected `ENOENT` by _another_ part of the code, too, that happens right before the calls to `CreateProcessW()`: the test whether a given path refers to a script that needs to be executed via an interpreter (such as `sh.exe`) obviously needs to open the file, and that obviously fails, setting `errno = ENOENT`!

I have currently no idea what function call could be responsible for re-setting `errno` to the reported `ERANGE`... But at least over here, when I partially apply this patch, the part that sets `errno = 0;`, `t0061.2` fails for me, too.

Change since v2:
- We no longer map `ERROR_SUCCESS` to 0, but instead raise a bug message when the code is asked to handle the "No error" error.

Changes since v2:
- fixed oneline of 2/2
- added ACK by Hannes to 1/2

Changes since v1:

- A copy/edit fail in the commit message was fixed.
- We now assign `errno` _only_ when the call to `CreateProcessW()` failed.
- For good measure, we teach the `err_win_to_posix()` function to translate `ERROR_SUCCESS` into the `errno` value 0.

Cc: Johannes Sixt <j6t@kdbg.org>