### PR TITLE
Fix GIT_TEST_COMMIT_GRAPH_CHANGED_PATHS env variable

### DIFF
--- a/builtin/commit.c
+++ b/builtin/commit.c
@@ -1701,7 +1701,9 @@ int cmd_commit(int argc, const char **argv, const char *prefix)
 		      "not exceeded, and then \"git restore --staged :/\" to recover."));
 
 	if (git_env_bool(GIT_TEST_COMMIT_GRAPH, 0) &&
-	    write_commit_graph_reachable(the_repository->objects->odb, 0, NULL))
+	    write_commit_graph_reachable(the_repository->objects->odb,
+					 git_env_bool(GIT_TEST_COMMIT_GRAPH_CHANGED_PATHS, 0) ? COMMIT_GRAPH_WRITE_BLOOM_FILTERS : 0,
+					 NULL))
 		return 1;
 
 	repo_rerere(the_repository, 0);

--- a/revision.c
+++ b/revision.c
@@ -661,6 +661,15 @@ static void prepare_to_use_bloom_filter(struct rev_info *revs)
 	if (!revs->commits)
 	    return;
 
+	if (revs->prune_data.has_wildcard)
+		return;
+	if (revs->prune_data.nr > 1)
+		return;
+	if (revs->prune_data.magic ||
+	    (revs->prune_data.nr &&
+	     revs->prune_data.items[0].magic))
+		return;
+
 	repo_parse_commit(revs->repo, revs->commits->item);
 
 	if (!revs->repo->objects->commit_graph)


### PR DESCRIPTION
While I was playing around with Bloom filters and `git blame`, I purposefully got it working with some scenarios but not all. Then I tried to trigger a failing build in the blame tests using `GIT_TEST_COMMIT_GRAPH_CHANGED_PATHS=1`. But the tests all succeeded!

Examining the data, I see that the commit-graph doesn't have the Bloom filter chunks at all. This is because we are not setting the flag in the right spot.

The `GIT_TEST_COMMIT_GRAPH=1` variable triggers a commit-graph write during `git commit`, so we need to update the code there instead of just inspecting the variable in `git commit-graph write`.

By updating this variable, I saw some test failures in other tests regarding non-exact pathspecs.

I based this change on [1]

Thanks,
-Stolee

[1] https://lore.kernel.org/git/pull.601.v2.git.1586437211842.gitgitgadget@gmail.com/

Cc: me@ttaylorr.com, jnareb@gmail.com, garimasigit@gmail.com