### PR TITLE
Do not skip tagged revisions in the GitHub workflow runs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
   ci-config:
     runs-on: ubuntu-latest
     outputs:
-      enabled: ${{ steps.check-ref.outputs.enabled }}
+      enabled: ${{ steps.check-ref.outputs.enabled }}${{ steps.skip-if-redundant.outputs.enabled }}
     steps:
       - name: try to clone ci-config branch
         continue-on-error: true
@@ -35,6 +35,43 @@ jobs:
             enabled=no
           fi
           echo "::set-output name=enabled::$enabled"
+      - name: skip if the commit or tree was already tested
+        id: skip-if-redundant
+        uses: actions/github-script@v3
+        if: steps.check-ref.outputs.enabled == 'yes'
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            // Figure out workflow ID, commit and tree
+            const { data: run } = await github.actions.getWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId,
+            });
+            const workflow_id = run.workflow_id;
+            const head_sha = run.head_sha;
+            const tree_id = run.head_commit.tree_id;
+
+            // See whether there is a successful run for that commit or tree
+            const { data: runs } = await github.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              per_page: 500,
+              status: 'success',
+              workflow_id,
+            });
+            for (const run of runs.workflow_runs) {
+              if (head_sha === run.head_sha) {
+                core.warning(`Successful run for the commit ${head_sha}: ${run.html_url}`);
+                core.setOutput('enabled', ' but skip');
+                break;
+              }
+              if (tree_id === run.head_commit.tree_id) {
+                core.warning(`Successful run for the tree ${tree_id}: ${run.html_url}`);
+                core.setOutput('enabled', ' but skip');
+                break;
+              }
+            }
 
   windows-build:
     needs: ci-config

--- a/ci/lib.sh
+++ b/ci/lib.sh
@@ -149,6 +149,7 @@ then
 	CI_REPO_SLUG="$GITHUB_REPOSITORY"
 	CI_JOB_ID="$GITHUB_RUN_ID"
 	CC="${CC:-gcc}"
+	DONT_SKIP_TAGS=t
 
 	cache_dir="$HOME/none"
 
@@ -167,6 +168,7 @@ good_trees_file="$cache_dir/good-trees"
 
 mkdir -p "$cache_dir"
 
+test -n "${DONT_SKIP_TAGS-}" ||
 skip_branch_tip_with_tag
 skip_good_tree
 


### PR DESCRIPTION
Whenever a GitGitGadget Pull Request is sent to the Git mailing list, a tag is pushed to gitgitgadget/git to commemorate that iteration.

The `push` event caused for that triggers the CI/PR workflow, and reveals a pretty old bug where the `windows-build` steps are skipped for tagged revisions, but the `windows-test` steps are not (and will therefore fail).

That means, of course, that every GitGitGadget PR is marked with a failed test once it is submitted.

This patch series is designed to address this issue, and is based on `am/ci-wsfix` (the initial round was based on `dd/ci-swap-azure-pipelines-with-github-actions` but would now cause merge conflicts).

Changes since v1:

- Rather than returning early from `skip_branch_tip_with_tag()`, we now skip the function call altogether when run in a GitHub workflow.
- The intention of the tag skipping was replicated by introducing another check in `ci-config`: is there a successful workflow run for the same commit (or at least for the same tree)? If yes, skip, referring to that successful run.

cc: SZEDER Gábor <szeder.dev@gmail.com>
cc: Johannes Schindelin <Johannes.Schindelin@gmx.de>