### PR TITLE
git-gui: allow opening work trees from the startup dialog

### DIFF
--- a/lib/choose_repository.tcl
+++ b/lib/choose_repository.tcl
@@ -362,8 +362,19 @@ proc _is_git {path {outdir_var ""}} {
 		gets $fp line
 		close $fp
 		if {[regexp "^gitdir: (.+)$" $line line link_target]} {
+			set check_path [file normalize $path]
 			set path [file join [file dirname $path] $link_target]
 			set path [file normalize $path]
+
+			if {[file exists [file join $path gitdir]]} {
+				set fp [open [file join $path gitdir] r]
+				gets $fp worktree_path
+				close $fp
+				if {[string equal $check_path $worktree_path]} {
+					set outdir $path
+					return 1
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
In proc _is_git check that supplied path is a valid work tree path.
This allows the choose_repository::pick dialog to accept path to a
work tree directory.

Signed-off-by: Mikhail Terekhov <termim@gmail.com>

Thanks for taking the time to contribute to Git! Please be advised that the
Git community does not use github.com for their contributions. Instead, we use
a mailing list (git@vger.kernel.org) for code submissions, code reviews, and
bug reports. Nevertheless, you can use GitGitGadget (https://gitgitgadget.github.io/)
to conveniently send your Pull Requests commits to our mailing list.

Please read the "guidelines for contributing" linked above!
