### PR TITLE
sequencer: comment out the 'squash!' line

### DIFF
--- a/sequencer.c
+++ b/sequencer.c
@@ -1756,6 +1756,7 @@ static int update_squash_messages(struct repository *r,
 		strbuf_addf(&buf, _("This is the commit message #%d:"),
 			    ++opts->current_fixup_count + 1);
 		strbuf_addstr(&buf, "\n\n");
+		strbuf_addf(&buf, "%c ", comment_line_char);
 		strbuf_addstr(&buf, body);
 	} else if (command == TODO_FIXUP) {
 		strbuf_addf(&buf, "\n%c ", comment_line_char);

--- a/t/t3404-rebase-interactive.sh
+++ b/t/t3404-rebase-interactive.sh
@@ -513,8 +513,6 @@ test_expect_success C_LOCALE_OUTPUT 'squash and fixup generate correct log messa
 	cat >expect-squash-fixup <<-\EOF &&
 	B
 
-	D
-
 	ONCE
 	EOF
 	git checkout -b squash-fixup E &&
@@ -1325,7 +1323,7 @@ test_expect_success 'rebase -i commits that overwrite untracked files (squash)' 
 	test_cmp_rev HEAD F &&
 	rm file6 &&
 	git rebase --continue &&
-	test $(git cat-file commit HEAD | sed -ne \$p) = I &&
+	test $(git cat-file commit HEAD | sed -ne \$p) = F &&
 	git reset --hard original-branch2
 '
 

--- a/t/t3900-i18n-commit.sh
+++ b/t/t3900-i18n-commit.sh
@@ -226,10 +226,6 @@ test_commit_autosquash_multi_encoding () {
 		git rev-list HEAD >actual &&
 		test_line_count = 3 actual &&
 		iconv -f $old -t UTF-8 "$TEST_DIRECTORY"/t3900/$msg >expect &&
-		if test $flag = squash; then
-			subject="$(head -1 expect)" &&
-			printf "\nsquash! %s\n" "$subject" >>expect
-		fi &&
 		git cat-file commit HEAD^ >raw &&
 		(sed "1,/^$/d" raw | iconv -f $new -t utf-8) >actual &&
 		test_cmp expect actual


### PR DESCRIPTION
When performing a squash commit, the commit comments are combined into a
single commit.  Since the subject line of the squash commit is used to
identify the squash-to target commit, it cannot offer any useful
contribution to the new commit message.  Therefore, the squash commit
subject line it commented out from the combined message (much like a
fixup commit's full comment).

The body of a squash commit may contain additional content to add to the
commit message, so this part of the squash commit message is retained.

Since this change what the expected post-rebase commit comment would look
like, related test expectations are adjusted to reflect the the new
expectation.  A new test is added for the new expectation.

Signed-off-by: Michael Rappazzo <rappazzo@gmail.com>