### PR TITLE
sparse-checkout: use extern for global variables

### DIFF
--- a/cache.h
+++ b/cache.h
@@ -958,8 +958,8 @@ extern int protect_hfs;
 extern int protect_ntfs;
 extern const char *core_fsmonitor;
 
-int core_apply_sparse_checkout;
-int core_sparse_checkout_cone;
+extern int core_apply_sparse_checkout;
+extern int core_sparse_checkout_cone;
 
 /*
  * Include broken refs in all ref iterations, which will


### PR DESCRIPTION
I noticed this issue when resolving conflicts with our VFS for Git-enabled branch in microsoft/git.

When I moved the global for core.sparseCheckout along with creating the global for core.sparseCheckoutCone, I dropped the "extern" by habit. (We are dropping these from function declarations, usually.) However, this means something different for variables, and could lead to bugs. I haven't found any, but it's better to be safe, right?

Thanks,
-Stolee

