### PR TITLE
MyFirstObjectWalk: remove unnecessary conditional statement

### DIFF
--- a/Documentation/MyFirstObjectWalk.txt
+++ b/Documentation/MyFirstObjectWalk.txt
@@ -357,9 +357,6 @@ static void walken_commit_walk(struct rev_info *rev)
 	...
 
 	while ((commit = get_revision(rev))) {
-		if (!commit)
-			continue;
-
 		strbuf_reset(&prettybuf);
 		pp_commit_easy(CMIT_FMT_ONELINE, commit, &prettybuf);
 		puts(prettybuf.buf);


### PR DESCRIPTION
Our introductory documentation made me scratch my head because our example contains dead code. I'd like to remove it lest we confuse future contributors.

Cc: Emily Shaffer <emilyshaffer@google.com>