### PR TITLE
doc: include `git rev-list` description in `git log` doc

### DIFF
--- a/Documentation/git-log.txt
+++ b/Documentation/git-log.txt
@@ -15,6 +15,9 @@ DESCRIPTION
 -----------
 Shows the commit logs.
 
+:git-log: 1
+include::rev-list-description.txt[]
+
 The command takes options applicable to the linkgit:git-rev-list[1]
 command to control what is shown and how, and options applicable to
 the linkgit:git-diff[1] command to control how the changes

--- a/Documentation/git-log.txt
+++ b/Documentation/git-log.txt
@@ -15,9 +15,9 @@ DESCRIPTION
 -----------
 Shows the commit logs.
 
-The command takes options applicable to the `git rev-list`
+The command takes options applicable to the linkgit:git-rev-list[1]
 command to control what is shown and how, and options applicable to
-the `git diff-*` commands to control how the changes
+the linkgit:git-diff[1] command to control how the changes
 each commit introduces are shown.
 
 

--- a/Documentation/git-rev-list.txt
+++ b/Documentation/git-rev-list.txt
@@ -19,12 +19,12 @@ given commit(s), but exclude commits that are reachable from the one(s)
 given with a '{caret}' in front of them.  The output is given in reverse
 chronological order by default.
 
-You can think of this as a set operation.  Commits given on the command
-line form a set of commits that are reachable from any of them, and then
-commits reachable from any of the ones given with '{caret}' in front are
-subtracted from that set.  The remaining commits are what comes out in the
-command's output.  Various other options and paths parameters can be used
-to further limit the result.
+You can think of this as a set operation. Commits reachable from any of
+the commits given on the command line form a set, and then commits reachable
+from any of the ones given with '{caret}' in front are subtracted from that
+set.  The remaining commits are what comes out in the command's output.
+Various other options and paths parameters can be used to further limit the
+result.
 
 Thus, the following command:
 

--- a/Documentation/git-rev-list.txt
+++ b/Documentation/git-rev-list.txt
@@ -14,44 +14,7 @@ SYNOPSIS
 DESCRIPTION
 -----------
 
-List commits that are reachable by following the `parent` links from the
-given commit(s), but exclude commits that are reachable from the one(s)
-given with a '{caret}' in front of them.  The output is given in reverse
-chronological order by default.
-
-You can think of this as a set operation. Commits reachable from any of
-the commits given on the command line form a set, and then commits reachable
-from any of the ones given with '{caret}' in front are subtracted from that
-set.  The remaining commits are what comes out in the command's output.
-Various other options and paths parameters can be used to further limit the
-result.
-
-Thus, the following command:
-
------------------------------------------------------------------------
-$ git rev-list foo bar ^baz
------------------------------------------------------------------------
-
-means "list all the commits which are reachable from 'foo' or 'bar', but
-not from 'baz'".
-
-A special notation "'<commit1>'..'<commit2>'" can be used as a
-short-hand for "^'<commit1>' '<commit2>'". For example, either of
-the following may be used interchangeably:
-
------------------------------------------------------------------------
-$ git rev-list origin..HEAD
-$ git rev-list HEAD ^origin
------------------------------------------------------------------------
-
-Another special notation is "'<commit1>'...'<commit2>'" which is useful
-for merges.  The resulting set of commits is the symmetric difference
-between the two operands.  The following two commands are equivalent:
-
------------------------------------------------------------------------
-$ git rev-list A B --not $(git merge-base --all A B)
-$ git rev-list A...B
------------------------------------------------------------------------
+include::rev-list-description.txt[]
 
 'rev-list' is a very essential Git command, since it
 provides the ability to build and traverse commit ancestry graphs. For

--- a/Documentation/git-rev-list.txt
+++ b/Documentation/git-rev-list.txt
@@ -14,6 +14,7 @@ SYNOPSIS
 DESCRIPTION
 -----------
 
+:git-rev-list: 1
 include::rev-list-description.txt[]
 
 'rev-list' is a very essential Git command, since it

--- a/Documentation/git-rev-list.txt
+++ b/Documentation/git-rev-list.txt
@@ -29,19 +29,19 @@ to further limit the result.
 Thus, the following command:
 
 -----------------------------------------------------------------------
-	$ git rev-list foo bar ^baz
+$ git rev-list foo bar ^baz
 -----------------------------------------------------------------------
 
 means "list all the commits which are reachable from 'foo' or 'bar', but
 not from 'baz'".
 
 A special notation "'<commit1>'..'<commit2>'" can be used as a
-short-hand for "{caret}'<commit1>' '<commit2>'". For example, either of
+short-hand for "^'<commit1>' '<commit2>'". For example, either of
 the following may be used interchangeably:
 
 -----------------------------------------------------------------------
-	$ git rev-list origin..HEAD
-	$ git rev-list HEAD ^origin
+$ git rev-list origin..HEAD
+$ git rev-list HEAD ^origin
 -----------------------------------------------------------------------
 
 Another special notation is "'<commit1>'...'<commit2>'" which is useful
@@ -49,8 +49,8 @@ for merges.  The resulting set of commits is the symmetric difference
 between the two operands.  The following two commands are equivalent:
 
 -----------------------------------------------------------------------
