### PR TITLE
clarify .gitignore ** pattern documentation

### DIFF
--- a/Documentation/gitignore.txt
+++ b/Documentation/gitignore.txt
@@ -117,7 +117,7 @@ full pathname may have special meaning:
 
  - A leading "`**`" followed by a slash means match in all
    directories. For example, "`**/foo`" matches file or directory
-   "`foo`" anywhere, the same as pattern "`foo`". "`**/foo/bar`"
+   "`foo`" anywhere, the same as pattern "`**/foo/bar`"
    matches file or directory "`bar`" anywhere that is directly
    under directory "`foo`".
 


### PR DESCRIPTION
I found myself confused by the `". "`sentence junction here: https://github.com/git/git/commit/237ec6e40d4fd1a0190c4ffde6d18278abc5853a#r36665052
This PR clarifies that section