### PR TITLE
command-list.txt: add gitfaq to the list of guides

### DIFF
--- a/command-list.txt
+++ b/command-list.txt
@@ -198,6 +198,7 @@ gitcore-tutorial                        guide
 gitcvs-migration                        guide
 gitdiffcore                             guide
 giteveryday                             guide
+gitfaq                                  guide
 gitglossary                             guide
 githooks                                guide
 gitignore                               guide


### PR DESCRIPTION
The new FAQ is not listed in `command-list.txt`, so it does not show up in `git help --guides`.

I think this should be included in 2.27.0.

CC: brian m. carlson <sandals@crustytoothpaste.net>
