### PR TITLE
[RFC] parallel checkout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@
 /git-check-mailmap
 /git-check-ref-format
 /git-checkout
+/git-checkout--helper
 /git-checkout-index
 /git-cherry
 /git-cherry-pick

--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -88,6 +88,7 @@ TECH_DOCS += technical/multi-pack-index
 TECH_DOCS += technical/pack-format
 TECH_DOCS += technical/pack-heuristics
 TECH_DOCS += technical/pack-protocol
+TECH_DOCS += technical/parallel-checkout
 TECH_DOCS += technical/partial-clone
 TECH_DOCS += technical/protocol-capabilities
 TECH_DOCS += technical/protocol-common

--- a/Documentation/config/core.txt
+++ b/Documentation/config/core.txt
@@ -637,3 +637,8 @@ core.parallelCheckoutThreshold::
 	and process overhead.  When enabled, parallel checkout will not
 	be attempted when the number of files to be updated is less than
 	the threshold.	Defaults to 1,000 when unset or set to 0.
+
+core.parallelCheckoutHelpers::
+	The number of background `checkout--helper` processes to create.
+	Defaults to a reasonable number based upon the number of CPUs
+	when unset or set to 0.

--- a/Documentation/config/core.txt
+++ b/Documentation/config/core.txt
@@ -646,3 +646,8 @@ core.parallelCheckoutHelpers::
 core.parallelCheckoutWriters::
 	The number of writer threads to create within each `checkout--helper`
 	process.  Defaults to 1.
+
+core.parallelCheckoutPreload::
+	The number of blobs to preload into memory in each `checkout--helper`
+	process.  Increasing this and the number of writer threads may allow
+	better concurrency within each helper process.  Defaults to 10.

--- a/Documentation/config/core.txt
+++ b/Documentation/config/core.txt
@@ -629,3 +629,11 @@ core.abbrev::
 
 core.parallelCheckout::
 	A boolean to enable parallel checkout.
+
+core.parallelCheckoutThreshold::
+	Set the threshold for actually attempting a parallel checkout.
+	For checkouts only modifying a small number of files, a normal
+	(sequential) checkout should be faster because it avoids thread
+	and process overhead.  When enabled, parallel checkout will not
+	be attempted when the number of files to be updated is less than
+	the threshold.	Defaults to 1,000 when unset or set to 0.

--- a/Documentation/config/core.txt
+++ b/Documentation/config/core.txt
@@ -626,3 +626,6 @@ core.abbrev::
 	in your repository, which hopefully is enough for
 	abbreviated object names to stay unique for some time.
 	The minimum length is 4.
+
+core.parallelCheckout::
+	A boolean to enable parallel checkout.

--- a/Documentation/config/core.txt
+++ b/Documentation/config/core.txt
@@ -642,3 +642,7 @@ core.parallelCheckoutHelpers::
 	The number of background `checkout--helper` processes to create.
 	Defaults to a reasonable number based upon the number of CPUs
 	when unset or set to 0.
+
+core.parallelCheckoutWriters::
+	The number of writer threads to create within each `checkout--helper`
+	process.  Defaults to 1.

