### PR TITLE
Fix git-gui--askpass on Windows

### DIFF
--- a/git-gui--askpass
+++ b/git-gui--askpass
@@ -56,6 +56,11 @@ proc finish {} {
 		}
 	}
 
+	# On Windows, force the encoding to UTF-8: it is what `git.exe` expects
+	if {$::tcl_platform(platform) eq {windows}} {
+		set ::answer [encoding convertto utf-8 $::answer]
+	}
+
 	puts $::answer
 	set ::rc 0
 }


### PR DESCRIPTION
Windows has this odd thing where there is an active code page (somewhat like `LC_CTYPE`) and there is no _real_ UTF-8 code page. So we need to help `git-gui--askpass` along a bit to be of use when asking for credentials.

Changes since v1:
- Fixed indentation