### PR TITLE
gitmodules: link to gitsubmodules guide

### DIFF
--- a/Documentation/gitmodules.txt
+++ b/Documentation/gitmodules.txt
@@ -121,7 +121,7 @@ submodules a URL is specified which can be used for cloning the submodules.
 
 SEE ALSO
 --------
-linkgit:git-submodule[1] linkgit:git-config[1]
+linkgit:git-submodule[1], linkgit:gitsubmodules[7], linkgit:git-config[1]
 
 GIT
 ---


### PR DESCRIPTION
Presently in the manpages git-submodule[1] links to gitsubmodules[7]
and gitmodules[5], gitsubmodules[7] links to git-submodule[1] and gitmodules[5],
but gitmodules[5] only link to git-submodule[1] (and git-config[1]).

Add a link to gitsubmodules[7] so that a person stumbling upon gitmodules
can quickly access gitsubmodules, which has a more high-level overview of
submodule usage.