### PR TITLE
complete: zsh: add missing sub cmd completion candidates

### DIFF
--- a/contrib/completion/git-completion.zsh
+++ b/contrib/completion/git-completion.zsh
@@ -150,9 +150,11 @@ __git_zsh_cmd_common ()
 	push:'update remote refs along with associated objects'
 	rebase:'forward-port local commits to the updated upstream head'
 	reset:'reset current HEAD to the specified state'
+	restore:'restore working tree files'
 	rm:'remove files from the working tree and from the index'
 	show:'show various types of objects'
 	status:'show the working tree status'
+	switch:'switch branches'
 	tag:'create, list, delete or verify a tag object signed with GPG')
 	_describe -t common-commands 'common commands' list && _ret=0
 }


### PR DESCRIPTION
Add missing 'restore' and 'switch' sub commands to zsh completion
candidate output. E.g.

```
$ git re<tab>
rebase    -- forward-port local commits to the updated upstream head
reset     -- reset current HEAD to the specified state
restore   -- restore working tree files
```

```
$ git s<tab>
show      -- show various types of objects
status    -- show the working tree status
switch    -- switch branches
```

Signed-off-by: Terry Moschou <tmoschou@gmail.com>

Thanks for taking the time to contribute to Git! Please be advised that the
Git community does not use github.com for their contributions. Instead, we use
a mailing list (git@vger.kernel.org) for code submissions, code reviews, and
bug reports. Nevertheless, you can use GitGitGadget (https://gitgitgadget.github.io/)
to conveniently send your Pull Requests commits to our mailing list.

Please read the "guidelines for contributing" linked above!
