### PR TITLE
Improve line log documentation

### DIFF
--- a/Documentation/git-log.txt
+++ b/Documentation/git-log.txt
@@ -76,7 +76,8 @@ produced by `--stat`, etc.
 	(or the function name regex <funcname>) within the <file>.  You may
 	not give any pathspec limiters.  This is currently limited to
 	a walk starting from a single revision, i.e., you may only
-	give zero or one positive revision arguments.
+	give zero or one positive revision arguments, and
+	<start> and <end> (or <funcname>) must exist in the starting revision.
 	You can specify this option more than once. Implies `--patch`.
 	Patch output can be suppressed using `--no-patch`, but other diff formats
 	(namely `--raw`, `--numstat`, `--shortstat`, `--dirstat`, `--summary`,

--- a/Documentation/git-log.txt
+++ b/Documentation/git-log.txt
@@ -77,7 +77,10 @@ produced by `--stat`, etc.
 	not give any pathspec limiters.  This is currently limited to
 	a walk starting from a single revision, i.e., you may only
 	give zero or one positive revision arguments.
-	You can specify this option more than once.
+	You can specify this option more than once. Implies `--patch`.
+	Patch output can be suppressed using `--no-patch`, but other diff formats
+	(namely `--raw`, `--numstat`, `--shortstat`, `--dirstat`, `--summary`,
+	`--name-only`, `--name-status`, `--check`) are not currently implemented.
 +
 include::line-range-format.txt[]
 

--- a/Documentation/gitk.txt
+++ b/Documentation/gitk.txt
@@ -105,7 +105,8 @@ linkgit:git-rev-list[1] for a complete list.
 	(or the function name regex <funcname>) within the <file>.  You may
 	not give any pathspec limiters.  This is currently limited to
 	a walk starting from a single revision, i.e., you may only
-	give zero or one positive revision arguments.
+	give zero or one positive revision arguments, and
+	<start> and <end> (or <funcname>) must exist in the starting revision.
 	You can specify this option more than once. Implies `--patch`.
 	Patch output can be suppressed using `--no-patch`, but other diff formats
 	(namely `--raw`, `--numstat`, `--shortstat`, `--dirstat`, `--summary`,

--- a/Documentation/gitk.txt
+++ b/Documentation/gitk.txt
@@ -106,7 +106,10 @@ linkgit:git-rev-list[1] for a complete list.
 	not give any pathspec limiters.  This is currently limited to
 	a walk starting from a single revision, i.e., you may only
 	give zero or one positive revision arguments.
-	You can specify this option more than once.
+	You can specify this option more than once. Implies `--patch`.
+	Patch output can be suppressed using `--no-patch`, but other diff formats
+	(namely `--raw`, `--numstat`, `--shortstat`, `--dirstat`, `--summary`,
+	`--name-only`, `--name-status`, `--check`) are not currently implemented.
 +
 *Note:* gitk (unlike linkgit:git-log[1]) currently only understands
 this option if you specify it "glued together" with its argument.  Do


### PR DESCRIPTION
These two patches add more information to the documentation for line history (`git log -L`) : 
- Mention explicitly that only the `--patch` and `--no-patch` diff formats  are supported 
- Mention that parameters `<start>`, `<end>` and `<funcname>` must exist in the starting revision

Regarding point 2 :     I stumbled upon this while reading the history of 'filter_refs' in fetch-pack.c.
I did
    
        git log -s -L :filter_refs:fetch-pack.c

which shows a list of commits starting with 745f7a8cac (fetch-pack: move core
code to libgit.a, 2012-10-26). So then I did

        git log  -s -L :filter_refs:fetch-pack.c -L :filter_refs:builtin/fetch-pack.c
    
which fails with
    
        fatal: -L parameter 'filter_refs' starting at line 1: no match

Changes since v1:
- Shorten the commit titles
- Use long options names for `--patch` and `--no-patch`
- Remove inexact mention of `--function-context`
- Reword the clarification regarding `<start>`, `<end>` and `<funcname>` so that it doesn't apply only to regex parameters
- Also add this clarification to `Documentation/gitk.txt` since it applies there as well

CC: Thomas Rast <tr@thomasrast.ch>, Junio C Hamano <gitster@pobox.com>, Matthieu Moy <Matthieu.Moy@imag.fr>, SZEDER Gábor <szeder.dev@gmail.com>, Derrick Stolee <stolee@gmail.com>