### PR TITLE
Fix difftool problem with intent-to-add files

### DIFF
--- a/diff-lib.c
+++ b/diff-lib.c
@@ -220,8 +220,7 @@ int run_diff_files(struct rev_info *revs, unsigned int option)
 			} else if (revs->diffopt.ita_invisible_in_index &&
 				   ce_intent_to_add(ce)) {
 				diff_addremove(&revs->diffopt, '+', ce->ce_mode,
-					       the_hash_algo->empty_tree, 0,
-					       ce->name, 0);
+					       &null_oid, 0, ce->name, 0);
 				continue;
 			}
 

--- a/t/t2203-add-intent.sh
+++ b/t/t2203-add-intent.sh
@@ -240,7 +240,6 @@ test_expect_success 'i-t-a files shown as new for "diff", "diff-files"; not-new 
 
 	hash_e=$(git hash-object empty) &&
 	hash_n=$(git hash-object not-empty) &&
-	hash_t=$(git hash-object -t tree /dev/null) &&
 
 	cat >expect.diff_p <<-EOF &&
 	diff --git a/empty b/empty
@@ -259,8 +258,8 @@ test_expect_success 'i-t-a files shown as new for "diff", "diff-files"; not-new 
 	 create mode 100644 not-empty
 	EOF
 	cat >expect.diff_a <<-EOF &&
-	:000000 100644 0000000 $(git rev-parse --short $hash_t) A$(printf "\t")empty
-	:000000 100644 0000000 $(git rev-parse --short $hash_t) A$(printf "\t")not-empty
+	:000000 100644 0000000 0000000 A$(printf "\t")empty
+	:000000 100644 0000000 0000000 A$(printf "\t")not-empty
 	EOF
 
 	git add -N empty not-empty &&

--- a/t/t7800-difftool.sh
+++ b/t/t7800-difftool.sh
@@ -720,6 +720,14 @@ test_expect_success SYMLINKS 'difftool --dir-diff handles modified symlinks' '
 	test_cmp expect actual
 '
 
+test_expect_success 'add -N and difftool -d' '
+	test_when_finished git reset --hard &&
+
+	test_write_lines A B C >intent-to-add &&
+	git add -N intent-to-add &&
+	git difftool --dir-diff --extcmd ls
+'
+
 test_expect_success 'outside worktree' '
 	echo 1 >1 &&
 	echo 2 >2 &&


### PR DESCRIPTION
This problem was reported in https://github.com/git-for-windows/git/issues/2677, but the problem actually lies with `git diff --raw`, and it seems that the bug has been with us ever since` --intent-to-add` was introduced.

Changes since v4:

- Improved both commit messages after feedback from Junio.

Changes since v3:

- Instead of showing the same OID in `git diff-files --raw` as in `git diff-files -p` for intent-to-add files, we now imitate the logic for modified (non-intent-to-add) files: we show the "null" OID (i.e. all-zero).

- As a consequence, we no longer just undo the inadvertent change where intent-to-add files were reported with the empty tree instead of the empty blob, but we fix the bug that has been with us since `run_diff_files()` was taught about intent-to-add files, i.e. we fix the original bug of 425a28e0a4e (diff-lib: allow ita entries treated as "not yet exist in index", 2016-10-24), at long last.

Changes since v2:

- Now we also drop the no-longer-used definition of `hash_t` in t2203.

Changes since v1:

- Rebased onto `sk/diff-files-show-i-t-a-as-new`.
- Verified that `sk/diff-files-show-i-t-a-as-new` does not completely resolve the issue (the `--raw` output still claims the empty blob as the post-image, although the `difftool` symptom "went away").
- Amended the central patch of this PR to include a fix for the regression test that was introduced in `sk/diff-files-show-i-t-a-as-new`: it expected the raw diff to contain the hash of the empty tree object (which is incorrect no matter how you turn it: _any_ hash in any raw diff should refer to blob objects).
- Reordered the patches so that the central patch comes first (otherwise, the "empty tree" fix would cause a test failure in t2203).

Cc: Srinidhi Kaushik <shrinidhi.kaushik@gmail.com>