### PR TITLE
sparse-checkout: allow one-character directories in cone mode

### DIFF
--- a/dir.c
+++ b/dir.c
@@ -682,7 +682,7 @@ static void add_pattern_to_hashsets(struct pattern_list *pl, struct path_pattern
 		return;
 	}
 
-	if (given->patternlen <= 2 ||
+	if (given->patternlen < 2 ||
 	    *given->pattern == '*' ||
 	    strstr(given->pattern, "**")) {
 		/* Not a cone pattern. */

--- a/t/t1091-sparse-checkout-builtin.sh
+++ b/t/t1091-sparse-checkout-builtin.sh
@@ -417,9 +417,19 @@ test_expect_success 'pattern-checks: too short' '
 	cat >repo/.git/info/sparse-checkout <<-\EOF &&
 	/*
 	!/*/
-	/a
+	/
 	EOF
 	check_read_tree_errors repo "a" "disabling cone pattern matching"
+'
+test_expect_success 'pattern-checks: not too short' '
+	cat >repo/.git/info/sparse-checkout <<-\EOF &&
+	/*
+	!/*/
+	/b/
+	EOF
+	git -C repo read-tree -mu HEAD 2>err &&
+	test_must_be_empty err &&
+	check_files repo a
 '
 
 test_expect_success 'pattern-checks: trailing "*"' '


### PR DESCRIPTION
This is based on `ds/sparse-add`.

I discovered this while taking v2.25.1 and `ds/sparse-add` into our fork of Git and testing it with Scalar.

Off-by-one errors are tricky, sometimes.

Thanks,
-Stolee