### PR TITLE
WIP: Add config for commitgraph.writeChangedPaths

### DIFF
--- a/Documentation/config.txt
+++ b/Documentation/config.txt
@@ -340,6 +340,8 @@ include::config/column.txt[]
 
 include::config/commit.txt[]
 
+include::config/commitgraph.txt[]
+
 include::config/credential.txt[]
 
 include::config/completion.txt[]

--- a/Documentation/config/commitgraph.txt
+++ b/Documentation/config/commitgraph.txt
@@ -1,0 +1,3 @@
+commitgraph.writeChangedPaths::
+  A boolean to enable/disable inclusion of changed paths bloom
+  filter in the commitgraph. Default to false.

--- a/repo-settings.c
+++ b/repo-settings.c
@@ -15,43 +15,43 @@ void prepare_repo_settings(struct repository *r)
 	/* Defaults */
 	memset(&r->settings, -1, sizeof(r->settings));
 
-	if (!repo_config_get_bool(r, "core.commitgraph", &value))
+	if (!repo_config_get_bool(r, "core.commitGraph", &value))
 		r->settings.core_commit_graph = value;
-	if (!repo_config_get_bool(r, "gc.writecommitgraph", &value))
+	if (!repo_config_get_bool(r, "gc.writeCommitGraph", &value))
 		r->settings.gc_write_commit_graph = value;
 	UPDATE_DEFAULT_BOOL(r->settings.core_commit_graph, 1);
 	UPDATE_DEFAULT_BOOL(r->settings.gc_write_commit_graph, 1);
 
 	if (!repo_config_get_int(r, "index.version", &value))
 		r->settings.index_version = value;
-	if (!repo_config_get_maybe_bool(r, "core.untrackedcache", &value)) {
+	if (!repo_config_get_maybe_bool(r, "core.untrackedCache", &value)) {
 		if (value == 0)
 			r->settings.core_untracked_cache = UNTRACKED_CACHE_REMOVE;
 		else
 			r->settings.core_untracked_cache = UNTRACKED_CACHE_WRITE;
-	} else if (!repo_config_get_string(r, "core.untrackedcache", &strval)) {
+	} else if (!repo_config_get_string(r, "core.untrackedCache", &strval)) {
 		if (!strcasecmp(strval, "keep"))
 			r->settings.core_untracked_cache = UNTRACKED_CACHE_KEEP;
 
 		free(strval);
 	}
 
-	if (!repo_config_get_string(r, "fetch.negotiationalgorithm", &strval)) {
+	if (!repo_config_get_string(r, "fetch.negotiationAlgorithm", &strval)) {
 		if (!strcasecmp(strval, "skipping"))
 			r->settings.fetch_negotiation_algorithm = FETCH_NEGOTIATION_SKIPPING;
 		else
 			r->settings.fetch_negotiation_algorithm = FETCH_NEGOTIATION_DEFAULT;
 	}
 
-	if (!repo_config_get_bool(r, "pack.usesparse", &value))
+	if (!repo_config_get_bool(r, "pack.useSparse", &value))
 		r->settings.pack_use_sparse = value;
 	UPDATE_DEFAULT_BOOL(r->settings.pack_use_sparse, 1);
 
-	if (!repo_config_get_bool(r, "feature.manyfiles", &value) && value) {
+	if (!repo_config_get_bool(r, "feature.manyFiles", &value) && value) {
 		UPDATE_DEFAULT_BOOL(r->settings.index_version, 4);
 		UPDATE_DEFAULT_BOOL(r->settings.core_untracked_cache, UNTRACKED_CACHE_WRITE);
 	}
-	if (!repo_config_get_bool(r, "fetch.writecommitgraph", &value))
+	if (!repo_config_get_bool(r, "fetch.writeCommitGraph", &value))
 		r->settings.fetch_write_commit_graph = value;
 	if (!repo_config_get_bool(r, "feature.experimental", &value) && value) {
 		UPDATE_DEFAULT_BOOL(r->settings.fetch_negotiation_algorithm, FETCH_NEGOTIATION_SKIPPING);

--- a/repo-settings.c
+++ b/repo-settings.c
@@ -53,6 +53,8 @@ void prepare_repo_settings(struct repository *r)
 	}
 	if (!repo_config_get_bool(r, "fetch.writeCommitGraph", &value))
 		r->settings.fetch_write_commit_graph = value;
+	if (!repo_config_get_bool(r, "commitgraph.writeChangedPaths", &value))
+		r->settings.commit_graph_write_changed_paths = value;
 	if (!repo_config_get_bool(r, "feature.experimental", &value) && value) {
 		UPDATE_DEFAULT_BOOL(r->settings.fetch_negotiation_algorithm, FETCH_NEGOTIATION_SKIPPING);
 		UPDATE_DEFAULT_BOOL(r->settings.fetch_write_commit_graph, 1);

--- a/repository.h
+++ b/repository.h
@@ -31,6 +31,7 @@ struct repo_settings {
 	int core_commit_graph;
 	int gc_write_commit_graph;
 	int fetch_write_commit_graph;
+	int commit_graph_write_changed_paths;
 
 	int index_version;
 	enum untracked_cache_setting core_untracked_cache;


### PR DESCRIPTION
# This is a WIP PR, DO NOT MERGE.

We have recently added Bloom filter with `--changed-paths` in `git commit-graph write` command. However end-users rarely interact with this command directly. Instead, end users often relies on `fetch.writeCommitGraph=true` and `gc.writeCommitGraph=true` as a 1 time setting tweaks to keep their repository up-to-date.

In this patch series, I want to introduce `commitgraph.writeChangedPaths` configuration key that users can rely on to have Bloom filter included in their commitgraph reliably.

General walkthrough of the patch series:

- [X] 1/6: Preparation style fix
- [X] 2/6: Introduce the config key and documentation
- [ ] 3/6: Apply config key into `fetch` when `fetch.writeCommitGraph=true`
- [ ] 4/6: Apply config key to `gc` when `gc.writeCommitGraph=true`
- [ ] 5/6: Apply config key to `commit-graph write`
- [ ] 6/6: Create `commit-graph write --no-changed-paths` that would help users specifically override the config setting when needed.