### PR TITLE
unpack-trees: correctly compute result count

### DIFF
--- a/unpack-trees.c
+++ b/unpack-trees.c
@@ -1305,14 +1305,14 @@ static int clear_ce_flags_dir(struct index_state *istate,
 
 	if (pl->use_cone_patterns && orig_ret == MATCHED_RECURSIVE) {
 		struct cache_entry **ce = cache;
-		rc = (cache_end - cache) / sizeof(struct cache_entry *);
+		rc = cache_end - cache;
 
 		while (ce < cache_end) {
 			(*ce)->ce_flags &= ~clear_mask;
 			ce++;
 		}
 	} else if (pl->use_cone_patterns && orig_ret == NOT_MATCHED) {
-		rc = (cache_end - cache) / sizeof(struct cache_entry *);
+		rc = cache_end - cache;
 	} else {
 		rc = clear_ce_flags_1(istate, cache, cache_end - cache,
 				      prefix,


### PR DESCRIPTION
Here is a very small fix to the cone-mode pattern-matching in unpack-trees.c. Johannes found this while running a Coverity scan for other issues. He alerted me to the problem and I could immediately see _my_ error here. In creating this patch, most of my time was spent asking "how did this work before?" and "why didn't this hurt performance?" Hopefully my commit message explains this thoroughly enough.

As for making it into the release, I don't know. The change is small, it has a very limited scope, but this flaw is also not really hurting anything in a major way.

Thanks,
-Stolee

Cc: peff@peff.net, johannes.schindelin@gmx.de