### PR TITLE
[QUIMBY] CI run for show-gitdir on top of gitster/es/outside-repo-errmsg-hints

### DIFF
--- a/pathspec.c
+++ b/pathspec.c
@@ -438,9 +438,13 @@ static void init_pathspec_item(struct pathspec_item *item, unsigned flags,
 	} else {
 		match = prefix_path_gently(prefix, prefixlen,
 					   &prefixlen, copyfrom);
-		if (!match)
+		if (!match) {
+			const char *hint_path = get_git_work_tree();
+			if (!hint_path)
+				hint_path = get_git_dir();
 			die(_("%s: '%s' is outside repository at '%s'"), elt,
-			    copyfrom, absolute_path(get_git_work_tree()));
+			    copyfrom, absolute_path(hint_path));
+		}
 	}
 
 	item->match = match;

--- a/setup.c
+++ b/setup.c
@@ -120,9 +120,13 @@ char *prefix_path_gently(const char *prefix, int len,
 char *prefix_path(const char *prefix, int len, const char *path)
 {
 	char *r = prefix_path_gently(prefix, len, NULL, path);
-	if (!r)
+	if (!r) {
+		const char *hint_path = get_git_work_tree();
+		if (!hint_path)
+			hint_path = get_git_dir();
 		die(_("'%s' is outside repository at '%s'"), path,
-		    absolute_path(get_git_work_tree()));
+		    absolute_path(hint_path));
+	}
 	return r;
 }
 


### PR DESCRIPTION
This pull request was created by https://github.com/nasamuffin/quimby, a tool for Git contributors who are accustomed to a git-format-patch/git-send-email workflow but want to see the GitGitGadget CI run results. It should probably be ignored!