--- a/Documentation/technical/parallel-checkout.txt
+++ b/Documentation/technical/parallel-checkout.txt
@@ -1,0 +1,570 @@
+= Parallel Checkout Design Notes
+
+The "Parallel Checkout" feature attempts to use multiple processes and
+threads to improve the performance of checkout-related commands, such as
+`clone`, `checkout`, `reset`, `sparse-checkout`, and others.
+
+These commands have the following basic steps:
+
+* Step 1: Read the current `.git/index` into memory.
+
+* Step 2: Modify the in-memory index based upon the command (e.g.
+  `checkout` or `clone`) and temporarily mark all `cache-entries` that
+  need to be updated.
+
+* Step 3: Populate the worktree to match the new candidate index.
+   This includes iterating over all of the to-be-updated
+   `cache-entries` and deleting, creating, or overwriting the
+   associated files in the worktree.
+
+* Step 4: Write the new index to disk.
+
+Step 3 is the focus of the "parallel checkout" effort described here.
+It dominates the execution time for most of the above command types.
+
+== Classic Implementation
+
+For the purposes of discussion here, the current "classic"
+implementation of Step 3 has 3 layers:
+
+* Step 3a: `unpack-trees.c:check_updates()` contains a series of
+   single-threaded loops iterating over the `cache-entries` array.
+   The main loop in this function calls the next layer for each of the
+   to-be-updated entries.
+
+* Step 3b: `entry.c:checkout_entry()` examines the existing worktree
+   for file conflicts, collisions, and unsaved changes.  It creates
+   and deletes directories as necessary.  It calls the next layer for
+   each file to be created.
+   
+* Step 3c: `entry.c:write_entry()` loads the blob into memory (unzip
+   and de-deltafy), smudges it if necessary, creates the file in the
+   worktree, writes the smudged contents, calls `fstat()` or
+   `lstat()`, and updates the `cache-entry`.
+
+== Rejected Multi-Threaded Solution
+
+The "simple" solution of just spreading the set of to-be-updated
+`cache-entries` across multiple threads is not currently possible.
+All of the problems identified in <<Appendix-A>> and <<Appendix-B>>
+would need to be addressed before this could be successful.
+
+It is unclear if the additional locking overhead and complexity
+would result in any performance gains.  So this approach was rejected.
+
+== Multi-Process Solution
+
+Parallel checkout alters Step 3 to use multiple `checkout--helper`
+background processes to distribute the work.  These long-running
+processes are controlled by the foreground Git command using the
+existing sub-process mechanism.
+
+=== Overview
+
+Parallelization is based upon the following higher-level concepts:
+
+. ODB threading issues <<Appendix-B>> are eliminated by using
+  multiple background processes that each access the ODB in a
+  single-threaded manner.
+
+. A sequential iteration of the `cache_entries[]` determines
+  the set of "parallel-eligible" files.
+
+  .. Per-file smudge parameters are computed to avoid the attribute
+     stack issues described in A5.
+
+  .. Only files that have simple or no smudging requirements are
+     considered to be eligible.  File that require an external
+     filter or long-running filter process are considered not-eligible.
+     This lets us avoid A6 and A7.
+
+  .. These eligible `cache_entries` are added to a
+     `parallel_checkout_items[]` to simplify partitioning
+     and dispatching to helper processes.
+
+     ... Non-eligible files are handled sequentially using
+         the classic implementation.
+
+. Each `checkout--helper` process is assigned a set of eligible
+  files to be updated.
+
+  .. Each helper is given the `OID`, `pathname`, and smudging
+     parameters needed to create each assigned file in the worktree.
+
+     ... Each helper is able to fetch each blob, smudge them, and
+         write them to the worktree without needing to access the
+         on-disk index.
++
+This is necessary since the foreground process does not write the
+new index to disk until Step 4.  It also avoids `index.lock` contention
+issues between the foreground process and multiple helper processes.
+
+  .. Each helper directly writes files to the worktree.
++
+It can do this because it has the blob in-memory and knows the
+smudging parameters.
++
+This is unlike the delayed/queued mechanism (LFS) which returns the
+blob content to the foreground process for smudging and writing to disk.
+
+  .. Each helper calls `lstat()` or `fstat()` to get the resulting
+     `struct stat` data for each file and sends it to the
+     foreground process, so that the foreground process can update the
+     in-memory index as if it had written the file.
++     
+This avoids a possibly expensive `lstat()` in the foreground process
+(I'm looking at you, Windows) and prevents the helper processes from
+having to update the on-disk index.
+
+  .. Each helper returns error status for each file to allow the
+     foreground process to handle it in the proper context.
+
+. Each `checkout--helper` process is multi-threaded forming several
+  producer-consumer queues.
+
+  .. A *command-and-control thread* to talk with the foreground command,
+     receive the set of files, and return `struct stat`, error, and
+     progress data.
+
+  .. A *blob preload thread* to sequentially fetch blobs from the ODB
+     into a queue.  The size of the preload queue is configurable and
+     allows the 1 or more blobs to be assembled in memory before they
+     are needed.
+
+     ... Preloading can also optionally smudge the queued
+         blobs so that they are ready to be written.
+
+     ... File writing may be synchronized by the foreground process
+         as in the classic algorithm, but this thread allows the
+         blob to be ready in memory in advance of that.
+
+  .. 1 or more *writer threads* to create files in the worktree using
+     the preloaded blobs.
+
+     ... Writer threads also smudge the queued blobs if the preload
+         thread did not do so.
+
+. Files that raised an error in a `checkout--helper` are retried by the
+  foreground process when appropriate since the foreground process has
+  more context.  This allows for case-insensitive collision reporting
+  during clone, for example.
+
+=== Parallel Checkout Modes
+
+Parallel Checkout can operate in either `synchronous` or `asynchronous` mode
+depending on the type of the foreground command.
+
+==== Synchronous Mode
+
+Synchronous mode is a minimal first step at parallelizing checkout
+and tries to maintain existing classic mode semantics as much
+as possible.
+
+Its main advantage is that it distributes blob loading (de-delta
+and unzip) across multiple processes without requiring any changes
+to the ODB code.
+
+* `checkout--helper` instances each receive their file assignments of
+  parallel-eligible files.  Files are assigned in "horizontal"
+  (round-robin) fashion so that each helper has every _nth_ file in
+  the `parallel_checkout_items[]`.
+
+* The helpers begin asynchronously and sequentially preloading blobs
+  to fill their preload queue.
+
+* The helpers have a single "writer thread" and it waits for an
+  explicit `sync_write` command from the foreground process before
+  writing the next blob to the worktree.
+
+* `lstat()` data and error status is returned to the foreground
+  process to complete the synchronous request.
+
+* The foreground process uses a slightly modified version of the
+  classic algorithm where files are created one at a time in Step 3c.
+
+  ** It iterates over the full set of files to be updated.  Directly
+     handling the non-eligible ones and sending `sync_write` requests
+     to the appropriate helper process for the others.
+
+     *** This effectively iterates over the _n_ helpers because of the
+          round-robin assignment.  This improves concurrency since the
+          _n_ helpers should have already preloaded the next _n_ needed
+          blobs.
+
+     *** The foreground process `sync_write` request should only be
+         blocked for the duration actual file write into the worktree,
+         since the blob should already be preloaded and smudged.
+
+     *** However, it does mean that if the current helper is writing
+         an extremely large file, the foreground process will be
+         blocked for the duration.
+
+         **** This prevents writer threads in other helpers from
+              working because they are waiting for a `sync_write`
+              request.
+
+         **** [TODO] It might be possible to relax this and
+              interleave these `sync_write` requests.
+              See <<Appendix-F-F1>>.
+
+     *** This iteration mechanism preserves the order of operations
+         WRT the worktree and the sequence of file creations.
+
+     *** All directory creation and deletion, file deletion, and
+         collision detection is handled by the foreground process as
+         in the classic algorithm.
+
+This mode is appropriate for all commands that build upon
+`unpack-trees.c:check_updates()`, since the net effect is that
+blob loading and file writing is moved out-of-proc; everything
+else is handled by the foreground process and in the classic
+implementation sequencing.
+
+==== Asynchronous Mode
+
+Asynchronous mode attempts to fully parallelize checkout with some
+slight semantic differences.  It replaces the classic and synchronous
+mode algorithms completely and tries to create files as quickly as
+possible.
+
+In this mode:
+
+* `checkout-helper` instances receive a "vertical" set of file assignments
+  by dividing the `parallel_checkout_items[]` into _n_ contiguous chunks.
++
+This will keep helpers in their own portion of the worktree and (hopefully)
+avoid filesystem contention on individual directories.
+
+* The helpers begin asynchronously and sequentially preloading blobs
+  to fill their preload queue (as before).
+
+* The helpers have 1 or more (_m_) writer threads that compete for preloaded
+  blobs and write them to the worktree as soon as possible.
+
+  ** The helpers are responsible for creating worktree directories as necessary.
+
+  ** The helpers will not overwrite an existing file.
+
+  ** If a file is successfully created in the worktree, `lstat()` data  is
+     collected for each file for later reporting to the foreground process.
+
+* The foreground process uses a polling `async_progress` request to
+  bulk collect file results and advance the on-screen progress meter.
+
+* After all helpers have completed their assignments, the foreground
+  process sequentially handles any remaining files or errors using
+  the classic mode algorithm.
+
+This mode is appropriate for commands like `clone` and `sparse-checkout set`
+where the worktree is primarily being populated for the first time
+rather than a branch switch where most files are being overwritten.
+
+* This is because the helper refuses to overwrite an existing file, and
+  instead returns an error and expects the foreground process to handle it
+  which just wastes time.
+
+===== Asynchronous Mode Caveats
+
+* Case-insensitive collisions
+
+  ** Async mode will have upto _n * m_ threads writing files concurrently
+     and in a racy order.
++
+When there is a case-insensitive file collision in classic or sync
+mode the contents of the file on disk will match one of the file peers
+when the foreground process completes.  It is unspecified which one
+that will be, but given the sequential nature of the algorithm, the
+result is predictable.
++
+However, in async mode, all files are created in a racy order, so
+we lose the preditability.
+
+     *** One of the writer threads will win the race and report
+         success to the foreground process.  Writes to the other peer
+         files will fail because `checkout--helper` does not overwrite
+         existing files.  Errors are returned to the foreground process
+	 for each of the losing files so that it can report the
+	 collision as it does in classic mode.
+
+* File-vs-directory collisions
+
+  ** TBC...
+
+* TBC...
+
+=== Config Settings
+
+TBC...
+
+=== Test Settings
+
+TBC...
+
+[[Appendix-A]]
+== Appendix A: Classic Mode Threading Issues
+
+The following issues were discovered while investigating how to
+parallelize checkout.  There may be others.
+
+* A1: `checkout_entry()` (Step 3b) has implicit order dependencies.  A
+      sequential iteration over the array of `cache-entries` is equivalent
+      to a depth-first iteration over the directories and files listed in
+      the new in-memory index and reconciling with the worktree.  This
+      includes creating and deleting directories as necessary and handling
+      file-vs-directory collisions between the existing worktree and the
+      new in-memory index.
++
+There would be racy competition between
+multiple threads working in the same part of the worktree.
+
+* A2: `checkout_entry()` (Step 3b) handles case-insensitive collisions in
+      `clone` on Mac and Windows, such as when a Linux-created directory
+      contains both `foo` and `FOO`.
++
+The collision detection code would require a lock on the
+in-memory index to search for collision-peers (by inode) and set
+the CE_MATCHED on them.
+
+* A3: `write_entry()` (Step 3c) makes use of several subsystems (i.e. the ODB)
+      that are not thread-safe.  See <<Appendix-B>> for more details on the
+      ODB.
+
+* A4: There is a long code path between the `lstat()` in Step 3b and
+      the `open()` in Step 3c that would need a lock to avoid races with
+      other threads.
+
+* A5: The smudging rules for each file is based upon the concatentation of
+      the various `.gitattributes` file(s) in the directory path
+      containing the file.  Git maintains a stack of the open attributes
+      as the depth-first iteration walks the array of `cache-entries`.
++
+A multi-threaded solution would need to either move the stack into TLS
+data and let each worker thread manage its own stack or we would
+need to coordinate all of the worker threads to always be working in
+the same directory.
++
+Furthermore, `checkout_entry()` (Step 3b) sometimes needs to `clean`
+an existing file to ensure unsaved changes are not overwritten (in
+`ie_match_stat()`) and needs access to the attribute stack.
+
+* A6: `write_entry()` (Step 3c) might cause a file to be routed to the
+      "delayed queue", such as Git-LFS.  This is a single long-running
+      process that runs in the background to download blobs while the
+      foreground checkout continues normally for non-LFS files.  (And
+      a subsequent "retry" request completes the item.)
++
+There is only one long-running LFS process, so multi-threaded requests
+would need to be coordinated in some fashion.
+
+* A7: File smudging in `write_entry()` (Step 3c) might make use of an
+      external (one shot) `filter` or (long-running) `process filter`
+      before it can write the file to the worktree.  These filters are
+      black-boxes to Git and may have their own internal locking or
+      non-concurrent assumptions.
++
+It might not be safe to run multiple instances concurrently.
+
+[[Appendix-B]]
+== Appendix B: ODB Threading Issues
+
+During this effort, the following problems and potential problems were
+identified with the ODB.  There may be others.
+
+The ODB contains a global `packed-git` list containing the set of
+packfiles currently known to the Git process.  These will require
+detailed locking and study.
+
+This includes:
+
+* B1: The packed-git list itself which is extended as additional
+      packfiles are referenced any that may or may not have open file
+      descriptors.  A lock would be needed when extending this list.
+
+* B2: The packed-git list also contains a MRU/LRU list which defines an
+      alternate ordering of the above global list for search purposes.
+      A lock would be needed when re-ordering this list.
+
+* B3: There are config settings to limit on the number concurrently open
+      packfiles and rules for discarding/closing LRU ones.  A lock would
+      be needed when releasing resources.
+
+* B4: Likewise, there are config settings to limit size and number of
+      of active mmap regions (aka windows) on opened packfiles.
+
+* B5: Ref-counting for both packfiles and mmap regions would need to
+      be coordinated and there is a risk of deadlock when under file
+      descriptor or memory pressure with multiple threads randomly
+      accessing packfile objects.
+
+[[Appendix-C]]
+== Appendix C: Prior Efforts
+
+TBC...
+
+[[Appendix-F]]
+== Appendix F: Future Work
+
+[[Appendix-F-F1]]
+=== F1: [TODO] Interleave `sync_write`
+
+In Synchronous Mode, the foreground process sends a `sync_write` to a
+single helper and waits for the result.
+
+The writer thread in the helper writes the smudged file content to the
+worktree.  It creates a new file.  It will not overwrite an existing
+file.  After the file is closed, it returns `lstat()` data to the
+foreground process.
+
+During this time interval, other helper writer threads are idle.  (The
+blob preload threads are still active if their queues still have
+capacity.)  But the foreground process is blocked and there are no
+in-flight `sync_write` commands to the other helpers.
+
+* The main point of concern is the ordering of the file
+  creation (to preserve compatibility with the classic
+  algorithm).
+
+* If the `sync_write` request returned partial results when
+  the file was successfully created and then returned final
+  results when the file was completely written, the foreground
+  process could interleave _n_ requests without changing the
+  order of operations.
+
+* This would be most useful in cases where files are large
+  enough for the time to write the contents exceeds the
+  overhead of the extra inter-process communication (and
+  possibly threading in the foreground process).
+
+However, this might open us up to file-vs-directory and case-insensitive
+collision complications described in A1 and A2.
+
+TODO Before attempting this, measure how much time the foreground
+process is blocked waiting for `sync_write` to return and if the time
+taken by the writer thread was actually in creating, writing, closing,
+or lstat'ing the file and/or if the writer was blocked waiting for
+the blob to be loaded and smudged.
+
+[[Appendix-F-F2]]
+=== F2: [TODO] Use MIDX to sort in async mode
+
+In Asynchronous Mode, since files are populated in a racy order, the
+foreground process could sort the items in `parallel_checkout_items[]`
+based upon their packfile and offset before distributing them to the
+_n_ helper processes.  This could allow the helper processes to more
+efficiently use the virtual memory and preload blobs from the packfiles.
+
+TODO Should this only be enabled if MIDX is enabled?
+
+TODO What is the best partitioning ("vertial", "horizontal", or other)
+for assigning files to helper processes to minimize virtual memory
+contention?
+
+[[Appendix-F-F3]]
+=== F3: [TODO] Memory footprint tuning
+
+The background helpers processes are all aggressively accessing
+the ODB and may have hundreds of packfiles mmap'd.  On 64-bit
+systems, the default values for `core.packedGitWindowsSize` and
+`core.packedGitLimit` are very large.  It is quite easy for _n_
+background processes to completely consume all system memory and
+make the system unresponsive.
+
+TODO Should `parallel-checkout.c` set smaller limits for the helper
+processes (and maybe for itself too)?
+
+[[Appendix-F-F4]]
+=== F4: [TODO] Split blob preload into load and unzip phases
+
+Preliminary tests show that unzip dominates the time spent preloading
+blobs.  Can we improve the overall runtime by re-ordering some of these
+steps?
+
+When a packed object is loaded, we have to walk the delta-chain, build
+a stack of the OIDs, and then for each object in the chain: fetch it,
+unzip it, and apply the delta to the previous.
+
+We are limited to one preload thread because of locking concerns in
+the ODB.
+
+TODO Restructure the above (at the expense of using more memory)
+to fetch all of the raw objects (as stored in the ODB), unzipping them,
+and then applying the series of delta.  Only the first step would need
+the ODB lock.  The unzip operations could be done outside the lock
+(and maybe in parallel).  And finally, the de-delta step could run
+sequentially afterwards or interleaved with the unzip.
+
+TODO If successful, consider having more than one preload thread in
+asynchronous mode.
+
+[[Appendix-F-F5]]
+=== F5: [TODO] Cache existence of .gitattributes
+
+During the sequential iteration of `cache-entries` in `check_updates_loop()`,
+Git has to maintain the attribute stack.
+This is the set of "active" `.gitattribute` files that are current during
+this (effectively) depth-first walk of the tree.
+
+For example, as it iterates over the `cache_entry[]` and visits
+`a/b/c/d/e/foo.txt` it has to do binary searches on `cache_entry[]`
+for:
+
+    a/.gitattributes
+    a/b/.gitattributes
+    ...
+    a/b/c/d/e/.gitattributes
+
+The code does cache the results, so when it visits `a/b/c/d/e/foo2.txt`,
+it already has the answer.  Likewise, when it visits `a/b/x/bar.txt`,
+it pops the attribute stack for `e`, `d`, and `c`, and only has to
+lookup `a/b/x/.gitattributes`.
+
+This means that Git does a search the first time that every directory
+is visited.  For a very rarely used feature, this could save `O(d log n)`
+work.
+
+TODO Consider inserting something into a prior iteration to set a bit
+on the directory to indicate that it has a `.gitattributes` file in it.
+This would let us maintain the attribute stack without the binary searches.
+
+NOTE This needs to be in a prior iteration and not in the current
+iteration so that it can be order independent, since the repo might
+contain `a/b/c/d/e/.a.txt` that would be visited in the (sorted) index
+before `a/b/c/d/e/.gitattributes`.
+
+[[Appendix-F-F6]]
+=== F6: [TODO] Support stream smudging
+
+Currently blobs are smudged into another buffer and do not
+make use of the stream smudging mechanism.  (This was just a
+development short-cut, not an actual hard problem.)
+
+. In Synchronous Mode, this allows smudging to occur as part of the
+  preload, so that the foreground process only has to wait for the
+  pre-smudged content to be written to the worktree.
+
+. In Asynchronous Mode, writer threads do the smudging to avoid
+  slowing slowing the preload thread.
+
+TODO In Asynchronous Mode, refactor the writer thread slightly to allow
+stream smudging near the file creation and writing code.
+
+TODO In Synchronous Mode, turn off smudging in the preload thread and
+let the above refactored code handle it.
+
+[[Appendix-F-F7]]
+=== F7: [TODO] Investigate when to use Asynchronous Mode
+
+TODO Decide which commands should prefer async mode over sync mode.
+
+TBC...
+
+[[Appendix-F-F8]]
+=== F8: [TODO] Update `cache-tree` in Parallel
+
+In `unpack_trees()` after the call to `check_updates()` there is an
+optional call to `cache_tree_update()` to rebuild the `cache_tree`
+data structure.  This is very slow for some commands.
+
+In both Sync and Async Modes, it should be possible to have a thread
+in the foreground process to incrementally update the `cache_tree`
+as partial results are received from helper processes.

--- a/Makefile
+++ b/Makefile
@@ -933,6 +933,7 @@ LIB_OBJS += pack-revindex.o
 LIB_OBJS += pack-write.o
 LIB_OBJS += packfile.o
 LIB_OBJS += pager.o
+LIB_OBJS += parallel-checkout.o
 LIB_OBJS += parse-options-cb.o
 LIB_OBJS += parse-options.o
 LIB_OBJS += patch-delta.o

--- a/Makefile
+++ b/Makefile
@@ -1047,6 +1047,7 @@ BUILTIN_OBJS += builtin/check-attr.o
 BUILTIN_OBJS += builtin/check-ignore.o
 BUILTIN_OBJS += builtin/check-mailmap.o
 BUILTIN_OBJS += builtin/check-ref-format.o
+BUILTIN_OBJS += builtin/checkout--helper.o
 BUILTIN_OBJS += builtin/checkout-index.o
 BUILTIN_OBJS += builtin/checkout.o
 BUILTIN_OBJS += builtin/clean.o

--- a/builtin.h
+++ b/builtin.h
@@ -122,6 +122,7 @@ int cmd_branch(int argc, const char **argv, const char *prefix);
 int cmd_bundle(int argc, const char **argv, const char *prefix);
 int cmd_cat_file(int argc, const char **argv, const char *prefix);
 int cmd_checkout(int argc, const char **argv, const char *prefix);
+int cmd_checkout__helper(int argc, const char **argv, const char *prefix);
 int cmd_checkout_index(int argc, const char **argv, const char *prefix);
 int cmd_check_attr(int argc, const char **argv, const char *prefix);
 int cmd_check_ignore(int argc, const char **argv, const char *prefix);

--- a/builtin/checkout--helper.c
+++ b/builtin/checkout--helper.c
@@ -1,0 +1,1288 @@
+#include "builtin.h"
+#include "cache.h"
+#include "config.h"
+#include "pkt-line.h"
+#include "trace2.h"
+#include "thread-utils.h"
+#include "parse-options.h"
+#include "object-store.h"
+#include "checkout--helper.h"
+#include "json-writer.h"
+
+/*
+ * This is used as a label prefix in all error messages
+ * and in any trace2 messages to identify this child
+ * process.
+ */
+static char t2_category_name[100];
+static int child_nr = -1;
+
+/*
+ * New --> Queued --> Loading --> Loaded --> Writing --> Done
+ */
+enum item_state {
+	ITEM_STATE__NEW = 0,
+	ITEM_STATE__QUEUED,
+	ITEM_STATE__LOADING,
+	ITEM_STATE__LOADED,
+	ITEM_STATE__WRITING,
+	ITEM_STATE__DONE,
+};
+
+struct item {
+	enum item_state item_state;
+	enum checkout_helper__item_error_class item_error_class;
+	int item_errno;
+
+	/* These fields are specified by the client. */
+	int pc_item_nr;
+	int helper_item_nr;
+	struct object_id oid;
+	struct conv_attrs ca;
+	char *path;
+	int mode;
+
+	/* These fields are computed as we load and write the item. */
+	int skip;
+	int checked_smudge;
+	unsigned long content_size;
+	void *content;
+	struct stat st;
+};
+
+/*
+ * When (count > 0), this defines a range of items of the form:
+ *     [begin, end)
+ * where:
+ *     begin = (end - count)
+ *
+ * When (count == 0), this defines an empty range.
+ */
+struct item_range {
+	int count;
+	int end;
+};
+
+struct item_vec {
+	struct item **array;
+	int nr, alloc;
+};
+
+static struct item_vec item_vec;
+static struct item_range preload_range;
+
+/*
+ * The total number of items that we had errors on.
+ * The total number of items that we actually smudged.
+ *
+ * These are for tracing only.
+ */
+static int total_error_count;
+static int total_smudged_count;
+
+/*
+ * We always start writing the items in the order queued and expect
+ * the client to request them in that order.  Even when we have multiple
+ * writers, the items are pulled from the queue in that order.
+ *
+ * Therefore, we only keep track of the number of items authorized for
+ * writing and assume that everything in [0, end) is authorized.
+ *
+ * When in async mode, we set it to maxint. 
+ */
+#define ASYNC_MODE_VALUE maximum_signed_value_of_type(int)
+
+static int authorized_end;
+
+#define IS_ASYNCHRONOUS() (authorized_end == ASYNC_MODE_VALUE)
+#define IS_SYNCHRONOUS() (authorized_end != ASYNC_MODE_VALUE)
+
+/*
+ * The first item that should be returned in the next rogress request
+ * in asynch mode.
+ */
+static int progress_begin;
+
+static pthread_mutex_t main_mutex;
+static pthread_t preload_thread;
+static pthread_t *writer_thread_pool;
+
+/*
+ * Dynamic count of the number of busy writers.
+ *
+ * This is mainly for debugging, but does allow us to avoid sending
+ * a pthread signal when we already know all the writers are busy.
+ */
+static int nr_active_writers;
+
+static pthread_cond_t preload_cond;
+static pthread_cond_t writer_cond;
+static pthread_cond_t done_cond;
+
+static int in_shutdown;
+
+/*
+ * If we have spare cycles and plenty of memory, we should be able to
+ * keep n items (blob contents) in memory at all times.  This value
+ * was chosen at random.  It only needs to be large enough to keep the
+ * writer thread(s) from stalling while waiting for the preload thread
+ * to load a blob from the ODB.
+ *
+ * TODO Consider making this more flexible, such as being based on sum
+ * of the content sizes of all currently loaded blobs.  Or make it a
+ * function of the number of writer threads.
+ */
+static int preload_range_limit = DEFAULT_PARALLEL_CHECKOUT_PRELOAD;
+
+/*
+ * Number of writer threads in the thread pool.
+ *
+ * The size of the thread pool is a function of what type of checkout
+ * being attempted.  For example, a clone into an empty worktree should
+ * be able to write n files in parallel without worrying about stepping
+ * on uncommitted changes; whereas a branch switch might need to be more
+ * careful and populate files sequentially.
+ */
+static int writer_thread_pool_size = DEFAULT_PARALLEL_CHECKOUT_WRITERS;
+
+/*
+ * Allow verbose trace2 logging when this environment variable is set.
+ * This is primarily for the test suite to let us confirm that checkout--helper
+ * actually did the work.
+ *
+ * These brackets are somewhat arbitrary.
+ */
+#define TEST_VERBOSE_LEVEL__OFF           0
+#define TEST_VERBOSE_LEVEL__ERRORS        1
+#define TEST_VERBOSE_LEVEL__VERBOSE       2
+#define TEST_VERBOSE_LEVEL__VERY_VERBOSE  3
+
+static int test_verbose = TEST_VERBOSE_LEVEL__OFF;
+
+static void set_test_verbose(void)
+{
+	const char *value = getenv("GIT_TEST_CHECKOUT_HELPER_VERBOSE");
+
+	if (!trace2_is_enabled())
+		return;
+
+	if (value) {
+		int ivalue = strtol(value, NULL, 10);
+		if (ivalue > 0)
+			test_verbose = ivalue;
+	}
+}
+
+#define KV(kv)     #kv, kv
+#define KPV(p, kv) #kv, p->kv
+
+static void verbose_super_prefixed_path(struct json_writer *jw, const char *path)
+{
+	const char *super_prefix = get_super_prefix();
+
+	if (super_prefix) {
+		struct strbuf buf = STRBUF_INIT;
+
+		strbuf_addstr(&buf, super_prefix);
+		strbuf_addstr(&buf, path);
+
+		jw_object_string(jw, "super_path", buf.buf);
+
+		strbuf_release(&buf);
+	}
+}
+
+static void verbose_log_queued(const struct item *item)
+{
+	struct json_writer jw = JSON_WRITER_INIT;
+	const char *oid = oid_to_hex(&item->oid);
+	const struct conv_attrs *ca = &item->ca;
+
+	jw_object_begin(&jw, 0);
+	jw_object_intmax(&jw, KPV(item, helper_item_nr));
+	jw_object_intmax(&jw, KPV(item, pc_item_nr));
+	jw_object_intmax(&jw, KPV(item, mode));
+	jw_object_string(&jw, KV(oid));
+	jw_object_string(&jw, KPV(item, path));
+	jw_object_inline_begin_object(&jw, "ca");
+	jw_object_intmax(&jw, KPV(ca, attr_action));
+	jw_object_intmax(&jw, KPV(ca, crlf_action));
+	if (ca->working_tree_encoding)
+		jw_object_string(&jw, KPV(ca, working_tree_encoding));
+	jw_end(&jw);
+	jw_end(&jw);
+
+	trace2_data_json(t2_category_name, NULL, "queued", &jw);
+	jw_release(&jw);
+}
+
+static void verbose_log_preload_failed(const struct item *item)
+{
+	struct json_writer jw = JSON_WRITER_INIT;
+	const char *oid = oid_to_hex(&item->oid);
+
+	jw_object_begin(&jw, 0);
+	jw_object_intmax(&jw, KPV(item, helper_item_nr));
+	jw_object_string(&jw, KV(oid));
+	jw_object_string(&jw, KPV(item, path));
+	jw_end(&jw);
+
+	trace2_data_json(t2_category_name, NULL, "preload_failed", &jw);
+	jw_release(&jw);
+}
+
+static void verbose_log_preloaded(const struct item *item)
+{
+	struct json_writer jw = JSON_WRITER_INIT;
+	const char *oid = oid_to_hex(&item->oid);
+	intmax_t size = item->content_size;
+
+	jw_object_begin(&jw, 0);
+	jw_object_intmax(&jw, KPV(item, helper_item_nr));
+	jw_object_string(&jw, KV(oid));
+	jw_object_intmax(&jw, KV(size));
+	jw_object_string(&jw, KPV(item, path));
+	jw_end(&jw);
+
+	trace2_data_json(t2_category_name, NULL, "preloaded", &jw);
+	jw_release(&jw);
+}
+
+static void verbose_log_smudged(intmax_t helper_item_nr,
+				intmax_t old_size,
+				intmax_t new_size,
+				const char *path)
+{
+	struct json_writer jw = JSON_WRITER_INIT;
+
+	jw_object_begin(&jw, 0);
+	jw_object_intmax(&jw, KV(helper_item_nr));
+	jw_object_intmax(&jw, KV(old_size));
+	jw_object_intmax(&jw, KV(new_size));
+	jw_object_string(&jw, KV(path));
+	verbose_super_prefixed_path(&jw, path);
+	jw_end(&jw);
+
+	trace2_data_json(t2_category_name, NULL, "smudged", &jw);
+	jw_release(&jw);
+}
+
+static void verbose_log_writing(intmax_t helper_item_nr, const char *path)
+{
+	struct json_writer jw = JSON_WRITER_INIT;
+
+	jw_object_begin(&jw, 0);
+	jw_object_intmax(&jw, KV(helper_item_nr));
+	jw_object_string(&jw, KV(path));
+	verbose_super_prefixed_path(&jw, path);
+	jw_end(&jw);
+
+	trace2_data_json(t2_category_name, NULL, "writing", &jw);
+	jw_release(&jw);
+}
+
+static void verbose_log_open_failed(intmax_t helper_item_nr,
+				    intmax_t item_errno,
+				    const char *path)
+{
+	struct json_writer jw = JSON_WRITER_INIT;
+
+	jw_object_begin(&jw, 0);
+	jw_object_intmax(&jw, KV(helper_item_nr));
+	jw_object_intmax(&jw, KV(item_errno));
+	jw_object_string(&jw, KV(path));
+	verbose_super_prefixed_path(&jw, path);
+	jw_end(&jw);
+
+	trace2_data_json(t2_category_name, NULL, "open_failed", &jw);
+	jw_release(&jw);
+}
+
+static struct item *alloc_item(int pc_item_nr, int helper_item_nr, int mode,
+			       int attr, int crlf, int ident,
+			       const struct object_id *oid,
+			       char *encoding, char *path)
+{
+	struct item *item = xcalloc(1, sizeof(*item));
+
+	item->item_state = ITEM_STATE__NEW;
+	item->item_error_class = IEC__OK;
+	item->item_errno = 0;
+
+	item->pc_item_nr = pc_item_nr;
+	item->helper_item_nr = helper_item_nr;
+	item->mode = mode;
+	item->ca.attr_action = attr;
+	item->ca.crlf_action = crlf;
+	item->ca.ident = ident;
+	oidcpy(&item->oid, oid);
+	item->ca.working_tree_encoding = encoding;
+	item->path = path;
+
+	return item;
+}
+
+static void free_item(struct item *item)
+{
+	if (!item)
+		return;
+
+	free((char *)item->ca.working_tree_encoding);
+	free(item->path);
+	free(item->content);
+	free(item);
+}
+
+static void free_item_vec(void)
+{
+	/* ASSUME ON MAIN THREAD */
+
+	int k;
+
+	assert(in_shutdown); /* so no locking required */
+
+	for (k = 0; k < item_vec.nr; k++)
+		free_item(item_vec.array[k]);
+
+	FREE_AND_NULL(item_vec.array);
+	item_vec.nr = 0;
+	item_vec.alloc = 0;
+}
+
+static void item_vec_append(struct item *item)
+{
+	/* ASSUME ON MAIN THREAD */
+
+	pthread_mutex_lock(&main_mutex);
+
+	/*
+	 * As a sanity check, we require the client send us an
+	 * helper_item_nr for each item.  This value will later be
+	 * used by the client to receive status for the item.  To
+	 * avoid building yet another fancy/expensive lookup table, we
+	 * require this to be a simple integer matching the item's row
+	 * number in our vector.
+	 */
+	if (item->helper_item_nr != item_vec.nr)
+		BUG("invalid helper_item_nr (%d (exp %d)) for '%s'",
+		    item->helper_item_nr, item_vec.nr, item->path);
+
+	ALLOC_GROW(item_vec.array, item_vec.nr + 1, item_vec.alloc);
+	item_vec.array[item_vec.nr++] = item;
+
+	item->item_state = ITEM_STATE__QUEUED;
+
+	/*
+	 * We have a new item in the item queue, but don't bother
+	 * sending a pthread signal if we already know that the
+	 * preload read is busy and not blocked.  (We know that
+	 * because it hasn't filled its preload quota yet.)
+	 */
+	if (preload_range.count < preload_range_limit)
+	    pthread_cond_signal(&preload_cond);
+
+	pthread_mutex_unlock(&main_mutex);
+}
+
+/*
+ * Return the first item not marked DONE.
+ *
+ * Our caller can report results to the client process for
+ * the DONE items in [begin, <rval>).
+ *
+ * We take the lock while quickly scanning the item array.
+ * This gives us a snapshot of the set of DONE items.  Our
+ * caller should report that set and not try to get clever
+ * by repeatedly locking/unlocking/spinning.
+ */
+static int progress_first_not_done(void)
+{
+	/* ASSUME ON MAIN THREAD */
+
+	int k;
+
+	assert(IS_ASYNCHRONOUS());
+
+	pthread_mutex_lock(&main_mutex);
+
+	for (k = progress_begin; k < item_vec.nr; k++) {
+		if (item_vec.array[k]->item_state != ITEM_STATE__DONE)
+			break;
+	}
+
+	pthread_mutex_unlock(&main_mutex);
+
+	return k;
+}
+
+/*
+ * Load the contents of a blob into memory in the preload background
+ * thread.  Fill in the content and length, but otherwise do not alter
+ * the item state.
+ */
+static enum checkout_helper__item_error_class preload_get_item(struct item *item)
+{
+	/* ASSUME ON PRELOAD THREAD */
+	/* ASSERT NO LOCK HELD */
+
+	struct object_info oi = OBJECT_INFO_INIT;
+	enum object_type type;
+
+	oi.typep = &type;
+	oi.sizep = &item->content_size;
+	oi.contentp = &item->content;
+
+	if (oid_object_info_extended(the_repository, &item->oid, &oi, 0) < 0) {
+		if (test_verbose >= TEST_VERBOSE_LEVEL__ERRORS)
+			verbose_log_preload_failed(item);
+
+		return IEC__LOAD;
+	}
+
+	if (test_verbose >= TEST_VERBOSE_LEVEL__VERY_VERBOSE)
+		verbose_log_preloaded(item);
+
+	return IEC__OK;
+}
+
+struct my_create_file_data {
+	struct item *item;
+	int fd;
+};
+
+static int my_create_file_cb(const char *path, void *cb)
+{
+	struct my_create_file_data *d = (struct my_create_file_data *)cb;
+	unsigned int mode = d->item->mode & 0100 ? 0777 : 0666;
+
+	d->fd = open(d->item->path, O_WRONLY | O_CREAT | O_EXCL, mode);
+
+	return d->fd < 0;
+}
+
+static int do_smudge_item(struct item *item)
+{
+	unsigned long original_size = item->content_size;
+	size_t smudged_size;
+	struct strbuf nbuf = STRBUF_INIT;
+	enum conv_attrs_classification c = classify_conv_attrs(&item->ca);
+	int did_smudge = 0;
+
+	if (item->checked_smudge)
+		return 0;
+
+	/*
+	 * Note [1]:
+	 * In `item->path` we have the composed pathname (base_dir +
+	 * ce->name) and use it to populate the file.  However, the
+	 * code in `apply_filter` and `convert_to_working_tree` assume
+	 * they have just the ce->name.  But the smudge code only uses
+	 * `apply_filter` when a filter or process driver is defined.
+	 * Since those files are not "eligible", we do not have to care
+	 * about the distinction between `item->path` and `ce->name`.
+	 */
+	assert(!item->ca.drv);
+	assert(c != CA_CLASS_INCORE_FILTER);
+	assert(c != CA_CLASS_INCORE_PROCESS);
+
+	/*
+	 * See CA_CLASS_STREAMABLE.
+	 *
+	 * We always use `convert_to_working_tree_ca` to do in-core
+	 * smudging and do not attempt to use `get_stream_filter_ca`
+	 * to stream filter it.
+	 *
+	 * In synch mode, the whole point is to preload the blob into
+	 * memory and have the contents available for writing to the
+	 * worktree as soon as the foreground process is ready for it.
+	 * So we let the preload thread also pre-smudge it.  This lets
+	 * us only block the foreground process for the duration of
+	 * the actual open/write/close.  This implies that we can't
+	 * stream it.
+	 *
+	 * In asynch mode, the whole point is to have n writers trying
+	 * to populate the worktree as fast as possible.  Smudging is
+	 * thread-safe, so we let the writer threads do the work
+	 * rather the preload thread.  Therefore, it should be
+	 * possible to stream filter or in-core filter them.
+	 *
+	 * TODO investigate optional stream filtering when in
+	 * asynch mode.
+	 */
+
+	// TODO The parallel-checkout code was being written while
+	// TODO the checkout-metadata was being added.  During my
+	// TODO rebase/merge I ignored the meta data args.  IIUC
+	// TODO they are only used to give filter processes context.
+	// TODO Since parallel-checkout considers such filtered files
+	// TODO as not parallel-eligible, I do not think we need for
+	// TODO parallel-checkout.c to pass the meta data to the helper.
+	// TODO And we should just pass NULL here.
+	// TODO
+	// TODO Confirm my understanding of this.
+
+	if (convert_to_working_tree_ca(&item->ca, item->path, /* See [1] */
+				       item->content, original_size,
+				       &nbuf, NULL)) {
+		did_smudge = 1;
+
+		free(item->content);
+		item->content = strbuf_detach(&nbuf, &smudged_size);
+		item->content_size = (unsigned long)smudged_size;
+
+		if (test_verbose >= TEST_VERBOSE_LEVEL__VERBOSE)
+			verbose_log_smudged(item->helper_item_nr,
+					    original_size, smudged_size,
+					    item->path);
+	}
+
+	item->checked_smudge = 1;
+
+	strbuf_release(&nbuf);
+
+	return did_smudge;
+}
+
+static enum checkout_helper__item_error_class write_item_to_disk(struct item *item)
+{
+	/* ASSUME ON WRITER[x] THREAD */
+	/* ASSERT NO LOCK HELD */
+
+	enum checkout_helper__item_error_class iec = IEC__OK;
+	int did_fstat = 0;
+	struct my_create_file_data d = { item, -1 };
+
+	/*
+	 * We don't care if the item was actually smudged, but only that
+	 * either the preload or the writer thread did try to smudge it.
+	 */
+	assert(item->checked_smudge);
+
+	if (test_verbose >= TEST_VERBOSE_LEVEL__VERY_VERBOSE)
+		verbose_log_writing(item->helper_item_nr, item->path);
+
+	if (raceproof_create_file(item->path, my_create_file_cb, &d)) {
+		item->item_errno = errno;
+
+		if (test_verbose >= TEST_VERBOSE_LEVEL__ERRORS)
+			verbose_log_open_failed(item->helper_item_nr,
+						item->item_errno,
+						item->path);
+
+		iec = IEC__OPEN;
+		goto done;
+	}
+
+	assert(d.fd != -1);
+
+	if (write_in_full(d.fd, item->content, item->content_size) < 0) {
+		item->item_errno = errno;
+		iec = IEC__WRITE;
+
+		close(d.fd);
+		goto done;
+	}
+
+	if (fstat_is_reliable())
+		did_fstat = (fstat(d.fd, &item->st) == 0);
+
+	close(d.fd);
+
+	if (!did_fstat && lstat(item->path, &item->st) < 0) {
+		item->item_errno = errno;
+		iec = IEC__LSTAT;
+		goto done;
+	}
+
+done:
+	FREE_AND_NULL(item->content);
+
+	return iec;
+}
+
+static void *preload_thread_proc(void *_data)
+{
+	struct item *item;
+	enum checkout_helper__item_error_class iec;
+	int did_smudge;
+
+	trace2_thread_start("preload");
+
+	pthread_mutex_lock(&main_mutex);
+	while (1) {
+		if (in_shutdown)
+			break;
+
+		if (preload_range.end >= item_vec.nr ||
+		    preload_range.count >= preload_range_limit) {
+			/*
+			 * We've reached the current end of the queued
+			 * items or we've filled our quota of
+			 * in-memory blobs.  Wait for either condition
+			 * to change before we try to preload another
+			 * item.
+			 */
+			pthread_cond_wait(&preload_cond, &main_mutex);
+			continue;
+		}
+
+		item = item_vec.array[preload_range.end];
+
+		assert(item->item_state == ITEM_STATE__QUEUED);
+		if (!item->skip) {
+			item->item_state = ITEM_STATE__LOADING;
+
+			pthread_mutex_unlock(&main_mutex);
+
+			iec = preload_get_item(item);
+
+			/* When SYNC go ahead and smudge it now. */
+			did_smudge = (iec == IEC__OK &&
+				      IS_SYNCHRONOUS() &&
+				      do_smudge_item(item));
+
+			pthread_mutex_lock(&main_mutex);
+
+			total_smudged_count += did_smudge;
+			item->item_error_class = iec;
+		}
+
+		/*
+		 * Regardless of error/success of reading the blob,
+		 * we mark the item as loaded and include it in
+		 * our range because we want to keep a contiguous
+		 * series of rows "logically" in this state for quota
+		 * purposes.
+		 */
+		item->item_state = ITEM_STATE__LOADED;
+		preload_range.end++;
+		preload_range.count++;
+
+		if (nr_active_writers != writer_thread_pool_size)
+			pthread_cond_signal(&writer_cond);
+	}
+	pthread_mutex_unlock(&main_mutex);
+
+	trace2_thread_exit();
+	return NULL;
+}
+
+static void *writer_thread_proc(void *_data)
+{
+	struct item *item;
+	enum checkout_helper__item_error_class iec;
+	int helper_item_nr;
+	int did_smudge;
+
+	trace2_thread_start("writer");
+
+	pthread_mutex_lock(&main_mutex);
+	while (1) {
+		if (in_shutdown)
+			break;
+
+		if (!preload_range.count) {
+			/*
+			 * There are no preloaded items currently
+			 * ready in memory.
+			 */
+			pthread_cond_wait(&writer_cond, &main_mutex);
+			continue;
+		}
+
+		/* Get the first preloaded item (ready for writing). */
+		helper_item_nr = preload_range.end - preload_range.count;
+		if (IS_SYNCHRONOUS() &&
+		    helper_item_nr >= authorized_end) {
+			/*
+			 * In sync-mode, we must wait for the foreground
+			 * process to request this item be written.
+			 */
+			pthread_cond_wait(&writer_cond, &main_mutex);
+			continue;
+		}
+
+		item = item_vec.array[helper_item_nr];
+		assert(item->item_state == ITEM_STATE__LOADED);
+
+		/*
+		 * Remove it from the beginning of the preload range
+		 * and let the preload thread know that there is quota
+		 * space is available so that it can start preloading
+		 * the next blob while we write this one.
+		 */
+		preload_range.count--;
+		pthread_cond_signal(&preload_cond);
+
+		/*
+		 * Only if the item was successfully loaded into
+		 * memory do we try to write it to the worktree.
+		 * Otherwise, we just forward it to the done range.
+		 */
+		if (!item->skip && item->item_error_class == IEC__OK) {
+			item->item_state = ITEM_STATE__WRITING;
+
+			nr_active_writers++;
+
+			pthread_mutex_unlock(&main_mutex);
+
+			did_smudge = do_smudge_item(item);
+			iec = write_item_to_disk(item);
+
+			pthread_mutex_lock(&main_mutex);
+
+			nr_active_writers--;
+			total_smudged_count += did_smudge;
+			item->item_error_class = iec;
+		}
+
+		if (item->item_error_class != IEC__OK)
+			total_error_count++;
+
+		/*
+		 * Mark the item DONE.
+		 *
+		 * From this point forward we treat this item as read-only.
+		 */
+		item->item_state = ITEM_STATE__DONE;
+
+		/*
+		 * Signal the main thread than we have results for an item.
+		 */
+		pthread_cond_signal(&done_cond);
+	}
+	pthread_mutex_unlock(&main_mutex);
+
+	trace2_thread_exit();
+	return NULL;
+}
+
+typedef int (fn_helper_cmd)(void);
+
+struct helper_capability {
+	const char *name;
+	int client_has;
+	fn_helper_cmd *pfn_helper_cmd;
+};
+
+/*
+ * Receive data for an array of items and add them to the item_vec
+ * queue.
+ *
+ * We expect:
+ *     command=<cmd>
+ *     <binary 'checkout_helper__queue_item_record + variant-data' for item k>
+ *     <binary 'checkout_helper__queue_item_record + variant-data' for item k+1>
+ *     <binary 'checkout_helper__queue_item_record + variant-data' for item k+2>
+ *     ...
+ *     <flush>
+ *
+ * We do not send a response.
+ *
+ * The client process is free to send one big batch or to send
+ * multiple batches of items.
+ */
+static int helper_cmd__queue(void)
+{
+	struct item *item = NULL;
+	char *data_line;
+	int len;
+	struct checkout_helper__queue_item_record fixed_fields;
+	char *variant;
+	char *encoding;
+	char *name;
+
+	while (1) {
+		len = packet_read_line_gently(0, NULL, &data_line);
+		if (len < 0 || !data_line)
+			break;
+
+		if (len < sizeof(struct checkout_helper__queue_item_record))
+			BUG("%s[queue]: record too short (obs %d, exp %d)",
+			    t2_category_name, len, (int)sizeof(fixed_fields));
+
+		/*
+		 * memcpy the fixed portion into a proper structure to
+		 * guarantee memory alignment.
+		 */
+		memcpy(&fixed_fields, data_line,
+		       sizeof(struct checkout_helper__queue_item_record));
+
+		variant = data_line + sizeof(fixed_fields);
+		if (fixed_fields.len_encoding_name) {
+			encoding = xmemdupz(variant,
+					    fixed_fields.len_encoding_name);
+			variant += fixed_fields.len_encoding_name;
+		} else
+			encoding = NULL;
+
+		name = xmemdupz(variant, fixed_fields.len_name);
+
+		item = alloc_item(fixed_fields.pc_item_nr,
+				  fixed_fields.helper_item_nr,
+				  fixed_fields.ce_mode,
+				  fixed_fields.attr_action,
+				  fixed_fields.crlf_action,
+				  fixed_fields.ident,
+				  &fixed_fields.oid,
+				  encoding,
+				  name);
+		item_vec_append(item);
+
+		if (test_verbose >= TEST_VERBOSE_LEVEL__VERY_VERBOSE)
+			verbose_log_queued(item);
+	}
+
+	return 0;
+}
+
+static void send_1_item(const struct item *item, int helper_item_nr)
+{
+	/* ASSERT NO LOCK REQUIRED (because item is DONE) */
+
+	struct checkout_helper__item_result r;
+
+	memset(&r, 0, sizeof(r));
+	if (!item) {
+		r.helper_item_nr = helper_item_nr;
+		r.pc_item_nr = -1;
+		r.item_error_class = IEC__INVALID_ITEM;
+	} else {
+		assert(item->helper_item_nr == helper_item_nr);
+
+		r.helper_item_nr = item->helper_item_nr;
+		r.pc_item_nr = item->pc_item_nr;
+		r.item_error_class = item->item_error_class;
+		r.item_errno = item->item_errno;
+		r.st = item->st;
+	}
+
+	packet_write(1, (const char *)&r, sizeof(r));
+}
+
+/*
+ * This command verb is used by the client (foreground) process to
+ * request incremental progress reports and results from this helper
+ * process.
+ *
+ * We respond with the results for zero or more completed items (since
+ * the previous progress report).  A response with zero items just
+ * means that there are no new results since the last request.  The
+ * client knows how many items were assigned to this helper process
+ * and should keep polling until it receives results for all of them.
+ *
+ * We expect:
+ *     command=<cmd>
+ *     <flush>
+ *
+ * We respond:
+ *     [<result_k>
+ *      [<result_k+1>
+ *       [...]]]
+ *     <flush>
+ *
+ * This version always sends the full set of newly completed items.
+ * [] It does not wait or have a timeout to accumulate a minimum number
+ *    of items.
+ * [] It does not have a maximum number of items (chunk size) parameter.
+ * The assumption is that the client process is polling over 1 or more
+ * helper processes (and displaying console progress) and needs to
+ * control such things.  So for simplicity, we have omitted such things
+ * for now.
+ */
+static int helper_cmd__async_progress(void)
+{
+	char *data_line;
+	int len;
+	int end;
+	int k;
+
+	assert(IS_ASYNCHRONOUS());
+
+	/*
+	 * Eat the flush packet.  Since we currently don't expect any
+	 * parameters, eat them too.
+	 */
+	while (1) {
+		len = packet_read_line_gently(0, NULL, &data_line);
+		if (len < 0 || !data_line)
+			break;
+	}
+
+	end = progress_first_not_done();
+
+	/*
+	 * All items in contiguous range [begin, end) are marked DONE
+	 * and are treated as read-only.  Therefore, we can access them
+	 * without holding the lock.
+	 */
+	for (k = progress_begin; k < end; k++)
+		send_1_item(item_vec.array[k], k);
+
+	/*
+	 * The next progress response will start where we left off.
+	 */
+	progress_begin = end;
+
+	return packet_flush_gently(1);
+}
+
+static struct item *do_sync_write(int helper_item_nr)
+{
+	/* ASSUME ON MAIN THREAD */
+
+	struct item *item;
+	int k;
+
+	pthread_mutex_lock(&main_mutex);
+
+	if (helper_item_nr >= item_vec.nr) {
+		/* Cause an IEC__INVALID_ITEM to be returned to client. */
+		pthread_mutex_unlock(&main_mutex);
+		return NULL;
+	}
+
+	assert(authorized_end <= helper_item_nr);
+
+	/*
+	 * In sync mode "authorized_end" means that the files in the range
+	 * [0, end) have already been written and individual results sent
+	 * back to the client.
+	 *
+	 * Anything in the range [end, helper_item_nr) should be skipped.
+	 *
+	 * And we should wait for helper_item_nr to be written (by
+	 * extending the range just past this item).
+	 *
+	 * To minimize thread problems, we just set the "skip" bit on
+	 * the items that we don't want and leave the state unchanged
+	 * and keep it queued as it is.  Our background threads will
+	 * see this bit before they start processing the item and
+	 * short-cut the work and advance the item to the next state.
+	 */
+	for (k = authorized_end; k < helper_item_nr; k++) {
+		item_vec.array[k]->skip = 1;
+		authorized_end++;
+		pthread_cond_signal(&writer_cond);
+	}
+
+	authorized_end = helper_item_nr + 1;
+	pthread_cond_signal(&writer_cond);
+
+	item = item_vec.array[helper_item_nr];
+	while (item->item_state != ITEM_STATE__DONE)
+		pthread_cond_wait(&done_cond, &main_mutex);
+
+	pthread_mutex_unlock(&main_mutex);
+
+	return item;
+}
+
+/*
+ * This command verb is used by the client (foreground) process to
+ * request that we try to write a single item to the worktree and
+ * return the result.  This is only used when in sync mode and not
+ * in async mode.
+ *
+ * We require that the client request items in the order that they
+ * were queued (because that is how we have preloaded the blobs (and
+ * is the whole point of this exercise)).
+ *
+ * If the client skips an item, we assume that the skipped items
+ * should be discarded.  In entry.c:checkout_entry() there are several
+ * early returns that avoid calling entry.c:write_entry() and we
+ * assume that is the reason for the skip.
+ *
+ * We expect:
+ *     command=<cmd>
+ *     <binary 'checkout_helper__synch__write_record' for item k>
+ *     <flush>
+ *
+ * We respond with:
+ *     <result_k>
+ *     <flush>
+ */
+static int helper_cmd__sync_write(void)
+{
+	char *data_line;
+	int len;
+	struct checkout_helper__sync__write_record rec;
+	struct item *item;
+
+	assert(IS_SYNCHRONOUS());
+
+	len = packet_read_line_gently(0, NULL, &data_line);
+	if (len != sizeof(rec) || !data_line)
+		BUG("%s[sync_write]: invalid data-line", t2_category_name);
+	memcpy(&rec, data_line, sizeof(rec));
+
+	/* Eat the flush packet (and any other unexpected data lines). */
+	while (1) {
+		len = packet_read_line_gently(0, NULL, &data_line);
+		if (len < 0 || !data_line)
+			break;
+	}
+
+	item = do_sync_write(rec.helper_item_nr);
+	send_1_item(item, rec.helper_item_nr);
+
+	return packet_flush_gently(1);
+}
+
+static struct helper_capability caps[] = {
+	{ "queue",          0, helper_cmd__queue },
+	{ "async_progress", 0, helper_cmd__async_progress },
+	{ "sync_write",     0, helper_cmd__sync_write },
+	{ NULL, 0, NULL },
+};
+
+/*
+ * Handle the subprocess protocol handshake as described in:
+ * [] Documentation/technical/protocol-common.txt
+ * [] Documentation/technical/long-running-process-protocol.txt
+ *
+ * Return 1 if we have a protocol error.
+ */
+static int do_protocol_handshake(void)
+{
+#define OUR_SUBPROCESS_VERSION "1"
+
+	char *line;
+	int len;
+	int k;
+	int b_support_our_version = 0;
+
+	len = packet_read_line_gently(0, NULL, &line);
+	if (len < 0 || !line || strcmp(line, "checkout--helper-client")) {
+		error("server: subprocess welcome handshake failed: %s", line);
+		return 1;
+	}
+
+	while (1) {
+		const char *v;
+		len = packet_read_line_gently(0, NULL, &line);
+		if (len < 0 || !line)
+			break;
+		if (!skip_prefix(line, "version=", &v)) {
+			error("server: subprocess version handshake failed: %s",
+			      line);
+			return 1;
+		}
+		b_support_our_version |= (!strcmp(v, OUR_SUBPROCESS_VERSION));
+	}
+	if (!b_support_our_version) {
+		error("server: client does not support our version: %s",
+		      OUR_SUBPROCESS_VERSION);
+		return 1;
+	}
+
+	if (packet_write_fmt_gently(1, "checkout--helper-server\n") ||
+	    packet_write_fmt_gently(1, "version=%s\n",
+				    OUR_SUBPROCESS_VERSION) ||
+	    packet_flush_gently(1)) {
+		error("server: cannot write version handshake");
+		return 1;
+	}
+
+	while (1) {
+		const char *v;
+		int k;
+
+		len = packet_read_line_gently(0, NULL, &line);
+		if (len < 0 || !line)
+			break;
+		if (!skip_prefix(line, "capability=", &v)) {
+			error("server: subprocess capability handshake failed: %s",
+			      line);
+			return 1;
+		}
+		for (k = 0; caps[k].name; k++)
+			if (!strcmp(v, caps[k].name))
+				caps[k].client_has = 1;
+	}
+
+	for (k = 0; caps[k].name; k++)
+		if (caps[k].client_has)
+			if (packet_write_fmt_gently(1, "capability=%s\n",
+						    caps[k].name)) {
+				error("server: cannot write capabilities handshake: %s",
+				      caps[k].name);
+				return 1;
+			}
+	if (packet_flush_gently(1)) {
+		error("server: cannot write capabilities handshake");
+		return 1;
+	}
+
+	return 0;
+}
+
+static int server_loop(void)
+{
+	char *line;
+	const char *cmd;
+	int len;
+	int k;
+
+get_next_command:
+	len = packet_read_line_gently(0, NULL, &line);
+	if (len < 0 || !line)
+		return 0;
+
+	if (!skip_prefix(line, "command=", &cmd)) {
+		error("%s: invalid sequence '%s'", t2_category_name, line);
+		return 1;
+	}
+
+	for (k = 0; caps[k].name; k++) {
+		if (!strcmp(cmd, caps[k].name)) {
+			if (!caps[k].client_has) {
+				/*
+				 * The client sent a command that it didn't
+				 * claim that it understood.
+				 */
+				error("%s: invalid command '%s'",
+				      t2_category_name, line);
+				return 1;
+			}
+
+			if ((caps[k].pfn_helper_cmd)())
+				return 1;
+
+			goto get_next_command;
+		}
+	}
+
+	/* The server doesn't know about this command. */
+	error("%s: unsupported command '%s'", t2_category_name, line);
+	return 1;
+}
+
+static const char * const checkout_helper_usage[] = {
+	N_("git checkout-helper [<options>]"),
+	NULL
+};
+
+int cmd_checkout__helper(int argc, const char **argv, const char *prefix)
+{
+	int err = 0;
+	int w;
+	int b_asynchronous = 0;
+
+	struct option checkout_helper_options[] = {
+		OPT_INTEGER(0, "child", &child_nr, N_("child number")),
+		OPT_INTEGER('l', "preload", &preload_range_limit,
+			    N_("preload limit")),
+		OPT_INTEGER('w', "writers", &writer_thread_pool_size,
+			    N_("number of concurrent writers")),
+		OPT_BOOL('a', "asynch", &b_asynchronous,
+			 N_("asynchronously write files")),
+		OPT_END()
+	};
+
+	if (argc == 2 && !strcmp(argv[1], "-h"))
+		usage_with_options(checkout_helper_usage,
+				   checkout_helper_options);
+
+	preload_range_limit = core_parallel_checkout_preload;
+	writer_thread_pool_size = core_parallel_checkout_writers;
+
+	git_config(git_default_config, NULL);
+	argc = parse_options(argc, argv, prefix, checkout_helper_options,
+			     checkout_helper_usage, 0);
+
+	if (preload_range_limit < 1)
+		preload_range_limit = DEFAULT_PARALLEL_CHECKOUT_PRELOAD;
+	if (writer_thread_pool_size < 1)
+		writer_thread_pool_size = DEFAULT_PARALLEL_CHECKOUT_WRITERS;
+
+	if (b_asynchronous) {
+		authorized_end = ASYNC_MODE_VALUE;
+		trace2_cmd_mode("asynch");
+	} else {
+		trace2_cmd_mode("synch");
+	}
+
+	/*
+	 * Override the packed-git memory limits.
+	 *
+	 * The defaults for a 64 bit platform are too big on gigantic
+	 * repositories because we might 500GB of packfiles linger in
+	 * memory.  And if we also have _n_ `checkout_helper` processes
+	 * running in parallel, it can overload system memory.
+	 *
+	 * TODO Revisit how we override these 2 parameters.  It helps
+	 * keep _n_ helper processes from using 99+% of system memory
+	 * and making the machine almost non-responsive, but we should
+	 * tune this better.  These values were chosen because they are
+	 * the 32 bit defaults.  Perhaps pass them as command line args
+	 * so that parallel-checkout.c can set them based upon the total
+	 * number of helpers that it starts.
+	 */
+	if (packed_git_window_size > (1024L * 1024L * 32L))
+		packed_git_window_size = 1024L * 1024L * 32L;
+	if (packed_git_limit > (1024L * 1024L * 1024L))
+		packed_git_limit = 1024L * 1024L * 1024L;
+
+	trace2_data_intmax(t2_category_name, NULL, "packed/window",
+			   packed_git_window_size);
+	trace2_data_intmax(t2_category_name, NULL, "packed/limit",
+			   packed_git_limit);
+
+	set_test_verbose();
+
+	writer_thread_pool = xcalloc(writer_thread_pool_size,
+				     sizeof(pthread_t));
+
+	snprintf(t2_category_name, sizeof(t2_category_name),
+		 "helper[%02d]", child_nr);
+	packet_trace_identity(t2_category_name);
+
+	trace2_data_intmax(t2_category_name, NULL, "param/preload",
+			   preload_range_limit);
+	trace2_data_intmax(t2_category_name, NULL, "param/writers",
+			   writer_thread_pool_size);
+
+	if (do_protocol_handshake())
+		return 1;
+
+	pthread_mutex_init(&main_mutex, NULL);
+	pthread_cond_init(&preload_cond, NULL);
+	pthread_cond_init(&writer_cond, NULL);
+	pthread_cond_init(&done_cond, NULL);
+	pthread_create(&preload_thread, NULL, preload_thread_proc, NULL);
+	for (w = 0; w < writer_thread_pool_size; w++)
+		pthread_create(&writer_thread_pool[w], NULL,
+			       writer_thread_proc, NULL);
+
+	err = server_loop();
+
+	pthread_mutex_lock(&main_mutex);
+	in_shutdown = 1;
+	pthread_cond_signal(&preload_cond);
+	pthread_cond_broadcast(&writer_cond);
+	pthread_mutex_unlock(&main_mutex);
+
+	pthread_join(preload_thread, NULL);
+	for (w = 0; w < writer_thread_pool_size; w++)
+	    pthread_join(writer_thread_pool[w], NULL);
+
+	pthread_cond_destroy(&preload_cond);
+	pthread_cond_destroy(&writer_cond);
+	pthread_cond_destroy(&done_cond);
+	pthread_mutex_destroy(&main_mutex);
+
+	fflush(stderr);
+
+	trace2_data_intmax(t2_category_name, NULL, "item/count", item_vec.nr);
+	if (total_smudged_count)
+		trace2_data_intmax(t2_category_name, NULL, "item/smudge_count",
+				   total_smudged_count);
+	if (total_error_count)
+		trace2_data_intmax(t2_category_name, NULL, "item/error_count",
+				   total_error_count);
+
+	free_item_vec();
+
+	return err;
+}

--- a/cache-tree.c
+++ b/cache-tree.c
@@ -6,6 +6,7 @@
 #include "object-store.h"
 #include "replace-object.h"
 #include "promisor-remote.h"
+#include "trace2.h"
 
 #ifndef DEBUG_CACHE_TREE
 #define DEBUG_CACHE_TREE 0
@@ -733,10 +734,14 @@ void prime_cache_tree(struct repository *r,
 		      struct index_state *istate,
 		      struct tree *tree)
 {
+	trace2_region_enter("cache_tree", "prime", NULL);
+
 	cache_tree_free(&istate->cache_tree);
 	istate->cache_tree = cache_tree();
 	prime_cache_tree_rec(r, istate->cache_tree, tree);
 	istate->cache_changed |= CACHE_TREE_CHANGED;
+
+	trace2_region_leave("cache_tree", "prime", NULL);
 }
 
 /*

--- a/cache.h
+++ b/cache.h
@@ -975,6 +975,8 @@ extern int core_parallel_checkout;
 
 extern int core_parallel_checkout_threshold;
 
+extern int core_parallel_checkout_helpers;
+
 /*
  * Include broken refs in all ref iterations, which will
  * generally choke dangerous operations rather than letting

--- a/cache.h
+++ b/cache.h
@@ -966,6 +966,16 @@ extern int core_sparse_checkout_cone;
 extern int core_parallel_checkout;
 
 /*
+ * Default threshold for actually attempting a parallel checkout.
+ * This is an arbitrarily chosen value to account for thread and
+ * process overhead.  We assume that we need to modify more than
+ * this number of files to make it worth the extra effort.
+ */
+#define DEFAULT_PARALLEL_CHECKOUT_THRESHOLD 1000
+
+extern int core_parallel_checkout_threshold;
+
+/*
  * Include broken refs in all ref iterations, which will
  * generally choke dangerous operations rather than letting
  * them silently proceed without taking the broken ref into

--- a/cache.h
+++ b/cache.h
@@ -977,6 +977,9 @@ extern int core_parallel_checkout_threshold;
 
 extern int core_parallel_checkout_helpers;
 
+#define DEFAULT_PARALLEL_CHECKOUT_WRITERS 1
+extern int core_parallel_checkout_writers;
+
 /*
  * Include broken refs in all ref iterations, which will
  * generally choke dangerous operations rather than letting

--- a/cache.h
+++ b/cache.h
@@ -980,6 +980,9 @@ extern int core_parallel_checkout_helpers;
 #define DEFAULT_PARALLEL_CHECKOUT_WRITERS 1
 extern int core_parallel_checkout_writers;
 
+#define DEFAULT_PARALLEL_CHECKOUT_PRELOAD 10
+extern int core_parallel_checkout_preload;
+
 /*
  * Include broken refs in all ref iterations, which will
  * generally choke dangerous operations rather than letting

--- a/cache.h
+++ b/cache.h
@@ -963,6 +963,8 @@ extern const char *core_fsmonitor;
 extern int core_apply_sparse_checkout;
 extern int core_sparse_checkout_cone;
 
+extern int core_parallel_checkout;
+
 /*
  * Include broken refs in all ref iterations, which will
  * generally choke dangerous operations rather than letting

--- a/cache.h
+++ b/cache.h
@@ -148,6 +148,7 @@ struct cache_entry {
 	unsigned int ce_namelen;
 	unsigned int index;	/* for link extension */
 	struct object_id oid;
+	void *parallel_checkout_item; /* we do not own this */
 	char name[FLEX_ARRAY]; /* more */
 };
 
