### PR TITLE
[GSoC][RFC] print commits using ref-filter's logic

### DIFF
--- a/Documentation/config/log.txt
+++ b/Documentation/config/log.txt
@@ -48,3 +48,7 @@ log.mailmap::
 	If true, makes linkgit:git-log[1], linkgit:git-show[1], and
 	linkgit:git-whatchanged[1] assume `--use-mailmap`, otherwise
 	assume `--no-use-mailmap`. True by default.
+
+log.useRefFilter::
+	[EXPERIMENTAL] If true, forces `git log` to use ref-filter's logic.
+	Is `false` by default.

--- a/Makefile
+++ b/Makefile
@@ -943,6 +943,7 @@ LIB_OBJS += pathspec.o
 LIB_OBJS += pkt-line.o
 LIB_OBJS += preload-index.o
 LIB_OBJS += pretty.o
+LIB_OBJS += pretty-lib.o
 LIB_OBJS += prio-queue.o
 LIB_OBJS += progress.o
 LIB_OBJS += promisor-remote.o

--- a/builtin/log.c
+++ b/builtin/log.c
@@ -39,6 +39,9 @@
 #define MAIL_DEFAULT_WRAP 72
 #define COVER_FROM_AUTO_MAX_SUBJECT_LEN 100
 
+/* Set true to use ref-filter's logic in git log */
+static int log_use_ref_filter;
+
 /* Set a default date-time format for git log ("log.date" config variable) */
 static const char *default_date_mode = NULL;
 
@@ -487,6 +490,10 @@ static int git_log_config(const char *var, const char *value, void *cb)
 	}
 	if (!strcmp(var, "log.showsignature")) {
 		default_show_signature = git_config_bool(var, value);
+		return 0;
+	}
+	if (!strcmp(var, "log.usereffilter")) {
+		log_use_ref_filter = git_config_bool(var, value);
 		return 0;
 	}
 

--- a/builtin/log.c
+++ b/builtin/log.c
@@ -155,6 +155,7 @@ static void cmd_log_init_defaults(struct rev_info *rev)
 	rev->show_root_diff = default_show_root;
 	rev->subject_prefix = fmt_patch_subject_prefix;
 	rev->show_signature = default_show_signature;
+	rev->use_ref_filter = log_use_ref_filter;
 	rev->encode_email_headers = default_encode_email_headers;
 	rev->diffopt.flags.allow_textconv = 1;
 

--- a/log-tree.c
+++ b/log-tree.c
@@ -17,6 +17,7 @@
 #include "help.h"
 #include "interdiff.h"
 #include "range-diff.h"
+#include "pretty-lib.h"
 
 static struct decoration name_decoration = { "object names" };
 static int decoration_loaded;
@@ -756,7 +757,11 @@ void show_log(struct rev_info *opt)
 		ctx.from_ident = &opt->from_ident;
 	if (opt->graph)
 		ctx.graph_width = graph_width(opt->graph);
-	pretty_print_commit(&ctx, commit, &msgbuf);
+
+	if (opt->use_ref_filter)
+		ref_pretty_print_commit(&ctx, commit, &msgbuf);
+	else
+		pretty_print_commit(&ctx, commit, &msgbuf);
 
 	if (opt->add_signoff)
 		append_signoff(&msgbuf, 0, APPEND_SIGNOFF_DEDUP);

