### PR TITLE
[Outreachy][RFC] git: advice user when explicitly setting git-dir without work-tree

### DIFF
--- a/Documentation/git.txt
+++ b/Documentation/git.txt
@@ -110,9 +110,14 @@ foo.bar= ...`) sets `foo.bar` to the empty string which `git config
 	Do not pipe Git output into a pager.
 
 --git-dir=<path>::
-	Set the path to the repository. This can also be controlled by
-	setting the `GIT_DIR` environment variable. It can be an absolute
-	path or relative path to current working directory.
+	Set the path to the repository (i.e. the .git folder). This can also be
+	controlled by setting the `GIT_DIR` environment variable. It can be an
+	absolute path or relative path to current working directory.
+	
+	Note that --git-dir=<path> is not the same as -C=<path>.
+	It's preferrable to set --work-tree=<path> as well when setting
+	--git-dir to make sure Git will run your command across the correct
+	work tree.
 
 --work-tree=<path>::
 	Set the path to the working tree. It can be an absolute path

--- a/advice.c
+++ b/advice.c
@@ -31,6 +31,7 @@ int advice_graft_file_deprecated = 1;
 int advice_checkout_ambiguous_remote_branch_name = 1;
 int advice_nested_tag = 1;
 int advice_submodule_alternate_error_strategy_die = 1;
+int advice_set_git_dir_without_worktree = 1;
 
 static int advice_use_color = -1;
 static char advice_colors[][COLOR_MAXLEN] = {
@@ -91,6 +92,7 @@ static struct {
 	{ "checkoutAmbiguousRemoteBranchName", &advice_checkout_ambiguous_remote_branch_name },
 	{ "nestedTag", &advice_nested_tag },
 	{ "submoduleAlternateErrorStrategyDie", &advice_submodule_alternate_error_strategy_die },
+	{ "setGitDirWithoutWorktree", &advice_set_git_dir_without_worktree },
 
 	/* make this an alias for backward compatibility */
 	{ "pushNonFastForward", &advice_push_update_rejected }

--- a/advice.h
+++ b/advice.h
@@ -31,6 +31,7 @@ extern int advice_graft_file_deprecated;
 extern int advice_checkout_ambiguous_remote_branch_name;
 extern int advice_nested_tag;
 extern int advice_submodule_alternate_error_strategy_die;
+extern int advice_set_git_dir_without_worktree;
 
 int git_default_advice_config(const char *var, const char *value);
 __attribute__((format (printf, 1, 2)))

--- a/git.c
+++ b/git.c
@@ -133,6 +133,8 @@ void setup_auto_pager(const char *cmd, int def)
 static int handle_options(const char ***argv, int *argc, int *envchanged)
 {
 	const char **orig_argv = *argv;
+	int git_dir_is_set = 0;
+	int work_tree_is_set = 0;
 
 	while (*argc > 0) {
 		const char *cmd = (*argv)[0];
@@ -187,12 +189,14 @@ static int handle_options(const char ***argv, int *argc, int *envchanged)
 				usage(git_usage_string);
 			}
 			setenv(GIT_DIR_ENVIRONMENT, (*argv)[1], 1);
+			git_dir_is_set = 1;
 			if (envchanged)
 				*envchanged = 1;
 			(*argv)++;
 			(*argc)--;
 		} else if (skip_prefix(cmd, "--git-dir=", &cmd)) {
 			setenv(GIT_DIR_ENVIRONMENT, cmd, 1);
+			git_dir_is_set = 1;
 			if (envchanged)
 				*envchanged = 1;
 		} else if (!strcmp(cmd, "--namespace")) {
@@ -215,12 +219,14 @@ static int handle_options(const char ***argv, int *argc, int *envchanged)
 				usage(git_usage_string);
 			}
 			setenv(GIT_WORK_TREE_ENVIRONMENT, (*argv)[1], 1);
+			work_tree_is_set = 1;
 			if (envchanged)
 				*envchanged = 1;
 			(*argv)++;
 			(*argc)--;
 		} else if (skip_prefix(cmd, "--work-tree=", &cmd)) {
 			setenv(GIT_WORK_TREE_ENVIRONMENT, cmd, 1);
+			work_tree_is_set = 1;
 			if (envchanged)
 				*envchanged = 1;
 		} else if (!strcmp(cmd, "--super-prefix")) {
@@ -318,6 +324,13 @@ static int handle_options(const char ***argv, int *argc, int *envchanged)
 		(*argv)++;
 		(*argc)--;
 	}
+	if (advice_set_git_dir_without_worktree && git_dir_is_set &&
+	    !work_tree_is_set && !is_bare_repository())
+		advise("Setting --git-dir without specifying a worktree "
+		       "doesn't guarantee that Git will run your command "
+		       "accross the correct work tree, did you mean "
+		       "git -C <path>?");
+	
 	return (*argv) - orig_argv;
 }
 

--- a/t/t2050-git-dir-relative.sh
+++ b/t/t2050-git-dir-relative.sh
@@ -52,4 +52,8 @@ git --git-dir .git --work-tree .. commit -m subcommit &&
 test -r "${COMMIT_FILE}"
 '
 
+test_expect_success 'setting --git-dir without -work-tree displays hint' '
+git --git-dir .git status 2>output.err &&
+test_i18ngrep "did you mean git -C <path>" output.err
+'
 test_done

--- a/t/t5401-update-hooks.sh
+++ b/t/t5401-update-hooks.sh
@@ -118,6 +118,7 @@ test_expect_success 'send-pack produced no output' '
 '
 
 cat <<EOF >expect
+remote: hint: Setting --git-dir without specifying a worktree doesn't guarantee that Git will run your command accross the correct work tree, did you mean git -C <path>?
 remote: STDOUT pre-receive
 remote: STDERR pre-receive
 remote: STDOUT update refs/heads/master


### PR DESCRIPTION
git --git-dir <path> is a bit confusing and sometimes doesn't work as
the user would expect it to.

For example, if the user runs `git --git-dir=<path> status`, git
will not be able to figure out the work tree path on its own and
will assign the work tree to the user's current work directory.
When this assignment is wrong, then the output will not match the
user's expectations.

This patch suggests displaying a hint message when --git-dir is set
without the --work-tree advising the user to use git -C instead.
It also updates the documentation of git --git-dir to make it clearer.

