### PR TITLE
Make the tests that test `core.hideDotFiles` more robust

### DIFF
--- a/t/t0001-init.sh
+++ b/t/t0001-init.sh
@@ -399,7 +399,7 @@ test_expect_success MINGW '.git hidden' '
 		mkdir newdir &&
 		cd newdir &&
 		git init &&
-		is_hidden .git
+		test_path_is_hidden .git
 	) &&
 	check_config newdir/.git false unset
 '

--- a/t/t0001-init.sh
+++ b/t/t0001-init.sh
@@ -392,13 +392,6 @@ test_expect_success SYMLINKS 're-init to move gitdir symlink' '
 	test_path_is_dir realgitdir/refs
 '
 
-# Tests for the hidden file attribute on windows
-is_hidden () {
-	# Use the output of `attrib`, ignore the absolute path
-	case "$(attrib "$1")" in *H*?:*) return 0;; esac
-	return 1
-}
-
 test_expect_success MINGW '.git hidden' '
 	rm -rf newdir &&
 	(

--- a/t/t5611-clone-config.sh
+++ b/t/t5611-clone-config.sh
@@ -92,13 +92,6 @@ test_expect_success 'clone -c remote.<remote>.fetch=<refspec> --origin=<name>' '
 	test_cmp expect actual
 '
 
-# Tests for the hidden file attribute on windows
-is_hidden () {
-	# Use the output of `attrib`, ignore the absolute path
-	case "$(attrib "$1")" in *H*?:*) return 0;; esac
-	return 1
-}
-
 test_expect_success MINGW 'clone -c core.hideDotFiles' '
 	test_commit attributes .gitattributes "" &&
 	rm -rf child &&

--- a/t/t5611-clone-config.sh
+++ b/t/t5611-clone-config.sh
@@ -96,13 +96,13 @@ test_expect_success MINGW 'clone -c core.hideDotFiles' '
 	test_commit attributes .gitattributes "" &&
 	rm -rf child &&
 	git clone -c core.hideDotFiles=false . child &&
-	! is_hidden child/.gitattributes &&
+	! test_path_is_hidden child/.gitattributes &&
 	rm -rf child &&
 	git clone -c core.hideDotFiles=dotGitOnly . child &&
-	! is_hidden child/.gitattributes &&
+	! test_path_is_hidden child/.gitattributes &&
 	rm -rf child &&
 	git clone -c core.hideDotFiles=true . child &&
-	is_hidden child/.gitattributes
+	test_path_is_hidden child/.gitattributes
 '
 
 test_done

--- a/t/test-lib-functions.sh
+++ b/t/test-lib-functions.sh
@@ -1544,8 +1544,11 @@ test_bitmap_traversal () {
 	rm -f "$1.normalized" "$2.normalized"
 }
 
-# Tests for the hidden file attribute on windows
-is_hidden () {
+# Tests for the hidden file attribute on Windows
+test_path_is_hidden () {
+	test_have_prereq MINGW ||
+	BUG "test_path_is_hidden can only be used on Windows"
+
 	# Use the output of `attrib`, ignore the absolute path
 	case "$("$SYSTEMROOT"/system32/attrib "$1")" in *H*?:*) return 0;; esac
 	return 1

--- a/t/test-lib-functions.sh
+++ b/t/test-lib-functions.sh
@@ -1547,6 +1547,6 @@ test_bitmap_traversal () {
 # Tests for the hidden file attribute on windows
 is_hidden () {
 	# Use the output of `attrib`, ignore the absolute path
-	case "$(attrib "$1")" in *H*?:*) return 0;; esac
+	case "$("$SYSTEMROOT"/system32/attrib "$1")" in *H*?:*) return 0;; esac
 	return 1
 }

--- a/t/test-lib-functions.sh
+++ b/t/test-lib-functions.sh
@@ -1543,3 +1543,10 @@ test_bitmap_traversal () {
 	test_cmp "$1.normalized" "$2.normalized" &&
 	rm -f "$1.normalized" "$2.normalized"
 }
+
+# Tests for the hidden file attribute on windows
+is_hidden () {
+	# Use the output of `attrib`, ignore the absolute path
+	case "$(attrib "$1")" in *H*?:*) return 0;; esac
+	return 1
+}


### PR DESCRIPTION
We have this feature on Windows where the files starting with a dot can be marked hidden (whether a file is hidden by default or not is a matter of naming convention on Unix, but it is an explicit flag on Windows). This patch improves the regression tests of this feature, and it has been carried in Git for Windows for over three years.

Junio, I followed your advice, and did one more thing: the function is now renamed also only in 3/3.

Changes since v2:

- The first patch is now a true code move, no edits are snuck in.
- The typo fix, the function rename, and the prereq check are now all done as a "cleanup" patch (the third one).

Changes since v1:

- A preparatory patch now moves and renames `is_hidden` to `test-lib-functions.sh`
- A typo in the function's comment is fixed, while at it.