### PR TITLE
Prepare for Homebrew changing the gettext package

### DIFF
--- a/config.mak.uname
+++ b/config.mak.uname
@@ -133,8 +133,17 @@ ifeq ($(uname_S),Darwin)
 	HAVE_BSD_SYSCTL = YesPlease
 	FREAD_READS_DIRECTORIES = UnfortunatelyYes
 	HAVE_NS_GET_EXECUTABLE_PATH = YesPlease
-	BASIC_CFLAGS += -I/usr/local/include
-	BASIC_LDFLAGS += -L/usr/local/lib
+
+	# Workaround for `gettext` being keg-only and not even being linked via
+	# `brew link --force gettext`, should be obsolete as of
+	# https://github.com/Homebrew/homebrew-core/pull/53489
+	ifeq ($(shell test -d /usr/local/opt/gettext/ && echo y),y)
+		BASIC_CFLAGS += -I/usr/local/include -I/usr/local/opt/gettext/include
+		BASIC_LDFLAGS += -L/usr/local/lib -L/usr/local/opt/gettext/lib
+		ifeq ($(shell test -x /usr/local/opt/gettext/bin/msgfmt && echo y),y)
+			MSGFMT = /usr/local/opt/gettext/bin/msgfmt
+		endif
+	endif
 endif
 ifeq ($(uname_S),SunOS)
 	NEEDS_SOCKET = YesPlease


### PR DESCRIPTION
In an early Azure Pipelines preview of what is to come, I saw the `osx-clang` and `osx-gcc` jobs fail consistently.

This patch tries to prevent that from affecting our CI/PR builds.

Changes since v1:

- Described a bit better what the issue is, and that there is a "de-keg" change that should fix this (but as we no longer call `brew update`, some build agents, that won't matter for slightly out of date agents).
- Guarded the added flags behind a check whether the directory exists in the first place.

Cc: SZEDER Gábor <szeder.dev@gmail.com>, Eric Sunshine <sunshine@sunshineco.com>, Carlo Marcelo Arenas Belón <carenas@gmail.com>