### PR TITLE
[Outreachy] commit: display advice hints when commit fails

### DIFF
--- a/builtin/commit.c
+++ b/builtin/commit.c
@@ -961,6 +961,7 @@ static int prepare_to_commit(const char *index_file, const char *prefix,
 	 */
 	if (!committable && whence != FROM_MERGE && !allow_empty &&
 	    !(amend && is_a_merge(current_head))) {
+		s->hints = advice_status_hints;
 		s->display_comment_prefix = old_display_comment_prefix;
 		run_status(stdout, index_file, prefix, 0, s);
 		if (amend)

--- a/t/t7500-commit-template-squash-signoff.sh
+++ b/t/t7500-commit-template-squash-signoff.sh
@@ -382,4 +382,13 @@ test_expect_success 'check commit with unstaged rename and copy' '
 	)
 '
 
+test_expect_success 'commit without staging files fails and displays hints' '
+	echo "initial" >>file &&
+	git add file &&
+	git commit -m initial &&
+	echo "changes" >>file &&
+	test_must_fail git commit -m initial >actual &&
+	test_i18ngrep "no changes added to commit (use \"git add\" and/or \"git commit -a\")" actual
+'
+
 test_done


### PR DESCRIPTION
Display hints to the user when trying to commit without staging the modified
files first (when advice.statusHints is set to true). Change the output of the
unsuccessful commit from e.g:

  # [...]
  # Changes not staged for commit:
  #   modified:   builtin/commit.c
  #
  # no changes added to commit

to:

  # [...]
  # Changes not staged for commit:
  #   (use "git add <file>..." to update what will be committed)
  #   (use "git checkout -- <file>..." to discard changes in working directory)
  #
  #   modified:   ../builtin/commit.c
  #
  # no changes added to commit (use "git add" and/or "git commit -a")

In ea9882bfc4 (commit: disable status hints when writing to COMMIT_EDITMSG,
2013-09-12) the intent was to disable status hints when writing to
COMMIT_EDITMSG, but in fact the implementation disabled status messages in
more locations, e.g in case the commit wasn't successful, status hints
will still be disabled and no hints will be displayed to the user although
advice.statusHints is set to true.

Signed-off-by: Heba Waly <heba.waly@gmail.com>
