### PR TITLE
object.c: localize global the_repository variable into r

### DIFF
--- a/builtin/fsck.c
+++ b/builtin/fsck.c
@@ -375,6 +375,7 @@ static void check_object(struct object *obj)
 static void check_connectivity(void)
 {
 	int i, max;
+	struct repository *repo = NULL;
 
 	/* Traverse the pending reachable objects */
 	traverse_reachable();
@@ -400,12 +401,12 @@ static void check_connectivity(void)
 	}
 
 	/* Look up all the requirements, warn about missing objects.. */
-	max = get_max_object_index();
+	max = get_max_object_index(repo);
 	if (verbose)
 		fprintf_ln(stderr, _("Checking connectivity (%d objects)"), max);
 
 	for (i = 0; i < max; i++) {
-		struct object *obj = get_indexed_object(i);
+		struct object *obj = get_indexed_object(repo, i);
 
 		if (obj)
 			check_object(obj);

--- a/builtin/index-pack.c
+++ b/builtin/index-pack.c
@@ -218,14 +218,15 @@ static unsigned check_object(struct object *obj)
 static unsigned check_objects(void)
 {
 	unsigned i, max, foreign_nr = 0;
+	struct repository *repo = NULL;
 
-	max = get_max_object_index();
+	max = get_max_object_index(repo);
 
 	if (verbose)
 		progress = start_delayed_progress(_("Checking objects"), max);
 
 	for (i = 0; i < max; i++) {
-		foreign_nr += check_object(get_indexed_object(i));
+		foreign_nr += check_object(get_indexed_object(repo, i));
 		display_progress(progress, i + 1);
 	}
 

--- a/builtin/name-rev.c
+++ b/builtin/name-rev.c
@@ -456,6 +456,7 @@ static void name_rev_line(char *p, struct name_ref_data *data)
 int cmd_name_rev(int argc, const char **argv, const char *prefix)
 {
 	struct object_array revs = OBJECT_ARRAY_INIT;
+	struct repository *repo = NULL;
 	int all = 0, transform_stdin = 0, allow_undefined = 1, always = 0, peel_tag = 0;
 	struct name_ref_data data = { 0, 0, STRING_LIST_INIT_NODUP, STRING_LIST_INIT_NODUP };
 	struct option opts[] = {
@@ -553,9 +554,9 @@ int cmd_name_rev(int argc, const char **argv, const char *prefix)
 	} else if (all) {
 		int i, max;
 
-		max = get_max_object_index();
+		max = get_max_object_index(repo);
 		for (i = 0; i < max; i++) {
-			struct object *obj = get_indexed_object(i);
+			struct object *obj = get_indexed_object(repo, i);
 			if (!obj || obj->type != OBJ_COMMIT)
 				continue;
 			show_name(obj, NULL,

--- a/object.c
+++ b/object.c
@@ -10,14 +10,14 @@
 #include "packfile.h"
 #include "commit-graph.h"
 
-unsigned int get_max_object_index(void)
+unsigned int get_max_object_index(struct repository *r)
 {
-	return the_repository->parsed_objects->obj_hash_size;
+	return r->parsed_objects->obj_hash_size;
 }
 
-struct object *get_indexed_object(unsigned int idx)
+struct object *get_indexed_object(struct repository *r, unsigned int idx)
 {
-	return the_repository->parsed_objects->obj_hash[idx];
+	return r->parsed_objects->obj_hash[idx];
 }
 
 static const char *object_type_strings[] = {

--- a/object.h
+++ b/object.h
@@ -98,12 +98,12 @@ int type_from_string_gently(const char *str, ssize_t, int gentle);
 /*
  * Return the current number of buckets in the object hashmap.
  */
-unsigned int get_max_object_index(void);
+unsigned int get_max_object_index(struct repository *);
 
 /*
  * Return the object from the specified bucket in the object hashmap.
  */
-struct object *get_indexed_object(unsigned int);
+struct object *get_indexed_object(struct repository *, unsigned int);
 
 /*
  * This can be used to see if we have heard of the object before, but

--- a/shallow.c
+++ b/shallow.c
@@ -510,6 +510,7 @@ static void paint_down(struct paint_info *info, const struct object_id *oid,
 		       unsigned int id)
 {
 	unsigned int i, nr;
+	struct repository *repo = NULL;
 	struct commit_list *head = NULL;
 	int bitmap_nr = DIV_ROUND_UP(info->nr_bits, 32);
 	size_t bitmap_size = st_mult(sizeof(uint32_t), bitmap_nr);
@@ -563,9 +564,9 @@ static void paint_down(struct paint_info *info, const struct object_id *oid,
 		}
 	}
 
-	nr = get_max_object_index();
+	nr = get_max_object_index(repo);
 	for (i = 0; i < nr; i++) {
-		struct object *o = get_indexed_object(i);
+		struct object *o = get_indexed_object(repo, i);
 		if (o && o->type == OBJ_COMMIT)
 			o->flags &= ~SEEN;
 	}
@@ -608,6 +609,7 @@ void assign_shallow_commits_to_refs(struct shallow_info *info,
 	struct object_id *oid = info->shallow->oid;
 	struct oid_array *ref = info->ref;
 	unsigned int i, nr;
+	struct repository *repo = NULL;
 	int *shallow, nr_shallow = 0;
 	struct paint_info pi;
 
@@ -622,9 +624,9 @@ void assign_shallow_commits_to_refs(struct shallow_info *info,
 	 * Prepare the commit graph to track what refs can reach what
 	 * (new) shallow commits.
 	 */
-	nr = get_max_object_index();
+	nr = get_max_object_index(repo);
 	for (i = 0; i < nr; i++) {
-		struct object *o = get_indexed_object(i);
+		struct object *o = get_indexed_object(repo, i);
 		if (!o || o->type != OBJ_COMMIT)
 			continue;
 

--- a/upload-pack.c
+++ b/upload-pack.c
@@ -450,6 +450,7 @@ static int do_reachable_revlist(struct child_process *cmd,
 		"rev-list", "--stdin", NULL,
 	};
 	struct object *o;
+	struct repository *repo = NULL;
 	char namebuf[GIT_MAX_HEXSZ + 2]; /* ^ + hash + LF */
 	int i;
 	const unsigned hexsz = the_hash_algo->hexsz;
@@ -472,8 +473,8 @@ static int do_reachable_revlist(struct child_process *cmd,
 
 	namebuf[0] = '^';
 	namebuf[hexsz + 1] = '\n';
-	for (i = get_max_object_index(); 0 < i; ) {
-		o = get_indexed_object(--i);
+	for (i = get_max_object_index(repo); 0 < i; ) {
+		o = get_indexed_object(repo, --i);
 		if (!o)
 			continue;
 		if (reachable && o->type == OBJ_COMMIT)
@@ -520,6 +521,7 @@ static int get_reachable_list(struct object_array *src,
 	struct child_process cmd = CHILD_PROCESS_INIT;
 	int i;
 	struct object *o;
+	struct repository *repo = NULL;
 	char namebuf[GIT_MAX_HEXSZ + 2]; /* ^ + hash + LF */
 	const unsigned hexsz = the_hash_algo->hexsz;
 
@@ -538,8 +540,8 @@ static int get_reachable_list(struct object_array *src,
 			o->flags &= ~TMP_MARK;
 		}
 	}
-	for (i = get_max_object_index(); 0 < i; i--) {
-		o = get_indexed_object(i - 1);
+	for (i = get_max_object_index(repo); 0 < i; i--) {
+		o = get_indexed_object(repo, i - 1);
 		if (o && o->type == OBJ_COMMIT &&
 		    (o->flags & TMP_MARK)) {
 			add_object_array(o, NULL, reachable);


### PR DESCRIPTION
I have created this commit in response to https://github.com/gitgitgadget/git/issues/379#issue-503866117.
Don't merge this in yet.
As of now I am done with localizing 'the_repository' variable for 2 functions(2 more to go) of object.c.
Before proceeding further I would like to know if something could be done better particularly if every function needs to define(in order to pass as parameters):
>struct repository *repo = NULL;

Or can we include repository.h or some other header to avoid it.
I will update my PR accordingly including the other 2 functions, which will make object.c void of
'the_repository'.

Signed-off-by: Parth Gala <parthpgala@gmail.com>
