### PR TITLE
bisect: Removing subdirectory restrictions on git bisect

### DIFF
--- a/git-bisect.sh
+++ b/git-bisect.sh
@@ -31,6 +31,7 @@ git bisect run <cmd>...
 
 Please use "git help bisect" to get the full man page.'
 
+SUBDIRECTORY_OK=Yes
 OPTIONS_SPEC=
 . git-sh-setup
 


### PR DESCRIPTION
Given that git rebase was never prevented from running in subdirectories, it doesnt make sense to prevent git bisect to run from subdirectories as well. So subdirectory restrictions are now removed from git
bisect, i.e.: you can now run git bisect from any git subdirectory.

Signed-off-by: Nirmal Khedkar <nirmalhk7@gmail.com> 

Thanks for taking the time to contribute to Git! Please be advised that the
Git community does not use github.com for their contributions. Instead, we use
a mailing list (git@vger.kernel.org) for code submissions, code reviews, and
bug reports. Nevertheless, you can use GitGitGadget (https://gitgitgadget.github.io/)
to conveniently send your Pull Requests commits to our mailing list.

Please read the "guidelines for contributing" linked above!
