### PR TITLE
ERANGE strikes again: RFH

### DIFF
--- a/compat/snprintf.c
+++ b/compat/snprintf.c
@@ -22,6 +22,7 @@ int git_vsnprintf(char *str, size_t maxsize, const char *format, va_list ap)
 	va_list cp;
 	char *s;
 	int ret = -1;
+	int save_errno = errno;
 
 	if (maxsize > 0) {
 		va_copy(cp, ap);
@@ -33,7 +34,7 @@ int git_vsnprintf(char *str, size_t maxsize, const char *format, va_list ap)
 		str[maxsize-1] = 0;
 	}
 	if (ret != -1)
-		return ret;
+		goto out;
 
 	s = NULL;
 	if (maxsize < 128)
@@ -52,6 +53,8 @@ int git_vsnprintf(char *str, size_t maxsize, const char *format, va_list ap)
 			ret = -1;
 	}
 	free(s);
+out:
+	errno = save_errno;
 	return ret;
 }
 


### PR DESCRIPTION
I have to build with SNPRINTF_RETURNS_BOGUS. We know already that compat/snprintf overwrites errno with ERANGE in the case where a too small buffer is passed to the function.

I observe failures such as this one in t0410-partial-clone.sh:

++ git -C repo fsck
Checking object directories: 100% (256/256), done.
Checking objects: 100% (1/1), done.
fatal: failed to read object 3836707...snip...6591523: Result too large

The messages is from read_object_file_extended() in sha1-file.c.
It looks like we call into strbuf *after* a lower-level error return,
but *before* the error is checked. Does someone know where this
could happen?

The reason I'm asking is that today's tool chain is sufficiently broken for me
on Windows that I can't use the debugger. A hint where to start debugging
with fprintf would be helpful.