### PR TITLE
commit:fix use of uninitialized value [...] in server log

### DIFF
--- a/gitweb/README
+++ b/gitweb/README
@@ -66,5 +66,8 @@ AUTHORS
 Originally written by:
   Kay Sievers <kay.sievers@vrfy.org>
 
+Perl warning fix:
+  Raphaël Gertz <git@rapsys.eu>
+
 Any comment/question/concern to:
   Git mailing list <git@vger.kernel.org>

--- a/gitweb/gitweb.perl
+++ b/gitweb/gitweb.perl
@@ -1406,7 +1406,7 @@ sub href {
 
 		# since we destructively absorb parameters, we keep this
 		# boolean that remembers if we're handling a snapshot
-		my $is_snapshot = $params{'action'} eq 'snapshot';
+		my $is_snapshot = defined $params{'action'} && $params{'action'} eq 'snapshot';
 
 		# Summary just uses the project path URL, any other action is
 		# added to the URL
@@ -5998,7 +5998,7 @@ sub git_history_body {
 		      $cgi->a({-href => href(action=>$ftype, hash_base=>$commit, file_name=>$file_name)}, $ftype) . " | " .
 		      $cgi->a({-href => href(action=>"commitdiff", hash=>$commit)}, "commitdiff");
 
-		if ($ftype eq 'blob') {
+		if (defined $ftype && $ftype eq 'blob') {
 			print " | " .
 			      $cgi->a({-href => href(action=>"blob_plain", hash_base=>$commit, file_name=>$file_name)}, "raw");
 


### PR DESCRIPTION
This change fix the message about uninitialized value when trying to
access undefined hash indexes.

The error message fixed:
Use of uninitialized value $params{"action"} in string eq at gitweb.cgi
line 1377

Add myself as warning fix author.

Signed-off-by: Raphaël Gertz <git@rapsys.eu>