### PR TITLE
connected.c: reprepare packs for corner cases

### DIFF
--- a/connected.c
+++ b/connected.c
@@ -61,7 +61,11 @@ int check_connected(oid_iterate_fn fn, void *cb_data,
 		 * object is a promisor object. Instead, just make sure we
 		 * received, in a promisor packfile, the objects pointed to by
 		 * each wanted ref.
+		 *
+		 * Before checking for promisor packs, be sure we have the
+		 * latest pack-files loaded into memory.
 		 */
+		reprepare_packed_git(the_repository);
 		do {
 			struct packed_git *p;
 


### PR DESCRIPTION
I included how I found this (integrating v2.26.0-rc0 into Scalar), but I am able to reproduce it on my Linux machine using real fetches from github.com. I'm not sure why I was unable to reproduce the issue in test cases using the file:// URLs _or_ the HTTP tests.

Update in V2: I've updated the commit message to discuss the options presented on-list, but also provide why I'm keeping the code unchanged in light of that discussion.

Cc: jonathantanmy@google.com, me@ttaylorr.com, peff@peff.net