### PR TITLE
bloom: ignore renames when computing changed paths

### DIFF
--- a/bloom.c
+++ b/bloom.c
@@ -189,6 +189,7 @@ struct bloom_filter *get_bloom_filter(struct repository *r,
 
 	repo_diff_setup(r, &diffopt);
 	diffopt.flags.recursive = 1;
+	diffopt.detect_rename = 0;
 	diffopt.max_changes = max_changes;
 	diff_setup_done(&diffopt);
 


### PR DESCRIPTION
I promised [1] I would adapt the commit that was dropped from gs/commit-graph-path-filter [2] on top of gs/commit-graph-path-filter and jt/avoid-prefetch-when-able-in-diff. However, I noticed that the change was extremely simple and has value without basing it on jt/avoid-prefetch-when-able-in-diff.

This change applied to gs/commit-graph-path-filter has obvious CPU time improvements for computing changed-path Bloom filters (that I did not measure). The partial clone improvements require jt/avoid-prefetch-when-able-in-diff to be included, too, but the code does not depend on it at compile time.

Thanks,
-Stolee

[1] https://lore.kernel.org/git/7de2f54b-8704-a0e1-12aa-0ca9d3d70f6f@gmail.com/
[2] https://lore.kernel.org/git/55824cda89c1dca7756c8c2d831d6e115f4a9ddb.1585528298.git.gitgitgadget@gmail.com/

Cc: philipoakley@iee.email, peff@peff.net