### PR TITLE
credential: handle partial URLs in config settings again

### DIFF
--- a/credential.c
+++ b/credential.c
@@ -343,8 +343,31 @@ static int check_url_component(const char *url, int quiet,
 	return -1;
 }
 
-int credential_from_url_gently(struct credential *c, const char *url,
-			       int quiet)
+/*
+ * Potentially-partial URLs can, but do not have to, contain
+ *
+ * - a protocol (or scheme) of the form "<protocol>://"
+ *
+ * - a host name (the part after the protocol and before the first slash after
+ *   that, if any)
+ *
+ * - a user name and potentially a password (as "<user>[:<password>]@" part of
+ *   the host name)
+ *
+ * - a path (the part after the host name, if any, starting with the slash)
+ *
+ * Missing parts will be left unset in `struct credential`. Thus, `https://`
+ * will have only the `protocol` set, `example.com` only the host name, and
+ * `/git` only the path.
+ *
+ * Note that an empty host name in an otherwise fully-qualified URL (e.g.
+ * `cert:///path/to/cert.pem`) will be treated as unset if we expect the URL to
+ * be potentially partial, and only then (otherwise, the empty string is used).
+ *
+ * The credential_from_url() function does not allow partial URLs.
+ */
+static int credential_from_url_1(struct credential *c, const char *url,
+				 int allow_partial_url, int quiet)
 {
 	const char *at, *colon, *cp, *slash, *host, *proto_end;
 
@@ -357,12 +380,12 @@ int credential_from_url_gently(struct credential *c, const char *url,
 	 *   (3) proto://<user>:<pass>@<host>/...
 	 */
 	proto_end = strstr(url, "://");
-	if (!proto_end || proto_end == url) {
+	if (!allow_partial_url && (!proto_end || proto_end == url)) {
 		if (!quiet)
 			warning(_("url has no scheme: %s"), url);
 		return -1;
 	}
-	cp = proto_end + 3;
+	cp = proto_end ? proto_end + 3 : url;
 	at = strchr(cp, '@');
 	colon = strchr(cp, ':');
 	slash = strchrnul(cp, '/');
@@ -382,8 +405,10 @@ int credential_from_url_gently(struct credential *c, const char *url,
 		host = at + 1;
 	}
 
-	c->protocol = xmemdupz(url, proto_end - url);
-	c->host = url_decode_mem(host, slash - host);
+	if (proto_end && proto_end - url > 0)
+		c->protocol = xmemdupz(url, proto_end - url);
+	if (!allow_partial_url || slash - host > 0)
+		c->host = url_decode_mem(host, slash - host);
 	/* Trim leading and trailing slashes from path */
 	while (*slash == '/')
 		slash++;
@@ -403,6 +428,11 @@ int credential_from_url_gently(struct credential *c, const char *url,
 		return -1;
 
 	return 0;
+}
+
+int credential_from_url_gently(struct credential *c, const char *url, int quiet)
+{
+	return credential_from_url_1(c, url, 0, quiet);
 }
 
 void credential_from_url(struct credential *c, const char *url)

--- a/credential.h
+++ b/credential.h
@@ -32,7 +32,7 @@ void credential_write(const struct credential *, FILE *);
 /*
  * Parse a url into a credential struct, replacing any existing contents.
  *
- * Ifthe url can't be parsed (e.g., a missing "proto://" component), the
+ * If the url can't be parsed (e.g., a missing "proto://" component), the
  * resulting credential will be empty but we'll still return success from the
  * "gently" form.
  *

--- a/t/t0300-credentials.sh
+++ b/t/t0300-credentials.sh
@@ -448,4 +448,42 @@ test_expect_success 'credential system refuses to work with missing protocol' '
 	test_i18ncmp expect stderr
 '
 
+test_expect_success 'credential config with partial URLs' '
+	echo "echo password=yep" | write_script git-credential-yep &&
+	test_write_lines url=https://user@example.com/repo.git >stdin &&
+	for partial in \
+		example.com \
+		user@example.com \
+		https:// \
+		https://example.com \
+		https://example.com/ \
+		https://user@example.com \
+		https://user@example.com/ \
+		https://example.com/repo.git \
+		https://user@example.com/repo.git \
+		/repo.git
+	do
+		git -c credential.$partial.helper=yep \
+			credential fill <stdin >stdout &&
+		grep yep stdout ||
+		return 1
+	done &&
+
+	for partial in \
+		dont.use.this \
+		http:// \
+		/repo
+	do
+		git -c credential.$partial.helper=yep \
+			credential fill <stdin >stdout &&
+		! grep yep stdout ||
+		return 1
+	done &&
+
+	git -c credential.$partial.helper=yep \
+		-c credential.with%0anewline.username=uh-oh \
+		credential fill <stdin >stdout 2>stderr &&
+	test_i18ngrep "skipping credential lookup for key" stderr
+'
+
 test_done


### PR DESCRIPTION
This fixes [the problem illustrated by Peff's example](https://lore.kernel.org/git/20200422040644.GC3559880@coredump.intra.peff.net/), in `maint-2.17`:

```sh
  $ echo url=https://example.com |
    git -c credential.example.com.username=foo credential fill
  warning: url has no scheme: example.com
  fatal: credential url cannot be parsed: example.com
```

The fix is necessarily different than [what was proposed by brian](https://lore.kernel.org/git/20200422012344.2051103-1-sandals@crustytoothpaste.net/) because that fix targets v2.26.x which has 46fd7b390034 (credential: allow wildcard patterns when matching config, 2020-02-20).

This patch series targets `maint-2.17` instead (and might actually not be able to fix `maint` due to that wildcard pattern patch; I haven't had the time to check yet).

Please note that Git v2.17.4 will _not_ do what we would expect here: if any host name (without protocol) is specified, e.g. `-c credential.golli.wog.username = boo`, it will actually _ignore_ the host name. That is, this will populate the username:

```sh
  $ echo url=https://example.com |
    git -c credential.totally.bog.us.username=foo credential fill
```

Obviously, this is unexpected, as a Git config like this would leave the last specified user name as "winner":

```ini
[credential "first.com"]
    username = Whos On
[credential "second.com"]
    username = Who
```

This patch series fixes this. The quoted part of `[credential "<value>"]` will be interpreted as a partial URL:
- It can start with a protocol followed by `://`, but does not have to.
- If it starts with a protocol, the host name will always be set (if the `://` is followed immediately by yet another slash, then it will be set to the empty string).
- If it starts without a protocol, it is treated as a path if the value starts with a slash (and the host will be left unset).
- If it starts without a protocol and the first character is not a slash, it will be treated as a host name, optionally followed by a slash and the path.

Changes since v3:

- Removed the superfluous empty line at the end of the added test case.

Changes since v2:

- Refactored out the `credential_from_potentially_partial_url()` function so that existing callers (except for the one we want to change) stay untouched.
- When encountering an invalid URL while parsing the config, we no longer suppress the parser's warning.
- The test now uses the file name convention `stdin`/`stdout`/`stderr` of `t/lib-credential.sh`.

Changes since v1:

- The condition when the `c->host` field is set was made more intuitive.
- The "fix grammar" commit now has Jonathan's "reviewed-by" footer.
- Inverted the meaning of the parameter `strict` and renamed it to `allow_partial_urls`, to clarify its role.
- Enhanced the commit message of the second patch to illustrate the motivation for the lenient mode a bit better.
- [Not a change] I did leave the second and the third patch separate from one another. This makes it a lot easier to follow the iteration and to keep the reviews straight: it separates the "how do we make URL parts optional?" from the "where do we need URL parts to be optional?"
- A partial URL `https://` is now correctly interpreted as having only the protocol set, but not host name nor path.
- The lenient mode is now explained a lot more verbosely in the code comment in `credential.h`.
- When skipping a config setting, we now show the config key, not just the URL (which might be incomplete, i.e. not actually a URL).
- When skipping a config setting, the correct `struct credential` is cleared (i.e. the just-parsed one, not the one against which we wanted to match the just-parsed one).
- Added a ton more partial URLs to the test, and the test now also verifies that the warning comes out all right.

Cc: Jeff King <peff@peff.net>, "brian m. carlson" <sandals@crustytoothpaste.net>, Jonathan Nieder <jrnieder@gmail.com>, Ilya Tretyakov <it@it3xl.ru>, Junio C Hamano <gitster@pobox.com>