@@ -963,6 +964,10 @@ extern const char *core_fsmonitor;
 extern int core_apply_sparse_checkout;
 extern int core_sparse_checkout_cone;
 
+/*
+ * Set from core.parallelCheckout.
+ * See also GIT_TEST_PARALLEL_CHECKOUT.
+ */
 extern int core_parallel_checkout;
 
 /*
@@ -973,6 +978,10 @@ extern int core_parallel_checkout;
  */
 #define DEFAULT_PARALLEL_CHECKOUT_THRESHOLD 1000
 
+/*
+ * Set from core.parallelCheckoutThreshold.
+ * See also GIT_TEST_PARALLEL_CHECKOUT_THRESHOLD.
+ */
 extern int core_parallel_checkout_threshold;
 
 extern int core_parallel_checkout_helpers;
@@ -1719,6 +1728,7 @@ struct checkout {
 	int base_dir_len;
 	struct delayed_checkout *delayed_checkout;
 	struct checkout_metadata meta;
+	struct parallel_checkout *parallel_checkout;
 	unsigned force:1,
 		 quiet:1,
 		 not_new:1,

--- a/checkout--helper.h
+++ b/checkout--helper.h
@@ -1,0 +1,72 @@
+#ifndef CHECKOUT_HELPER_H
+#define CHECKOUT_HELPER_H
+
+#include "cache.h"
+
+/*
+ * Record format used by parallel-checkout.c to describe in item
+ * when queuing it to a checkout--helper process.  This is the
+ * fixed portion of the record.  Following it will be 2 strings:
+ * the encoding and the pathname.  These are NOT null terminated
+ * (since we have the exact lengths in the fixed-portion of the
+ * record).
+ */
+struct checkout_helper__queue_item_record {
+	uint32_t pc_item_nr;
+	uint32_t helper_item_nr;
+	uint32_t ce_mode;
+	uint32_t attr_action;
+	uint32_t crlf_action;
+	uint32_t ident;
+	uint32_t len_name;
+	uint32_t len_encoding_name;
+	struct object_id oid;
+};
+
+/*
+ * Record format used by parallel-checkout.c to request a synchronous
+ * write of an item.
+ */
+struct checkout_helper__sync__write_record {
+	uint32_t helper_item_nr;
+};
+
+/*
+ * The individual operation that failed within a `checkout--helper`
+ * request.
+ *
+ * Conceptually, this is half of a { <class>, <errno> } tuple.
+ */
+enum checkout_helper__item_error_class {
+	IEC__NO_RESULT = 0, /* no result from helper process (yet) */
+	IEC__INVALID_ITEM, /* helper does not know about this item */
+	IEC__OK,
+	IEC__LOAD, /* helper could not load blob into memory */
+	IEC__OPEN, /* helper could not create the file, see item_errno */
+	IEC__WRITE,
+	IEC__LSTAT,
+};
+
+/*
+ * `checkout--helper` can aysnchronously load the blob associated
+ * with an OID into memory, smudge it, write it to a requested
+ * pathname in the worktree, lstat() the new file, and later
+ * respond to the foreground process with the aggregate result.
+ *
+ * This is the fixed-width fixed-field response from `checkout--helper`
+ * for a single item.
+ *
+ * Encode the enum fields as fixed-width integers for portability
+ * and alignment.
+ *
+ * See `checkout--helper.c:send_1_item()`.
+ */
+struct checkout_helper__item_result {
+	uint32_t pc_item_nr;
+	uint32_t helper_item_nr;
+	uint32_t item_error_class; /* enum checkout_helper__item_error_class */
+	uint32_t item_errno;
+	struct stat st;
+};
+
+#endif /* CHECKOUT_HELPER_H */

--- a/config.c
+++ b/config.c
@@ -1416,6 +1416,13 @@ static int git_default_core_config(const char *var, const char *value, void *cb)
 		return 0;
 	}
 
