### PR TITLE
userdiff: add Julia to supported userdiff languages

### DIFF
--- a/Documentation/gitattributes.txt
+++ b/Documentation/gitattributes.txt
@@ -824,6 +824,8 @@ patterns are available:
 
 - `java` suitable for source code in the Java language.
 
+- `julia` suitable for source code in the Julia language.
+
 - `matlab` suitable for source code in the MATLAB and Octave languages.
 
 - `objc` suitable for source code in the Objective-C language.

--- a/t/t4018-diff-funcname.sh
+++ b/t/t4018-diff-funcname.sh
@@ -38,6 +38,7 @@ diffpatterns="
 	golang
 	html
 	java
+	julia
 	matlab
 	objc
 	pascal

--- a/t/t4018/julia-function
+++ b/t/t4018/julia-function
@@ -1,0 +1,5 @@
+function RIGHT()
+    # A comment
+    # Another comment
+    return ChangeMe
+end

--- a/t/t4018/julia-indented-function
+++ b/t/t4018/julia-indented-function
@@ -1,0 +1,8 @@
+function outer_function()
+    function RIGHT()
+        for i = 1:10
+            print(i)
+        end
+        # ChangeMe
+    end
+end

--- a/t/t4018/julia-inline-function
+++ b/t/t4018/julia-inline-function
@@ -1,0 +1,5 @@
+@inline function RIGHT()
+    # Prints Hello, then something else.
+    println("Hello")
+    println("ChangeMe")
+end

--- a/t/t4018/julia-macro
+++ b/t/t4018/julia-macro
@@ -1,0 +1,5 @@
+macro RIGHT()
+    # First comment
+    # Second comment
+    return :( println("ChangeMe") )
+end

--- a/t/t4018/julia-mutable-struct
+++ b/t/t4018/julia-mutable-struct
@@ -1,0 +1,5 @@
+mutable struct RIGHT
+    x
+    y::Int
+    ChangeMe
+end

--- a/t/t4018/julia-struct
+++ b/t/t4018/julia-struct
@@ -1,0 +1,5 @@
+struct RIGHT
+    x
+    y::Int
+    ChangeMe
+end

--- a/userdiff.c
+++ b/userdiff.c
@@ -79,6 +79,21 @@ PATTERNS("java",
 	 "|[-+0-9.e]+[fFlL]?|0[xXbB]?[0-9a-fA-F]+[lL]?"
 	 "|[-+*/<>%&^|=!]="
 	 "|--|\\+\\+|<<=?|>>>?=?|&&|\\|\\|"),
+PATTERNS("julia",
+	 "^[ \t]*(((mutable[ \t]+)?struct|(@.+[ \t])?function|macro)[ \t].*)$",
+	 /* -- */
+	 /* Binary literals */
+	 "[-+]?0b[01]+"
+	 /* Hexadecimal literals */
+	 "|[-+]?0x[0-9a-fA-F]+"
+	 /* Real and complex literals */
+	 "|[-+0-9.e_(im)]+"
+	 /* Should theoretically allow Unicode characters as part of
+	  * a word, such as U+2211. However, Julia reserves most of the
+	  * U+2200-U+22FF range (as well as others) as user-defined operators,
+	  * therefore they are not handled in this regex. */
+	 "|[a-zA-Z_][a-zA-Z0-9_!]*"
+	 "|--|\\+\\+|<<=?|>>>=?|>>=?|\\\\\\\\=?|//=?|&&|\\|\\||::|->|[-+*/<>%^&|=!$]=?"),
 PATTERNS("matlab",
 	 /*
 	  * Octave pattern is mostly the same as matlab, except that '%%%' and


### PR DESCRIPTION
Add xfuncname and word_regex patterns for Julia[1],
which is a language used in numerical analysis and
computational science.

The default behavior for xfuncname did not allow
functions to be indented, nor functions to have a
macro applied, such as @inline or @generated.

[1]: https://julialang.org

Signed-off-by: Ryan Zoeller <rtzoeller@rtzoeller.com>