### PR TITLE
gc: recommend `git gc --prune=now` instead of `git prune`

### DIFF
--- a/builtin/gc.c
+++ b/builtin/gc.c
@@ -692,7 +692,7 @@ int cmd_gc(int argc, const char **argv, const char *prefix)
 
 	if (auto_gc && too_many_loose_objects())
 		warning(_("There are too many unreachable loose objects; "
-			"run 'git prune' to remove them."));
+			"run 'git gc --prune=now' to remove them."));
 
 	if (!daemonized)
 		unlink(git_path("gc.log"));


### PR DESCRIPTION
`git prune` is a plumbing command and should not be run directly by
users. The corresponding porcelain command is `git gc`, which is
mentioned in the man page of `git prune`.

Signed-off-by: John Lin <johnlinp@gmail.com>

Fix according to #642.