--- a/pretty-lib.c
+++ b/pretty-lib.c
@@ -1,0 +1,52 @@
+#include "commit.h"
+#include "ref-filter.h"
+#include "pretty-lib.h"
+
+static size_t convert_format(struct strbuf *sb, const char *start, void *data)
+{
+	/* TODO - Add support for more formatting options */
+	switch (*start) {
+	case 'H':
+		strbuf_addstr(sb, "%(objectname)");
+		return 1;
+	case 'h':
+		strbuf_addstr(sb, "%(objectname:short)");
+		return 1;
+	case 'T':
+		strbuf_addstr(sb, "%(tree)");
+		return 1;
+	default:
+		die(_("invalid formatting option '%c'"), *start);
+	}
+}
+
+void ref_pretty_print_commit(struct pretty_print_context *pp,
+			 const struct commit *commit,
+			 struct strbuf *sb)
+{
+	struct ref_format format = REF_FORMAT_INIT;
+	struct strbuf sb_fmt = STRBUF_INIT;
+	const char *name = "refs";
+	const char *usr_fmt = get_user_format();
+
+	if (pp->fmt == CMIT_FMT_USERFORMAT) {
+		strbuf_expand(&sb_fmt, usr_fmt, convert_format, NULL);
+		format.format = sb_fmt.buf;
+	} else if (pp->fmt == CMIT_FMT_DEFAULT || pp->fmt == CMIT_FMT_MEDIUM) {
+		format.format = "Author: %(authorname) %(authoremail)\nDate:\t%(authordate)\n\n%(subject)\n\n%(body)";
+	} else if (pp->fmt == CMIT_FMT_ONELINE) {
+		format.format = "%(subject)";
+	} else if (pp->fmt == CMIT_FMT_SHORT) {
+		format.format = "Author: %(authorname) %(authoremail)\n\n\t%(subject)\n";
+	} else if (pp->fmt == CMIT_FMT_FULL) {
+		format.format = "Author: %(authorname) %(authoremail)\nCommit: %(committername) %(committeremail)\n\n%(subject)\n\n%(body)";
+	} else if (pp->fmt == CMIT_FMT_FULLER) {
+		format.format = "Author:\t\t%(authorname) %(authoremail)\nAuthorDate:\t%(authordate)\nCommit:\t\t%(committername) %(committeremail)\nCommitDate:\t%(committerdate)\n\n%(subject)\n\n%(body)";
+	}
+
+	format.need_newline_at_eol = 0;
+
+	verify_ref_format(&format);
+	pretty_print_ref(name, &commit->object.oid, &format);
+	strbuf_release(&sb_fmt);
+}

--- a/pretty-lib.h
+++ b/pretty-lib.h
@@ -1,0 +1,21 @@
+#ifndef PRETTY_LIB_H
+#define PRETTY_LIB_H
+
+/**
+ * This is a possibly temporary interface between
+ * ref-filter and pretty. This interface may disappear in the
+ * future if a way to use ref-filter directly is found.
+ * In the meantime, this interface would enable us to
+ * step by step replace the formatting code in pretty by the
+ * ref-filter code.
+*/
+
+/**
+ * Possible future replacement for "pretty_print_commit()".
+ * Uses ref-filter's logic.
+*/
+void ref_pretty_print_commit(struct pretty_print_context *pp,
+			const struct commit *commit,
+			struct strbuf *sb);
+
+#endif /* PRETTY_LIB_H */

--- a/pretty.c
+++ b/pretty.c
@@ -2016,3 +2016,8 @@ void pp_commit_easy(enum cmit_fmt fmt, const struct commit *commit,
 	pp.fmt = fmt;
 	pretty_print_commit(&pp, commit, sb);
 }
+
+const char *get_user_format(void)
+{
+	return user_format;
+}

--- a/pretty.h
+++ b/pretty.h
@@ -139,4 +139,7 @@ const char *format_subject(struct strbuf *sb, const char *msg,
 /* Check if "cmit_fmt" will produce an empty output. */
 int commit_format_is_empty(enum cmit_fmt);
 
+/* Returns user_format */
+const char *get_user_format(void);
+
 #endif /* PRETTY_H */

--- a/ref-filter.c
+++ b/ref-filter.c
@@ -2410,7 +2410,8 @@ void show_ref_array_item(struct ref_array_item *info,
 	fwrite(final_buf.buf, 1, final_buf.len, stdout);
 	strbuf_release(&error_buf);
 	strbuf_release(&final_buf);
-	putchar('\n');
+	if(format->need_newline_at_eol)
+		putchar('\n');
 }
 
 void pretty_print_ref(const char *name, const struct object_id *oid,

--- a/ref-filter.h
+++ b/ref-filter.h
@@ -81,11 +81,13 @@ struct ref_format {
 	int quote_style;
 	int use_color;
 
+	int need_newline_at_eol;
+
 	/* Internal state to ref-filter */
 	int need_color_reset_at_eol;
 };
 
-#define REF_FORMAT_INIT { NULL, 0, -1 }
+#define REF_FORMAT_INIT { NULL, 0, -1, 1 }
 
 /*  Macros for checking --merged and --no-merged options */
 #define _OPT_MERGED_NO_MERGED(option, filter, h) \

--- a/revision.h
+++ b/revision.h
@@ -210,7 +210,8 @@ struct rev_info {
 			missing_newline:1,
 			date_mode_explicit:1,
 			preserve_subject:1,
-			encode_email_headers:1;
+			encode_email_headers:1,
+			use_ref_filter:1;
 	unsigned int	disable_stdin:1;
 	/* --show-linear-break */
 	unsigned int	track_linear:1,


### PR DESCRIPTION
This is a step toward reusing ref-filter formatting logic in pretty to have one unified interface to extract all needed data from the object and to print it properly. 

In the process, I made few modifications. Although it doesn't impact the current flow of `git log` unless `log.usereffilter` is set true.

Thanks,
Hariom

