### PR TITLE
clean: demonstrate a bug with pathspecs

### DIFF
--- a/t/t7300-clean.sh
+++ b/t/t7300-clean.sh
@@ -737,4 +737,13 @@ test_expect_success MINGW 'handle clean & core.longpaths = false nicely' '
 	test_i18ngrep "too long" .git/err
 '
 
+test_expect_failure 'clean untracked paths by pathspec' '
+	git init untracked &&
+	mkdir untracked/dir &&
+	echo >untracked/dir/file.txt &&
+	git -C untracked clean -f dir/file.txt &&
+	ls untracked/dir >actual &&
+	test_must_be_empty actual
+'
+
 test_done


### PR DESCRIPTION
While integrating v2.25.0 into the microsoft/git fork, one of our
VFS for Git functional tests started failing. Looking into it, the only
possible place could have been where one of our integration
points with the virtualfilesystem hook was moved by c5c4edd
(dir: break part of read_directory_recursive() out for reuse, 2019-12-10)
and then used in the following two commits.

By reverting these two commits, we stopped the failure, but it
took a while before figuring out that it was a regression in Git
and not a failure in our integration to the new logic. Thanks
to Kevin Willford for producing a test case.

b9670c1 (dir: fix checks on common prefix directory, 2019-12-19)
is the culprit, so this patch is based on that. If rebased to c5c4edd,
then the test passes.

As for actually fixing this regression, I don't know how. This code
is pretty dense and I don't have a firm grasp of what is happening
in both b9670c1 and the following 777b420 (dir: synchronize
tread_leading_path() and read_directory_recursive()). Elijah
is CC'd in case he still has context on this area.

V2 fixes a typo in the commit short-sha references.

Thanks,
-Stolee

Cc: Kevin.Willford@microsoft.com, newren@gmail.com
