### PR TITLE
git-p4: use lfs.storage instead of local .git/lfs

### DIFF
--- a/git-p4.py
+++ b/git-p4.py
@@ -1257,9 +1257,15 @@ class GitLFS(LargeFileSystem):
             pointerFile = re.sub(r'Git LFS pointer for.*\n\n', '', pointerFile)
 
         oid = re.search(r'^oid \w+:(\w+)', pointerFile, re.MULTILINE).group(1)
+        # if someone use external lfs.storage ( not in local repo git )
+        lfs_path = gitConfig('lfs.storage')
+        if not lfs_path:
+            lfs_path = 'lfs'
+        if not os.path.isabs(lfs_path):
+            lfs_path = os.path.join(os.getcwd(), '.git', lfs_path)
         localLargeFile = os.path.join(
-            os.getcwd(),
-            '.git', 'lfs', 'objects', oid[:2], oid[2:4],
+            lfs_path,
+            'objects', oid[:2], oid[2:4],
             oid,
         )
         # LFS Spec states that pointer files should not have the executable bit set.


### PR DESCRIPTION
Use lfs.storage if it defined in git.config. If lfs.storage not define - used local .git/lfs.

Original code uses local .git/lfs in sync/clone operations, but if you have external lfs storage better to use it.
