### PR TITLE
Ignore the global PAX header in `import-tars.perl`

### DIFF
--- a/contrib/fast-import/import-tars.perl
+++ b/contrib/fast-import/import-tars.perl
@@ -139,6 +139,8 @@ foreach my $tar_file (@ARGV)
 			print FI "\n";
 		}
 
+		next if ($typeflag eq 'g'); # ignore global header
+
 		my $path;
 		if ($prefix) {
 			$path = "$prefix/$name";


### PR DESCRIPTION
This problem came up in Pacman-related work, where `PKGBUILD` definitions would reference the tarballs downloaded from GitHub, and patches would be applied on top. To work on those patches efficiently (e.g. when an upgrade to a new version of the project no longer lets those patches apply), I need to be able to import those tarballs into playground worktrees and work on them. I like to use `contrib/fast-import/import-tars.perl` for that purpose, but it really needs to strip the prefix, otherwise it is too tedious to work with it.

Changes since v1:

- Mentioned the implicit prefix-stripping feature of `import-tars.perl` in the commit message; Without that context, it is really hard to understand the motivation for this patch.
- Clarified in the commit message that this patch does not prevent any future patches that would _use_ the information contained in the global header.

Cc: René Scharfe <l.s.r@web.de>, brian m. carlson <sandals@crustytoothpaste.net>, Junio C Hamano <gitster@pobox.com>