-	$ git rev-list A B --not $(git merge-base --all A B)
-	$ git rev-list A...B
+$ git rev-list A B --not $(git merge-base --all A B)
+$ git rev-list A...B
 -----------------------------------------------------------------------
 
 'rev-list' is a very essential Git command, since it

--- a/Documentation/rev-list-description.txt
+++ b/Documentation/rev-list-description.txt
@@ -1,0 +1,38 @@
+List commits that are reachable by following the `parent` links from the
+given commit(s), but exclude commits that are reachable from the one(s)
+given with a '{caret}' in front of them.  The output is given in reverse
+chronological order by default.
+
+You can think of this as a set operation. Commits reachable from any of
+the commits given on the command line form a set, and then commits reachable
+from any of the ones given with '{caret}' in front are subtracted from that
+set.  The remaining commits are what comes out in the command's output.
+Various other options and paths parameters can be used to further limit the
+result.
+
+Thus, the following command:
+
+-----------------------------------------------------------------------
+$ git rev-list foo bar ^baz
+-----------------------------------------------------------------------
+
+means "list all the commits which are reachable from 'foo' or 'bar', but
+not from 'baz'".
+
+A special notation "'<commit1>'..'<commit2>'" can be used as a
+short-hand for "^'<commit1>' '<commit2>'". For example, either of
+the following may be used interchangeably:
+
+-----------------------------------------------------------------------
+$ git rev-list origin..HEAD
+$ git rev-list HEAD ^origin
+-----------------------------------------------------------------------
+
+Another special notation is "'<commit1>'...'<commit2>'" which is useful
+for merges.  The resulting set of commits is the symmetric difference
+between the two operands.  The following two commands are equivalent:
+
+-----------------------------------------------------------------------
+$ git rev-list A B --not $(git merge-base --all A B)
+$ git rev-list A...B
+-----------------------------------------------------------------------

--- a/Documentation/rev-list-description.txt
+++ b/Documentation/rev-list-description.txt
@@ -12,9 +12,16 @@ result.
 
 Thus, the following command:
 
+ifdef::git-rev-list[]
 -----------------------------------------------------------------------
 $ git rev-list foo bar ^baz
 -----------------------------------------------------------------------
+endif::git-rev-list[]
+ifdef::git-log[]
+-----------------------------------------------------------------------
+$ git log foo bar ^baz
+-----------------------------------------------------------------------
+endif::git-log[]
 
 means "list all the commits which are reachable from 'foo' or 'bar', but
 not from 'baz'".
@@ -23,16 +30,32 @@ A special notation "'<commit1>'..'<commit2>'" can be used as a
 short-hand for "^'<commit1>' '<commit2>'". For example, either of
 the following may be used interchangeably:
 
+ifdef::git-rev-list[]
 -----------------------------------------------------------------------
 $ git rev-list origin..HEAD
 $ git rev-list HEAD ^origin
 -----------------------------------------------------------------------
+endif::git-rev-list[]
+ifdef::git-log[]
+-----------------------------------------------------------------------
+$ git log origin..HEAD
+$ git log HEAD ^origin
+-----------------------------------------------------------------------
+endif::git-log[]
 
 Another special notation is "'<commit1>'...'<commit2>'" which is useful
 for merges.  The resulting set of commits is the symmetric difference
 between the two operands.  The following two commands are equivalent:
 
+ifdef::git-rev-list[]
 -----------------------------------------------------------------------
 $ git rev-list A B --not $(git merge-base --all A B)
 $ git rev-list A...B
 -----------------------------------------------------------------------
+endif::git-rev-list[]
+ifdef::git-log[]
+-----------------------------------------------------------------------
+$ git log A B --not $(git merge-base --all A B)
+$ git log A...B
+-----------------------------------------------------------------------
+endif::git-log[]

--- a/Documentation/revisions.txt
+++ b/Documentation/revisions.txt
@@ -254,6 +254,9 @@ specifying a single revision, using the notation described in the
 previous section, means the set of commits `reachable` from the given
 commit.
 
+Specifying several revisions means the set of commits reachable from
+any of the given commits.
+
 A commit's reachable set is the commit itself and the commits in
 its ancestry chain.
 


### PR DESCRIPTION
Changes since v2:
- applied Junio's suggestions 
- added a preparatory commit tweaking the wording of one sentence in the `git rev-list` description
- added a new commit adding a sentence in `revisions.txt` to mention explicitly what it means to list several revisions to form a range.

v2:
This series moves the nice explanation in the 'Description' section 
of the `git rev-list` man page to a separate file and includes this file 
in the `git log` man page.

This goal is to make readers more aware that they can write e.g.

    git log branch1 branch2 branch3 branch4 --not master

to see commits on each of branch1-4, that are not on master, 
since this is not immediately obvious (at least to me)
in the `git log` man page. 

Note that I made several commits for ease of reviewing,
I'll squash some if this would be preferred.

Changes since v1: took a completely different approach 
following the comments received from Junio and Taylor.

CC: Lawrence Siebert <lawrencesiebert@gmail.com>, Denton Liu <liu.denton@gmail.com>, Junio C Hamano <gitster@pobox.com>, Taylor Blau <me@ttaylorr.com>, Philip Oakley <philipoakley@iee.email>