### PR TITLE
[Outreachy] [RFC] branch: advise the user to checkout a different branch before deleting

### DIFF
--- a/advice.c
+++ b/advice.c
@@ -31,6 +31,7 @@ int advice_graft_file_deprecated = 1;
 int advice_checkout_ambiguous_remote_branch_name = 1;
 int advice_nested_tag = 1;
 int advice_submodule_alternate_error_strategy_die = 1;
+int advice_delete_checkedout_branch = 1;
 
 static int advice_use_color = -1;
 static char advice_colors[][COLOR_MAXLEN] = {
@@ -91,7 +92,8 @@ static struct {
 	{ "checkoutAmbiguousRemoteBranchName", &advice_checkout_ambiguous_remote_branch_name },
 	{ "nestedTag", &advice_nested_tag },
 	{ "submoduleAlternateErrorStrategyDie", &advice_submodule_alternate_error_strategy_die },
-
+	{ "deleteCheckedoutBranch", &advice_delete_checkedout_branch },
+	
 	/* make this an alias for backward compatibility */
 	{ "pushNonFastForward", &advice_push_update_rejected }
 };

--- a/advice.h
+++ b/advice.h
@@ -31,6 +31,7 @@ extern int advice_graft_file_deprecated;
 extern int advice_checkout_ambiguous_remote_branch_name;
 extern int advice_nested_tag;
 extern int advice_submodule_alternate_error_strategy_die;
+extern int advice_delete_checkedout_branch;
 
 int git_default_advice_config(const char *var, const char *value);
 __attribute__((format (printf, 1, 2)))

--- a/builtin/branch.c
+++ b/builtin/branch.c
@@ -240,6 +240,20 @@ static int delete_branches(int argc, const char **argv, int force, int kinds,
 				error(_("Cannot delete branch '%s' "
 					"checked out at '%s'"),
 				      bname.buf, wt->path);
+				if (advice_delete_checkedout_branch) {
+					if (wt->is_current) {
+						advise(_("The branch you are trying to delete is already "
+							"checked out, run the following command to "
+							"checkout a different branch then try again:\n"
+							"git switch <branch>"));
+					}
+					else {
+						advise(_("The branch you are trying to delete is checked "
+							"out on another worktree, run the following command "
+							"to checkout a different branch then try again:\n"
+							"git -C %s switch <branch>"), wt->path);
+					}
+				}
 				ret = 1;
 				continue;
 			}

--- a/t/t3200-branch.sh
+++ b/t/t3200-branch.sh
@@ -807,8 +807,10 @@ test_expect_success 'test deleting branch without config' '
 
 test_expect_success 'deleting currently checked out branch fails' '
 	git worktree add -b my7 my7 &&
-	test_must_fail git -C my7 branch -d my7 &&
-	test_must_fail git branch -d my7 &&
+	test_must_fail git -C my7 branch -d my7 2>output1.err &&
+	test_must_fail git branch -d my7 2>output2.err &&
+	test_i18ngrep "hint: The branch you are trying to delete is already checked out" output1.err &&
+	test_i18ngrep "hint: The branch you are trying to delete is checked out on another worktree" output2.err &&
 	rm -r my7 &&
 	git worktree prune
 '


### PR DESCRIPTION
When a user attempts to delete a checked out branch, an error message
is displayed saying: "error: Cannot delete branch <branch_name> checked
out at <path>". This patch suggests displaying a hint after the error
message advising the user to checkout another branch first using
"git checkout <branch_name>".