+	if (!strcmp(var, "core.parallelcheckouthelpers")) {
+		int x = git_config_int(var, value);
+		if (x > 0)
+			core_parallel_checkout_helpers = x;
+		return 0;
+	}
+
 	/* Add other config variables here and to Documentation/config.txt. */
 	return platform_core_config(var, value, cb);
 }

--- a/config.c
+++ b/config.c
@@ -1409,6 +1409,13 @@ static int git_default_core_config(const char *var, const char *value, void *cb)
 		return 0;
 	}
 
+	if (!strcmp(var, "core.parallelcheckoutthreshold")) {
+		int x = git_config_int(var, value);
+		core_parallel_checkout_threshold =
+			(x > 0) ? x : DEFAULT_PARALLEL_CHECKOUT_THRESHOLD;
+		return 0;
+	}
+
 	/* Add other config variables here and to Documentation/config.txt. */
 	return platform_core_config(var, value, cb);
 }

--- a/config.c
+++ b/config.c
@@ -1423,6 +1423,13 @@ static int git_default_core_config(const char *var, const char *value, void *cb)
 		return 0;
 	}
 
+	if (!strcmp(var, "core.parallelcheckoutwriters")) {
+		int x = git_config_int(var, value);
+		if (x > 0)
+			core_parallel_checkout_writers = x;
+		return 0;
+	}
+
 	/* Add other config variables here and to Documentation/config.txt. */
 	return platform_core_config(var, value, cb);
 }

--- a/config.c
+++ b/config.c
@@ -1430,6 +1430,13 @@ static int git_default_core_config(const char *var, const char *value, void *cb)
 		return 0;
 	}
 
+	if (!strcmp(var, "core.parallelcheckoutpreload")) {
+		int x = git_config_int(var, value);
+		if (x > 0)
+			core_parallel_checkout_preload = x;
+		return 0;
+	}
+
 	/* Add other config variables here and to Documentation/config.txt. */
 	return platform_core_config(var, value, cb);
 }

--- a/config.c
+++ b/config.c
@@ -1404,6 +1404,11 @@ static int git_default_core_config(const char *var, const char *value, void *cb)
 		return 0;
 	}
 
+	if (!strcmp(var, "core.parallelcheckout")) {
+		core_parallel_checkout = git_config_bool(var, value);
+		return 0;
+	}
+
 	/* Add other config variables here and to Documentation/config.txt. */
 	return platform_core_config(var, value, cb);
 }

--- a/convert.c
+++ b/convert.c
@@ -2029,3 +2029,22 @@ void clone_checkout_metadata(struct checkout_metadata *dst,
 	if (blob)
 		oidcpy(&dst->blob, blob);
 }
+
+enum conv_attrs_classification classify_conv_attrs(
+	const struct conv_attrs *ca)
+{
+	if (ca->drv) {
+		if (ca->drv->process)
+			return CA_CLASS_INCORE_PROCESS;
+		if (ca->drv->smudge || ca->drv->clean)
+			return CA_CLASS_INCORE_FILTER;
+	}
+
+	if (ca->working_tree_encoding)
+		return CA_CLASS_INCORE;
+
+	if (ca->crlf_action == CRLF_AUTO || ca->crlf_action == CRLF_AUTO_CRLF)
+		return CA_CLASS_INCORE;
+
+	return CA_CLASS_STREAMABLE;
+}

