### PR TITLE
prepare_shell_cmd: add code comment

### DIFF
--- a/run-command.c
+++ b/run-command.c
@@ -284,6 +284,12 @@ static const char **prepare_shell_cmd(struct argv_array *out, const char **argv)
 			argv_array_push(out, argv[0]);
 		else
 			argv_array_pushf(out, "%s \"$@\"", argv[0]);
+
+		/*
+		 * -c expects shell_name after command_string.
+		 * Pushing entire original argv below will pass argv[0]
+		 * as shell name.
+		 */
 	}
 
 	argv_array_pushv(out, argv);


### PR DESCRIPTION
While debugging something else, I was quite puzzled to see that
`prepare_shell_cmd()` duplicates the command before sending to sh, like:
    sh -c "git-upload-pack '../testrepo/.git'" "git-upload-pack '../testrepo/.git'"

A Windows programmer myself, initially I thought that it's a bug.

Add a clarifying comment.

Signed-off-by: Alexandr Miloslavskiy <alexandr.miloslavskiy@syntevo.com>

Thanks for taking the time to contribute to Git! Please be advised that the
Git community does not use github.com for their contributions. Instead, we use
a mailing list (git@vger.kernel.org) for code submissions, code reviews, and
bug reports. Nevertheless, you can use GitGitGadget (https://gitgitgadget.github.io/)
to conveniently send your Pull Requests commits to our mailing list.

Please read the "guidelines for contributing" linked above!
