### PR TITLE
initialize call to ARRAY_SIZE macro outside the control part of loop

### DIFF
--- a/git.c
+++ b/git.c
@@ -607,7 +607,8 @@ static struct cmd_struct commands[] = {
 static struct cmd_struct *get_builtin(const char *s)
 {
 	int i;
-	for (i = 0; i < ARRAY_SIZE(commands); i++) {
+	int get_array_size = ARRAY_SIZE(commands);
+	for (i = 0; i < get_array_size; i++) {
 		struct cmd_struct *p = commands + i;
 		if (!strcmp(s, p->cmd))
 			return p;
@@ -623,7 +624,8 @@ int is_builtin(const char *s)
 static void list_builtins(struct string_list *out, unsigned int exclude_option)
 {
 	int i;
-	for (i = 0; i < ARRAY_SIZE(commands); i++) {
+	int get_array_size = ARRAY_SIZE(commands);
+	for (i = 0; i < get_array_size; i++) {
 		if (exclude_option &&
 		    (commands[i].option & exclude_option))
 			continue;


### PR DESCRIPTION
git.c: initialize calls to ARRAY_SIZE macro outside control part of loop

Calls to ARRAY_SIZE macro are currently in test part of the loop
and are thus redundant. Initialization outside will fetch size of
commands array faster.
Any advice for improving in any area on my part would  be great.

Signed-off-by: Parth Gala <parthpgala@gmail.com>