--- a/convert.c
+++ b/convert.c
@@ -1973,22 +1973,30 @@ struct stream_filter *get_stream_filter(const struct index_state *istate,
 					const struct object_id *oid)
 {
 	struct conv_attrs ca;
-	struct stream_filter *filter = NULL;
 
 	convert_attrs(istate, &ca, path);
-	if (ca.drv && (ca.drv->process || ca.drv->smudge || ca.drv->clean))
+
+	return get_stream_filter_ca(&ca, oid);
+}
+
+struct stream_filter *get_stream_filter_ca(const struct conv_attrs *ca,
+					   const struct object_id *oid)
+{
+	struct stream_filter *filter = NULL;
+
+	if (ca->drv && (ca->drv->process || ca->drv->smudge || ca->drv->clean))
 		return NULL;
 
-	if (ca.working_tree_encoding)
+	if (ca->working_tree_encoding)
 		return NULL;
 
-	if (ca.crlf_action == CRLF_AUTO || ca.crlf_action == CRLF_AUTO_CRLF)
+	if (ca->crlf_action == CRLF_AUTO || ca->crlf_action == CRLF_AUTO_CRLF)
 		return NULL;
 
-	if (ca.ident)
+	if (ca->ident)
 		filter = ident_filter(oid);
 
-	if (output_eol(ca.crlf_action) == EOL_CRLF)
+	if (output_eol(ca->crlf_action) == EOL_CRLF)
 		filter = cascade_filter(filter, lf_to_crlf_filter());
 	else
 		filter = cascade_filter(filter, &null_filter_singleton);

--- a/convert.c
+++ b/convert.c
@@ -1291,8 +1291,8 @@ static int git_path_check_ident(struct attr_check_item *check)
 
 static struct attr_check *check;
 
-static void convert_attrs(const struct index_state *istate,
-			  struct conv_attrs *ca, const char *path)
+void convert_attrs(const struct index_state *istate,
+		   struct conv_attrs *ca, const char *path)
 {
 	struct attr_check_item *ccheck = NULL;
 

--- a/convert.c
+++ b/convert.c
@@ -1450,19 +1450,16 @@ void convert_to_git_filter_fd(const struct index_state *istate,
 	ident_to_git(dst->buf, dst->len, dst, ca.ident);
 }
 
-static int convert_to_working_tree_internal(const struct index_state *istate,
-					    const char *path, const char *src,
-					    size_t len, struct strbuf *dst,
-					    int normalizing,
-					    const struct checkout_metadata *meta,
-					    struct delayed_checkout *dco)
+static int convert_to_working_tree_internal_ca(const struct conv_attrs *ca,
+					       const char *path, const char *src,
+					       size_t len, struct strbuf *dst,
+					       int normalizing,
+					       const struct checkout_metadata *meta,
+					       struct delayed_checkout *dco)
 {
 	int ret = 0, ret_filter = 0;
-	struct conv_attrs ca;
 
-	convert_attrs(istate, &ca, path);
-
-	ret |= ident_to_worktree(src, len, dst, ca.ident);
+	ret |= ident_to_worktree(src, len, dst, ca->ident);
 	if (ret) {
 		src = dst->buf;
 		len = dst->len;
@@ -1472,26 +1469,41 @@ static int convert_to_working_tree_internal(const struct index_state *istate,
 	 * is a smudge or process filter (even if the process filter doesn't
 	 * support smudge).  The filters might expect CRLFs.
 	 */
-	if ((ca.drv && (ca.drv->smudge || ca.drv->process)) || !normalizing) {
-		ret |= crlf_to_worktree(src, len, dst, ca.crlf_action);
+	if ((ca->drv && (ca->drv->smudge || ca->drv->process)) || !normalizing) {
+		ret |= crlf_to_worktree(src, len, dst, ca->crlf_action);
 		if (ret) {
 			src = dst->buf;
 			len = dst->len;
 		}
 	}
 
-	ret |= encode_to_worktree(path, src, len, dst, ca.working_tree_encoding);
+	ret |= encode_to_worktree(path, src, len, dst, ca->working_tree_encoding);
 	if (ret) {
 		src = dst->buf;
 		len = dst->len;
 	}
 
 	ret_filter = apply_filter(
-		path, src, len, -1, dst, ca.drv, CAP_SMUDGE, meta, dco);
-	if (!ret_filter && ca.drv && ca.drv->required)
-		die(_("%s: smudge filter %s failed"), path, ca.drv->name);
+		path, src, len, -1, dst, ca->drv, CAP_SMUDGE, meta, dco);
+	if (!ret_filter && ca->drv && ca->drv->required)
+		die(_("%s: smudge filter %s failed"), path, ca->drv->name);
 
 	return ret | ret_filter;
+}
+
+static int convert_to_working_tree_internal(const struct index_state *istate,
+					    const char *path, const char *src,
+					    size_t len, struct strbuf *dst,
+					    int normalizing,
+					    const struct checkout_metadata *meta,
+					    struct delayed_checkout *dco)
+{
+	struct conv_attrs ca;
+
+	convert_attrs(istate, &ca, path);
+
+	return convert_to_working_tree_internal_ca(&ca, path, src, len, dst,
+						   normalizing, meta, dco);
 }
 
 int async_convert_to_working_tree(const struct index_state *istate,

--- a/convert.c
+++ b/convert.c
@@ -1523,6 +1523,14 @@ int convert_to_working_tree(const struct index_state *istate,
 	return convert_to_working_tree_internal(istate, path, src, len, dst, 0, meta, NULL);
 }
 
+int convert_to_working_tree_ca(const struct conv_attrs *ca,
+			       const char *path, const char *src,
+			       size_t len, struct strbuf *dst,
+			       const struct checkout_metadata *meta)
+{
+	return convert_to_working_tree_internal_ca(ca, path, src, len, dst, 0, meta, NULL);
+}
+
 int renormalize_buffer(const struct index_state *istate, const char *path,
 		       const char *src, size_t len, struct strbuf *dst)
 {

--- a/convert.c
+++ b/convert.c
@@ -24,17 +24,6 @@
 #define CONVERT_STAT_BITS_TXT_CRLF  0x2
 #define CONVERT_STAT_BITS_BIN       0x4
 
-enum crlf_action {
-	CRLF_UNDEFINED,
-	CRLF_BINARY,
-	CRLF_TEXT,
-	CRLF_TEXT_INPUT,
-	CRLF_TEXT_CRLF,
-	CRLF_AUTO,
-	CRLF_AUTO_INPUT,
-	CRLF_AUTO_CRLF
-};
-
 struct text_stat {
 	/* NUL, CR, LF and CRLF counts */
 	unsigned nul, lonecr, lonelf, crlf;
@@ -1299,14 +1288,6 @@ static int git_path_check_ident(struct attr_check_item *check)
 
 	return !!ATTR_TRUE(value);
 }
-
-struct conv_attrs {
-	struct convert_driver *drv;
-	enum crlf_action attr_action; /* What attr says */
-	enum crlf_action crlf_action; /* When no attr is set, use core.autocrlf */
-	int ident;
-	const char *working_tree_encoding; /* Supported encoding or default encoding if NULL */
-};
 
 static struct attr_check *check;
 

--- a/convert.h
+++ b/convert.h
@@ -123,6 +123,9 @@ void convert_to_git_filter_fd(const struct index_state *istate,
 int would_convert_to_git_filter_fd(const struct index_state *istate,
 				   const char *path);
 
+void convert_attrs(const struct index_state *istate,
+		   struct conv_attrs *ca, const char *path);
+
 /*
  * Initialize the checkout metadata with the given values.  Any argument may be
  * NULL if it is not applicable.  The treeish should be a commit if that is

--- a/convert.h
+++ b/convert.h
@@ -161,6 +161,8 @@ void reset_parsed_attributes(void);
 
 struct stream_filter; /* opaque */
 
+struct stream_filter *get_stream_filter_ca(const struct conv_attrs *ca,
+					   const struct object_id *oid);
 struct stream_filter *get_stream_filter(const struct index_state *istate,
 					const char *path,
 					const struct object_id *);

--- a/convert.h
+++ b/convert.h
@@ -100,6 +100,10 @@ int convert_to_working_tree(const struct index_state *istate,
 			    const char *path, const char *src,
 			    size_t len, struct strbuf *dst,
 			    const struct checkout_metadata *meta);
+int convert_to_working_tree_ca(const struct conv_attrs *ca,
+			       const char *path, const char *src,
+			       size_t len, struct strbuf *dst,
+			       const struct checkout_metadata *meta);
 int async_convert_to_working_tree(const struct index_state *istate,
 				  const char *path, const char *src,
 				  size_t len, struct strbuf *dst,

--- a/convert.h
+++ b/convert.h
@@ -37,6 +37,27 @@ enum eol {
 #endif
 };
 
+enum crlf_action {
+	CRLF_UNDEFINED,
+	CRLF_BINARY,
+	CRLF_TEXT,
+	CRLF_TEXT_INPUT,
+	CRLF_TEXT_CRLF,
+	CRLF_AUTO,
+	CRLF_AUTO_INPUT,
+	CRLF_AUTO_CRLF
+};
+
+struct convert_driver;
+
+struct conv_attrs {
+	struct convert_driver *drv;
+	enum crlf_action attr_action; /* What attr says */
+	enum crlf_action crlf_action; /* When no attr is set, use core.autocrlf */
+	int ident;
+	const char *working_tree_encoding; /* Supported encoding or default encoding if NULL */
+};
+
 enum ce_delay_state {
 	CE_NO_DELAY = 0,
 	CE_CAN_DELAY = 1,

--- a/convert.h
+++ b/convert.h
@@ -183,4 +183,37 @@ int stream_filter(struct stream_filter *,
 		  const char *input, size_t *isize_p,
 		  char *output, size_t *osize_p);
 
+enum conv_attrs_classification {
+	/*
+	 * The blob must be loaded into a buffer before it can be
+	 * smudged.  All smudging is done in-proc.
+	 */
+	CA_CLASS_INCORE,
+
+	/*
+	 * The blob must be loaded into a buffer, but uses a
+	 * single-file driver filter, such as rot13.
+	 */
+	CA_CLASS_INCORE_FILTER,
+
+	/*
+	 * The blob must be loaed into a buffer, but uses a
+	 * long-running driver process, such as LFS.  This might or
+	 * might not use delayed operations.  (The important thing is
+	 * that there is a single subordinate long-running process
+	 * handling all associated blobs and in case of delayed
+	 * operations, may hold per-blob state.)
+	 */
+	CA_CLASS_INCORE_PROCESS,
+
+	/*
+	 * The blob can be streamed and smudged without needing to
+	 * completely read it into a buffer.
+	 */
+	CA_CLASS_STREAMABLE,
+};
+
+enum conv_attrs_classification classify_conv_attrs(
+	const struct conv_attrs *ca);
+
 #endif /* CONVERT_H */

--- a/environment.c
+++ b/environment.c
@@ -69,6 +69,7 @@ int grafts_replace_parents = 1;
 int core_apply_sparse_checkout;
 int core_sparse_checkout_cone;
 int core_parallel_checkout;
+int core_parallel_checkout_threshold = DEFAULT_PARALLEL_CHECKOUT_THRESHOLD;
 int merge_log_config = -1;
 int precomposed_unicode = -1; /* see probe_utf8_pathname_composition() */
 unsigned long pack_size_limit_cfg;

--- a/environment.c
+++ b/environment.c
@@ -71,6 +71,7 @@ int core_sparse_checkout_cone;
 int core_parallel_checkout;
 int core_parallel_checkout_threshold = DEFAULT_PARALLEL_CHECKOUT_THRESHOLD;
 int core_parallel_checkout_helpers;
+int core_parallel_checkout_writers = DEFAULT_PARALLEL_CHECKOUT_WRITERS;
 int merge_log_config = -1;
 int precomposed_unicode = -1; /* see probe_utf8_pathname_composition() */
 unsigned long pack_size_limit_cfg;

--- a/environment.c
+++ b/environment.c
@@ -72,6 +72,7 @@ int core_parallel_checkout;
 int core_parallel_checkout_threshold = DEFAULT_PARALLEL_CHECKOUT_THRESHOLD;
 int core_parallel_checkout_helpers;
 int core_parallel_checkout_writers = DEFAULT_PARALLEL_CHECKOUT_WRITERS;
+int core_parallel_checkout_preload = DEFAULT_PARALLEL_CHECKOUT_PRELOAD;
 int merge_log_config = -1;
 int precomposed_unicode = -1; /* see probe_utf8_pathname_composition() */
 unsigned long pack_size_limit_cfg;

--- a/environment.c
+++ b/environment.c
@@ -68,6 +68,7 @@ char *notes_ref_name;
 int grafts_replace_parents = 1;
 int core_apply_sparse_checkout;
 int core_sparse_checkout_cone;
+int core_parallel_checkout;
 int merge_log_config = -1;
 int precomposed_unicode = -1; /* see probe_utf8_pathname_composition() */
 unsigned long pack_size_limit_cfg;

--- a/environment.c
+++ b/environment.c
@@ -70,6 +70,7 @@ int core_apply_sparse_checkout;
 int core_sparse_checkout_cone;
 int core_parallel_checkout;
 int core_parallel_checkout_threshold = DEFAULT_PARALLEL_CHECKOUT_THRESHOLD;
+int core_parallel_checkout_helpers;
 int merge_log_config = -1;
 int precomposed_unicode = -1; /* see probe_utf8_pathname_composition() */
 unsigned long pack_size_limit_cfg;

--- a/git.c
+++ b/git.c
@@ -483,6 +483,7 @@ static struct cmd_struct commands[] = {
 	{ "check-mailmap", cmd_check_mailmap, RUN_SETUP },
 	{ "check-ref-format", cmd_check_ref_format, NO_PARSEOPT  },
 	{ "checkout", cmd_checkout, RUN_SETUP | NEED_WORK_TREE },
+	{ "checkout--helper", cmd_checkout__helper, RUN_SETUP | SUPPORT_SUPER_PREFIX },
 	{ "checkout-index", cmd_checkout_index,
 		RUN_SETUP | NEED_WORK_TREE},
 	{ "cherry", cmd_cherry, RUN_SETUP },

--- a/parallel-checkout.c
+++ b/parallel-checkout.c
@@ -1,0 +1,1363 @@
+#include "cache.h"
+#include "blob.h"
+#include "object-store.h"
+#include "dir.h"
+#include "streaming.h"
+#include "submodule.h"
+#include "progress.h"
+#include "fsmonitor.h"
+#include "argv-array.h"
+#include "pkt-line.h"
+#include "quote.h"
+#include "sigchain.h"
+#include "sub-process.h"
+#include "trace2.h"
+#include "parallel-checkout.h"
+#include "checkout--helper.h"
+#include "thread-utils.h"
+#include "unpack-trees.h"
+
+int is_eligible_for_parallel_checkout(const struct conv_attrs *ca)
+{
+	enum conv_attrs_classification c = classify_conv_attrs(ca);
+
+	switch (c) {
+	default:
+		BUG("unsupported conv_attrs classification '%d'", c);
+		return 0;
+
+	case CA_CLASS_INCORE:
+		return 1;
+
+	case CA_CLASS_INCORE_FILTER:
+		/*
+		 * It would be safe to allow concurrent instances of
+		 * single-file smudge filters, like rot13, but we should
+		 * not assume that all filters are parallel-process safe.
+		 * So we don't allow this.
+		 */
+		return 0;
+
+	case CA_CLASS_INCORE_PROCESS:
+		/*
+		 * The parallel queue and the delayed queue are not
+		 * compatible and must be keep completely separate.
+		 * So "process" filtered items are not eligible for
+		 * parallel checkout.
+		 *
+		 * The process filter may return the blob content on the
+		 * initial request or it may return a "delayed" response
+		 * and not return the blob content until the CE_RETRY
+		 * request.  And we can't tell which without actually
+		 * asking the long-running process filter to do it.
+		 *
+		 * Furthermore, there should only be one instance of
+		 * the long-running process filter because we don't know
+		 * how it is managing its own concurrency.  And if we
+		 * spread the parallel queue across multiple threads or
+		 * processes, each would need to talk to their own
+		 * instance of the process filter and that could cause
+		 * problems.
+		 */
+		return 0;
+
+	case CA_CLASS_STREAMABLE:
+		return 1;
+	}
+}
+
+enum helper_spread_model {
+	/*
+	 * Spread the parallel-eligible items "horizontally" across
+	 * all of the helper processes.  For example, if we have h=10
+	 * helpers, helper[k] will receive {k, k+10, k+20, ...}.
+	 *
+	 * This should help spread the work of preloading the first h
+	 * blobs from the ODB as quickly as possible and should help
+	 * when sequentially populating the working directory.
+	 */
+	HSM__HORIZONTAL = 0,
+
+	/*
+	 * Spread the parallel-eligible items "vertically" across all
+	 * of the helper processes.  This is the normal way to slice
+	 * the array of items.
+	 *
+	 * This may help reduce kernel lock contention on individual
+	 * directories when populating items in a fully-parallel fashion
+	 * since helpers should be in different parts of the working
+	 * directory and (usually) not competing to add files to the
+	 * same sub-directory.
+	 */
+	HSM__VERTICAL,
+};
+
+static int nr_helper_processes_wanted;
+static int nr_writer_threads;
+static int nr_preloads;
+
+static int helper_pool_initialized;
+
+struct helper_process {
+	struct subprocess_entry subprocess; /* must be first */
+	unsigned int supported_capabilities;
+
+	/* the number of items sent to this helper */
+	int helper_item_count;
+
+	/* the number of items for which we've received results */
+	int helper_result_count;
+
+	/* don't try to talk to helper again after an IO error */
+	int helper_is_dead_to_us;
+};
+
+struct helper_pool {
+	/* we do not own the pointers within the array */
+	struct helper_process **array;
+	int nr, alloc;
+};
+
+/*
+ * The subprocess facility requires a hashmap to manage the children,
+ * but I want an array to directly access a particular child, so we
+ * have both a helper_pool and a helper_pool_map.  The map owns the
+ * pointers.
+ */
+static struct helper_pool helper_pool;
+static struct hashmap helper_pool_map;
+
+struct parallel_checkout_item {
+	/*
+	 * Back pointer to the cache_entry in istate->cache[].
+	 * We do not own this.
+	 */
+	struct cache_entry *ce;
+
+	struct conv_attrs ca;
+
+	/*
+	 * The position of this item within parallel_checkout.items[].
+	 * (It may not match the position in index.cache_entries[]
+	 * because not all cache-entries are "eligible" for parallel
+	 * checkout.
+	 */
+	int pc_item_nr;
+	/*
+	 * The number of the child helper process that we queued this item to.
+	 */
+	int child_nr;
+	/*
+	 * The item number that the child process knows it as.  This is a
+	 * contiguous series WRT that child.
+	 */
+	int helper_item_nr;
+
+	/*
+	 * Used in asynch mode to indicate that the progress meter has
+	 * been advanced for this item.  Usually, this means that the helper
+	 * has successfully populated the item.  (Or where there's a hard
+	 * error such that the classic code fallback wouldn't help.)
+	 *
+	 * Usually this is set when the CE_UPDATE bit is turned off.
+	 */
+	unsigned progress_claimed:1;
+
+	/*
+	 * Remember the error type and value received from the helper.
+	 */
+	enum checkout_helper__item_error_class item_error_class;
+	int item_errno;
+};
+
+struct parallel_checkout {
+	struct parallel_checkout_item **items;
+	int nr, alloc;
+	struct strbuf base_dir;
+	enum parallel_checkout_mode pcm;
+	enum helper_spread_model hsm;
+};
+
+int is_parallel_checkout_mode(const struct checkout *state,
+			      enum parallel_checkout_mode mode)
+{
+	if (!state->parallel_checkout)
+		return mode == PCM__NONE;
+
+	return state->parallel_checkout->pcm == mode;
+}
+
+static void free_parallel_checkout_item(struct parallel_checkout_item *item)
+{
+	if (!item)
+		return;
+
+	free((char *)item->ca.working_tree_encoding);
+	free(item);
+}
+
+static void free_parallel_checkout(struct parallel_checkout *pc)
+{
+	int k;
+
+	if (!pc)
+		return;
+
+	for (k = 0; k < pc->nr; k++)
+		free_parallel_checkout_item(pc->items[k]);
+
+	strbuf_release(&pc->base_dir);
+
+	free(pc);
+}
+
+/*
+ * Print an error message describing why the helper associated with
+ * this item could not create the file.  This lets the foreground
+ * process control the ordering of messages to better match the
+ * order from the classic (sequential) version.
+ */
+static void parallel_checkout__print_helper_error(
+	struct parallel_checkout_item *item)
+{
+	switch (item->item_error_class) {
+	case IEC__NO_RESULT:
+	case IEC__OK:
+		return;
+
+	case IEC__INVALID_ITEM:
+		/*
+		 * We asked helper[k] for an item that we did not send it.
+		 */
+		error("Invalid item for helper[%d] '%s'",
+		      item->child_nr, item->ce->name);
+		return;
+
+	case IEC__LOAD:
+		error("error loading blob for '%s': %s",
+		      item->ce->name, strerror(item->item_errno));
+		return;
+
+	case IEC__OPEN:
+		error("error creating file '%s': %s",
+		      item->ce->name, strerror(item->item_errno));
+		return;
+
+	case IEC__WRITE:
+		error("error writing to file '%s': %s",
+		      item->ce->name, strerror(item->item_errno));
+		return;
+
+	case IEC__LSTAT:
+		error("error stating file '%s': %s",
+		      item->ce->name, strerror(item->item_errno));
+		return;
+
+	default:
+		error("Invalid IEC for file '%s': %d",
+		      item->ce->name, item->item_error_class);
+		return;
+	}
+}
+
+#define CAP_QUEUE          (1u<<1)
+#define CAP_SYNC_WRITE     (1u<<2)
+#define CAP_ASYNC_PROGRESS (1u<<3)
+#define CAP_EVERYTHING     (CAP_QUEUE | CAP_SYNC_WRITE | CAP_ASYNC_PROGRESS)
+
+#define CAP_QUEUE_NAME          "queue"
+#define CAP_SYNC_WRITE_NAME     "sync_write"
+#define CAP_ASYNC_PROGRESS_NAME "async_progress"
+
+static int helper_start_fn(struct subprocess_entry *subprocess)
+{
+	static int versions[] = {1, 0};
+	static struct subprocess_capability capabilities[] = {
+		{ CAP_QUEUE_NAME, CAP_QUEUE },
+		{ CAP_SYNC_WRITE_NAME, CAP_SYNC_WRITE },
+		{ CAP_ASYNC_PROGRESS_NAME, CAP_ASYNC_PROGRESS },
+		{ NULL, 0 }
+	};
+
+	struct helper_process *hp = (struct helper_process *)subprocess;
+
+	return subprocess_handshake(subprocess, "checkout--helper", versions,
+				    NULL, capabilities,
+				    &hp->supported_capabilities);
+}
+
+/*
+ * Start a helper process.  The child_nr is there to force the subprocess
+ * mechanism to let us have more than one instance of the same executable
+ * (and to help with tracing).
+ *
+ * The returned helper_process pointer belongs to the map.
+ */
+static struct helper_process *helper_find_or_start_process(
+	struct parallel_checkout *pc,
+	unsigned int cap_needed,
+	int child_nr)
+{
+	struct helper_process *hp;
+	struct argv_array argv = ARGV_ARRAY_INIT;
+	struct strbuf quoted = STRBUF_INIT;
+
+	argv_array_push(&argv, "checkout--helper");
+	argv_array_pushf(&argv, "--child=%d", child_nr);
+	argv_array_pushf(&argv, "--writers=%d", nr_writer_threads);
+	argv_array_pushf(&argv, "--preload=%d", nr_preloads);
+
+	if (pc->pcm == PCM__ASYNCHRONOUS)
+		argv_array_push(&argv, "--asynch");
+	else if (pc->pcm == PCM__SYNCHRONOUS)
+		argv_array_push(&argv, "--no-asynch");
+
+	sq_quote_argv_pretty(&quoted, argv.argv);
+
+	if (!helper_pool_initialized) {
+		helper_pool_initialized = 1;
+		hashmap_init(&helper_pool_map, (hashmap_cmp_fn)cmd2process_cmp,
+			     NULL, 0);
+		hp = NULL;
+	} else
+		hp = (struct helper_process *)subprocess_find_entry(
+			&helper_pool_map, quoted.buf);
+
+	if (!hp) {
+		hp = xcalloc(1, sizeof(*hp));
+		hp->supported_capabilities = 0;
+
+		if (subprocess_start_argv(&helper_pool_map, &hp->subprocess,
+					  0, 1, &argv, helper_start_fn))
+			FREE_AND_NULL(hp);
+	}
+
+	if (hp &&
+	    (hp->supported_capabilities & cap_needed) != cap_needed) {
+		error("helper does not support needed capabilities");
+		subprocess_stop(&helper_pool_map, &hp->subprocess);
+		FREE_AND_NULL(hp);
+	}
+
+	argv_array_clear(&argv);
+	strbuf_release(&quoted);
+
+	return hp;
+}
+
+/*
+ * Cause all of our checkout--helper processes to exit.
+ *
+ * Closing our end of the pipe to their STDIN causes the server_loop
+ * to terminate and let the child exit normally.  We leave the actual
+ * zombie-reaping to the atexit() routines in run-command.c to save
+ * time -- their shutdown can happen in parallel with the rest of our
+ * checkout computation; that is, there is no need for us to wait()
+ * for them right now.
+ *
+ * Also, this method is faster than calling letting subprocess_stop()
+ * send a kill(SIGTERM) to the child and then wait() for it.
+ */
+static void stop_all_helpers(void)
+{
+	struct helper_process *hp;
+	int k;
+
+	trace2_region_enter("pcheckout", "stop_helpers", NULL);
+
+	for (k = 0; k < helper_pool.nr; k++) {
+		hp = helper_pool.array[k];
+
+		close(hp->subprocess.process.in);
+
+		hp->helper_is_dead_to_us = 1;
+
+		/* The pool does not own the pointer. */
+		helper_pool.array[k] = NULL;
+	}
+
+	trace2_region_leave("pcheckout", "stop_helpers", NULL);
+
+	FREE_AND_NULL(helper_pool.array);
+	helper_pool.nr = 0;
+	helper_pool.alloc = 0;
+}
+
+static void send__queue_item_record(struct parallel_checkout *pc,
+				    int pc_item_nr, int child_nr)
+{
+	struct parallel_checkout_item *item = pc->items[pc_item_nr];
+	struct conv_attrs *ca = &item->ca;
+	struct helper_process *hp = helper_pool.array[child_nr];
+	struct child_process *process = &hp->subprocess.process;
+	uint32_t len_name;
+	uint32_t len_encoding_name;
+	char *data = NULL;
+	size_t len_data;
+	struct checkout_helper__queue_item_record *fixed_fields;
+	char *variant;
+
+	/*
+	 * As described in is_eligible_for_parallel_checkout(), we
+	 * don't consider cache-entries that need an external tool to
+	 * be eligible.  So they should always have a null driver.  If
+	 * we decide to change this, we would also need to send the
+	 * driver fields to the helper.
+	 */
+	if (ca->drv)
+		BUG("ineligible cache-entry '%s'", item->ce->name);
+
+	assert(pc_item_nr == item->pc_item_nr);
+
+	/*
+	 * Update the item to remember with whom we queued it.
+	 */
+	item->child_nr = child_nr;
+	item->helper_item_nr = hp->helper_item_count++;
+
+	/*
+	 * Build binary record to send to the helper in 1 message
+	 * that won't require a lot of parsing on their side.
+	 */
+	len_name = pc->base_dir.len + item->ce->ce_namelen;
+	assert(len_name > 0);
+
+	if (ca->working_tree_encoding && *ca->working_tree_encoding)
+		len_encoding_name = strlen(ca->working_tree_encoding);
+	else
+		len_encoding_name = 0;
+
+	len_data = sizeof(struct checkout_helper__queue_item_record) +
+		len_name + len_encoding_name;
+
+	data = xcalloc(1, len_data);
+
+	fixed_fields = (struct checkout_helper__queue_item_record*)data;
+	fixed_fields->pc_item_nr = item->pc_item_nr;
+	fixed_fields->helper_item_nr = item->helper_item_nr;
+	fixed_fields->ce_mode = item->ce->ce_mode;
+	fixed_fields->attr_action = ca->attr_action;
+	fixed_fields->crlf_action = ca->crlf_action;
+	fixed_fields->ident = ca->ident;
+	fixed_fields->len_name = len_name;
+	fixed_fields->len_encoding_name = len_encoding_name;
+	oidcpy(&fixed_fields->oid, &item->ce->oid);
+
+	variant = data + sizeof(*fixed_fields);
+
+	/*
+	 * These string buffers are not null terminated, since we
+	 * have length fields in the fixed portion of the record.
+	 */
+	if (len_encoding_name) {
+		memcpy(variant, ca->working_tree_encoding, len_encoding_name);
+		variant += len_encoding_name;
+	}
+
+	memcpy(variant, pc->base_dir.buf, pc->base_dir.len);
+	variant += pc->base_dir.len;
+	memcpy(variant, item->ce->name, item->ce->ce_namelen);
+	variant += item->ce->ce_namelen;
+
+	packet_write(process->in, data, len_data);
+
+	free(data);
+}
+
+static void debug_dump_item(const struct parallel_checkout_item *item,
+			    const char *label,
+			    const struct stat *st)
+{
+#if 0
+	trace2_printf(
+		"%s: h[%d] item[%d,%d] e[%d,%d] st[%d,%d]",
+		label,
+
+		item->child_nr,
+
+		item->pc_item_nr,
+		item->helper_item_nr,
+
+		item->item_error_class,
+		item->item_errno,
+
+		st->st_size,
+		st->st_mtime);
+#endif
+}
+
+/*
+ * Send a "sync_write" command to ask the helper to write this
+ * item to the work tree and receive the result data.
+ *
+ * We expect the response to describe exactly 1 item (not a range).
+ *
+ * Return 1 if we have a packet IO error.
+ */
+static int send_cmd__sync_write(struct parallel_checkout_item *item,
+				struct stat *st)
+{
+	char buffer[LARGE_PACKET_MAX];
+	struct helper_process *hp = helper_pool.array[item->child_nr];
+	struct child_process *process = &hp->subprocess.process;
+	struct checkout_helper__sync__write_record rec;
+	const struct checkout_helper__item_result *temp;
+	char *line;
+	int len;
+
+	memset(&rec, 0, sizeof(rec));
+	rec.helper_item_nr = item->helper_item_nr;
+
+	packet_write_fmt_gently(process->in, "command=%s\n",
+				CAP_SYNC_WRITE_NAME);
+	packet_write(process->in, (const char *)&rec, sizeof(rec));
+	if (packet_flush_gently(process->in)) {
+		hp->helper_is_dead_to_us = 1;
+		return 1;
+	}
+
+	len = packet_read_line_gently_r(process->out, NULL, &line,
+					buffer, sizeof(buffer));
+	if (len < 0 || !line)
+		BUG("sync_write: premature flush or EOF");
+
+	if (len != sizeof(struct checkout_helper__item_result))
+		BUG("sync_write: wrong length (obs %d, exp %d)",
+		    len, (int)sizeof(struct checkout_helper__item_result));
+
+	temp = (const struct checkout_helper__item_result *)line;
+
+	item->item_error_class = temp->item_error_class;
+	item->item_errno = temp->item_errno;
+	memcpy(st, &temp->st, sizeof(struct stat));
+
+	debug_dump_item(item, "sync-write", st);
+
+	if (temp->helper_item_nr != item->helper_item_nr)
+		BUG("sync_write: h[%d] wrong item req[%d,%d] rcv[%d,%d]",
+		    item->child_nr,
+		    item->pc_item_nr, item->helper_item_nr,
+		    temp->pc_item_nr, temp->helper_item_nr);
+	if (temp->pc_item_nr != item->pc_item_nr ||
+	    temp->item_error_class == IEC__INVALID_ITEM)
+		BUG("sync_write: h[%d] unk item req[%d,%d] rcv[%d,%d]",
+		    item->child_nr,
+		    item->pc_item_nr, item->helper_item_nr,
+		    temp->pc_item_nr, temp->helper_item_nr);
+
+	/* eat the flush packet */
+	while (1) {
+		len = packet_read_line_gently_r(process->out, NULL, &line,
+						buffer, sizeof(buffer));
+		if (len < 0 || !line)
+			break;
+	}
+
+	return 0;
+}
+
+/*
+ * To helper[k] we send:
+ *     command=queue<LF>
+ *     <binary data for item>
+ *     <binary data for item>
+ *     ...
+ *     <flush>
+ *
+ * Where each record looks like:
+ *     <fixed-fields>[<encoding>]<path>
+ */
+static int send_items_to_helpers(struct parallel_checkout *pc)
+{
+	int child_nr;
+	int pc_item_nr;
+	int nr, k;
+	int err = 0;
+
+	trace2_region_enter("pcheckout", "send_items", NULL);
+
+	/*
+	 * Begin a queue command with each helper in parallel.
+	 */
+	for (child_nr = 0; child_nr < helper_pool.nr; child_nr++) {
+		struct helper_process *hp = helper_pool.array[child_nr];
+		struct child_process *process = &hp->subprocess.process;
+
+		if (packet_write_fmt_gently(process->in, "command=%s\n",
+					    CAP_QUEUE_NAME)) {
+			hp->helper_is_dead_to_us = 1;
+			err = 1;
+			goto done;
+		}
+	}
+
+	/*
+	 * Distribute the array of items to the helpers as part of
+	 * the queue command that we've opened.
+	 */
+	switch (pc->hsm) {
+	case HSM__HORIZONTAL:
+		for (pc_item_nr = 0; pc_item_nr < pc->nr; pc_item_nr++) {
+			child_nr = pc_item_nr % helper_pool.nr;
+
+			send__queue_item_record(pc, pc_item_nr, child_nr);
+		}
+		break;
+
+	case HSM__VERTICAL:
+		pc_item_nr = 0;
+		nr = DIV_ROUND_UP(pc->nr, helper_pool.nr);
+		for (child_nr = 0; child_nr < helper_pool.nr; child_nr++) {
+			for (k = 0;
+			     pc_item_nr < pc->nr && k < nr;
+			     pc_item_nr++, k++) {
+				send__queue_item_record(pc, pc_item_nr, child_nr);
+			}
+		}
+		break;
+
+	default:
+		BUG("unknown helper_spread_model %d", (int)pc->hsm);
+		break;
+	}
+
+	/*
+	 * close the queue command with each helper.
+	 */
+	for (child_nr = 0; child_nr < helper_pool.nr; child_nr++) {
+		struct helper_process *hp = helper_pool.array[child_nr];
+		struct child_process *process = &hp->subprocess.process;
+
+		if (packet_flush_gently(process->in)) {
+			hp->helper_is_dead_to_us = 1;
+			err = 1;
+			goto done;
+		}
+	}
+
+done:
+	trace2_region_leave("pcheckout", "send_items", NULL);
+
+	return err;
+}
+
+static int launch_all_helpers(struct parallel_checkout *pc)
+{
+	struct helper_process *hp;
+	int err = 0;
+
+	trace2_region_enter("pcheckout", "launch_helpers", NULL);
+
+	ALLOC_GROW(helper_pool.array, nr_helper_processes_wanted, helper_pool.alloc);
+
+	while (helper_pool.nr < nr_helper_processes_wanted) {
+		hp = helper_find_or_start_process(pc, CAP_EVERYTHING, helper_pool.nr);
+		if (!hp) {
+			err = 1;
+			break;
+		}
+
+		helper_pool.array[helper_pool.nr++] = hp;
+	}
+
+	trace2_region_leave("pcheckout", "launch_helpers", NULL);
+
+	return err;
+}
+
+/*
+ * Is parallel-checkout enabled?
+ *
+ * Let environment variable override the config setting so that we
+ * can force in on in the test suite.
+ */
+int parallel_checkout_enabled(void)
+{
+	static int is_enabled = -1;
+
+	if (is_enabled < 0) {
+		const char *value = getenv("GIT_TEST_PARALLEL_CHECKOUT");
+		if (value)
+			is_enabled = strtol(value, NULL, 10);
+		else
+			is_enabled = core_parallel_checkout;
+	}
+
+	return is_enabled;
+}
+
+/*
+ * Get parallel-checkout threshold.
+ *
+ * Let environment variable override the config setting so that we
+ * can force a value in the test suite.
+ */
+int parallel_checkout_threshold(void)
+{
+	static int threshold = -1;
+
+	if (threshold < 0) {
+		const char *value;
+
+		threshold = core_parallel_checkout_threshold;
+
+		value = getenv("GIT_TEST_PARALLEL_CHECKOUT_THRESHOLD");
+		if (value) {
+			int ivalue = strtol(value, NULL, 10);
+			if (ivalue > 0)
+				threshold = ivalue;
+		}
+	}
+
+	return threshold;
+}
+
+/*
+ * TODO evaluate the current command args to determine whether we
+ * should run sync or async.  For example, in a clone or when extending
+ * a sparse-checkout (and we expect to be newly populating an empty
+ * worktree), we can run async.  And if we are switching branches and
+ * need to look for dirty files before overwriting them, we should run
+ * in sync mode.
+ */
+static enum parallel_checkout_mode compute_best_pcm(
+	struct checkout *state,
+	struct unpack_trees_options *o)
+{
+	const char *value = getenv("GIT_TEST_PARALLEL_CHECKOUT_MODE");
+
+	if (value) {
+		if (!strcmp(value, "sync"))
+			return PCM__SYNCHRONOUS;
+		if (!strcmp(value, "async"))
+			return PCM__ASYNCHRONOUS;
+		warning("unknown value for GIT_TEST_PARALLEL_CHECKOUT_MODE '%s'",
+			value);
+		/*fallthru*/
+	}
+
+	// TODO
+	// TODO do something here...
+	// TODO
+	return PCM__SYNCHRONOUS;
+}
+
+enum parallel_checkout_mode setup_parallel_checkout(
+	struct checkout *state,
+	struct unpack_trees_options *o)
+{
+	struct parallel_checkout *pc = NULL;
+	enum parallel_checkout_mode pcm = PCM__NONE;
+	int nr_updated_files = 0;
+	int nr_eligible_files = 0;
+	int err;
+	int k;
+
+	if (!parallel_checkout_enabled())
+		return PCM__NONE;
+
+	/*
+	 * Disallow parallel-checkout if this obscure flag is turned on
+	 * since it makes the work to be done even more dependent on the
+	 * current state of the working directory.
+	 */
+	if (state->not_new)
+		return PCM__NONE;
+
+	/*
+	 * Disallow parallel-checkout if we're not actually going to
+	 * populate the worktree.
+	 */
+	if (!o->update || o->dry_run)
+		return PCM__NONE;
+
+	/*
+	 * See if we have enough CPUs to be effective and choose how many
+	 * background checkout--helper processes we should start.
+	 *
+	 * If the user set a config value, we try to respect it.
+	 *
+	 * When unspecified, we start with the number of CPUs and adapt
+	 * because each helper will have at least 3 threads (main, preload,
+	 * and (upto n) writers).  And round down because of the (current)
+	 * foreground process.
+	 */
+	if (core_parallel_checkout_helpers > 0)
+		nr_helper_processes_wanted = core_parallel_checkout_helpers;
+	else
+		nr_helper_processes_wanted = online_cpus() / 3;
+	if (nr_helper_processes_wanted < 1)
+		return PCM__NONE;
+
+	trace2_region_enter("pcheckout", "setup", NULL);
+
+	/*
+	 * First-order approximation of the total amount of work required.
+	 *
+	 * In this loop, only count the regular files that need updating
+	 * (and without regard to eligibility) because this needs to be a
+	 * fast threshold scan.
+	 */
+	for (k = 0; k < state->istate->cache_nr; k++) {
+		const struct cache_entry *ce = state->istate->cache[k];
+
+		if (!(ce->ce_flags & CE_UPDATE))
+			continue;
+
+		if ((ce->ce_mode & S_IFMT) != S_IFREG)
+			continue;
+
+		if (ce->ce_flags & CE_WT_REMOVE)
+		    BUG("both update and delete flags are set on %s",
+			ce->name);
+
+		nr_updated_files++;
+	}
+	if (nr_updated_files < parallel_checkout_threshold())
+		goto done;
+
+	pc = xcalloc(1, sizeof(*state->parallel_checkout));
+
+	strbuf_init(&pc->base_dir, 0);
+	strbuf_add(&pc->base_dir, state->base_dir, state->base_dir_len);
+
+	pcm = compute_best_pcm(state, o);
+	pc->pcm = pcm;
+
+	/*
+	 * When in synchronous mode, files are not written until explicitly
+	 * and individually requested by the client.  So the only goal of
+	 * parallel-checkout is to distribute blob preloading across multiple
+	 * processes.  So we spread horizontally, so that all helper processes
+	 * get some of the first blobs in the index.
+	 *
+	 * When in asynchronous mode, spread the other way so that the
+	 * helper process are touching different parts of the file
+	 * system when writing their allotment (in the obscure hope
+	 * that that will ease any per-directory lock contention in
+	 * the kernel).
+	 */
+	if (pc->pcm == PCM__SYNCHRONOUS)
+		pc->hsm = HSM__HORIZONTAL;
+	else
+		pc->hsm = HSM__VERTICAL;
+
+	/*
+	 * When in synchronous mode, we only need 1 writer because files are
+	 * not written until explicitly and individually requested by the
+	 * client.  So ignore the config settings.
+	 */
+	if (pc->pcm == PCM__SYNCHRONOUS)
+		nr_writer_threads = 1;
+	else {
+		nr_writer_threads = core_parallel_checkout_writers;
+		if (nr_writer_threads < 1)
+			nr_writer_threads = DEFAULT_PARALLEL_CHECKOUT_WRITERS;
+	}
+
+	nr_preloads = core_parallel_checkout_preload;
+	if (nr_preloads < 1)
+		nr_preloads = DEFAULT_PARALLEL_CHECKOUT_PRELOAD;
+
+	/*
+	 * Queue the set of ELIGIBLE regular files that need to be updated.
+	 *
+	 * Use this sequential pass thru the index to capture the smudging
+	 * rules required for each file.
+	 *
+	 * [] The rules for the .gitattributes "attribute stack" make
+	 *    it path-relative.  So we evaluate the stack sequentially
+	 *    during the index iteration which visits paths in
+	 *    depth-first order and naturally fits the stack mode.
+	 *
+	 * [] This avoids the natural tendency to try to delay the
+	 *    evaluation of the attribute stack until we are in a
+	 *    parallel context and distribute the work.
+	 *
+	 *    This is problematic because:
+	 *
+	 *    [] It would require the attribute stack code to be
+	 *       thread-safe and/or introduce lock overhead to that
+	 *       computation.
+	 *
+	 *    [] During the attribute stack evaluation we may need to hit
+	 *       the ODB to fetch a not-yet-populated ".gitattributes" file
+	 *       somewhere deep in the tree to evaluate a peer item in the
+	 *       current directory or in a child directory visited before
+	 *       the attributes file is visited during this depth-first
+	 *       iteration.  Since we know the ODB is not thread safe, we
+	 *       want to avoid that situation.
+	 */
+	trace2_region_enter("pcheckout", "build_items", NULL);
+	for (k = 0; k < state->istate->cache_nr; k++) {
+		struct cache_entry *ce = state->istate->cache[k];
+		struct parallel_checkout_item *item;
+		struct conv_attrs ca;
+
+		if (!(ce->ce_flags & CE_UPDATE))
+			continue;
+		if ((ce->ce_mode & S_IFMT) != S_IFREG)
+			continue;
+
+		convert_attrs(state->istate, &ca, ce->name);
+		if (!is_eligible_for_parallel_checkout(&ca))
+			continue;
+
+		nr_eligible_files++;
+
+		item = xcalloc(1, sizeof(*item));
+
+		item->ce = ce;
+		ce->parallel_checkout_item = item;
+
+		item->ca.drv = ca.drv;
+		item->ca.attr_action = ca.attr_action;
+		item->ca.crlf_action = ca.crlf_action;
+		item->ca.ident = ca.ident;
+		if (ca.working_tree_encoding && *ca.working_tree_encoding)
+			item->ca.working_tree_encoding =
+				strdup(ca.working_tree_encoding);
+
+		item->pc_item_nr = pc->nr; /* our position in the item array */
+
+		item->child_nr = -1; /* not yet assigned to a helper process */
+		item->helper_item_nr = -1; /* not yet sent to a helper process */
+
+		ALLOC_GROW(pc->items, pc->nr + 1, pc->alloc);
+		pc->items[pc->nr++] = item;
+	}
+	trace2_region_leave("pcheckout", "build_items", NULL);
+	assert(pc->nr == nr_eligible_files);
+	if (pc->nr < parallel_checkout_threshold()) {
+		free_parallel_checkout(pc);
+		goto done;
+	}
+
+	if (launch_all_helpers(pc)) {
+		free_parallel_checkout(pc);
+		stop_all_helpers();
+		goto done;
+	}
+
+	sigchain_push(SIGPIPE, SIG_IGN);
+	err = send_items_to_helpers(pc);
+	sigchain_pop(SIGPIPE);
+
+	if (err) {
+		free_parallel_checkout(pc);
+		stop_all_helpers();
+		goto done;
+	}
+
+	/*
+	 * Actually enable parallel checkout.
+	 */
+	state->parallel_checkout = pc;
+	assert(pc->pcm != PCM__NONE);
+
+done:
+	trace2_data_intmax("pcheckout", NULL, "ce/nr_total",
+			   state->istate->cache_nr);
+	trace2_data_intmax("pcheckout", NULL, "ce/nr_updated",
+			   nr_updated_files);
+	trace2_data_intmax("pcheckout", NULL, "ce/nr_eligible",
+			   nr_eligible_files);
+	trace2_data_intmax("pcheckout", NULL, "core/threshold",
+			   parallel_checkout_threshold());
+
+	trace2_data_intmax("pcheckout", NULL, "pcm", pcm);
+	if (pcm != PCM__NONE) {
+		trace2_data_intmax("pcheckout", NULL, "helper/processes",
+				   nr_helper_processes_wanted);
+		trace2_data_intmax("pcheckout", NULL, "helper/writer_threads",
+				   nr_writer_threads);
+		trace2_data_intmax("pcheckout", NULL, "helper/preload_count",
+				   nr_preloads);
+	}
+
+	trace2_region_leave("pcheckout", "setup", NULL);
+
+	return pcm;
+}
+
+void finish_parallel_checkout(struct checkout *state)
+{
+	if (!state->parallel_checkout)
+		return;
+
+	trace2_region_enter("pcheckout", "finish", NULL);
+
+	free_parallel_checkout(state->parallel_checkout);
+	state->parallel_checkout = NULL;
+
+	trace2_region_leave("pcheckout", "finish", NULL);
+}
+
+/*
+ * Apply successful response from the helper (and lstat data) to the
+ * cache-entry.
+ *
+ * This should match the code at the bottom of entry.c:write_entry()
+ * at the "finish:" label.
+ */
+static void parallel_checkout__update_cache_entry(
+	const struct checkout *state,
+	struct cache_entry *ce,
+	enum checkout_helper__item_error_class item_error_class,
+	struct stat *st)
+{
+#if 0
+#ifdef GIT_WINDOWS_NATIVE
+	/* Flush cached lstat in fscache after writing to disk. */
+	flush_fscache();
+#endif
+#endif
+
+	if (state->refresh_cache) {
+		assert(state->istate);
+
+		if (item_error_class == IEC__OK) {
+			fill_stat_cache_info(state->istate, ce, st);
+			ce->ce_flags |= CE_UPDATE_IN_BASE;
+			mark_fsmonitor_invalid(state->istate, ce);
+			state->istate->cache_changed |= CE_ENTRY_CHANGED;
+		}
+	}
+}
+
+/*
+ * Was this item succefully populated by an asynchronous-mode helper?
+ *
+ * Returns:
+ * 1 if the item was successfully populated.
+ * 0 if there is a retryable error.
+ * -1 if there was an error that should not be retried.
+ *
+ * Emit an error message for the latter ones.
+ */
+int parallel_checkout__async__classify_result(const struct checkout *state,
+					      struct cache_entry *ce,
+					      struct progress *progress,
+					      unsigned *result_cnt)
+{
+	struct parallel_checkout_item *item = ce->parallel_checkout_item;
+	unsigned cnt = *result_cnt;
+	int result;
+
+	assert(state->parallel_checkout->pcm == PCM__ASYNCHRONOUS);
+	assert(item);
+
+	switch (item->item_error_class) {
+	case IEC__OK:
+		/*
+		 * This item was completely handled and progress meter
+		 * was advanced.
+		 */
+		assert(item->progress_claimed);
+		assert(!(ce->ce_flags & CE_UPDATE));
+		result = 1;
+
+		break;
+
+	case IEC__NO_RESULT:
+		/*
+		 * The helper died or for some other reason we did not get
+		 * a response for this item.  The progress meter was not
+		 * advanced.
+		 */
+		assert(!item->progress_claimed);
+		assert(ce->ce_flags & CE_UPDATE);
+
+		result = 0;
+		break;
+
+	case IEC__OPEN:
+		/*
+		 * The helper could not create the file, suppress
+		 * the error message and let the classic code try it.
+		 *
+		 * The progress meter was not advanced.
+		 *
+		 * (The parallel code doesn't try do the
+		 * lstat/is-clean/delete logic -- it only does
+		 * open(O_CREAT).)  This has the side-effect of adding
+		 * it to the clone collision data if appropriate.)
+		 */
+		assert(!item->progress_claimed);
+		assert(ce->ce_flags & CE_UPDATE);
+
+		result = 0;
+		break;
+
+	default:
+		/*
+		 * For any other helper errors, just print the error
+		 * message and go on.
+		 *
+		 * We only really expect a missing blob or full disk
+		 * error and trying it again probably won't fix that.
+		 *
+		 * Advance the progress meter.
+		 */
+		assert(!item->progress_claimed);
+		assert(ce->ce_flags & CE_UPDATE);
+		parallel_checkout__print_helper_error(item);
+
+		item->progress_claimed = 1;
+		display_progress(progress, ++cnt);
+		ce->ce_flags &= ~CE_UPDATE;
+
+		result = -1;
+		break;
+	}
+
+	*result_cnt = cnt;
+
+	return result;
+}
+
+/*
+ * Was this item created by a helper?
+ */
+int parallel_checkout__created_file(struct cache_entry *ce)
+{
+	struct parallel_checkout_item *item = ce->parallel_checkout_item;
+
+	assert(item);
+
+	switch (item->item_error_class) {
+	case IEC__NO_RESULT: /* we don't know */
+		return 0;
+
+	case IEC__INVALID_ITEM: /* item unknown to helper */
+		return 0;
+
+	case IEC__OK:
+		return 1;
+
+	case IEC__LOAD:
+		return 0;
+
+	case IEC__OPEN:
+		return 0;
+
+	case IEC__WRITE: /* created but couldn't write (eg. disk space?) */
+		return 1;
+
+	case IEC__LSTAT: /* created but couldn't lstat ? */
+		return 1;
+
+	default:
+		error("Invalid IEC for file '%s': %d",
+		      item->ce->name, item->item_error_class);
+		return 0;
+	}
+}
+
+/*
+ * Ask the helper associated with this cache-entry to write the
+ * smudged content to disk.  Block the current process until it
+ * is finished.
+ *
+ * This is conceptually a peer of entry.c:write_entry() but uses
+ * the parallel-checkout helpers to actually populate the worktree.
+ * It assumes that entry.c:checkout_entry() has already handled
+ * creating and deleting of directories and/or files that would
+ * collide with the file we are about to create.
+ *
+ * This function is much simpler than entry.c:write_entry() because
+ * the parallel-eligible code only queues up certain types of
+ * regular files and we don't have to worry about symlinks, gitlinks,
+ * and etc.
+ *
+ * We also assume that we are not writing to a temp file and
+ * therefore don't need an alternate path.
+ *
+ * Use this routine when the checkout needs to be very synchronous
+ * WRT how/when files are populated in the worktree (such as after
+ * sequentially scanning for uncomitted changes before overwriting).
+ *
+ * Return 1 if we have any errors.
+ */
+int parallel_checkout__sync__write_entry(const struct checkout *state,
+					 struct cache_entry *ce)
+{
+	struct parallel_checkout_item *item = ce->parallel_checkout_item;
+	struct stat st;
+	int err = 0;
+
+	assert(item->ce == ce);
+
+	sigchain_push(SIGPIPE, SIG_IGN);
+	err = send_cmd__sync_write(item, &st);
+	sigchain_pop(SIGPIPE);
+
+	parallel_checkout__update_cache_entry(state, ce,
+					      item->item_error_class, &st);
+	parallel_checkout__print_helper_error(item);
+
+	err |= item->item_error_class != IEC__OK;
+
+	return err;
+}
+
+/*
+ * Request progress information and item results from a helper.
+ *
+ * We receive data for zero or more items.  This is the set of
+ * contiguous items (from the point of view of this helper) that
+ * are currently marked DONE and haven't been previously reported.
+ *
+ * Return 1 if we have a packet IO failure.  (Errors for actually
+ * populating files are handled later.)
+ */
+static int get_helper_progress(const struct checkout *state, int child_nr,
+			       struct progress *progress, unsigned *result_cnt)
+{
+	char buffer[LARGE_PACKET_MAX];
+	struct parallel_checkout *pc = state->parallel_checkout;
+	struct helper_process *hp = helper_pool.array[child_nr];
+	struct child_process *process = &hp->subprocess.process;
+	struct parallel_checkout_item *item;
+	char *line;
+	int len;
+	struct stat st;
+	const struct checkout_helper__item_result *temp;
+	unsigned cnt = *result_cnt;
+
+	packet_write_fmt_gently(process->in, "command=%s\n",
+				CAP_ASYNC_PROGRESS_NAME);
+	if (packet_flush_gently(process->in)) {
+		hp->helper_is_dead_to_us = 1;
+		return 1;
+	}
+
+	while (1) {
+		len = packet_read_line_gently_r(process->out, NULL, &line,
+						buffer, sizeof(buffer));
+		if (len < 0 || !line)
+			break;
+
+		if (len != sizeof(struct checkout_helper__item_result))
+			BUG("checkout-helper response wrong (obs %d, exp %d)",
+			    len,
+			    (int)sizeof(struct checkout_helper__item_result));
+
+		/*
+		 * Peek at the response and make sure it looks right before use it.
+		 */
+		temp = (const struct checkout_helper__item_result *)line;
+		assert(temp->item_error_class != IEC__NO_RESULT);
+		assert(temp->item_error_class != IEC__INVALID_ITEM);
+		assert(temp->helper_item_nr < hp->helper_item_count);
+		assert(temp->pc_item_nr < pc->nr);
+
+		/*
+		 * Find the corresponding parallel_checkout_item in our vector
+		 * for the response and verify that is the one we sent to the
+		 * helper.
+		 */
+		item = pc->items[temp->pc_item_nr];
+		assert(item->helper_item_nr == temp->helper_item_nr);
+		assert(item->pc_item_nr == temp->pc_item_nr);
+		assert(item->child_nr == child_nr);
+
+		item->item_error_class = temp->item_error_class;
+		item->item_errno = temp->item_errno;
+		memcpy(&st, &temp->st, sizeof(st));
+
+		debug_dump_item(item, "async-progress", &st);
+
+		if (temp->helper_item_nr != hp->helper_result_count)
+			BUG("did not receive contiguous, in-order item results");
+		hp->helper_result_count++;
+
+		parallel_checkout__update_cache_entry(state, item->ce,
+						      item->item_error_class,
+						      &st);
+
+		if (item->item_error_class == IEC__OK) {
+			/*
+			 * Only if everything succeeded do we claim that we've
+			 * updated the item and advance the progress meter.
+			 * For failures, we let the sequential loop decide whether
+			 * to retry and how/when to advance the progress meter.
+			 */
+			item->progress_claimed = 1;
+			display_progress(progress, ++cnt);
+			item->ce->ce_flags &= ~CE_UPDATE;
+		}
+	}
+
+	*result_cnt = cnt;
+	return 0;
+}
+
+static int child_is_finished(int child_nr)
+{
+	struct helper_process *hp = helper_pool.array[child_nr];
+
+	if (hp->helper_is_dead_to_us)
+		return 1;
+	if (hp->helper_result_count == hp->helper_item_count)
+		return 1;
+
+	return 0;
+}
+
+/*
+ * Poll for progress and item results from all of the helpers.
+ *
+ * This spins until we have results for all items from all helpers.
+ *
+ * The assumption is that we sent one big batch to each helper at
+ * the start because we believe that each helper will probably take
+ * about the same amount of time on their portion.  Specifically,
+ * our caller is not attempting to chunk smaller batches to each
+ * helper in an attempt to send subsequent batches to helpers that
+ * finish early.
+ *
+ * Returns 1 if there was a packet IO failure.
+ */
+int parallel_checkout__async__progress(const struct checkout *state,
+				       struct progress *progress,
+				       unsigned *result_cnt)
+{
+	int child_nr;
+	int err = 0;
+	int nr_children_still_working = 0;
+
+	assert(is_parallel_checkout_mode(state, PCM__ASYNCHRONOUS));
+
+	trace2_region_enter("pcheckout", "async/progress", NULL);
+
+	sigchain_push(SIGPIPE, SIG_IGN);
+
+	do {
+		nr_children_still_working = helper_pool.nr;
+
+		for (child_nr = 0; child_nr < helper_pool.nr; child_nr++) {
+			if (child_is_finished(child_nr))
+				nr_children_still_working--;
+			else
+				err |= get_helper_progress(state, child_nr,
+							   progress,
+							   result_cnt);
+		}
+	} while (nr_children_still_working);
+
+	sigchain_pop(SIGPIPE);
+
+	trace2_region_leave("pcheckout", "async/progress", NULL);
+
+	/*
+	 * The checkout--helpers have completed all of the items
+	 * that they have been given.  We currently send everything
+	 * in a single batch, so we have no more need for the helper
+	 * processes.  Gently tell them to exit while our caller
+	 * continues to process the results.
+	 */
+	stop_all_helpers();
+
+	return err;
+}

--- a/parallel-checkout.h
+++ b/parallel-checkout.h
@@ -1,0 +1,68 @@
+
+#ifndef PARALLEL_CHECKOUT_H
+#define PARALLEL_CHECKOUT_H
+
+struct cache_entry;
+struct checkout;
+struct conv_attrs;
+struct progress;
+struct unpack_trees_options;
+
+enum parallel_checkout_mode {
+	/*
+	 * parallel-checkout is disabled.
+	 */
+	PCM__NONE = 0,
+
+	/*
+	 * The checkout--helper processes are throttled and must wait
+	 * for a sync request to write an item to the worktree.
+	 *
+	 * Use this mode when switching branches where we have to spend
+	 * most of the time confirming that we won't overwrite uncomitted
+	 * changes to existing files in the work tree.
+	 */
+	PCM__SYNCHRONOUS,
+
+	/*
+	 * The checkout--helper process is not throttled and can write
+	 * items to the worktree as soon as the blobs are available in
+	 * memory.
+	 *
+	 * For example, we can use this mode when doing a clone when we
+	 * do not expect existing files in the work tree and minimal
+	 * collisions with untracked/dirty files.
+	 */
+	PCM__ASYNCHRONOUS,
+};
+
+int is_parallel_checkout_mode(const struct checkout *state,
+			      enum parallel_checkout_mode mode);
+
+int is_eligible_for_parallel_checkout(const struct conv_attrs *ca);
+
+enum parallel_checkout_mode setup_parallel_checkout(
+	struct checkout *state,
+	struct unpack_trees_options *o);
+
+void finish_parallel_checkout(struct checkout *state);
+
+int parallel_checkout__sync__write_entry(const struct checkout *state,
+					 struct cache_entry *ce);
+
+int parallel_checkout__async__progress(const struct checkout *state,
+				       struct progress *progress,
+				       unsigned *result_cnt);
+
+int parallel_checkout__async__classify_result(const struct checkout *state,
+					      struct cache_entry *ce,
+					      struct progress *progress,
+					      unsigned *result_cnt);
+
+int parallel_checkout__created_file(struct cache_entry *ce);
+
+int parallel_checkout_enabled(void);
+
+int parallel_checkout_threshold(void);
+
+#endif /* PARALLEL_CHECKOUT_H */

--- a/pkt-line.c
+++ b/pkt-line.c
@@ -409,16 +409,23 @@ char *packet_read_line(int fd, int *len_p)
 				  packet_buffer, sizeof(packet_buffer));
 }
 
-int packet_read_line_gently(int fd, int *dst_len, char **dst_line)
+int packet_read_line_gently_r(int fd, int *dst_len, char **dst_line,
+			      char *buffer, size_t buffer_size)
 {
 	int len = packet_read(fd, NULL, NULL,
-			      packet_buffer, sizeof(packet_buffer),
+			      buffer, buffer_size,
 			      PACKET_READ_CHOMP_NEWLINE|PACKET_READ_GENTLE_ON_EOF);
 	if (dst_len)
 		*dst_len = len;
 	if (dst_line)
-		*dst_line = (len > 0) ? packet_buffer : NULL;
+		*dst_line = (len > 0) ? buffer : NULL;
 	return len;
+}
+
+int packet_read_line_gently(int fd, int *dst_len, char **dst_line)
+{
+	return packet_read_line_gently_r(fd, dst_len, dst_line,
+					 packet_buffer, sizeof(packet_buffer));
 }
 
 char *packet_read_line_buf(char **src, size_t *src_len, int *dst_len)

--- a/pkt-line.c
+++ b/pkt-line.c
@@ -239,7 +239,7 @@ void packet_buf_write_len(struct strbuf *buf, const char *data, size_t len)
 
 int write_packetized_from_fd(int fd_in, int fd_out)
 {
-	static char buf[LARGE_PACKET_DATA_MAX];
+	char buf[LARGE_PACKET_DATA_MAX];
 	int err = 0;
 	ssize_t bytes_to_write;
 

--- a/pkt-line.c
+++ b/pkt-line.c
@@ -9,7 +9,14 @@
  */
 char packet_buffer[LARGE_PACKET_MAX];
 
+/*
+ * Warning: `packet_trace_prefix` and the static variables `in_pack`
+ * and `sideband` inside of `packet_trace()` make packet tracing not
+ * safe for threaded or concurrent operations.
+ * TODO Eventually, we should revisit this.
+ */
 static const char *packet_trace_prefix = "git";
+
 static struct trace_key trace_packet = TRACE_KEY_INIT(PACKET);
 static struct trace_key trace_pack = TRACE_KEY_INIT(PACKFILE);
 

--- a/pkt-line.c
+++ b/pkt-line.c
@@ -152,19 +152,21 @@ static void format_packet(struct strbuf *out, const char *prefix,
 static int packet_write_fmt_1(int fd, int gently, const char *prefix,
 			      const char *fmt, va_list args)
 {
-	static struct strbuf buf = STRBUF_INIT;
+	struct strbuf buf = STRBUF_INIT;
+	int err = 0;
 
-	strbuf_reset(&buf);
 	format_packet(&buf, prefix, fmt, args);
 	if (write_in_full(fd, buf.buf, buf.len) < 0) {
 		if (!gently) {
 			check_pipe(errno);
 			die_errno(_("packet write with format failed"));
 		}
-		return error(_("packet write with format failed"));
+		err = error(_("packet write with format failed"));
 	}
 
-	return 0;
+	strbuf_release(&buf);
+
+	return err;
 }
 
 void packet_write_fmt(int fd, const char *fmt, ...)

--- a/pkt-line.c
+++ b/pkt-line.c
@@ -397,10 +397,16 @@ static char *packet_read_line_generic_r(int fd,
 	return (len > 0) ? buffer : NULL;
 }
 
-char *packet_read_line(int fd, int *len_p)
+char *packet_read_line_r(int fd, int *len_p, char *buffer, size_t buffer_size)
 {
 	return packet_read_line_generic_r(fd, NULL, NULL, len_p,
-					  packet_buffer, sizeof(packet_buffer));
+					  buffer, buffer_size);
+}
+
+char *packet_read_line(int fd, int *len_p)
+{
+	return packet_read_line_r(fd, len_p,
+				  packet_buffer, sizeof(packet_buffer));
 }
 
 int packet_read_line_gently(int fd, int *dst_len, char **dst_line)

--- a/pkt-line.c
+++ b/pkt-line.c
@@ -191,7 +191,7 @@ int packet_write_fmt_gently(int fd, const char *fmt, ...)
 
 static int packet_write_gently(const int fd_out, const char *buf, size_t size)
 {
-	static char packet_write_buffer[LARGE_PACKET_MAX];
+	char packet_write_buffer[LARGE_PACKET_MAX];
 	size_t packet_size;
 
 	if (size > sizeof(packet_write_buffer) - 4)

--- a/pkt-line.h
+++ b/pkt-line.h
@@ -115,6 +115,12 @@ char *packet_read_line_r(int fd, int *size, char *buffer, size_t buffer_size);
  * length of the packet is written to it.
  */
 int packet_read_line_gently(int fd, int *size, char **dst_line);
+/*
+ * Version of `packet_read_line_gently()` that uses a supplied buffer
+ * rather than a static buffer.
+ */
+int packet_read_line_gently_r(int fd, int *size, char **dst_line,
+			      char *buffer, size_t buffer_size);
 
 /*
  * Same as packet_read_line, but read from a buf rather than a descriptor;

--- a/pkt-line.h
+++ b/pkt-line.h
@@ -99,6 +99,11 @@ enum packet_read_status packet_read_with_status(int fd, char **src_buffer,
  * packet is written to it.
  */
 char *packet_read_line(int fd, int *size);
+/*
+ * Version of `packet_read_line()` that uses a supplied buffer
+ * rather than a static buffer.
+ */
+char *packet_read_line_r(int fd, int *size, char *buffer, size_t buffer_size);
 
 /*
  * Convenience wrapper for packet_read that sets the PACKET_READ_GENTLE_ON_EOF

--- a/pkt-line.h
+++ b/pkt-line.h
@@ -201,6 +201,12 @@ enum packet_read_status packet_reader_peek(struct packet_reader *reader);
 #define DEFAULT_PACKET_MAX 1000
 #define LARGE_PACKET_MAX 65520
 #define LARGE_PACKET_DATA_MAX (LARGE_PACKET_MAX - 4)
+
+/*
+ * Warning: `packet_buffer` is public and directly referenced from many
+ * source files.  This makes threaded use of packet_ routines unsafe.
+ * TODO Eventually, we should phase this out with a proper API.
+ */
 extern char packet_buffer[LARGE_PACKET_MAX];
 
 struct packet_writer {

--- a/read-cache.c
+++ b/read-cache.c
@@ -1840,6 +1840,7 @@ static struct cache_entry *create_from_disk(struct mem_pool *ce_mem_pool,
 	ce->ce_namelen = len;
 	ce->index = 0;
 	hashcpy(ce->oid.hash, ondisk->data);
+	ce->parallel_checkout_item = NULL;
 	memcpy(ce->name, name, len);
 	ce->name[len] = '\0';
 

--- a/sub-process.c
+++ b/sub-process.c
@@ -4,6 +4,7 @@
 #include "sub-process.h"
 #include "sigchain.h"
 #include "pkt-line.h"
+#include "quote.h"
 
 int cmd2process_cmp(const void *unused_cmp_data,
 		    const struct hashmap_entry *eptr,
@@ -118,6 +119,53 @@ int subprocess_start(struct hashmap *hashmap, struct subprocess_entry *entry, co
 	err = startfn(entry);
 	if (err) {
 		error("initialization for subprocess '%s' failed", cmd);
+		subprocess_stop(hashmap, entry);
+		return err;
+	}
+
+	hashmap_add(hashmap, &entry->ent);
+	return 0;
+}
+
+int subprocess_start_argv(struct hashmap *hashmap,
+			  struct subprocess_entry *entry,
+			  int use_shell,
+			  int is_git_cmd,
+			  const struct argv_array *argv,
+			  subprocess_start_fn startfn)
+{
+	int err;
+	int k;
+	struct child_process *process;
+	struct strbuf quoted = STRBUF_INIT;
+
+	process = &entry->process;
+
+	child_process_init(process);
+	for (k = 0; k < argv->argc; k++)
+		argv_array_push(&process->args, argv->argv[k]);
+	process->use_shell = use_shell;
+	process->in = -1;
+	process->out = -1;
+	process->git_cmd = is_git_cmd;
+	process->clean_on_exit = 1;
+	process->clean_on_exit_handler = subprocess_exit_handler;
+	process->trace2_child_class = "subprocess";
+
+	sq_quote_argv_pretty(&quoted, argv->argv);
+	entry->cmd = strbuf_detach(&quoted, 0);
+
+	err = start_command(process);
+	if (err) {
+		error("cannot fork to run subprocess '%s'", entry->cmd);
+		return err;
+	}
+
+	hashmap_entry_init(&entry->ent, strhash(entry->cmd));
+
+	err = startfn(entry);
+	if (err) {
+		error("initialization for subprocess '%s' failed", entry->cmd);
 		subprocess_stop(hashmap, entry);
 		return err;
 	}

--- a/sub-process.h
+++ b/sub-process.h
@@ -57,6 +57,13 @@ typedef int(*subprocess_start_fn)(struct subprocess_entry *entry);
 int subprocess_start(struct hashmap *hashmap, struct subprocess_entry *entry, const char *cmd,
 		subprocess_start_fn startfn);
 
+int subprocess_start_argv(struct hashmap *hashmap,
+			  struct subprocess_entry *entry,
+			  int use_shell,
+			  int is_git_cmd,
+			  const struct argv_array *argv,
+			  subprocess_start_fn startfn);
+
 /* Kill a subprocess and remove it from the subprocess hashmap. */
 void subprocess_stop(struct hashmap *hashmap, struct subprocess_entry *entry);
 

--- a/t/README
+++ b/t/README
@@ -416,6 +416,21 @@ GIT_TEST_DISALLOW_ABBREVIATED_OPTIONS=<boolean>, when true (which is
 the default when running tests), errors out when an abbreviated option
 is used.
 
+GIT_TEST_PARALLEL_CHECKOUT=<n>, enables parallel-checkout when set
+and non-zero.  This overrides the value of 'core.parallelCheckout'.
+
+GIT_TEST_PARALLEL_CHECKOUT_MODE=<string>, forces parallel-checkout use
+either "sync" or "async" mode and override the normal command-based
+detection.  This is to allow a/b testing when comparing performance
+times.
+
+GIT_TEST_PARALLEL_CHECKOUT_THRESHOLD=<n>, sets parallel-checkout
+threshold.  This overrides the value of 'core.parallelCheckoutThreshold'.
+
+GIT_TEST_CHECKOUT_HELPER_VERBOSE=<n>, when non-zero enables verbose
+Trace2 logging in checkout--helper.
+
+
 Naming Tests
 ------------
 

--- a/t/perf/README
+++ b/t/perf/README
@@ -131,6 +131,14 @@ After that you will want to use some of the following:
 
 At least one of the first two is required!
 
+Alternatively, you can create an empty test directory and borrow an
+existing repository.  The exported variable $GIT_PERF_BORROW_REPO will
+be set to the path of the "normal" or "large" repository.  Tests are
+expected to treat this repository as read-only.
+
+	test_perf_borrow_default_repo
+	test_perf_borrow_large_repo
+
 You can use test_expect_success as usual. In both test_expect_success
 and in test_perf, running "git" points to the version that is being
 perf-tested. The $MODERN_GIT variable points to the git wrapper for the

--- a/t/perf/p2080-parallel-checkout-clone.sh
+++ b/t/perf/p2080-parallel-checkout-clone.sh
@@ -1,0 +1,104 @@
+#!/bin/sh
+
+test_description='performance test for parallel-checkout'
+
+. ./perf-lib.sh
+
+# The path to the borrowed source repo will be in $GIT_PERF_BORROW_REPO
+# We must treat it as read-only.
+#
+test_perf_borrow_large_repo
+
+# We create an instance of the repository in each `test_perf`, but
+# to allow `./run` to work, we need to delete them inside the
+# `test_perf` block, so that time gets added to the test.
+#
+# TODO Is there a way to get around that?
+#
+#
+# Each clone command inclues `| cat` to eat the exit code.
+# This is avoid long-pathname problems on Windows.  (Every
+# large third-party repo I tested seemed to have a few deeply
+# nested files that are too long when appended to the trash
+# name directory.)
+#
+# TODO Is there a better way to handle this?  This was a problem
+# even when using the `--root` option (which helps, but not
+# enough).
+
+# Classic (sequential) mode for comparison.
+#
+test_perf 'clone classic' '
+	git -c advice.detachedHead=false \
+	    -c core.parallelcheckout=0 \
+		clone -- "$GIT_PERF_BORROW_REPO" r_classic | cat &&
+	rm -rf r_classic
+'
+
+# Sync mode.
+#
+# Sync mode always uses exactly 1 writer regardless what we pass in.
+#
+test_sync_h_attempts='4'
+test_sync_w_attempts='1'
+test_sync_p_attempts='02 10'
+
+for h in ${test_sync_h_attempts}
+do
+	export h
+	for w in ${test_sync_w_attempts}
+	do
+		export w
+		for p in ${test_sync_p_attempts}
+		do
+			export p
+
+			test_perf "clone..sync h${h} w${w} p$p" '
+				r_out=./r_sync_h${h}_w${w}_p$p
+
+				GIT_TEST_PARALLEL_CHECKOUT_THRESHOLD=1 \
+				GIT_TEST_PARALLEL_CHECKOUT_MODE=sync \
+				git -c core.parallelcheckout=1 \
+				    -c core.parallelcheckouthelpers=${h} \
+				    -c core.parallelcheckoutwriters=${w} \
+				    -c core.parallelcheckoutpreload=${p} \
+					clone -- $GIT_PERF_BORROW_REPO $r_out | cat &&
+				rm -rf $r_out
+			'
+		done
+	done
+done
+
+# Async mode.
+#
+test_async_h_attempts='4'
+test_async_w_attempts='1 2 3'
+test_async_p_attempts='02 10'
+
+for h in ${test_async_h_attempts}
+do
+	export h
+	for w in ${test_async_w_attempts}
+	do
+		export w
+		for p in ${test_async_p_attempts}
+		do
+			export p
+
+			test_perf "clone.async h${h} w${w} p$p" '
+				r_out=./r_async_h${h}_w${w}_p$p
+
+				GIT_TEST_PARALLEL_CHECKOUT_THRESHOLD=1 \
+				GIT_TEST_PARALLEL_CHECKOUT_MODE=async \
+				git -c core.parallelcheckout=1 \
+				    -c core.parallelcheckouthelpers=${h} \
+				    -c core.parallelcheckoutwriters=${w} \
+				    -c core.parallelcheckoutpreload=${p} \
+					clone -- "$GIT_PERF_BORROW_REPO" $r_out | cat &&
+				rm -rf $r_out
+			'
+		done
+	done
+done
+
+test_done

--- a/t/perf/p2081-parallel-checkout-sparse.sh
+++ b/t/perf/p2081-parallel-checkout-sparse.sh
@@ -1,0 +1,167 @@
+#!/bin/sh
+
+test_description='performance test for sparse-checkout using parallel-checkout'
+
+. ./perf-lib.sh
+
+# The path to the borrowed source repo will be in $GIT_PERF_BORROW_REPO
+# We must treat it as read-only.
+#
+test_perf_borrow_large_repo
+
+if test -z "$GIT_PERF_SPARSE_SET"; then
+	echo "warning: \$GIT_PERF_SPARSE_SET is not set, using sparse-checkout disable." >&2
+else
+	export GIT_PERF_SPARSE_SET
+fi
+
+# We create an instance of the repository in each `test_perf`, but
+# to allow `./run` to work, we need to delete them inside the
+# `test_perf` block, so that time gets added to the test.
+#
+# TODO Is there a way to get around that?
+
+# Classic (sequential) mode for comparison.
+#
+test_perf 'sparse-checkout classic' '
+	git -c advice.detachedHead=false \
+	    -c core.parallelcheckout=0 \
+		clone --sparse -- "$GIT_PERF_BORROW_REPO" r_classic &&
+
+	git -C r_classic config --worktree core.sparseCheckoutCone true &&
+
+	if test -z "$GIT_PERF_SPARSE_SET"; then
+		git -C r_classic \
+		    -c core.parallelcheckout=0 \
+			sparse-checkout disable | cat
+	else
+		cat $GIT_PERF_SPARSE_SET | \
+			git -C r_classic \
+			    -c core.parallelcheckout=0 \
+				sparse-checkout add --stdin | cat
+	fi
+
+	git -C r_classic ls-files | wc -l >&2 &&
+
+	rm -rf r_classic
+'
+
+# Sync mode.
+#
+# Sync mode always uses exactly 1 writer regardless what we pass in.
+#
+test_sync_h_attempts='4'
+test_sync_w_attempts='1'
+test_sync_p_attempts='02 10'
+
+for h in ${test_sync_h_attempts}
+do
+	export h
+	for w in ${test_sync_w_attempts}
+	do
+		export w
+		for p in ${test_sync_p_attempts}
+		do
+			export p
+
+			test_perf "sparse-checkout..sync h${h} w${w} p$p" '
+				r_out=./r_sync_h${h}_w${w}_p$p
+
+				GIT_TEST_PARALLEL_CHECKOUT_THRESHOLD=1 \
+				GIT_TEST_PARALLEL_CHECKOUT_MODE=sync \
+				git -c core.parallelcheckout=1 \
+				    -c core.parallelcheckouthelpers=${h} \
+				    -c core.parallelcheckoutwriters=${w} \
+				    -c core.parallelcheckoutpreload=${p} \
+					clone --sparse -- "$GIT_PERF_BORROW_REPO" $r_out &&
+
+				git -C $r_out config --worktree core.sparseCheckoutCone true &&
+
+				if test -z "$GIT_PERF_SPARSE_SET"; then
+					GIT_TEST_PARALLEL_CHECKOUT_THRESHOLD=1 \
+					GIT_TEST_PARALLEL_CHECKOUT_MODE=sync \
+					git -C $r_out \
+					    -c core.parallelcheckout=1 \
+					    -c core.parallelcheckouthelpers=${h} \
+					    -c core.parallelcheckoutwriters=${w} \
+					    -c core.parallelcheckoutpreload=${p} \
+						sparse-checkout disable | cat
+				else
+					cat $GIT_PERF_SPARSE_SET | \
+						GIT_TEST_PARALLEL_CHECKOUT_THRESHOLD=1 \
+						GIT_TEST_PARALLEL_CHECKOUT_MODE=sync \
+						git -C $r_out \
+						    -c core.parallelcheckout=1 \
+						    -c core.parallelcheckouthelpers=${h} \
+						    -c core.parallelcheckoutwriters=${w} \
+						    -c core.parallelcheckoutpreload=${p} \
+							sparse-checkout add --stdin | cat
+				fi &&
+
+				git -C $r_out ls-files | wc -l >&2 &&
+
+				rm -rf $r_out
+			'
+		done
+	done
+done
+
+# Async mode.
+#
+test_async_h_attempts='4'
+test_async_w_attempts='1 2 3'
+test_async_p_attempts='02 10'
+
+for h in ${test_async_h_attempts}
+do
+	export h
+	for w in ${test_async_w_attempts}
+	do
+		export w
+		for p in ${test_async_p_attempts}
+		do
+			export p
+
+			test_perf "sparse-checkout.async h${h} w${w} p$p" '
+				r_out=./r_async_h${h}_w${w}_p$p
+
+				GIT_TEST_PARALLEL_CHECKOUT_THRESHOLD=1 \
+				GIT_TEST_PARALLEL_CHECKOUT_MODE=async \
+				git -c core.parallelcheckout=1 \
+				    -c core.parallelcheckouthelpers=${h} \
+				    -c core.parallelcheckoutwriters=${w} \
+				    -c core.parallelcheckoutpreload=${p} \
+					clone --sparse -- "$GIT_PERF_BORROW_REPO" $r_out &&
+
+				git -C $r_out config --worktree core.sparseCheckoutCone true &&
+
+				if test -z "$GIT_PERF_SPARSE_SET"; then
+					GIT_TEST_PARALLEL_CHECKOUT_THRESHOLD=1 \
+					GIT_TEST_PARALLEL_CHECKOUT_MODE=async \
+					git -C $r_out \
+					    -c core.parallelcheckout=1 \
+					    -c core.parallelcheckouthelpers=${h} \
+					    -c core.parallelcheckoutwriters=${w} \
+					    -c core.parallelcheckoutpreload=${p} \
+						sparse-checkout disable | cat
+				else
+					cat $GIT_PERF_SPARSE_SET | \
+						GIT_TEST_PARALLEL_CHECKOUT_THRESHOLD=1 \
+						GIT_TEST_PARALLEL_CHECKOUT_MODE=async \
+						git -C $r_out \
+						    -c core.parallelcheckout=1 \
+						    -c core.parallelcheckouthelpers=${h} \
+						    -c core.parallelcheckoutwriters=${w} \
+						    -c core.parallelcheckoutpreload=${p} \
+							sparse-checkout add --stdin | cat
+				fi &&
+
+				git -C $r_out ls-files | wc -l >&2 &&
+
+				rm -rf $r_out
+			'
+		done
+	done
+done
+
+test_done

--- a/t/perf/perf-lib.sh
+++ b/t/perf/perf-lib.sh
@@ -128,6 +128,19 @@ test_perf_large_repo () {
 	fi
 	test_perf_create_repo_from "${1:-$TRASH_DIRECTORY}" "$GIT_PERF_LARGE_REPO"
 }
+test_perf_borrow_default_repo () {
+	GIT_PERF_BORROW_REPO=$GIT_PERF_REPO
+	export GIT_PERF_BORROW_REPO
+}
+test_perf_borrow_large_repo () {
+	if test "$GIT_PERF_LARGE_REPO" = "$GIT_BUILD_DIR"; then
+		echo "warning: \$GIT_PERF_LARGE_REPO is \$GIT_BUILD_DIR." >&2
+		echo "warning: This will work, but may not be a sufficiently large repo" >&2
+		echo "warning: for representative measurements." >&2
+	fi
+	GIT_PERF_BORROW_REPO=$GIT_PERF_LARGE_REPO
+	export GIT_PERF_BORROW_REPO
+}
 test_checkout_worktree () {
 	git checkout-index -u -a ||
 	error "git checkout-index failed"

--- a/t/t2080-parallel-checkout-attributes.sh
+++ b/t/t2080-parallel-checkout-attributes.sh
@@ -1,0 +1,375 @@
+#!/bin/sh
+
+test_description='Parallel Checkout (Attributes)'
+
+. ./test-lib.sh
+
+TEST_ROOT="$(pwd)"
+
+# Create some raw data files with well-known properties.
+# These will not be under version control, but rather be used
+# to create test cases later.
+
+setup () {
+	git config --local core.parallelcheckoutthreshold 1
+
+	cat >.gitignore <<-\EOF
+		*.DATA
+		actual
+		expect
+	EOF
+
+	git add .gitignore
+	git commit -m "gitignore"
+
+	git branch base
+
+	printf "LINEONE\nLINETWO\nLINETHREE\n"         >LF.DATA
+	printf "LINEONE\r\nLINETWO\r\nLINETHREE\r\n" >CRLF.DATA
+
+	cp LF.DATA                                   LF.UTF8.DATA
+	cat LF.DATA | iconv -f UTF-8 -t UTF-16LE >LF.UTF16LE.DATA
+	cat LF.DATA | iconv -f UTF-8 -t UTF-32LE >LF.UTF32LE.DATA
+
+	printf "\$Id: 7c8e93673a55d18460dc3ca2866f2236fb20a172 \$\nLINEONE\n" \
+	       >A.LF.IDENT.DATA
+	printf "\$Id\$\nLINEONE\n"                                            \
+	       >B.LF.IDENT.DATA
+	printf "\$Id: 0000000000000000000000000000000000000000 \$\nLINEONE\n" \
+	       >C.LF.IDENT.DATA
+	printf "\$Id: ffffffffffffffffffffffffffffffffffffffff \$\nLINEONE\n" \
+	       >D.LF.IDENT.DATA
+}
+
+test_expect_success setup '
+	setup
+'
+
+# The following tests each commit a series of files and rules to
+# smudge them.
+#
+# Delete and recreate the files using `reset --hard`.
+# This calls `check_updates_loop` to repopulate the files.
+#
+# Restore them once with the classic sequential logic.
+# Then repeat and let `checkout--helper` assist.
+#
+# The point here is to verify that both methods give the same answer
+# and that the conv_attr data sent to the helper contains sufficient
+# information to smudge files properly (and without access to the
+# index or attribute stack).
+#
+# WARNING: I'm using test_cmp_bin() here rather than test_cmp() because
+# WARNING: test_cmp() is a wrapper that calls "test-tool cmp" which calls
+# WARNING: strbuf_getline() and it ***EATS*** CRLF vs LF differences and
+# WARNING: makes most of these tests useless.
+
+test_expect_success verify_eol_handling '
+	test_when_finished "rm -f actual* expect* event.log" &&
+
+	git checkout base &&
+	git branch verify_eol_handling &&
+	git checkout verify_eol_handling &&
+
+	cat >.gitattributes <<-\EOF &&
+		*.dash-text     -text
+		*.text-lf       text eol=lf
+		*.text-crlf     text eol=crlf
+	EOF
+	git add .gitattributes &&
+	git commit -m "attrs" &&
+
+	printf "LINEONE\nLINETWO\nLINETHREE\n"         >LF.DATA &&
+	printf "LINEONE\r\nLINETWO\r\nLINETHREE\r\n" >CRLF.DATA &&
+
+	cp LF.DATA   f_01.dash-text &&
+	cp LF.DATA   f_02.text-lf &&
+	cp LF.DATA   f_03.text-crlf &&
+
+	cp CRLF.DATA f_04.dash-text &&
+	cp CRLF.DATA f_05.text-lf &&
+	cp CRLF.DATA f_06.text-crlf &&
+
+	cat >expect <<-\EOF &&
+		i/crlf w/crlf attr/-text f_04.dash-text
+		i/lf w/crlf attr/text eol=crlf f_03.text-crlf
+		i/lf w/crlf attr/text eol=crlf f_06.text-crlf
+		i/lf w/lf attr/-text f_01.dash-text
+		i/lf w/lf attr/text eol=lf f_02.text-lf
+		i/lf w/lf attr/text eol=lf f_05.text-lf
+	EOF
+
+	git add f_* &&
+	git commit -m "setup" &&
+
+	rm -rf f_* &&
+	git -c core.parallelcheckout=0 reset --hard &&
+
+	test_cmp_bin f_01.dash-text LF.DATA &&
+	test_cmp_bin f_02.text-lf   LF.DATA &&
+	test_cmp_bin f_03.text-crlf CRLF.DATA &&
+	test_cmp_bin f_04.dash-text CRLF.DATA &&
+	test_cmp_bin f_05.text-lf   LF.DATA &&
+	test_cmp_bin f_06.text-crlf CRLF.DATA &&
+
+	git ls-files f_* --eol >actual_0 &&
+	sed -e "s/	/ /g" -e "s/  */ /g" <actual_0 | sort >actual &&
+	test_cmp_bin actual expect &&
+
+	rm -rf f_* &&
+
+	# Force 2 helper processes instead of relying on the builtin
+	# calculation which is based upon the value of `online_cpus()`
+	# and may disable parallel-checkout on small PR/CI build machines.
+
+	GIT_TRACE2_EVENT=$TEST_ROOT/event.log \
+		GIT_TEST_CHECKOUT_HELPER_VERBOSE=99 \
+			git -c core.parallelcheckout=1 \
+			    -c core.parallelcheckouthelpers=2 \
+				reset --hard &&
+
+	# Verify that checkout--helper was used on all of the files.
+	grep -q "checkout--helper.*writing.*f_01" event.log &&
+	grep -q "checkout--helper.*writing.*f_02" event.log &&
+	grep -q "checkout--helper.*writing.*f_03" event.log &&
+	grep -q "checkout--helper.*writing.*f_04" event.log &&
+	grep -q "checkout--helper.*writing.*f_05" event.log &&
+	grep -q "checkout--helper.*writing.*f_06" event.log &&
+
+	# And that it only smudged the right ones.
+	grep -q -v "checkout--helper.*smudge.*f_01" event.log &&
+	grep -q -v "checkout--helper.*smudge.*f_02" event.log &&
+	grep -q    "checkout--helper.*smudge.*f_03" event.log &&
+	grep -q -v "checkout--helper.*smudge.*f_04" event.log &&
+	grep -q -v "checkout--helper.*smudge.*f_05" event.log &&
+	grep -q    "checkout--helper.*smudge.*f_06" event.log &&
+
+	test_cmp_bin f_01.dash-text LF.DATA &&
+	test_cmp_bin f_02.text-lf   LF.DATA &&
+	test_cmp_bin f_03.text-crlf CRLF.DATA &&
+	test_cmp_bin f_04.dash-text CRLF.DATA &&
+	test_cmp_bin f_05.text-lf   LF.DATA &&
+	test_cmp_bin f_06.text-crlf CRLF.DATA &&
+
+	git ls-files f_* --eol >actual_raw &&
+	sed -e "s/	/ /g" -e "s/  */ /g" <actual_raw | sort >actual &&
+	test_cmp_bin actual expect
+'
+
+test_expect_success verify_encoding_handling '
+	test_when_finished "rm -f actual* expect*" &&
+
+	git checkout base &&
+	git branch verify_encoding_handling &&
+	git checkout verify_encoding_handling &&
+
+	cat >.gitattributes <<-\EOF &&
+		*.text-lf-utf8     text eol=lf working-tree-encoding=utf-8
+		*.text-lf-utf16le  text eol=lf working-tree-encoding=utf-16le
+		*.text-lf-utf32le  text eol=lf working-tree-encoding=utf-32le
+	EOF
+	git add .gitattributes &&
+	git commit -m "attrs" &&
+
+	cp LF.UTF8.DATA    f_01.text-lf-utf8 &&
+	cp LF.UTF16LE.DATA f_02.text-lf-utf16le &&
+	cp LF.UTF32LE.DATA f_03.text-lf-utf32le &&
+
+	git add f_* &&
+	git commit -m "setup" &&
+
+	cat >expect_eol <<-\EOF &&
+		i/lf w/-text attr/text eol=lf f_02.text-lf-utf16le
+		i/lf w/-text attr/text eol=lf f_03.text-lf-utf32le
+		i/lf w/lf attr/text eol=lf f_01.text-lf-utf8
+	EOF
+
+	cat >expect_all <<-\EOF &&
+		f_01.text-lf-utf8: eol: lf
+		f_01.text-lf-utf8: text: set
+		f_01.text-lf-utf8: working-tree-encoding: utf-8
+		f_02.text-lf-utf16le: eol: lf
+		f_02.text-lf-utf16le: text: set
+		f_02.text-lf-utf16le: working-tree-encoding: utf-16le
+		f_03.text-lf-utf32le: eol: lf
+		f_03.text-lf-utf32le: text: set
+		f_03.text-lf-utf32le: working-tree-encoding: utf-32le
+	EOF
+
+	rm -rf f_* &&
+	git -c core.parallelcheckout=0 reset --hard &&
+
+	test_cmp_bin f_01.text-lf-utf8    LF.UTF8.DATA &&
+	test_cmp_bin f_02.text-lf-utf16le LF.UTF16LE.DATA &&
+	test_cmp_bin f_03.text-lf-utf32le LF.UTF32LE.DATA &&
+
+	git ls-files f_* --eol >actual_raw &&
+	sed -e "s/	/ /g" -e "s/  */ /g" <actual_raw | sort >actual_eol &&
+	test_cmp_bin actual_eol expect_eol &&
+
+	git check-attr --all f_* | sort >actual_all &&
+	test_cmp_bin actual_all expect_all &&
+
+	rm -rf f_* &&
+	git -c core.parallelcheckout=1 reset --hard &&
+
+	test_cmp_bin f_01.text-lf-utf8    LF.UTF8.DATA &&
+	test_cmp_bin f_02.text-lf-utf16le LF.UTF16LE.DATA &&
+	test_cmp_bin f_03.text-lf-utf32le LF.UTF32LE.DATA &&
+
+	git ls-files f_* --eol >actual_raw &&
+	sed -e "s/	/ /g" -e "s/  */ /g" <actual_raw | sort >actual_eol &&
+	test_cmp_bin actual_eol expect_eol &&
+
+	git check-attr --all f_* | sort >actual_all &&
+	test_cmp_bin actual_all expect_all
+'
+
+test_expect_success verify_ident_handling '
+	test_when_finished "rm -f actual* expect* event.log" &&
+
+	git checkout base &&
+	git branch verify_ident_handling &&
+	git checkout verify_ident_handling &&
+
+	cat >.gitattributes <<-\EOF &&
+		*.text-lf-ident    text eol=lf ident
+	EOF
+	git add .gitattributes &&
+	git commit -m "attrs" &&
+
+	cp A.LF.IDENT.DATA    f_01.text-lf-ident &&
+	cp B.LF.IDENT.DATA    f_02.text-lf-ident &&
+	cp C.LF.IDENT.DATA    f_03.text-lf-ident &&
+	cp D.LF.IDENT.DATA    f_04.text-lf-ident &&
+
+	git add f_* &&
+	git commit -m "setup" &&
+
+	cat >expect_eol <<-\EOF &&
+		i/lf w/lf attr/text eol=lf f_01.text-lf-ident
+		i/lf w/lf attr/text eol=lf f_02.text-lf-ident
+		i/lf w/lf attr/text eol=lf f_03.text-lf-ident
+		i/lf w/lf attr/text eol=lf f_04.text-lf-ident
+	EOF
+
+	cat >expect_all <<-\EOF &&
+		f_01.text-lf-ident: eol: lf
+		f_01.text-lf-ident: ident: set
+		f_01.text-lf-ident: text: set
+		f_02.text-lf-ident: eol: lf
+		f_02.text-lf-ident: ident: set
+		f_02.text-lf-ident: text: set
+		f_03.text-lf-ident: eol: lf
+		f_03.text-lf-ident: ident: set
+		f_03.text-lf-ident: text: set
+		f_04.text-lf-ident: eol: lf
+		f_04.text-lf-ident: ident: set
+		f_04.text-lf-ident: text: set
+	EOF
+
+	rm -rf f_* &&
+	git -c core.parallelcheckout=0 reset --hard &&
+
+	test_cmp_bin f_01.text-lf-ident    A.LF.IDENT.DATA &&
+	test_cmp_bin f_02.text-lf-ident    A.LF.IDENT.DATA &&
+	test_cmp_bin f_03.text-lf-ident    A.LF.IDENT.DATA &&
+	test_cmp_bin f_04.text-lf-ident    A.LF.IDENT.DATA &&
+
+	git ls-files f_* --eol >actual_raw &&
+	sed -e "s/	/ /g" -e "s/  */ /g" <actual_raw | sort >actual_eol &&
+	test_cmp_bin actual_eol expect_eol &&
+
+	git check-attr --all f_* | sort >actual_all &&
+	test_cmp_bin actual_all expect_all &&
+
+	rm -rf f_* &&
+
+	GIT_TRACE2_EVENT=$TEST_ROOT/event.log \
+		GIT_TEST_CHECKOUT_HELPER_VERBOSE=99 \
+			git -c core.parallelcheckout=1 \
+			    -c core.parallelcheckouthelpers=2 \
+				reset --hard &&
+
+	grep -q "checkout--helper.*smudge.*f_01" event.log &&
+	grep -q "checkout--helper.*smudge.*f_02" event.log &&
+	grep -q "checkout--helper.*smudge.*f_03" event.log &&
+	grep -q "checkout--helper.*smudge.*f_04" event.log &&
+
+	test_cmp_bin f_01.text-lf-ident    A.LF.IDENT.DATA &&
+	test_cmp_bin f_02.text-lf-ident    A.LF.IDENT.DATA &&
+	test_cmp_bin f_03.text-lf-ident    A.LF.IDENT.DATA &&
+	test_cmp_bin f_04.text-lf-ident    A.LF.IDENT.DATA &&
+
+	git ls-files f_* --eol >actual_raw &&
+	sed -e "s/	/ /g" -e "s/  */ /g" <actual_raw | sort >actual_eol &&
+	test_cmp_bin actual_eol expect_eol &&
+
+	git check-attr --all f_* | sort >actual_all &&
+	test_cmp_bin actual_all expect_all
+'
+
+# When there are nested .gitattribute files, the `check_updates_loop` code
+# uses `read_blob_data_from_index` to fetch each of the attribute files and
+# build the path-relative attribute stack during the cache-entry iteration.
+# This complicates traditional multithreaded ODB access.
+#
+# The point of this test is to ensure that properly crafted conv_attr data
+# is computed and sent to the helper.  We want that both the classic and the
+# helper version to produce the same result.
+
+test_expect_success verify_nested_attr '
+	test_when_finished "rm -f actual* expect* event.log" &&
+
+	git checkout base &&
+	git branch verify_nested_attr &&
+	git checkout verify_nested_attr &&
+
+	cat >.gitattributes <<-\EOF &&
+		*.text    text eol=lf
+	EOF
+	git add .gitattributes &&
+	git commit -m "attrs" &&
+
+	mkdir d1 d1/d2 &&
+	cp LF.DATA d1/d2/f_01.text &&
+	cp LF.DATA d1/d2/f_02.text &&
+	git add d1 &&
+
+	git commit -m "setup" &&
+
+	cat >d1/.gitattributes <<-\EOF &&
+		*.text    text eol=crlf
+	EOF
+	cat >d1/d2/.gitattributes <<-\EOF &&
+		*.text    text eol=crlf
+	EOF
+	git add d1 &&
+	git commit -m "attrs2" &&
+
+	# Switch back to the "base" branch to delete all of the files
+	# created in the current branch and the switch back to this
+	# branch to have them created with the new (attrs2) attributes.
+
+	git checkout base &&
+	git -c core.parallelcheckout=0 checkout verify_nested_attr &&
+
+	test_cmp_bin d1/d2/f_01.text CRLF.DATA &&
+	test_cmp_bin d1/d2/f_02.text CRLF.DATA &&
+
+	git checkout base &&
+
+	GIT_TRACE2_EVENT=$TEST_ROOT/event.log \
+		GIT_TEST_CHECKOUT_HELPER_VERBOSE=99 \
+			git -c core.parallelcheckout=1 \
+			    -c core.parallelcheckouthelpers=2 \
+				checkout verify_nested_attr &&
+
+	grep -q "checkout--helper.*smudge.*f_01" event.log &&
+	grep -q "checkout--helper.*smudge.*f_02" event.log &&
+
+	test_cmp_bin d1/d2/f_01.text CRLF.DATA &&
+	test_cmp_bin d1/d2/f_02.text CRLF.DATA
+'
+
+test_done

--- a/t/t2081-parallel-checkout-collisions.sh
+++ b/t/t2081-parallel-checkout-collisions.sh
@@ -1,0 +1,183 @@
+#!/bin/sh
+
+test_description='Parallel Checkout (Collisions)'
+
+. ./test-lib.sh
+
+TEST_ROOT="$(pwd)"
+
+write_script <<\EOF "$TEST_ROOT/rot13.sh"
+tr \
+  'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ' \
+  'nopqrstuvwxyzabcdefghijklmNOPQRSTUVWXYZABCDEFGHIJKLM'
+EOF
+
+# When there are pathname collisions during a clone on a case-insensitive
+# filesystem, Git should report a warning listing the all of the colliding
+# files.  The sequential code does collision detection by calling lstat()
+# before trying to open(O_CREAT) the file.  Then for item k, it searches
+# cache-entries[0, k-1] for the other entry.
+#
+# This is not sufficient in async mode where parallel-eligible files
+# are created in parallel, because colliding files may be created in a
+# racy order.
+#
+# These tests are to verify that the collision detection is extended
+# to allow for racy order.
+#
+# This test is based on the collision detection test in t5601.
+#
+test_expect_success CASE_INSENSITIVE_FS 'clone on case-insensitive fs' '
+	test_when_finished "rm -rf warning.* repo.* event.* icasefs" &&
+
+	git init icasefs &&
+	git -C icasefs config --local core.parallelcheckoutthreshold 1 &&
+
+	o=$(git -C icasefs hash-object -w --stdin </dev/null | hex2oct) &&
+	t=$(printf "100644 File_X\0${o}100644 File_x\0${o}100644 file_X\0${o}100644 file_x\0${o}" |
+		git -C icasefs hash-object -w -t tree --stdin) &&
+	c=$(git -C icasefs commit-tree -m BranchX $t) &&
+	git -C icasefs update-ref refs/heads/BranchX $c &&
+
+	git -c core.parallelcheckout=0 clone -b BranchX icasefs repo.0 2>warning.0 &&
+
+	grep File_X warning.0 &&
+	grep File_x warning.0 &&
+	grep file_X warning.0 &&
+	grep file_x warning.0 &&
+	test_i18ngrep "the following paths have collided" warning.0 &&
+
+	# The sync version should behave exactly the same as the
+	# classic version.
+	#
+	# Force 2 helper processes instead of relying on the builtin
+	# calculation which is based upon the value of `online_cpus()`
+	# and may disable parallel-checkout on small PR/CI build machines.
+
+	GIT_TRACE2_EVENT=$TEST_ROOT/event.1 \
+	  GIT_TEST_CHECKOUT_HELPER_VERBOSE=99 \
+	    GIT_TEST_PARALLEL_CHECKOUT_THRESHOLD=1 \
+	      GIT_TEST_PARALLEL_CHECKOUT_MODE=sync \
+		git -c core.parallelcheckout=1 \
+		    -c core.parallelcheckouthelpers=2 \
+			clone -b BranchX icasefs repo.1 2>warning.1 &&
+
+	# Verify that checkout--helper was used on all of the files.
+	grep -q "checkout--helper.*writing.*File_X" event.1 &&
+	grep -q "checkout--helper.*writing.*File_x" event.1 &&
+	grep -q "checkout--helper.*writing.*file_X" event.1 &&
+	grep -q "checkout--helper.*writing.*file_x" event.1 &&
+
+	grep -q -v "checkout--helper.*open_failed" event.1 &&
+
+	grep File_X warning.1 &&
+	grep File_x warning.1 &&
+	grep file_X warning.1 &&
+	grep file_x warning.1 &&
+	test_i18ngrep "the following paths have collided" warning.1 &&
+
+	# The async version should behave the similarly but also get 3
+	# IEC__OPEN errors, since all 4 files are parallel-eligible
+	# and only 1 will win the race (before we fallback to the classic
+	# code to fixes things).
+
+	GIT_TRACE2_EVENT=$TEST_ROOT/event.2 \
+	  GIT_TEST_CHECKOUT_HELPER_VERBOSE=99 \
+	    GIT_TEST_PARALLEL_CHECKOUT_THRESHOLD=1 \
+	      GIT_TEST_PARALLEL_CHECKOUT_MODE=async \
+		git -c core.parallelcheckout=1 \
+		    -c core.parallelcheckouthelpers=2 \
+			clone -b BranchX icasefs repo.2 2>warning.2 &&
+
+	# Verify that checkout--helper was used on all of the files.
+	grep -q "checkout--helper.*writing.*File_X" event.2 &&
+	grep -q "checkout--helper.*writing.*File_x" event.2 &&
+	grep -q "checkout--helper.*writing.*file_X" event.2 &&
+	grep -q "checkout--helper.*writing.*file_x" event.2 &&
+
+	grep "checkout--helper.*open_failed" event.2 >event.failed.2 &&
+	test_line_count = 3 event.failed.2 &&
+
+	grep File_X warning.2 &&
+	grep File_x warning.2 &&
+	grep file_X warning.2 &&
+	grep file_x warning.2 &&
+	test_i18ngrep "the following paths have collided" warning.2
+'
+
+# Files with clean/smudge filters are not parallel-eligible.  They are
+# processed sequentially (in the "async/remainder" region) *after* all
+# of the parallel-eligible files.
+#
+# This test uses ".gitattributes" to force an alternate ordering.
+# We make the (alphabetically) first file non-eligible to cause it
+# to be populated last.
+#
+# We have to use "core.ignoreCase=0" so that only the first file matches
+# the pattern.
+#
+# However, this test does not work on Windows because collision detection
+# is an approximation (using strcasecmp()).  It works on OSX because
+# collision detection uses inode numbers for exact matching.
+#
+# This test steals the rot13 code from t0021.
+#
+test_expect_success CASE_INSENSITIVE_FS,!MINGW,!CYGWIN 'clone on case-insensitive fs with filter' '
+	test_when_finished "rm -rf warning.* repo.* event.* icasefs" &&
+
+	git init icasefs &&
+	git -C icasefs config --local core.parallelcheckoutthreshold 1 &&
+
+	a=$(echo "File_X filter=rot13" | git -C icasefs hash-object -w --stdin | hex2oct) &&
+
+	o=$(git -C icasefs hash-object -w --stdin </dev/null | hex2oct) &&
+	t=$(printf "100644 .gitattributes\0${a}100644 File_X\0${o}100644 File_x\0${o}100644 file_X\0${o}100644 file_x\0${o}" |
+		git -C icasefs hash-object -w -t tree --stdin) &&
+	c=$(git -C icasefs commit-tree -m BranchX $t) &&
+	git -C icasefs update-ref refs/heads/BranchX $c &&
+
+	git -c core.parallelcheckout=0 \
+		-c core.ignoreCase=0 \
+		-c filter.rot13.smudge=../rot13.sh \
+		-c filter.rot13.clean=../rot13.sh \
+		clone -b BranchX icasefs repo.0 2>warning.0 &&
+
+	grep File_X warning.0 &&
+	grep File_x warning.0 &&
+	grep file_X warning.0 &&
+	grep file_x warning.0 &&
+	test_i18ngrep "the following paths have collided" warning.0 &&
+
+	GIT_TRACE2_EVENT=$TEST_ROOT/event.2 \
+	  GIT_TEST_CHECKOUT_HELPER_VERBOSE=99 \
+	    GIT_TEST_PARALLEL_CHECKOUT_THRESHOLD=1 \
+	      GIT_TEST_PARALLEL_CHECKOUT_MODE=async \
+		git -c core.parallelcheckout=1 \
+		    -c core.parallelcheckouthelpers=2 \
+		    -c core.ignoreCase=0 \
+		    -c filter.rot13.smudge=../rot13.sh \
+		    -c filter.rot13.clean=../rot13.sh \
+			clone -b BranchX icasefs repo.2 2>warning.2 &&
+
+	# Verify that checkout--helper was ONLY used on the non-rot13 files.
+	grep -q -v "checkout--helper.*writing.*File_X" event.2 &&
+	grep -q    "checkout--helper.*writing.*File_x" event.2 &&
+	grep -q    "checkout--helper.*writing.*file_X" event.2 &&
+	grep -q    "checkout--helper.*writing.*file_x" event.2 &&
+
+	# Verify that we got IEC__OPEN errors for 2 of the 3 files (which
+	# also ensures that the non-eligible files are populated after the
+	# eligible ones).
+	grep "checkout--helper.*open_failed" event.2 >event.failed.2 &&
+	test_line_count = 2 event.failed.2 &&
+
+	# Verify that the set of files in the collision matches the
+	# classic version.
+	grep File_X warning.2 &&
+	grep File_x warning.2 &&
+	grep file_X warning.2 &&
+	grep file_x warning.2 &&
+	test_i18ngrep "the following paths have collided" warning.2
+'
+
+test_done

--- a/t/t2082-parallel-checkout-basics.sh
+++ b/t/t2082-parallel-checkout-basics.sh
@@ -1,0 +1,102 @@
+#!/bin/sh
+
+test_description='Parallel Checkout (Basics)'
+
+. ./test-lib.sh
+
+TEST_ROOT="$(pwd)"
+
+R_BASE=$GIT_BUILD_DIR
+
+# Test to ensure that `parallel-checkout` basically works on a `clone`.
+# This confirms that helpers can be started and the resulting worktree
+# is populated correctly.
+#
+# The very verbose settings are very noise, but let us confirm that
+# files were created by the helpers.  (So don't bother looking at the
+# run times here.)
+#
+test_expect_success verbose_basic_local_clone '
+	test_when_finished "rm -rf *async* *classic* *sync*" &&
+
+	# Use Classic Mode
+
+	GIT_TRACE2_EVENT=$TEST_ROOT/classic.log \
+		git -c advice.detachedHead=false \
+		    -c core.parallelcheckout=0 \
+			clone -- $R_BASE r_classic &&
+
+	# Verify that both the worktree and the index were created correctly.
+
+	git -C r_classic --no-optional-locks \
+		status --porcelain=v2 >classic.out &&
+	test_must_be_empty classic.out &&
+	git -C r_classic diff-files --quiet &&
+
+	# Rebuild the index from scratch, rescan the mtimes, and verify that
+	# the worktree was correctly created.
+	git -C r_classic read-tree HEAD &&
+	git -C r_classic status --porcelain=v2 >classic.out &&
+	test_must_be_empty classic.out &&
+
+	# Use Synchronous Mode
+
+	GIT_TRACE2_EVENT=$TEST_ROOT/sync.log \
+	  GIT_TEST_CHECKOUT_HELPER_VERBOSE=99 \
+	    GIT_TEST_PARALLEL_CHECKOUT_THRESHOLD=1 \
+	      GIT_TEST_PARALLEL_CHECKOUT_MODE=sync \
+		git -c advice.detachedHead=false \
+		    -c core.parallelcheckout=1 \
+		    -c core.parallelcheckouthelpers=2 \
+			clone -- $R_BASE r_sync &&
+
+	git -C r_sync --no-optional-locks \
+		status --porcelain=v2 >sync.out &&
+	test_must_be_empty sync.out &&
+	git -C r_sync diff-files --quiet &&
+
+	git -C r_sync read-tree HEAD &&
+	git -C r_sync status --porcelain=v2 >sync.out &&
+	test_must_be_empty sync.out &&
+
+	# Expect at least one verbose message from the helpers to confirm
+	# that we got into the parallel-checkout code.
+	grep -q "data_json.*checkout--helper.*writing" sync.log &&
+	
+	# Confirm that the helpers were started in sync mode.
+	grep -q "start.*checkout--helper.*--no-async" sync.log &&
+
+	# Use Asynchronous Mode
+
+	GIT_TRACE2_EVENT=$TEST_ROOT/async.log \
+	  GIT_TEST_CHECKOUT_HELPER_VERBOSE=99 \
+	    GIT_TEST_PARALLEL_CHECKOUT_THRESHOLD=1 \
+	      GIT_TEST_PARALLEL_CHECKOUT_MODE=async \
+		git -c advice.detachedHead=false \
+		    -c core.parallelcheckout=1 \
+		    -c core.parallelcheckouthelpers=2 \
+			clone -- $R_BASE r_async &&
+
+	git -C r_async --no-optional-locks \
+		status --porcelain=v2 >async.out &&
+	test_must_be_empty async.out &&
+	git -C r_async diff-files --quiet &&
+
+	git -C r_async read-tree HEAD &&
+	git -C r_async status --porcelain=v2 >async.out &&
+	test_must_be_empty async.out &&
+
+	grep -q "data_json.*checkout--helper.*writing" async.log &&
+	grep -q "start.*checkout--helper.*--async" async.log &&
+
+	# Just to be paranoid, actually compare the contents of the
+	# worktrees directly.  This avoids any of the caching tricks
+	# that Git is doing for us.
+	rm -rf r_classic/.git &&
+	rm -rf r_sync/.git &&
+	rm -rf r_async/.git &&
+	diff -r --brief r_classic r_sync &&
+	diff -r --brief r_classic r_async
+'
+
+test_done

--- a/unpack-trees.c
+++ b/unpack-trees.c
@@ -1735,6 +1735,7 @@ int unpack_trees(unsigned len, struct tree_desc *t, struct unpack_trees_options 
 	if (o->dst_index) {
 		move_index_extensions(&o->result, o->src_index);
 		if (!ret) {
+			trace2_region_enter("unpack_trees", "cache_tree", NULL);
 			if (git_env_bool("GIT_TEST_CHECK_CACHE_TREE", 0))
 				cache_tree_verify(the_repository, &o->result);
 			if (!o->result.cache_tree)
@@ -1743,6 +1744,7 @@ int unpack_trees(unsigned len, struct tree_desc *t, struct unpack_trees_options 
 				cache_tree_update(&o->result,
 						  WRITE_TREE_SILENT |
 						  WRITE_TREE_REPAIR);
+			trace2_region_leave("unpack_trees", "cache_tree", NULL);
 		}
 
 		o->result.updated_workdir = 1;

--- a/unpack-trees.c
+++ b/unpack-trees.c
@@ -1731,7 +1731,10 @@ int unpack_trees(unsigned len, struct tree_desc *t, struct unpack_trees_options 
 		}
 	}
 
+	trace2_region_enter("unpack_trees", "check_updates", NULL);
 	ret = check_updates(o, &o->result) ? (-2) : 0;
+	trace2_region_leave("unpack_trees", "check_updates", NULL);
+
 	if (o->dst_index) {
 		move_index_extensions(&o->result, o->src_index);
 		if (!ret) {

--- a/unpack-trees.c
+++ b/unpack-trees.c
@@ -1938,6 +1938,7 @@ enum update_sparsity_result update_sparsity(struct unpack_trees_options *o)
 		BUG("update_sparsity() called wrong");
 
 	trace_performance_enter();
+	trace2_region_enter("unpack_trees", "update_sparsity", NULL);
 
 	/* If we weren't given patterns, use the recorded ones */
 	if (!o->pl) {
@@ -1953,6 +1954,7 @@ enum update_sparsity_result update_sparsity(struct unpack_trees_options *o)
 	mark_new_skip_worktree(o->pl, o->src_index, 0,
 			       CE_NEW_SKIP_WORKTREE, o->verbose_update);
 
+	trace2_region_enter("unpack_trees", "update_sparsity/loop", NULL);
 	/* Then loop over entries and update/remove as needed */
 	ret = UPDATE_SPARSITY_SUCCESS;
 	empty_worktree = 1;
@@ -1973,6 +1975,7 @@ enum update_sparsity_result update_sparsity(struct unpack_trees_options *o)
 		if (!ce_skip_worktree(ce))
 			empty_worktree = 0;
 	}
+	trace2_region_leave("unpack_trees", "update_sparsity/loop", NULL);
 
 	/*
 	 * Sparse checkout is meant to narrow down checkout area
@@ -1995,6 +1998,7 @@ done:
 	o->show_all_errors = old_show_all_errors;
 	if (free_pattern_list)
 		clear_pattern_list(&pl);
+	trace2_region_leave("unpack_trees", "update_sparsity", NULL);
 	trace_performance_leave("update_sparsity");
 	return ret;
 }

--- a/unpack-trees.c
+++ b/unpack-trees.c
@@ -460,6 +460,8 @@ static int check_updates(struct unpack_trees_options *o,
 					   to_fetch.oid, to_fetch.nr);
 		oid_array_clear(&to_fetch);
 	}
+
+	trace2_region_enter("unpack_trees", "check_updates_loop", NULL);
 	for (i = 0; i < index->cache_nr; i++) {
 		struct cache_entry *ce = index->cache[i];
 
@@ -472,6 +474,8 @@ static int check_updates(struct unpack_trees_options *o,
 			errs |= checkout_entry(ce, &state, NULL, NULL);
 		}
 	}
+	trace2_region_leave("unpack_trees", "check_updates_loop", NULL);
+
 	stop_progress(&progress);
 	errs |= finish_delayed_checkout(&state, NULL);
 	git_attr_set_direction(GIT_ATTR_CHECKIN);


### PR DESCRIPTION
This is an attempt to speed up `clone`, `checkout` and other commands that
call `unpack_trees()` by using multiple helper processes.  This avoids the need
to make the ODB thread-safe.

This series logically contains 4 parts.  The first 3 could be split into 1 or more
independent series.

[1] The first 7 commits (prefixed with `pkt-line`) make it safer to use multiple pkt-line
connections at the same time by removing static buffers.

[2] The next 3 commits (prefixed with `sub-process`) make it safer to use multiple
long-running sub-processes at the same time.

[3] The next 6 commits (prefixed with `convert`) refactor the smudging code slightly
to make the `struct conv_attrs` structure public and make it separate its computation
from its use when smudging a file.

[4] The actual parallel-checkout changes.  It logically consists of:
[4a] 4 Commits to add tracing and minor refactoring in `unpack-trees.c`.
[4b] 5 Commits to add new `core.parallelCheckout*` config settings.
[4c] 1 Commit to create a new `checkout--helper` builtin command.
[4d] 1 Commit to implement the actual parallel-checkout logic.
[4e] 3 Commits containing new tests.
[4f] 2 Commits containing documentation.

The design document is in the final commit.  It may help to review it first.

There are several TODOs left in the code as well in Appendix F.
And as always, more tests are required.
