### PR TITLE
Moving documentation changes from dscho/git:inclusive-naming.

### DIFF
--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -49,7 +49,7 @@ endif
 
 MAN_XML = $(patsubst %.txt,%.xml,$(MAN_TXT))
 MAN_HTML = $(patsubst %.txt,%.html,$(MAN_TXT))
-GIT_MAN_REF = master
+GIT_MAN_REF = main
 
 OBSOLETE_HTML += everyday.html
 OBSOLETE_HTML += git-remote-helpers.html
@@ -93,7 +93,6 @@ TECH_DOCS += technical/protocol-capabilities
 TECH_DOCS += technical/protocol-common
 TECH_DOCS += technical/protocol-v2
 TECH_DOCS += technical/racy-git
-TECH_DOCS += technical/reftable
 TECH_DOCS += technical/send-pack-pipeline
 TECH_DOCS += technical/shallow
 TECH_DOCS += technical/signature-format

--- a/Documentation/MyFirstContribution.txt
+++ b/Documentation/MyFirstContribution.txt
@@ -113,15 +113,15 @@ commands such as `sl`.)
 
 Let's start by making a development branch to work on our changes. Per
 `Documentation/SubmittingPatches`, since a brand new command is a new feature,
-it's fine to base your work on `master`. However, in the future for bugfixes,
+it's fine to base your work on `main`. However, in the future for bugfixes,
 etc., you should check that document and base it on the appropriate branch.
 
-For the purposes of this document, we will base all our work on the `master`
+For the purposes of this document, we will base all our work on the `main`
 branch of the upstream project. Create the `psuh` branch you will use for
 development like so:
 
 ----
-$ git checkout -b psuh origin/master
+$ git checkout -b psuh origin/main
 ----
 
 We'll make a number of commits here in order to demonstrate how to send a topic
@@ -417,7 +417,7 @@ the declarations and the logic, respectively.
 
 ...
 
-	c = lookup_commit_reference_by_name("origin/master");
+	c = lookup_commit_reference_by_name("origin/main");
 
 	if (c != NULL) {
 		pp_commit_easy(CMIT_FMT_ONELINE, c, &commitline);
@@ -438,12 +438,12 @@ pretty-prints the commit according to that shorthand. These are similar to the
 formats available with `--pretty=FOO` in many Git commands.
 
 Build it and run, and if you're using the same name in the example, you should
-see the subject line of the most recent commit in `origin/master` that you know
+see the subject line of the most recent commit in `origin/main` that you know
 about. Neat! Let's commit that as well.
 
 ----
 $ git add builtin/psuh.c
-$ git commit -sm "psuh: display the top of origin/master"
+$ git commit -sm "psuh: display the top of origin/main"
 ----
 
 [[add-documentation]]
@@ -780,13 +780,13 @@ by running `git branch`. If you didn't, now is a good time to move your new
 commits to their own branch.
 
 As mentioned briefly at the beginning of this document, we are basing our work
-on `master`, so go ahead and update as shown below, or using your preferred
+on `main`, so go ahead and update as shown below, or using your preferred
 workflow.
 
 ----
-$ git checkout master
+$ git checkout main
 $ git pull -r
-$ git rebase master psuh
+$ git rebase main psuh
 ----
 
 Finally, you're ready to push your new topic branch! (Due to our branch and
@@ -904,7 +904,7 @@ Sending emails with Git is a two-part process; before you can prepare the emails
 themselves, you'll need to prepare the patches. Luckily, this is pretty simple:
 
 ----
-$ git format-patch --cover-letter -o psuh/ master..psuh
+$ git format-patch --cover-letter -o psuh/ main..psuh
 ----
 
 The `--cover-letter` parameter tells `format-patch` to create a cover letter
@@ -915,8 +915,8 @@ The `-o psuh/` parameter tells `format-patch` to place the patch files into a
 directory. This is useful because `git send-email` can take a directory and
 send out all the patches from there.
 
-`master..psuh` tells `format-patch` to generate patches for the difference
-between `master` and `psuh`. It will make one patch file per commit. After you
+`main..psuh` tells `format-patch` to generate patches for the difference
+between `main` and `psuh`. It will make one patch file per commit. After you
 run, you can go have a look at each of the patches with your favorite text
 editor and make sure everything looks alright; however, it's not recommended to
 make code fixups via the patch file. It's a better idea to make the change the
@@ -1038,7 +1038,7 @@ similar.
 First, generate your v2 patches again:
 
 ----
-$ git format-patch -v2 --cover-letter -o psuh/ master..psuh
+$ git format-patch -v2 --cover-letter -o psuh/ main..psuh
 ----
 
 This will add your v2 patches, all named like `v2-000n-my-commit-subject.patch`,
@@ -1179,11 +1179,11 @@ look at the section below this one for some context.)
 [[after-approval]]
 === After Review Approval
 
-The Git project has four integration branches: `pu`, `next`, `master`, and
+The Git project has four integration branches: `pu`, `next`, `main`, and
 `maint`. Your change will be placed into `pu` fairly early on by the maintainer
 while it is still in the review process; from there, when it is ready for wider
 testing, it will be merged into `next`. Plenty of early testers use `next` and
-may report issues. Eventually, changes in `next` will make it to `master`,
+may report issues. Eventually, changes in `next` will make it to `main`,
 which is typically considered stable. Finally, when a new release is cut,
 `maint` is used to base bugfixes onto. As mentioned at the beginning of this
 document, you can read `Documents/SubmittingPatches` for some more info about
@@ -1214,4 +1214,4 @@ against the appropriate GitGitGadget/Git branch.
 
 If you're using `git send-email`, you can use it the same way as before, but you
 should generate your diffs from `<topic>..<mybranch>` and base your work on
-`<topic>` instead of `master`.
+`<topic>` instead of `main`.

--- a/Documentation/MyFirstObjectWalk.txt
+++ b/Documentation/MyFirstObjectWalk.txt
@@ -24,10 +24,10 @@ revision walk is used for operations like `git log`.
 
 == Setting Up
 
-Create a new branch from `master`.
+Create a new branch from `main`.
 
 ----
-git checkout -b revwalk origin/master
+git checkout -b revwalk origin/main
 ----
 
 We'll put our fiddling into a new command. For fun, let's name it `git walken`.

--- a/Documentation/SubmittingPatches
+++ b/Documentation/SubmittingPatches
@@ -13,23 +13,23 @@ In general, always base your work on the oldest branch that your
 change is relevant to.
 
 * A bugfix should be based on `maint` in general. If the bug is not
-  present in `maint`, base it on `master`. For a bug that's not yet
-  in `master`, find the topic that introduces the regression, and
+  present in `maint`, base it on `main`. For a bug that's not yet
+  in `main`, find the topic that introduces the regression, and
   base your work on the tip of the topic.
 
-* A new feature should be based on `master` in general. If the new
-  feature depends on a topic that is in `pu`, but not in `master`,
+* A new feature should be based on `main` in general. If the new
+  feature depends on a topic that is in `pu`, but not in `main`,
   base your work on the tip of that topic.
 
-* Corrections and enhancements to a topic not yet in `master` should
+* Corrections and enhancements to a topic not yet in `main` should
   be based on the tip of that topic. If the topic has not been merged
   to `next`, it's alright to add a note to squash minor corrections
   into the series.
 
 * In the exceptional case that a new feature depends on several topics
-  not in `master`, start working on `next` or `pu` privately and send
+  not in `main`, start working on `next` or `pu` privately and send
   out patches for discussion. Before the final merge, you may have to
-  wait until some of the dependent topics graduate to `master`, and
+  wait until some of the dependent topics graduate to `main`, and
   rebase your work.
 
 * Some parts of the system have dedicated maintainers with their own
@@ -37,7 +37,7 @@ change is relevant to.
   these parts should be based on their trees.
 
 To find the tip of a topic branch, run `git log --first-parent
-master..pu` and look for the merge commit. The second parent of this
+main..pu` and look for the merge commit. The second parent of this
 commit is the tip of the topic branch.
 
 [[separate-commits]]
@@ -177,7 +177,7 @@ Please make sure your patch does not add commented out debugging code,
 or include any extra files which do not relate to what your patch
 is trying to achieve. Make sure to review
 your patch after generating it, to ensure accuracy.  Before
-sending out, please make sure it cleanly applies to the `master`
+sending out, please make sure it cleanly applies to the `main`
 branch head.  If you are preparing a work based on "next" branch,
 that is fine, but please mark it as such.
 
@@ -420,7 +420,7 @@ help you find out who they are.
   good.  Send it to the maintainer and cc the list.
 
 . A topic branch is created with the patch and is merged to `next`,
-  and cooked further and eventually graduates to `master`.
+  and cooked further and eventually graduates to `main`.
 
 In any time between the (2)-(3) cycle, the maintainer may pick it up
 from the list and queue it to `pu`, in order to make it easier for
@@ -431,11 +431,11 @@ their trees themselves.
 == Know the status of your patch after submission
 
 * You can use Git itself to find out when your patch is merged in
-  master. `git pull --rebase` will automatically skip already-applied
+  main. `git pull --rebase` will automatically skip already-applied
   patches, and will let you know. This works only if you rebase on top
   of the branch in which your patch has been merged (i.e. it will not
   tell you if your patch is merged in pu if you rebase on top of
-  master).
+  main).
 
 * Read the Git mailing list, the maintainer regularly posts messages
   entitled "What's cooking in git.git" and "What's in git.git" giving

--- a/Documentation/config.txt
+++ b/Documentation/config.txt
@@ -348,6 +348,8 @@ include::config/diff.txt[]
 
 include::config/difftool.txt[]
 
+include::config/extensions.txt[]
+
 include::config/fastimport.txt[]
 
 include::config/feature.txt[]

--- a/Documentation/config/core.txt
+++ b/Documentation/config/core.txt
@@ -626,3 +626,8 @@ core.abbrev::
 	in your repository, which hopefully is enough for
 	abbreviated object names to stay unique for some time.
 	The minimum length is 4.
+
+core.mainBranch::
+	The name of the main (or: primary) branch in the current repository.
+	For historical reasons, `master` is used as the fall-back for this
+	setting.

--- a/Documentation/config/extensions.txt
+++ b/Documentation/config/extensions.txt
@@ -1,0 +1,7 @@
+extensions.objectFormat::
+	Specify the hash algorithm to use.  The acceptable values are `sha1`
+	and (if supported) `sha256`.  If not specified, `sha1` is assumed.
++
+Note that this setting should only by set by linkgit:git-init[1] or
+linkgit:git-clone[1].  Trying to change it after initialization will not
+work and will produce hard-to-diagnose issues.

--- a/Documentation/config/init.txt
+++ b/Documentation/config/init.txt
@@ -1,3 +1,7 @@
 init.templateDir::
 	Specify the directory from which templates will be copied.
 	(See the "TEMPLATE DIRECTORY" section of linkgit:git-init[1].)
+
+init.defaultBranch::
+	Allows overriding the default branch name e.g. when initializing
+	a new repository or when cloning an empty repository.

--- a/Documentation/config/push.txt
+++ b/Documentation/config/push.txt
@@ -37,9 +37,9 @@ This mode has become the default in Git 2.0.
 * `matching` - push all branches having the same name on both ends.
   This makes the repository you are pushing to remember the set of
   branches that will be pushed out (e.g. if you always push 'maint'
-  and 'master' there and no other branches, the repository you push
+  and 'main' there and no other branches, the repository you push
   to will have these two branches, and your local 'maint' and
-  'master' will be pushed there).
+  'main' will be pushed there).
 +
 To use this mode effectively, you have to make sure _all_ the
 branches you would push out are ready to be pushed out before

--- a/Documentation/config/transfer.txt
+++ b/Documentation/config/transfer.txt
@@ -53,10 +53,10 @@ If you have multiple hideRefs values, later entries override earlier ones
 +
 If a namespace is in use, the namespace prefix is stripped from each
 reference before it is matched against `transfer.hiderefs` patterns.
-For example, if `refs/heads/master` is specified in `transfer.hideRefs` and
-the current namespace is `foo`, then `refs/namespaces/foo/refs/heads/master`
-is omitted from the advertisements but `refs/heads/master` and
-`refs/namespaces/bar/refs/heads/master` are still advertised as so-called
+For example, if `refs/heads/main` is specified in `transfer.hideRefs` and
+the current namespace is `foo`, then `refs/namespaces/foo/refs/heads/main`
+is omitted from the advertisements but `refs/heads/main` and
+`refs/namespaces/bar/refs/heads/main` are still advertised as so-called
 "have" lines. In order to match refs before stripping, add a `^` in front of
 the ref name. If you combine `!` and `^`, `!` must be specified first.
 +

--- a/Documentation/doc-diff
+++ b/Documentation/doc-diff
@@ -4,9 +4,9 @@
 # Compared to a source diff, this can reveal mistakes in the formatting.
 # For example:
 #
-#   ./doc-diff origin/master HEAD
+#   ./doc-diff origin/main HEAD
 #
-# would show the differences introduced by a branch based on master.
+# would show the differences introduced by a branch based on main.
 
 OPTIONS_SPEC="\
 doc-diff [options] <from> <to> [-- <diff-options>]

--- a/Documentation/git-archimport.txt
+++ b/Documentation/git-archimport.txt
@@ -45,7 +45,7 @@ archives that it imports, it is also possible to specify Git branch names
 manually.  To do so, write a Git branch name after each <archive/branch>
 parameter, separated by a colon.  This way, you can shorten the Arch
 branch names and convert Arch jargon to Git jargon, for example mapping a
-"PROJECT{litdd}devo{litdd}VERSION" branch to "master".
+"PROJECT{litdd}devo{litdd}VERSION" branch to "main".
 
 Associating multiple Arch branches to one Git branch is possible; the
 result will make the most sense only if no commits are made to the first

--- a/Documentation/git-bisect-lk2009.txt
+++ b/Documentation/git-bisect-lk2009.txt
@@ -294,7 +294,7 @@ the branch we were in before we started bisecting:
 $ git bisect reset
 Checking out files: 100% (21549/21549), done.
 Previous HEAD position was 2ddcca3... Linux 2.6.26-rc1
-Switched to branch 'master'
+Switched to branch 'main'
 -------------
 
 Driving a bisection automatically
@@ -1229,7 +1229,7 @@ message or the author. And it can also be used instead of git "grafts"
 to link a repository with another old repository.
 
 In fact it's this last feature that "sold" it to the Git community, so
-it is now in the "master" branch of Git's Git repository and it should
+it is now in the "main" branch of Git's Git repository and it should
 be released in Git 1.6.5 in October or November 2009.
 
 One problem with "git replace" is that currently it stores all the

--- a/Documentation/git-branch.txt
+++ b/Documentation/git-branch.txt
@@ -331,7 +331,7 @@ $ git branch -D test                                    <2>
 <1> Delete the remote-tracking branches "todo", "html" and "man". The next
     'fetch' or 'pull' will create them again unless you configure them not to.
     See linkgit:git-fetch[1].
-<2> Delete the "test" branch even if the "master" branch (or whichever branch
+<2> Delete the "test" branch even if the "main" branch (or whichever branch
     is currently checked out) does not have all commits from the test branch.
 
 Listing branches from a specific remote::

--- a/Documentation/git-bundle.txt
+++ b/Documentation/git-bundle.txt
@@ -66,8 +66,8 @@ unbundle <file>::
 	A list of arguments, acceptable to 'git rev-parse' and
 	'git rev-list' (and containing a named ref, see SPECIFYING REFERENCES
 	below), that specifies the specific objects and references
-	to transport.  For example, `master~10..master` causes the
-	current master reference to be packaged along with all objects
+	to transport.  For example, `main~10..main` causes the
+	current main reference to be packaged along with all objects
 	added since its 10th ancestor commit.  There is no explicit
 	limit to the number of references and objects that may be
 	packaged.
@@ -112,12 +112,12 @@ SPECIFYING REFERENCES
 
 'git bundle' will only package references that are shown by
 'git show-ref': this includes heads, tags, and remote heads.  References
-such as `master~1` cannot be packaged, but are perfectly suitable for
+such as `main~1` cannot be packaged, but are perfectly suitable for
 defining the basis.  More than one reference may be packaged, and more
 than one basis can be specified.  The objects packaged are those not
 contained in the union of the given bases.  Each basis can be
-specified explicitly (e.g. `^master~10`), or implicitly (e.g.
-`master~10..master`, `--since=10.days.ago master`).
+specified explicitly (e.g. `^main~10`), or implicitly (e.g.
+`main~10..main`, `--since=10.days.ago main`).
 
 It is very important that the basis used be held by the destination.
 It is okay to err on the side of caution, causing the bundle file
@@ -139,7 +139,7 @@ Assume you want to transfer the history from a repository R1 on machine A
 to another repository R2 on machine B.
 For whatever reason, direct connection between A and B is not allowed,
 but we can move data from A to B via some mechanism (CD, email, etc.).
-We want to update R2 with development made on the branch master in R1.
+We want to update R2 with development made on the branch main in R1.
 
 To bootstrap the process, you can first create a bundle that does not have
 any basis. You can use a tag to remember up to what commit you last
@@ -148,8 +148,8 @@ with an incremental bundle:
 
 ----------------
 machineA$ cd R1
-machineA$ git bundle create file.bundle master
-machineA$ git tag -f lastR2bundle master
+machineA$ git bundle create file.bundle main
+machineA$ git tag -f lastR2bundle main
 ----------------
 
 Then you transfer file.bundle to the target machine B. Because this
@@ -157,7 +157,7 @@ bundle does not require any existing object to be extracted, you can
 create a new repository on machine B by cloning from it:
 
 ----------------
-machineB$ git clone -b master /home/me/tmp/file.bundle R2
+machineB$ git clone -b main /home/me/tmp/file.bundle R2
 ----------------
 
 This will define a remote called "origin" in the resulting repository that
@@ -179,8 +179,8 @@ incremental bundle to update the other repository:
 
 ----------------
 machineA$ cd R1
-machineA$ git bundle create file.bundle lastR2bundle..master
-machineA$ git tag -f lastR2bundle master
+machineA$ git bundle create file.bundle lastR2bundle..main
+machineA$ git tag -f lastR2bundle main
 ----------------
 
 You then transfer the bundle to the other machine to replace
@@ -201,19 +201,19 @@ the linkgit:git-log[1] command. Here are more examples:
 You can use a tag that is present in both:
 
 ----------------
-$ git bundle create mybundle v1.0.0..master
+$ git bundle create mybundle v1.0.0..main
 ----------------
 
 You can use a basis based on time:
 
 ----------------
-$ git bundle create mybundle --since=10.days master
+$ git bundle create mybundle --since=10.days main
 ----------------
 
 You can use the number of commits:
 
 ----------------
-$ git bundle create mybundle -10 master
+$ git bundle create mybundle -10 main
 ----------------
 
 You can run `git-bundle verify` to see if you can extract from a bundle
@@ -231,7 +231,7 @@ regular repository which it fetches or pulls from. You can, for example, map
 references when fetching:
 
 ----------------
-$ git fetch mybundle master:localRef
+$ git fetch mybundle main:localRef
 ----------------
 
 You can also see what references it offers:

--- a/Documentation/git-checkout.txt
+++ b/Documentation/git-checkout.txt
@@ -361,15 +361,15 @@ For more details, see the 'pathspec' entry in linkgit:gitglossary[7].
 
 DETACHED HEAD
 -------------
-`HEAD` normally refers to a named branch (e.g. `master`). Meanwhile, each
+`HEAD` normally refers to a named branch (e.g. `main`). Meanwhile, each
 branch refers to a specific commit. Let's look at a repo with three
-commits, one of them tagged, and with branch `master` checked out:
+commits, one of them tagged, and with branch `main` checked out:
 
 ------------
-           HEAD (refers to branch 'master')
+           HEAD (refers to branch 'main')
             |
             v
-a---b---c  branch 'master' (refers to commit 'c')
+a---b---c  branch 'main' (refers to commit 'c')
     ^
     |
   tag 'v2.0' (refers to commit 'b')
@@ -377,17 +377,17 @@ a---b---c  branch 'master' (refers to commit 'c')
 
 When a commit is created in this state, the branch is updated to refer to
 the new commit. Specifically, 'git commit' creates a new commit `d`, whose
-parent is commit `c`, and then updates branch `master` to refer to new
-commit `d`. `HEAD` still refers to branch `master` and so indirectly now refers
+parent is commit `c`, and then updates branch `main` to refer to new
+commit `d`. `HEAD` still refers to branch `main` and so indirectly now refers
 to commit `d`:
 
 ------------
 $ edit; git add; git commit
 
-               HEAD (refers to branch 'master')
+               HEAD (refers to branch 'main')
                 |
                 v
-a---b---c---d  branch 'master' (refers to commit 'd')
+a---b---c---d  branch 'main' (refers to commit 'd')
     ^
     |
   tag 'v2.0' (refers to commit 'b')
@@ -400,12 +400,12 @@ checkout commit `b` (here we show two ways this may be done):
 
 ------------
 $ git checkout v2.0  # or
-$ git checkout master^^
+$ git checkout main^^
 
    HEAD (refers to commit 'b')
     |
     v
-a---b---c---d  branch 'master' (refers to commit 'd')
+a---b---c---d  branch 'main' (refers to commit 'd')
     ^
     |
   tag 'v2.0' (refers to commit 'b')
@@ -424,7 +424,7 @@ $ edit; git add; git commit
       v
       e
      /
-a---b---c---d  branch 'master' (refers to commit 'd')
+a---b---c---d  branch 'main' (refers to commit 'd')
     ^
     |
   tag 'v2.0' (refers to commit 'b')
@@ -441,22 +441,22 @@ $ edit; git add; git commit
 	  v
       e---f
      /
-a---b---c---d  branch 'master' (refers to commit 'd')
+a---b---c---d  branch 'main' (refers to commit 'd')
     ^
     |
   tag 'v2.0' (refers to commit 'b')
 ------------
 
 In fact, we can perform all the normal Git operations. But, let's look
-at what happens when we then checkout `master`:
+at what happens when we then checkout `main`:
 
 ------------
-$ git checkout master
+$ git checkout main
 
-               HEAD (refers to branch 'master')
+               HEAD (refers to branch 'main')
       e---f     |
      /          v
-a---b---c---d  branch 'master' (refers to commit 'd')
+a---b---c---d  branch 'main' (refers to commit 'd')
     ^
     |
   tag 'v2.0' (refers to commit 'b')
@@ -509,13 +509,13 @@ to checkout these paths out of the index.
 EXAMPLES
 --------
 
-. The following sequence checks out the `master` branch, reverts
+. The following sequence checks out the `main` branch, reverts
   the `Makefile` to two revisions back, deletes `hello.c` by
   mistake, and gets it back from the index.
 +
 ------------
-$ git checkout master             <1>
-$ git checkout master~2 Makefile  <2>
+$ git checkout main             <1>
+$ git checkout main~2 Makefile  <2>
 $ rm -f hello.c
 $ git checkout hello.c            <3>
 ------------

--- a/Documentation/git-cherry-pick.txt
+++ b/Documentation/git-cherry-pick.txt
@@ -48,7 +48,7 @@ OPTIONS
 	default, as if the `--no-walk` option was specified, see
 	linkgit:git-rev-list[1]. Note that specifying a range will
 	feed all <commit>... arguments to a single revision walk
-	(see a later example that uses 'maint master..next').
+	(see a later example that uses 'maint main..next').
 
 -e::
 --edit::
@@ -167,36 +167,36 @@ include::sequencer.txt[]
 
 EXAMPLES
 --------
-`git cherry-pick master`::
+`git cherry-pick main`::
 
 	Apply the change introduced by the commit at the tip of the
-	master branch and create a new commit with this change.
+	main branch and create a new commit with this change.
 
-`git cherry-pick ..master`::
-`git cherry-pick ^HEAD master`::
+`git cherry-pick ..main`::
+`git cherry-pick ^HEAD main`::
 
 	Apply the changes introduced by all commits that are ancestors
-	of master but not of HEAD to produce new commits.
+	of main but not of HEAD to produce new commits.
 
-`git cherry-pick maint next ^master`::
-`git cherry-pick maint master..next`::
+`git cherry-pick maint next ^main`::
+`git cherry-pick maint main..next`::
 
 	Apply the changes introduced by all commits that are
-	ancestors of maint or next, but not master or any of its
+	ancestors of maint or next, but not main or any of its
 	ancestors.  Note that the latter does not mean `maint` and
-	everything between `master` and `next`; specifically,
-	`maint` will not be used if it is included in `master`.
+	everything between `main` and `next`; specifically,
+	`maint` will not be used if it is included in `main`.
 
-`git cherry-pick master~4 master~2`::
+`git cherry-pick main~4 main~2`::
 
 	Apply the changes introduced by the fifth and third last
-	commits pointed to by master and create 2 new commits with
+	commits pointed to by main and create 2 new commits with
 	these changes.
 
-`git cherry-pick -n master~1 next`::
+`git cherry-pick -n main~1 next`::
 
 	Apply to the working tree and the index the changes introduced
-	by the second last commit pointed to by master and by the last
+	by the second last commit pointed to by main and by the last
 	commit pointed to by next, but do not create any commit with
 	these changes.
 
@@ -208,9 +208,9 @@ EXAMPLES
 	are in next but not HEAD to the current branch, creating a new
 	commit for each new change.
 
-`git rev-list --reverse master -- README | git cherry-pick -n --stdin`::
+`git rev-list --reverse main -- README | git cherry-pick -n --stdin`::
 
-	Apply the changes introduced by all commits on the master
+	Apply the changes introduced by all commits on the main
 	branch that touched README to the working tree and index,
 	so the result can be inspected and made into a single new
 	commit if suitable.

--- a/Documentation/git-cherry.txt
+++ b/Documentation/git-cherry.txt
@@ -51,9 +51,9 @@ applied by the upstream maintainer.  In such a workflow you might
 create and send a topic branch like this:
 
 ------------
-$ git checkout -b topic origin/master
+$ git checkout -b topic origin/main
 # work and create some commits
-$ git format-patch origin/master
+$ git format-patch origin/main
 $ git send-email ... 00*
 ------------
 
@@ -61,7 +61,7 @@ Later, you can see whether your changes have been applied by saying
 (still on `topic`):
 
 ------------
-$ git fetch  # update your notion of origin/master
+$ git fetch  # update your notion of origin/main
 $ git cherry -v
 ------------
 
@@ -72,8 +72,8 @@ In a situation where topic consisted of three commits, and the
 maintainer applied two of them, the situation might look like:
 
 ------------
-$ git log --graph --oneline --decorate --boundary origin/master...topic
-* 7654321 (origin/master) upstream tip commit
+$ git log --graph --oneline --decorate --boundary origin/main...topic
+* 7654321 (origin/main) upstream tip commit
 [... snip some other commits ...]
 * cccc111 cherry-pick of C
 * aaaa111 cherry-pick of A
@@ -89,7 +89,7 @@ In such cases, git-cherry shows a concise summary of what has yet to
 be applied:
 
 ------------
-$ git cherry origin/master topic
+$ git cherry origin/main topic
 - cccc000... commit C
 + bbbb000... commit B
 - aaaa000... commit A
@@ -97,8 +97,8 @@ $ git cherry origin/master topic
 
 Here, we see that the commits A and C (marked with `-`) can be
 dropped from your `topic` branch when you rebase it on top of
-`origin/master`, while the commit B (marked with `+`) still needs to
-be kept so that it will be sent to be applied to `origin/master`.
+`origin/main`, while the commit B (marked with `+`) still needs to
+be kept so that it will be sent to be applied to `origin/main`.
 
 
 Using a limit
@@ -109,8 +109,8 @@ other work that is not in upstream.  Expanding on the previous
 example, this might look like:
 
 ------------
-$ git log --graph --oneline --decorate --boundary origin/master...topic
-* 7654321 (origin/master) upstream tip commit
+$ git log --graph --oneline --decorate --boundary origin/main...topic
+* 7654321 (origin/main) upstream tip commit
 [... snip some other commits ...]
 * cccc111 cherry-pick of C
 * aaaa111 cherry-pick of A
@@ -129,7 +129,7 @@ By specifying `base` as the limit, you can avoid listing commits
 between `base` and `topic`:
 
 ------------
-$ git cherry origin/master topic base
+$ git cherry origin/main topic base
 - cccc000... commit C
 + bbbb000... commit B
 - aaaa000... commit A

--- a/Documentation/git-clone.txt
+++ b/Documentation/git-clone.txt
@@ -30,8 +30,8 @@ currently active branch.
 
 After the clone, a plain `git fetch` without arguments will update
 all the remote-tracking branches, and a `git pull` without
-arguments will in addition merge the remote master branch into the
-current master branch, if any (this is untrue when "--single-branch"
+arguments will in addition merge the remote main branch into the
+current main branch, if any (this is untrue when "--single-branch"
 is given; see below).
 
 This default configuration is achieved by creating references to

--- a/Documentation/git-config.txt
+++ b/Documentation/git-config.txt
@@ -144,8 +144,8 @@ See also <<FILES>>.
 
 --blob blob::
 	Similar to `--file` but use the given blob instead of a file. E.g.
-	you can use 'master:.gitmodules' to read values from the file
-	'.gitmodules' in the master branch. See "SPECIFYING REVISIONS"
+	you can use 'main:.gitmodules' to read values from the file
+	'.gitmodules' in the main branch. See "SPECIFYING REVISIONS"
 	section in linkgit:gitrevisions[7] for a more complete list of
 	ways to spell blob names.
 

--- a/Documentation/git-cvsimport.txt
+++ b/Documentation/git-cvsimport.txt
@@ -35,7 +35,7 @@ Please see the section <<issues,ISSUES>> for further reference.
 
 You should *never* do any work of your own on the branches that are
 created by 'git cvsimport'.  By default initial import will create and populate a
-"master" branch from the CVS repository's main branch which you're free
+"main" branch from the CVS repository's main branch which you're free
 to work with; after that, you need to 'git merge' incremental imports, or
 any CVS branches, yourself.  It is advisable to specify a named remote via
 -r to separate and protect the incoming branches.
@@ -78,11 +78,11 @@ OPTIONS
 	from CVS is imported to the 'origin' branch within the Git
 	repository, as `HEAD` already has a special meaning for Git.
 	When a remote is specified the `HEAD` branch is named
-	remotes/<remote>/master mirroring 'git clone' behaviour.
+	remotes/<remote>/main mirroring 'git clone' behaviour.
 	Use this option if you want to import into a different
 	branch.
 +
-Use '-o master' for continuing an import that was initially done by
+Use '-o main' for continuing an import that was initially done by
 the old cvs2git tool.
 
 -i::

--- a/Documentation/git-cvsserver.txt
+++ b/Documentation/git-cvsserver.txt
@@ -199,11 +199,11 @@ allowing access over SSH.
 5. Clients should now be able to check out the project. Use the CVS 'module'
    name to indicate what Git 'head' you want to check out.  This also sets the
    name of your newly checked-out directory, unless you tell it otherwise with
-   `-d <dir_name>`.  For example, this checks out 'master' branch to the
-   `project-master` directory:
+   `-d <dir_name>`.  For example, this checks out 'main' branch to the
+   `project-main` directory:
 +
 ------
-     cvs co -d project-master master
+     cvs co -d project-main main
 ------
 
 [[dbbackend]]

--- a/Documentation/git-diff.txt
+++ b/Documentation/git-diff.txt
@@ -154,14 +154,14 @@ $ git diff HEAD^ HEAD      <3>
 Comparing branches::
 +
 ------------
-$ git diff topic master    <1>
-$ git diff topic..master   <2>
-$ git diff topic...master  <3>
+$ git diff topic main    <1>
+$ git diff topic..main   <2>
+$ git diff topic...main  <3>
 ------------
 +
-<1> Changes between the tips of the topic and the master branches.
+<1> Changes between the tips of the topic and the main branches.
 <2> Same as above.
-<3> Changes that occurred on the master branch since when the topic
+<3> Changes that occurred on the main branch since when the topic
     branch was started off it.
 
 Limiting the diff output::

--- a/Documentation/git-fast-export.txt
+++ b/Documentation/git-fast-export.txt
@@ -121,10 +121,10 @@ by keeping the marks the same across runs.
 
 --reference-excluded-parents::
 	By default, running a command such as `git fast-export
-	master~5..master` will not include the commit master{tilde}5
-	and will make master{tilde}4 no longer have master{tilde}5 as
-	a parent (though both the old master{tilde}4 and new
-	master{tilde}4 will have all the same files).  Use
+	main~5..main` will not include the commit main{tilde}5
+	and will make main{tilde}4 no longer have main{tilde}5 as
+	a parent (though both the old main{tilde}4 and new
+	main{tilde}4 will have all the same files).  Use
 	--reference-excluded-parents to instead have the stream
 	refer to commits in the excluded range of history by their
 	sha1sum.  Note that the resulting stream can only be used by a
@@ -152,11 +152,11 @@ by keeping the marks the same across runs.
 [<git-rev-list-args>...]::
 	A list of arguments, acceptable to 'git rev-parse' and
 	'git rev-list', that specifies the specific objects and references
-	to export.  For example, `master~10..master` causes the
-	current master reference to be exported along with all objects
+	to export.  For example, `main~10..main` causes the
+	current main reference to be exported along with all objects
 	added since its 10th ancestor commit and (unless the
 	--reference-excluded-parents option is specified) all files
-	common to master{tilde}9 and master{tilde}10.
+	common to main{tilde}9 and main{tilde}10.
 
 EXAMPLES
 --------
@@ -170,17 +170,17 @@ empty repository.  Except for reencoding commits that are not in
 UTF-8, it would be a one-to-one mirror.
 
 -----------------------------------------------------
-$ git fast-export master~5..master |
-	sed "s|refs/heads/master|refs/heads/other|" |
+$ git fast-export main~5..main |
+	sed "s|refs/heads/main|refs/heads/other|" |
 	git fast-import
 -----------------------------------------------------
 
-This makes a new branch called 'other' from 'master~5..master'
-(i.e. if 'master' has linear history, it will take the last 5 commits).
+This makes a new branch called 'other' from 'main~5..main'
+(i.e. if 'main' has linear history, it will take the last 5 commits).
 
 Note that this assumes that none of the blobs and commit messages
 referenced by that revision range contains the string
-'refs/heads/master'.
+'refs/heads/main'.
 
 
 ANONYMIZING

--- a/Documentation/git-fast-import.txt
+++ b/Documentation/git-fast-import.txt
@@ -1279,7 +1279,7 @@ An example crash:
 ====
 	$ cat >in <<END_OF_INPUT
 	# my very first test commit
-	commit refs/heads/master
+	commit refs/heads/main
 	committer Shawn O. Pearce <spearce> 19283 -0400
 	# who is that guy anyway?
 	data <<EOF
@@ -1307,7 +1307,7 @@ An example crash:
 	Most Recent Commands Before Crash
 	---------------------------------
 	  # my very first test commit
-	  commit refs/heads/master
+	  commit refs/heads/main
 	  committer Shawn O. Pearce <spearce> 19283 -0400
 	  # who is that guy anyway?
 	  data <<EOF
@@ -1321,11 +1321,11 @@ An example crash:
 
 	  pos  clock name
 	  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	   1)      0 refs/heads/master
+	   1)      0 refs/heads/main
 
 	Inactive Branches
 	-----------------
-	refs/heads/master:
+	refs/heads/main:
 	  status      : active loaded dirty
 	  tip commit  : 0000000000000000000000000000000000000000
 	  old tree    : 0000000000000000000000000000000000000000

--- a/Documentation/git-fetch-pack.txt
+++ b/Documentation/git-fetch-pack.txt
@@ -116,7 +116,7 @@ be in a separate packet, and the list must end with a flush packet.
 
 <refs>...::
 	The remote heads to update from. This is relative to
-	$GIT_DIR (e.g. "HEAD", "refs/heads/master").  When
+	$GIT_DIR (e.g. "HEAD", "refs/heads/main").  When
 	unspecified, update from all heads the remote side has.
 +
 If the remote has enabled the options `uploadpack.allowTipSHA1InWant`,

--- a/Documentation/git-fetch.txt
+++ b/Documentation/git-fetch.txt
@@ -79,14 +79,14 @@ This configuration is used in two ways:
   hierarchy.
 
 * When `git fetch` is run with explicit branches and/or tags
-  to fetch on the command line, e.g. `git fetch origin master`, the
+  to fetch on the command line, e.g. `git fetch origin main`, the
   <refspec>s given on the command line determine what are to be
-  fetched (e.g. `master` in the example,
-  which is a short-hand for `master:`, which in turn means
-  "fetch the 'master' branch but I do not explicitly say what
+  fetched (e.g. `main` in the example,
+  which is a short-hand for `main:`, which in turn means
+  "fetch the 'main' branch but I do not explicitly say what
   remote-tracking branch to update with it from the command line"),
   and the example command will
-  fetch _only_ the 'master' branch.  The `remote.<repository>.fetch`
+  fetch _only_ the 'main' branch.  The `remote.<repository>.fetch`
   values determine which
   remote-tracking branch, if any, is updated.  When used in this
   way, the `remote.<repository>.fetch` values do not have any
@@ -206,7 +206,7 @@ used.
 In compact output mode, specified with configuration variable
 fetch.output, if either entire `<from>` or `<to>` is found in the
 other string, it will be substituted with `*` in the other string. For
-example, `master -> origin/master` becomes `master -> origin/*`.
+example, `main -> origin/main` becomes `main -> origin/*`.
 
 flag::
 	A single character indicating the status of the ref:

--- a/Documentation/git-filter-branch.txt
+++ b/Documentation/git-filter-branch.txt
@@ -533,7 +533,7 @@ an alternative to git-filter-branch which does not suffer from these
 performance problems or the safety problems (mentioned below). For those
 with existing tooling which relies upon git-filter-branch, 'git
 repo-filter' also provides
-https://github.com/newren/git-filter-repo/blob/master/contrib/filter-repo-demos/filter-lamely[filter-lamely],
+https://github.com/newren/git-filter-repo/blob/main/contrib/filter-repo-demos/filter-lamely[filter-lamely],
 a drop-in git-filter-branch replacement (with a few caveats).  While
 filter-lamely suffers from all the same safety issues as
 git-filter-branch, it at least ameliorates the performance issues a

--- a/Documentation/git-fmt-merge-msg.txt
+++ b/Documentation/git-fmt-merge-msg.txt
@@ -61,11 +61,11 @@ EXAMPLES
 --------
 
 ---------
-$ git fetch origin master
+$ git fetch origin main
 $ git fmt-merge-msg --log <$GIT_DIR/FETCH_HEAD
 ---------
 
-Print a log message describing a merge of the "master" branch from
+Print a log message describing a merge of the "main" branch from
 the "origin" remote.
 
 

--- a/Documentation/git-format-patch.txt
+++ b/Documentation/git-format-patch.txt
@@ -460,7 +460,7 @@ One way to test if your MUA is set up correctly is:
 
 * Apply it:
 
-    $ git fetch <project> master:test-apply
+    $ git fetch <project> main:test-apply
     $ git switch test-apply
     $ git restore --source=HEAD --staged --worktree :/
     $ git am a.patch

--- a/Documentation/git-imap-send.txt
+++ b/Documentation/git-imap-send.txt
@@ -112,7 +112,7 @@ that the "Folder doesn't exist".
 
 Once the commits are ready to be sent, run the following command:
 
-  $ git format-patch --cover-letter -M --stdout origin/master | git imap-send
+  $ git format-patch --cover-letter -M --stdout origin/main | git imap-send
 
 Just make sure to disable line wrapping in the email client (GMail's web
 interface will wrap lines no matter what, so you need to use a real

--- a/Documentation/git-index-pack.txt
+++ b/Documentation/git-index-pack.txt
@@ -93,6 +93,14 @@ OPTIONS
 --max-input-size=<size>::
 	Die, if the pack is larger than <size>.
 
+--object-format=<hash-algorithm>::
+	Specify the given object format (hash algorithm) for the pack.  The valid
+	values are 'sha1' and (if enabled) 'sha256'.  The default is the algorithm for
+	the current repository (set by `extensions.objectFormat`), or 'sha1' if no
+	value is set or outside a repository.
++
+This option cannot be used with --stdin.
+
 NOTES
 -----
 

--- a/Documentation/git-init.txt
+++ b/Documentation/git-init.txt
@@ -11,6 +11,7 @@ SYNOPSIS
 [verse]
 'git init' [-q | --quiet] [--bare] [--template=<template_directory>]
 	  [--separate-git-dir <git dir>] [--object-format=<format]
+	  [-b <branch-name> | --main-branch=<branch-name>]
 	  [--shared[=<permissions>]] [directory]
 
 
@@ -20,7 +21,7 @@ DESCRIPTION
 This command creates an empty Git repository - basically a `.git`
 directory with subdirectories for `objects`, `refs/heads`,
 `refs/tags`, and template files.  An initial `HEAD` file that
-references the HEAD of the master branch is also created.
+references the HEAD of the main branch is also created.
 
 If the `$GIT_DIR` environment variable is set then it specifies a path
 to use instead of `./.git` for the base of the repository.
@@ -66,6 +67,12 @@ repository.  This file acts as filesystem-agnostic Git symbolic link to the
 repository.
 +
 If this is reinitialization, the repository will be moved to the specified path.
+
+-b <branch-name::
+--main-branch=<branch-name>::
+
+Use the specified name for the main (or: initial) branch in the newly created
+repository. If not specified, fall back to the default name: `main`.
 
 --shared[=(false|true|umask|group|all|world|everybody|0xxx)]::
 

--- a/Documentation/git-log.txt
+++ b/Documentation/git-log.txt
@@ -154,10 +154,10 @@ EXAMPLES
 	any of remote-tracking branches for 'origin' (what you have that
 	origin doesn't).
 
-`git log master --not --remotes=*/master`::
+`git log main --not --remotes=*/main`::
 
-	Shows all commits that are in local master but not in any remote
-	repository master branches.
+	Shows all commits that are in local main but not in any remote
+	repository main branches.
 
 `git log -p -m --first-parent`::
 

--- a/Documentation/git-ls-remote.txt
+++ b/Documentation/git-ls-remote.txt
@@ -101,8 +101,8 @@ f25a265a342aed6041ab0cc484224d9ca54b6f41	refs/tags/v0.99.1
 7ceca275d047c90c0c7d5afb13ab97efdf51bd6e	refs/tags/v0.99.3
 c5db5456ae3b0873fc659c19fafdde22313cc441	refs/tags/v0.99.2
 0918385dbd9656cab0d1d81ba7453d49bbc16250	refs/tags/junio-gpg-pub
-$ git ls-remote http://www.kernel.org/pub/scm/git/git.git master pu rc
-5fe978a5381f1fbad26a80e682ddd2a401966740	refs/heads/master
+$ git ls-remote http://www.kernel.org/pub/scm/git/git.git main pu rc
+5fe978a5381f1fbad26a80e682ddd2a401966740	refs/heads/main
 c781a84b5204fb294c9ccc79f8b3baceeb32c061	refs/heads/pu
 $ git remote add korg http://www.kernel.org/pub/scm/git/git.git
 $ git ls-remote --tags korg v\*

--- a/Documentation/git-merge-base.txt
+++ b/Documentation/git-merge-base.txt
@@ -162,33 +162,33 @@ Discussion on fork-point mode
 -----------------------------
 
 After working on the `topic` branch created with `git switch -c
-topic origin/master`, the history of remote-tracking branch
-`origin/master` may have been rewound and rebuilt, leading to a
+topic origin/main`, the history of remote-tracking branch
+`origin/main` may have been rewound and rebuilt, leading to a
 history of this shape:
 
 ....
 		 o---B2
 		/
----o---o---B1--o---o---o---B (origin/master)
+---o---o---B1--o---o---o---B (origin/main)
 	\
 	 B0
 	  \
 	   D0---D1---D (topic)
 ....
 
-where `origin/master` used to point at commits B0, B1, B2 and now it
+where `origin/main` used to point at commits B0, B1, B2 and now it
 points at B, and your `topic` branch was started on top of it back
-when `origin/master` was at B0, and you built three commits, D0, D1,
+when `origin/main` was at B0, and you built three commits, D0, D1,
 and D, on top of it.  Imagine that you now want to rebase the work
-you did on the topic on top of the updated origin/master.
+you did on the topic on top of the updated origin/main.
 
-In such a case, `git merge-base origin/master topic` would return the
+In such a case, `git merge-base origin/main topic` would return the
 parent of B0 in the above picture, but B0^..D is *not* the range of
 commits you would want to replay on top of B (it includes B0, which
 is not what you wrote; it is a commit the other side discarded when
 it moved its tip from B0 to B1).
 
-`git merge-base --fork-point origin/master topic` is designed to
+`git merge-base --fork-point origin/main topic` is designed to
 help in such a case.  It takes not only B but also B0, B1, and B2
 (i.e. old tips of the remote-tracking branches your repository's
 reflog knows about) into account to see on which commit your topic
@@ -198,11 +198,11 @@ discarded.
 
 Hence
 
-    $ fork_point=$(git merge-base --fork-point origin/master topic)
+    $ fork_point=$(git merge-base --fork-point origin/main topic)
 
 will find B0, and
 
-    $ git rebase --onto origin/master $fork_point topic
+    $ git rebase --onto origin/main $fork_point topic
 
 will replay D0, D1 and D on top of B to create a new history of this
 shape:
@@ -210,7 +210,7 @@ shape:
 ....
 		 o---B2
 		/
----o---o---B1--o---o---o---B (origin/master)
+---o---o---B1--o---o---o---B (origin/main)
 	\                   \
 	 B0                  D0'--D1'--D' (topic - updated)
 	  \
@@ -219,7 +219,7 @@ shape:
 
 A caveat is that older reflog entries in your repository may be
 expired by `git gc`.  If B0 no longer appears in the reflog of the
-remote-tracking branch `origin/master`, the `--fork-point` mode
+remote-tracking branch `origin/main`, the `--fork-point` mode
 obviously cannot find it and fails, avoiding to give a random and
 useless result (such as the parent of B0, like the same command
 without the `--fork-point` option gives).
@@ -228,12 +228,12 @@ Also, the remote-tracking branch you use the `--fork-point` mode
 with must be the one your topic forked from its tip.  If you forked
 from an older commit than the tip, this mode would not find the fork
 point (imagine in the above sample history B0 did not exist,
-origin/master started at B1, moved to B2 and then B, and you forked
-your topic at origin/master^ when origin/master was B1; the shape of
+origin/main started at B1, moved to B2 and then B, and you forked
+your topic at origin/main^ when origin/main was B1; the shape of
 the history would be the same as above, without B0, and the parent
-of B1 is what `git merge-base origin/master topic` correctly finds,
+of B1 is what `git merge-base origin/main topic` correctly finds,
 but the `--fork-point` mode will not, because it is not one of the
-commits that used to be at the tip of origin/master).
+commits that used to be at the tip of origin/main).
 
 
 See also

--- a/Documentation/git-merge.txt
+++ b/Documentation/git-merge.txt
@@ -24,24 +24,24 @@ from another repository and can be used by hand to merge changes
 from one branch into another.
 
 Assume the following history exists and the current branch is
-"`master`":
+"`main`":
 
 ------------
 	  A---B---C topic
 	 /
-    D---E---F---G master
+    D---E---F---G main
 ------------
 
 Then "`git merge topic`" will replay the changes made on the
-`topic` branch since it diverged from `master` (i.e., `E`) until
-its current commit (`C`) on top of `master`, and record the result
+`topic` branch since it diverged from `main` (i.e., `E`) until
+its current commit (`C`) on top of `main`, and record the result
 in a new commit along with the names of the two parent commits and
 a log message from the user describing the changes.
 
 ------------
 	  A---B---C topic
 	 /         \
-    D---E---F---G---H master
+    D---E---F---G---H main
 ------------
 
 The second syntax ("`git merge --abort`") can only be run after the

--- a/Documentation/git-p4.txt
+++ b/Documentation/git-p4.txt
@@ -12,7 +12,7 @@ SYNOPSIS
 'git p4 clone' [<sync options>] [<clone options>] <p4 depot path>...
 'git p4 sync' [<sync options>] [<p4 depot path>...]
 'git p4 rebase'
-'git p4 submit' [<submit options>] [<master branch name>]
+'git p4 submit' [<submit options>] [<main branch name>]
 
 
 DESCRIPTION
@@ -74,9 +74,9 @@ This:
 1. Creates an empty Git repository in a subdirectory called 'project'.
 +
 2. Imports the full contents of the head revision from the given p4
-   depot path into a single commit in the Git branch 'refs/remotes/p4/master'.
+   depot path into a single commit in the Git branch 'refs/remotes/p4/main'.
 +
-3. Creates a local branch, 'master' from this remote and checks it out.
+3. Creates a local branch, 'main' from this remote and checks it out.
 
 To reproduce the entire p4 history in Git, use the '@all' modifier on
 the depot path:
@@ -103,7 +103,7 @@ $ git init
 $ git p4 sync //path/in/your/perforce/depot
 ------------
 This imports the specified depot into
-'refs/remotes/p4/master' in an existing Git repository.  The
+'refs/remotes/p4/main' in an existing Git repository.  The
 `--branch` option can be used to specify a different branch to
 be used for the p4 content.
 
@@ -139,7 +139,7 @@ variable 'git-p4.client'.  The p4 client must exist, but the client root
 will be created and populated if it does not already exist.
 
 To submit all changes that are in the current Git branch but not in
-the 'p4/master' branch, use:
+the 'p4/main' branch, use:
 ------------
 $ git p4 submit
 ------------
@@ -155,7 +155,7 @@ $ git p4 submit --commit <sha1>
 $ git p4 submit --commit <sha1..sha1>
 ------------
 
-The upstream reference is generally 'refs/remotes/p4/master', but can
+The upstream reference is generally 'refs/remotes/p4/main', but can
 be overridden using the `--origin=` command-line option.
 
 The p4 changes will be created as the user invoking 'git p4 submit'. The
@@ -215,7 +215,7 @@ These options can be used in the initial 'clone' as well as in
 subsequent 'sync' operations.
 
 --branch <ref>::
-	Import changes into <ref> instead of refs/remotes/p4/master.
+	Import changes into <ref> instead of refs/remotes/p4/main.
 	If <ref> starts with refs/, it is used as is.  Otherwise, if
 	it does not start with p4/, that prefix is added.
 +
@@ -223,7 +223,7 @@ By default a <ref> not starting with refs/ is treated as the
 name of a remote-tracking branch (under refs/remotes/).  This
 behavior can be modified using the --import-local option.
 +
-The default <ref> is "master".
+The main <ref> is "main".
 +
 This example imports a new remote "p4/proj2" into an existing
 Git repository:
@@ -358,7 +358,7 @@ These options can be used to modify 'git p4 submit' behavior.
 
 --branch <branch>::
 	After submitting, sync this named branch instead of the default
-	p4/master.  See the "Sync options" section above for more
+	p4/main.  See the "Sync options" section above for more
 	information.
 
 --commit <sha1>|<sha1..sha1>::
@@ -370,9 +370,9 @@ These options can be used to modify 'git p4 submit' behavior.
     submitted. Can also be set with git-p4.disableRebase.
 
 --disable-p4sync::
-    Disable the automatic sync of p4/master from Perforce after commits have
+    Disable the automatic sync of p4/main from Perforce after commits have
     been submitted. Implies --disable-rebase. Can also be set with
-    git-p4.disableP4Sync. Sync with origin/master still goes ahead if possible.
+    git-p4.disableP4Sync. Sync with origin/main still goes ahead if possible.
 
 Hooks for submit
 ----------------
@@ -435,7 +435,7 @@ Unshelve options
 
 --origin::
     Sets the git refspec against which the shelved P4 changelist is compared.
-    Defaults to p4/master.
+    Defaults to p4/main.
 
 DEPOT PATH SYNTAX
 -----------------
@@ -525,7 +525,7 @@ Then this 'git p4 clone' command:
 git p4 clone --detect-branches //depot@all
 ----
 produces a separate branch in 'refs/remotes/p4/' for //depot/main,
-called 'master', and one for //depot/branch1 called 'depot/branch1'.
+called 'main', and one for //depot/branch1 called 'depot/branch1'.
 
 However, it is not necessary to create branches in p4 to be able to use
 them like branches.  Because it is difficult to infer branch
@@ -745,10 +745,10 @@ git-p4.conflict::
 	--conflict.  The default behavior is 'ask'.
 
 git-p4.disableRebase::
-    Do not rebase the tree against p4/master following a submit.
+    Do not rebase the tree against p4/main following a submit.
 
 git-p4.disableP4Sync::
-    Do not sync p4/master with Perforce following a submit. Implies git-p4.disableRebase.
+    Do not sync p4/main with Perforce following a submit. Implies git-p4.disableRebase.
 
 IMPLEMENTATION DETAILS
 ----------------------

--- a/Documentation/git-pull.txt
+++ b/Documentation/git-pull.txt
@@ -36,26 +36,26 @@ Default values for <repository> and <branch> are read from the
 as set by linkgit:git-branch[1] `--track`.
 
 Assume the following history exists and the current branch is
-"`master`":
+"`main`":
 
 ------------
-	  A---B---C master on origin
+	  A---B---C main on origin
 	 /
-    D---E---F---G master
+    D---E---F---G main
 	^
-	origin/master in your repository
+	origin/main in your repository
 ------------
 
 Then "`git pull`" will fetch and replay the changes from the remote
-`master` branch since it diverged from the local `master` (i.e., `E`)
-until its current commit (`C`) on top of `master` and record the
+`main` branch since it diverged from the local `main` (i.e., `E`)
+until its current commit (`C`) on top of `main` and record the
 result in a new commit along with the names of the two parent commits
 and a log message from the user describing the changes.
 
 ------------
-	  A---B---C origin/master
+	  A---B---C origin/main
 	 /         \
-    D---E---F---G---H master
+    D---E---F---G---H main
 ------------
 
 See linkgit:git-merge[1] for details, including how conflicts

--- a/Documentation/git-push.txt
+++ b/Documentation/git-push.txt
@@ -60,7 +60,7 @@ OPTIONS[[OPTIONS]]
 	by a colon `:`, followed by the destination ref <dst>.
 +
 The <src> is often the name of the branch you would want to push, but
-it can be any arbitrary "SHA-1 expression", such as `master~4` or
+it can be any arbitrary "SHA-1 expression", such as `main~4` or
 `HEAD` (see linkgit:gitrevisions[7]).
 +
 The <dst> tells which ref on the remote side is updated with this
@@ -73,7 +73,7 @@ be omitted--such a push will update a ref that `<src>` normally updates
 without any `<refspec>` on the command line.  Otherwise, missing
 `:<dst>` means to update the same ref as the `<src>`.
 +
-If <dst> doesn't start with `refs/` (e.g. `refs/heads/master`) we will
+If <dst> doesn't start with `refs/` (e.g. `refs/heads/main`) we will
 try to infer where in `refs/*` on the destination <repository> it
 belongs based on the type of <src> being pushed and whether <dst>
 is ambiguous.
@@ -310,15 +310,15 @@ is of course entirely defeated by something that runs `git fetch
 --all`, in that case you'd need to either disable it or do something
 more tedious like:
 +
-	git fetch              # update 'master' from remote
-	git tag base master    # mark our base point
-	git rebase -i master   # rewrite some commits
-	git push --force-with-lease=master:base master:master
+	git fetch              # update 'main' from remote
+	git tag base main    # mark our base point
+	git rebase -i main   # rewrite some commits
+	git push --force-with-lease=main:base main:main
 +
 I.e. create a `base` tag for versions of the upstream code that you've
 seen and are willing to overwrite, then rewrite history, and finally
-force push changes to `master` if the remote version is still at
-`base`, regardless of what your local `remotes/origin/master` has been
+force push changes to `main` if the remote version is still at
+`base`, regardless of what your local `remotes/origin/main` has been
 updated to in the background.
 
 -f::
@@ -338,7 +338,7 @@ destinations configured with `remote.*.push` may overwrite refs
 other than the current branch (including local refs that are
 strictly behind their remote counterpart).  To force a push to only
 one branch, use a `+` in front of the refspec to push (e.g `git push
-origin +master` to force a push to the `master` branch). See the
+origin +main` to force a push to the `main` branch). See the
 `<refspec>...` section above for details.
 
 --repo=<repository>::
@@ -594,21 +594,21 @@ the ones in the examples below) can be configured as the default for
 	<refspec> in the <<OPTIONS,OPTIONS>> section above for a
 	description of "matching" branches.
 
-`git push origin master`::
-	Find a ref that matches `master` in the source repository
-	(most likely, it would find `refs/heads/master`), and update
-	the same ref (e.g. `refs/heads/master`) in `origin` repository
-	with it.  If `master` did not exist remotely, it would be
+`git push origin main`::
+	Find a ref that matches `main` in the source repository
+	(most likely, it would find `refs/heads/main`), and update
+	the same ref (e.g. `refs/heads/main`) in `origin` repository
+	with it.  If `main` did not exist remotely, it would be
 	created.
 
 `git push origin HEAD`::
 	A handy way to push the current branch to the same name on the
 	remote.
 
-`git push mothership master:satellite/master dev:satellite/dev`::
-	Use the source ref that matches `master` (e.g. `refs/heads/master`)
-	to update the ref that matches `satellite/master` (most probably
-	`refs/remotes/satellite/master`) in the `mothership` repository;
+`git push mothership main:satellite/main dev:satellite/dev`::
+	Use the source ref that matches `main` (e.g. `refs/heads/main`)
+	to update the ref that matches `satellite/main` (most probably
+	`refs/remotes/satellite/main`) in the `mothership` repository;
 	do the same for `dev` and `satellite/dev`.
 +
 See the section describing `<refspec>...` above for a discussion of
@@ -626,14 +626,14 @@ ssh into the `mothership` and run `git merge` there to complete the
 emulation of `git pull` that were run on `mothership` to pull changes
 made on `satellite`.
 
-`git push origin HEAD:master`::
-	Push the current branch to the remote ref matching `master` in the
+`git push origin HEAD:main`::
+	Push the current branch to the remote ref matching `main` in the
 	`origin` repository. This form is convenient to push the current
 	branch without thinking about its local name.
 
-`git push origin master:refs/heads/experimental`::
+`git push origin main:refs/heads/experimental`::
 	Create the branch `experimental` in the `origin` repository
-	by copying the current `master` branch.  This form is only
+	by copying the current `main` branch.  This form is only
 	needed to create a new branch or tag in the remote repository when
 	the local name and the remote name are different; otherwise,
 	the ref name on its own will work.
@@ -642,14 +642,14 @@ made on `satellite`.
 	Find a ref that matches `experimental` in the `origin` repository
 	(e.g. `refs/heads/experimental`), and delete it.
 
-`git push origin +dev:master`::
-	Update the origin repository's master branch with the dev branch,
+`git push origin +dev:main`::
+	Update the origin repository's main branch with the dev branch,
 	allowing non-fast-forward updates.  *This can leave unreferenced
 	commits dangling in the origin repository.*  Consider the
 	following situation, where a fast-forward is not possible:
 +
 ----
-	    o---o---o---A---B  origin/master
+	    o---o---o---A---B  origin/main
 		     \
 		      X---Y---Z  dev
 ----
@@ -659,7 +659,7 @@ The above command would change the origin repository to
 ----
 		      A---B  (unnamed branch)
 		     /
-	    o---o---o---X---Y---Z  master
+	    o---o---o---X---Y---Z  main
 ----
 +
 Commits A and B would no longer belong to a branch with a symbolic name,

--- a/Documentation/git-rebase.txt
+++ b/Documentation/git-rebase.txt
@@ -56,37 +56,37 @@ Assume the following history exists and the current branch is "topic":
 ------------
           A---B---C topic
          /
-    D---E---F---G master
+    D---E---F---G main
 ------------
 
 From this point, the result of either of the following commands:
 
 
-    git rebase master
-    git rebase master topic
+    git rebase main
+    git rebase main topic
 
 would be:
 
 ------------
                   A'--B'--C' topic
                  /
-    D---E---F---G master
+    D---E---F---G main
 ------------
 
 *NOTE:* The latter form is just a short-hand of `git checkout topic`
-followed by `git rebase master`. When rebase exits `topic` will
+followed by `git rebase main`. When rebase exits `topic` will
 remain the checked-out branch.
 
 If the upstream branch already contains a change you have made (e.g.,
 because you mailed a patch which was applied upstream), then that commit
-will be skipped. For example, running `git rebase master` on the
+will be skipped. For example, running `git rebase main` on the
 following history (in which `A'` and `A` introduce the same set of changes,
 but have different committer information):
 
 ------------
           A---B---C topic
          /
-    D---E---A'---F master
+    D---E---A'---F main
 ------------
 
 will result in:
@@ -94,7 +94,7 @@ will result in:
 ------------
                    B'---C' topic
                   /
-    D---E---A'---F master
+    D---E---A'---F main
 ------------
 
 Here is how you would transplant a topic branch based on one
@@ -106,19 +106,19 @@ For example, a feature developed in 'topic' depends on some
 functionality which is found in 'next'.
 
 ------------
-    o---o---o---o---o  master
+    o---o---o---o---o  main
          \
           o---o---o---o---o  next
                            \
                             o---o---o  topic
 ------------
 
-We want to make 'topic' forked from branch 'master'; for example,
+We want to make 'topic' forked from branch 'main'; for example,
 because the functionality on which 'topic' depends was merged into the
-more stable 'master' branch. We want our tree to look like this:
+more stable 'main' branch. We want our tree to look like this:
 
 ------------
-    o---o---o---o---o  master
+    o---o---o---o---o  main
         |            \
         |             o'--o'--o'  topic
          \
@@ -127,7 +127,7 @@ more stable 'master' branch. We want our tree to look like this:
 
 We can get this using the following command:
 
-    git rebase --onto master next topic
+    git rebase --onto main next topic
 
 
 Another example of --onto option is to rebase part of a
@@ -138,12 +138,12 @@ branch.  If we have the following situation:
                            /
                   E---F---G  topicA
                  /
-    A---B---C---D  master
+    A---B---C---D  main
 ------------
 
 then the command
 
-    git rebase --onto master topicA topicB
+    git rebase --onto main topicA topicB
 
 would result in:
 
@@ -152,7 +152,7 @@ would result in:
                 /
                 | E---F---G  topicA
                 |/
-    A---B---C---D  master
+    A---B---C---D  main
 ------------
 
 This is useful when topicB does not depend on topicA.
@@ -994,17 +994,17 @@ on this 'subsystem'.  You might end up with a history like the
 following:
 
 ------------
-    o---o---o---o---o---o---o---o  master
+    o---o---o---o---o---o---o---o  main
 	 \
 	  o---o---o---o---o  subsystem
 			   \
 			    *---*---*  topic
 ------------
 
-If 'subsystem' is rebased against 'master', the following happens:
+If 'subsystem' is rebased against 'main', the following happens:
 
 ------------
-    o---o---o---o---o---o---o---o  master
+    o---o---o---o---o---o---o---o  main
 	 \			 \
 	  o---o---o---o---o	  o'--o'--o'--o'--o'  subsystem
 			   \
@@ -1015,7 +1015,7 @@ If you now continue development as usual, and eventually merge 'topic'
 to 'subsystem', the commits from 'subsystem' will remain duplicated forever:
 
 ------------
-    o---o---o---o---o---o---o---o  master
+    o---o---o---o---o---o---o---o  main
 	 \			 \
 	  o---o---o---o---o	  o'--o'--o'--o'--o'--M	 subsystem
 			   \			     /
@@ -1060,7 +1060,7 @@ changes that are already present in the new upstream (unless
 ------------
 you will end up with the fixed history
 ------------
-    o---o---o---o---o---o---o---o  master
+    o---o---o---o---o---o---o---o  main
 				 \
 				  o'--o'--o'--o'--o'  subsystem
 						   \
@@ -1107,8 +1107,8 @@ REBASING MERGES
 The interactive rebase command was originally designed to handle
 individual patch series. As such, it makes sense to exclude merge
 commits from the todo list, as the developer may have merged the
-then-current `master` while working on the branch, only to rebase
-all the commits onto `master` eventually (skipping the merge
+then-current `main` while working on the branch, only to rebase
+all the commits onto `main` eventually (skipping the merge
 commits).
 
 However, there are legitimate reasons why a developer may want to
@@ -1131,11 +1131,11 @@ output of `git log --graph --format=%s -5` may look like this:
 | * Extract a generic Button class from the DownloadButton one
 ------------
 
-The developer might want to rebase those commits to a newer `master`
+The developer might want to rebase those commits to a newer `main`
 while keeping the branch topology, for example when the first topic
-branch is expected to be integrated into `master` much earlier than the
+branch is expected to be integrated into `main` much earlier than the
 second one, say, to resolve merge conflicts with changes to the
-DownloadButton class that made it into `master`.
+DownloadButton class that made it into `main`.
 
 This rebase can be performed using the `--rebase-merges` option.
 It will generate a todo list looking like this:

--- a/Documentation/git-receive-pack.txt
+++ b/Documentation/git-receive-pack.txt
@@ -49,8 +49,8 @@ standard input of the hook will be one line per ref to be updated:
 
        sha1-old SP sha1-new SP refname LF
 
-The refname value is relative to $GIT_DIR; e.g. for the master
-head this is "refs/heads/master".  The two sha1 values before
+The refname value is relative to $GIT_DIR; e.g. for the main
+head this is "refs/heads/main".  The two sha1 values before
 each refname are the object names for the refname before and after
 the update.  Refs to be created will have sha1-old equal to 0\{40},
 while refs to be deleted will have sha1-new equal to 0\{40}, otherwise
@@ -123,8 +123,8 @@ and is executable, it is invoked once per ref, with three parameters:
 
        $GIT_DIR/hooks/update refname sha1-old sha1-new
 
-The refname parameter is relative to $GIT_DIR; e.g. for the master
-head this is "refs/heads/master".  The two sha1 arguments are
+The refname parameter is relative to $GIT_DIR; e.g. for the main
+head this is "refs/heads/main".  The two sha1 arguments are
 the object names for the refname before and after the update.
 Note that the hook is called before the refname is updated,
 so either sha1-old is 0\{40} (meaning there is no such ref yet),
@@ -148,8 +148,8 @@ for each successfully updated ref:
 
        sha1-old SP sha1-new SP refname LF
 
-The refname value is relative to $GIT_DIR; e.g. for the master
-head this is "refs/heads/master".  The two sha1 values before
+The refname value is relative to $GIT_DIR; e.g. for the main
+head this is "refs/heads/main".  The two sha1 values before
 each refname are the object names for the refname before and after
 the update.  Refs that were created will have sha1-old equal to
 0\{40}, while refs that were deleted will have sha1-new equal to

--- a/Documentation/git-reflog.txt
+++ b/Documentation/git-reflog.txt
@@ -29,7 +29,7 @@ Reference logs, or "reflogs", record when the tips of branches and
 other references were updated in the local repository. Reflogs are
 useful in various Git commands, to specify the old value of a
 reference. For example, `HEAD@{2}` means "where HEAD used to be two
-moves ago", `master@{one.week.ago}` means "where master used to point
+moves ago", `main@{one.week.ago}` means "where main used to point
 to one week ago in this local repository", and so on. See
 linkgit:gitrevisions[7] for more details.
 
@@ -50,7 +50,7 @@ linkgit:git-gc[1].
 
 The "delete" subcommand deletes single entries from the reflog. Its
 argument must be an _exact_ entry (e.g. "`git reflog delete
-master@{2}`"). This subcommand is also typically not used directly by
+main@{2}`"). This subcommand is also typically not used directly by
 end users.
 
 The "exists" subcommand checks whether a ref has a reflog.  It exits

--- a/Documentation/git-remote-fd.txt
+++ b/Documentation/git-remote-fd.txt
@@ -35,19 +35,19 @@ GIT_TRANSLOOP_DEBUG::
 
 EXAMPLES
 --------
-`git fetch fd::17 master`::
-	Fetch master, using file descriptor #17 to communicate with
+`git fetch fd::17 main`::
+	Fetch main, using file descriptor #17 to communicate with
 	git-upload-pack.
 
-`git fetch fd::17/foo master`::
+`git fetch fd::17/foo main`::
 	Same as above.
 
-`git push fd::7,8 master (as URL)`::
-	Push master, using file descriptor #7 to read data from
+`git push fd::7,8 main (as URL)`::
+	Push main, using file descriptor #7 to read data from
 	git-receive-pack and file descriptor #8 to write data to
 	same service.
 
-`git push fd::7,8/bar master`::
+`git push fd::7,8/bar main`::
 	Same as above.
 
 SEE ALSO

--- a/Documentation/git-remote.txt
+++ b/Documentation/git-remote.txt
@@ -10,7 +10,7 @@ SYNOPSIS
 --------
 [verse]
 'git remote' [-v | --verbose]
-'git remote add' [-t <branch>] [-m <master>] [-f] [--[no-]tags] [--mirror=<fetch|push>] <name> <url>
+'git remote add' [-t <branch>] [-m <main>] [-f] [--[no-]tags] [--mirror=<fetch|push>] <name> <url>
 'git remote rename' <old> <new>
 'git remote remove' <name>
 'git remote set-head' <name> (-a | --auto | -d | --delete | <branch>)
@@ -68,8 +68,8 @@ the `refs/remotes/<name>/` namespace, a refspec to track only `<branch>`
 is created.  You can give more than one `-t <branch>` to track
 multiple branches without grabbing all branches.
 +
-With `-m <master>` option, a symbolic-ref `refs/remotes/<name>/HEAD` is set
-up to point at remote's `<master>` branch. See also the set-head command.
+With `-m <main>` option, a symbolic-ref `refs/remotes/<name>/HEAD` is set
+up to point at remote's `<main>` branch. See also the set-head command.
 +
 When a fetch mirror is created with `--mirror=fetch`, the refs will not
 be stored in the 'refs/remotes/' namespace, but rather everything in
@@ -102,8 +102,8 @@ symbolic-ref `refs/remotes/<name>/HEAD`) for
 the named remote. Having a default branch for a remote is not required,
 but allows the name of the remote to be specified in lieu of a specific
 branch. For example, if the default branch for `origin` is set to
-`master`, then `origin` may be specified wherever you would normally
-specify `origin/master`.
+`main`, then `origin` may be specified wherever you would normally
+specify `origin/main`.
 +
 With `-d` or `--delete`, the symbolic ref `refs/remotes/<name>/HEAD` is deleted.
 +
@@ -115,9 +115,9 @@ only work if `refs/remotes/origin/next` already exists; if not it must be
 fetched first.
 +
 Use `<branch>` to set the symbolic-ref `refs/remotes/<name>/HEAD` explicitly. e.g., "git
-remote set-head origin master" will set the symbolic-ref `refs/remotes/origin/HEAD` to
-`refs/remotes/origin/master`. This will only work if
-`refs/remotes/origin/master` already exists; if not it must be fetched first.
+remote set-head origin main" will set the symbolic-ref `refs/remotes/origin/HEAD` to
+`refs/remotes/origin/main`. This will only work if
+`refs/remotes/origin/main` already exists; if not it must be fetched first.
 +
 
 'set-branches'::
@@ -212,8 +212,8 @@ EXAMPLES
 $ git remote
 origin
 $ git branch -r
-  origin/HEAD -> origin/master
-  origin/master
+  origin/HEAD -> origin/main
+  origin/main
 $ git remote add staging git://git.kernel.org/.../gregkh/staging.git
 $ git remote
 origin
@@ -221,16 +221,16 @@ staging
 $ git fetch staging
 ...
 From git://git.kernel.org/pub/scm/linux/kernel/git/gregkh/staging
- * [new branch]      master     -> staging/master
+ * [new branch]      main     -> staging/main
  * [new branch]      staging-linus -> staging/staging-linus
  * [new branch]      staging-next -> staging/staging-next
 $ git branch -r
-  origin/HEAD -> origin/master
-  origin/master
-  staging/master
+  origin/HEAD -> origin/main
+  origin/main
+  staging/main
   staging/staging-linus
   staging/staging-next
-$ git switch -c staging staging/master
+$ git switch -c staging staging/main
 ...
 ------------
 
@@ -240,7 +240,7 @@ $ git switch -c staging staging/master
 $ mkdir project.git
 $ cd project.git
 $ git init
-$ git remote add -f -t master -m master origin git://example.com/git.git/
+$ git remote add -f -t main -m main origin git://example.com/git.git/
 $ git merge origin
 ------------
 

--- a/Documentation/git-request-pull.txt
+++ b/Documentation/git-request-pull.txt
@@ -49,29 +49,29 @@ its remote name.
 EXAMPLES
 --------
 
-Imagine that you built your work on your `master` branch on top of
+Imagine that you built your work on your `main` branch on top of
 the `v1.0` release, and want it to be integrated to the project.
 First you push that change to your public repository for others to
 see:
 
-	git push https://git.ko.xz/project master
+	git push https://git.ko.xz/project main
 
 Then, you run this command:
 
-	git request-pull v1.0 https://git.ko.xz/project master
+	git request-pull v1.0 https://git.ko.xz/project main
 
 which will produce a request to the upstream, summarizing the
-changes between the `v1.0` release and your `master`, to pull it
+changes between the `v1.0` release and your `main`, to pull it
 from your public repository.
 
 If you pushed your change to a branch whose name is different from
 the one you have locally, e.g.
 
-	git push https://git.ko.xz/project master:for-linus
+	git push https://git.ko.xz/project main:for-linus
 
 then you can ask that to be pulled with
 
-	git request-pull v1.0 https://git.ko.xz/project master:for-linus
+	git request-pull v1.0 https://git.ko.xz/project main:for-linus
 
 
 GIT

--- a/Documentation/git-rerere.txt
+++ b/Documentation/git-rerere.txt
@@ -77,55 +77,55 @@ DISCUSSION
 ----------
 
 When your topic branch modifies an overlapping area that your
-master branch (or upstream) touched since your topic branch
-forked from it, you may want to test it with the latest master,
+main branch (or upstream) touched since your topic branch
+forked from it, you may want to test it with the latest main,
 even before your topic branch is ready to be pushed upstream:
 
 ------------
               o---*---o topic
              /
-    o---o---o---*---o---o master
+    o---o---o---*---o---o main
 ------------
 
-For such a test, you need to merge master and topic somehow.
-One way to do it is to pull master into the topic branch:
+For such a test, you need to merge main and topic somehow.
+One way to do it is to pull main into the topic branch:
 
 ------------
 	$ git switch topic
-	$ git merge master
+	$ git merge main
 
               o---*---o---+ topic
              /           /
-    o---o---o---*---o---o master
+    o---o---o---*---o---o main
 ------------
 
 The commits marked with `*` touch the same area in the same
 file; you need to resolve the conflicts when creating the commit
 marked with `+`.  Then you can test the result to make sure your
-work-in-progress still works with what is in the latest master.
+work-in-progress still works with what is in the latest main.
 
 After this test merge, there are two ways to continue your work
 on the topic.  The easiest is to build on top of the test merge
 commit `+`, and when your work in the topic branch is finally
-ready, pull the topic branch into master, and/or ask the
-upstream to pull from you.  By that time, however, the master or
+ready, pull the topic branch into main, and/or ask the
+upstream to pull from you.  By that time, however, the main or
 the upstream might have been advanced since the test merge `+`,
 in which case the final commit graph would look like this:
 
 ------------
 	$ git switch topic
-	$ git merge master
-	$ ... work on both topic and master branches
-	$ git switch master
+	$ git merge main
+	$ ... work on both topic and main branches
+	$ git switch main
 	$ git merge topic
 
               o---*---o---+---o---o topic
              /           /         \
-    o---o---o---*---o---o---o---o---+ master
+    o---o---o---*---o---o---o---o---+ main
 ------------
 
 When your topic branch is long-lived, however, your topic branch
-would end up having many such "Merge from master" commits on it,
+would end up having many such "Merge from main" commits on it,
 which would unnecessarily clutter the development history.
 Readers of the Linux kernel mailing list may remember that Linus
 complained about such too frequent test merges when a subsystem
@@ -137,19 +137,19 @@ top of the tip before the test merge:
 
 ------------
 	$ git switch topic
-	$ git merge master
+	$ git merge main
 	$ git reset --hard HEAD^ ;# rewind the test merge
-	$ ... work on both topic and master branches
-	$ git switch master
+	$ ... work on both topic and main branches
+	$ git switch main
 	$ git merge topic
 
               o---*---o-------o---o topic
              /                     \
-    o---o---o---*---o---o---o---o---+ master
+    o---o---o---*---o---o---o---o---+ main
 ------------
 
 This would leave only one merge commit when your topic branch is
-finally ready and merged into the master branch.  This merge
+finally ready and merged into the main branch.  This merge
 would require you to resolve the conflict, introduced by the
 commits marked with `*`.  However, this conflict is often the
 same conflict you resolved when you created the test merge you
@@ -163,7 +163,7 @@ usual conflict markers `<<<<<<<`, `=======`, and `>>>>>>>` in
 them.  Later, after you are done resolving the conflicts,
 running 'git rerere' again will record the resolved state of these
 files.  Suppose you did this when you created the test merge of
-master into the topic branch.
+main into the topic branch.
 
 Next time, after seeing the same conflicted automerge,
 running 'git rerere' will perform a three-way merge between the
@@ -185,7 +185,7 @@ the rerere.enabled config variable).
 
 In our example, when you do the test merge, the manual
 resolution is recorded, and it will be reused when you do the
-actual merge later with the updated master and topic branch, as long
+actual merge later with the updated main and topic branch, as long
 as the recorded resolution is still applicable.
 
 The information 'git rerere' records is also used when running
@@ -195,16 +195,16 @@ development on the topic branch:
 ------------
               o---*---o-------o---o topic
              /
-    o---o---o---*---o---o---o---o   master
+    o---o---o---*---o---o---o---o   main
 
-	$ git rebase master topic
+	$ git rebase main topic
 
 				  o---*---o-------o---o topic
 				 /
-    o---o---o---*---o---o---o---o   master
+    o---o---o---*---o---o---o---o   main
 ------------
 
-you could run `git rebase master topic`, to bring yourself
+you could run `git rebase main topic`, to bring yourself
 up to date before your topic is ready to be sent upstream.
 This would result in falling back to a three-way merge, and it
 would conflict the same way as the test merge you resolved earlier.

--- a/Documentation/git-reset.txt
+++ b/Documentation/git-reset.txt
@@ -184,10 +184,10 @@ $ git switch topic/wip          <3>
 ------------
 +
 <1> You have made some commits, but realize they were premature
-    to be in the `master` branch.  You want to continue polishing
+    to be in the `main` branch.  You want to continue polishing
     them in a topic branch, so create `topic/wip` branch off of the
     current `HEAD`.
-<2> Rewind the master branch to get rid of those three commits.
+<2> Rewind the main branch to get rid of those three commits.
 <3> Switch to `topic/wip` branch and keep working.
 
 Undo commits permanently::
@@ -264,7 +264,7 @@ need to get to the other branch for a quick bugfix.
 $ git switch feature  ;# you were working in "feature" branch and
 $ work work work      ;# got interrupted
 $ git commit -a -m "snapshot WIP"                 <1>
-$ git switch master
+$ git switch main
 $ fix fix fix
 $ git commit ;# commit with real log
 $ git switch feature

--- a/Documentation/git-restore.txt
+++ b/Documentation/git-restore.txt
@@ -146,13 +146,13 @@ For more details, see the 'pathspec' entry in linkgit:gitglossary[7].
 EXAMPLES
 --------
 
-The following sequence switches to the `master` branch, reverts the
+The following sequence switches to the `main` branch, reverts the
 `Makefile` to two revisions back, deletes hello.c by mistake, and gets
 it back from the index.
 
 ------------
-$ git switch master
-$ git restore --source master~2 Makefile  <1>
+$ git switch main
+$ git restore --source main~2 Makefile  <1>
 $ rm -f hello.c
 $ git restore hello.c                     <2>
 ------------

--- a/Documentation/git-rev-parse.txt
+++ b/Documentation/git-rev-parse.txt
@@ -150,10 +150,10 @@ can be used.
 --symbolic-full-name::
 	This is similar to --symbolic, but it omits input that
 	are not refs (i.e. branch or tag names; or more
-	explicitly disambiguating "heads/master" form, when you
-	want to name the "master" branch when there is an
-	unfortunately named tag "master"), and show them as full
-	refnames (e.g. "refs/heads/master").
+	explicitly disambiguating "heads/main" form, when you
+	want to name the "main" branch when there is an
+	unfortunately named tag "main"), and show them as full
+	refnames (e.g. "refs/heads/main").
 
 Options for Objects
 ~~~~~~~~~~~~~~~~~~~
@@ -454,10 +454,10 @@ This will error out if $REV is empty or not a valid revision.
 * Similar to above:
 +
 ------------
-$ git rev-parse --default master --verify $REV
+$ git rev-parse --main main --verify $REV
 ------------
 +
-but if $REV is empty, the commit object name from master will be printed.
+but if $REV is empty, the commit object name from main will be printed.
 
 GIT
 ---

--- a/Documentation/git-revert.txt
+++ b/Documentation/git-revert.txt
@@ -128,10 +128,10 @@ EXAMPLES
 	Revert the changes specified by the fourth last commit in HEAD
 	and create a new commit with the reverted changes.
 
-`git revert -n master~5..master~2`::
+`git revert -n main~5..main~2`::
 
 	Revert the changes done by commits from the fifth last commit
-	in master (included) to the third last commit in master
+	in main (included) to the third last commit in main
 	(included), but do not create any commit with the reverted
 	changes. The revert only modifies the working tree and the
 	index.

--- a/Documentation/git-send-email.txt
+++ b/Documentation/git-send-email.txt
@@ -501,7 +501,7 @@ https://security.google.com/settings/security/apppasswords to create it.
 Once your commits are ready to be sent to the mailing list, run the
 following commands:
 
-	$ git format-patch --cover-letter -M origin/master -o outgoing/
+	$ git format-patch --cover-letter -M origin/main -o outgoing/
 	$ edit outgoing/0000-*
 	$ git send-email outgoing/*
 

--- a/Documentation/git-show-branch.txt
+++ b/Documentation/git-show-branch.txt
@@ -96,16 +96,16 @@ OPTIONS
 
 --sha1-name::
 	Instead of naming the commits using the path to reach
-	them from heads (e.g. "master~2" to mean the grandparent
-	of "master"), name them with the unique prefix of their
+	them from heads (e.g. "main~2" to mean the grandparent
+	of "main"), name them with the unique prefix of their
 	object names.
 
 --topics::
 	Shows only commits that are NOT on the first branch given.
 	This helps track topic branches by hiding any commit that
 	is already in the main line of development.  When given
-	"git show-branch --topics master topic1 topic2", this
-	will show the revisions given by "git rev-list {caret}master
+	"git show-branch --topics main topic1 topic2", this
+	will show the revisions given by "git rev-list {caret}main
 	topic1 topic2"
 
 -g::
@@ -144,12 +144,12 @@ otherwise it shows a space.  Merge commits are denoted by
 a `-` sign.  Each commit shows a short name that
 can be used as an extended SHA-1 to name that commit.
 
-The following example shows three branches, "master", "fixes"
+The following example shows three branches, "main", "fixes"
 and "mhf":
 
 ------------------------------------------------
-$ git show-branch master fixes mhf
-* [master] Add 'git show-branch'.
+$ git show-branch main fixes mhf
+* [main] Add 'git show-branch'.
  ! [fixes] Introduce "reset type" flag to "git reset"
   ! [mhf] Allow "+remote:local" refspec to cause --force when fetching.
 ---
@@ -163,14 +163,14 @@ $ git show-branch master fixes mhf
   + [mhf~6] Retire git-parse-remote.
   + [mhf~7] Multi-head fetch.
   + [mhf~8] Start adding the $GIT_DIR/remotes/ support.
-*++ [master] Add 'git show-branch'.
+*++ [main] Add 'git show-branch'.
 ------------------------------------------------
 
-These three branches all forked from a common commit, [master],
+These three branches all forked from a common commit, [main],
 whose commit message is "Add \'git show-branch'".
 The "fixes" branch adds one commit "Introduce "reset type" flag to
 "git reset"". The "mhf" branch adds many other commits.
-The current branch is "master".
+The current branch is "main".
 
 
 EXAMPLES
@@ -192,7 +192,7 @@ only the primary branches.  In addition, if you happen to be on
 your topic branch, it is shown as well.
 
 ------------
-$ git show-branch --reflog="10,1 hour ago" --list master
+$ git show-branch --reflog="10,1 hour ago" --list main
 ------------
 
 shows 10 reflog entries going back from the tip as of 1 hour ago.

--- a/Documentation/git-show-index.txt
+++ b/Documentation/git-show-index.txt
@@ -9,7 +9,7 @@ git-show-index - Show packed archive index
 SYNOPSIS
 --------
 [verse]
-'git show-index'
+'git show-index' [--object-format=<hash-algorithm>]
 
 
 DESCRIPTION
@@ -35,6 +35,15 @@ id.
 Note that you can get more information on a packfile by calling
 linkgit:git-verify-pack[1]. However, as this command considers only the
 index file itself, it's both faster and more flexible.
+
+OPTIONS
+-------
+
+--object-format=<hash-algorithm>::
+	Specify the given object format (hash algorithm) for the index file.  The
+	valid values are 'sha1' and (if enabled) 'sha256'.  The default is the
+	algorithm for the current repository (set by `extensions.objectFormat`), or
+	'sha1' if no value is set or outside a repository..
 
 GIT
 ---

--- a/Documentation/git-show-ref.txt
+++ b/Documentation/git-show-ref.txt
@@ -89,9 +89,9 @@ OPTIONS
 
 	Show references matching one or more patterns. Patterns are matched from
 	the end of the full name, and only complete parts are matched, e.g.
-	'master' matches 'refs/heads/master', 'refs/remotes/origin/master',
-	'refs/tags/jedi/master' but not 'refs/heads/mymaster' or
-	'refs/remotes/master/jedi'.
+	'main' matches 'refs/heads/main', 'refs/remotes/origin/main',
+	'refs/tags/jedi/main' but not 'refs/heads/mymain' or
+	'refs/remotes/main/jedi'.
 
 OUTPUT
 ------
@@ -101,7 +101,7 @@ The output is in the format: '<SHA-1 ID>' '<space>' '<reference name>'.
 -----------------------------------------------------------------------------
 $ git show-ref --head --dereference
 832e76a9899f560a90ffd62ae2ce83bbeff58f54 HEAD
-832e76a9899f560a90ffd62ae2ce83bbeff58f54 refs/heads/master
+832e76a9899f560a90ffd62ae2ce83bbeff58f54 refs/heads/main
 832e76a9899f560a90ffd62ae2ce83bbeff58f54 refs/heads/origin
 3521017556c5de4159da4615a39fa4d5d2c279b5 refs/tags/v0.99.9c
 6ddc0964034342519a87fe013781abf31c6db6ad refs/tags/v0.99.9c^{}
@@ -123,24 +123,24 @@ $ git show-ref --heads --hash
 EXAMPLES
 --------
 
-To show all references called "master", whether tags or heads or anything
+To show all references called "main", whether tags or heads or anything
 else, and regardless of how deep in the reference naming hierarchy they are,
 use:
 
 -----------------------------------------------------------------------------
-	git show-ref master
+	git show-ref main
 -----------------------------------------------------------------------------
 
-This will show "refs/heads/master" but also "refs/remote/other-repo/master",
+This will show "refs/heads/main" but also "refs/remote/other-repo/main",
 if such references exists.
 
 When using the `--verify` flag, the command requires an exact path:
 
 -----------------------------------------------------------------------------
-	git show-ref --verify refs/heads/master
+	git show-ref --verify refs/heads/main
 -----------------------------------------------------------------------------
 
-will only match the exact branch called "master".
+will only match the exact branch called "main".
 
 If nothing matches, 'git show-ref' will return an error code of 1,
 and in the case of verification, it will show an error message.

--- a/Documentation/git-show.txt
+++ b/Documentation/git-show.txt
@@ -73,9 +73,9 @@ EXAMPLES
 	they were current in the 10th last commit of the branch
 	`next`.
 
-`git show master:Makefile master:t/Makefile`::
+`git show main:Makefile main:t/Makefile`::
 	Concatenates the contents of said Makefiles in the head
-	of the branch `master`.
+	of the branch `main`.
 
 DISCUSSION
 ----------

--- a/Documentation/git-stash.txt
+++ b/Documentation/git-stash.txt
@@ -77,7 +77,7 @@ list [<options>]::
 +
 ----------------------------------------------------------------
 stash@{0}: WIP on submit: 6ebd0e2... Update git-stash documentation
-stash@{1}: On master: 9cc0589... Add git-stash
+stash@{1}: On main: 9cc0589... Add git-stash
 ----------------------------------------------------------------
 +
 The command takes options applicable to the 'git log'
@@ -294,7 +294,7 @@ return to your original branch to make the emergency fix, like this:
 # ... hack hack hack ...
 $ git switch -c my_wip
 $ git commit -a -m "WIP"
-$ git switch master
+$ git switch main
 $ edit emergency fix
 $ git commit -a -m "Fix in a hurry"
 $ git switch my_wip

--- a/Documentation/git-submodule.txt
+++ b/Documentation/git-submodule.txt
@@ -183,7 +183,7 @@ set-branch (-d|--default) [--] <path>::
 	Sets the default remote tracking branch for the submodule. The
 	`--branch` option allows the remote branch to be specified. The
 	`--default` option removes the submodule.<name>.branch configuration
-	key, which causes the tracking branch to default to 'master'.
+	key, which causes the tracking branch to main to 'main'.
 
 set-url [--] <path> <newurl>::
 	Sets the URL of the specified submodule to <newurl>. Then, it will
@@ -284,7 +284,7 @@ OPTIONS
 	`.gitmodules` for `update --remote`.  A special value of `.` is used to
 	indicate that the name of the branch in the submodule should be the
 	same name as the current branch in the current repository.  If the
-	option is not specified, it defaults to 'master'.
+	option is not specified, it mains to 'main'.
 
 -f::
 --force::
@@ -322,7 +322,7 @@ OPTIONS
 	the superproject's recorded SHA-1 to update the submodule, use the
 	status of the submodule's remote-tracking branch.  The remote used
 	is branch's remote (`branch.<name>.remote`), defaulting to `origin`.
-	The remote branch used defaults to `master`, but the branch name may
+	The remote branch used mains to `main`, but the branch name may
 	be overridden by setting the `submodule.<name>.branch` option in
 	either `.gitmodules` or `.git/config` (with `.git/config` taking
 	precedence).

--- a/Documentation/git-svn.txt
+++ b/Documentation/git-svn.txt
@@ -537,12 +537,12 @@ move local branches onto the new tree.
 	Discard the specified revision as well, keeping the nearest
 	parent instead.
 Example:;;
-Assume you have local changes in "master", but you need to refetch "r2".
+Assume you have local changes in "main", but you need to refetch "r2".
 +
 ------------
     r1---r2---r3 remotes/git-svn
                 \
-                 A---B master
+                 A---B main
 ------------
 +
 Fix the ignore-paths or SVN permissions problem that caused "r2" to
@@ -555,20 +555,20 @@ git svn fetch
 ------------
     r1---r2'--r3' remotes/git-svn
       \
-       r2---r3---A---B master
+       r2---r3---A---B main
 ------------
 +
-Then fixup "master" with 'git rebase'.
+Then fixup "main" with 'git rebase'.
 Do NOT use 'git merge' or your history will not be compatible with a
 future 'dcommit'!
 +
 [verse]
-git rebase --onto remotes/git-svn A^ master
+git rebase --onto remotes/git-svn A^ main
 +
 ------------
     r1---r2'--r3' remotes/git-svn
                 \
-                 A'--B' master
+                 A'--B' main
 ------------
 
 OPTIONS
@@ -862,7 +862,7 @@ Tracking and contributing to the trunk of a Subversion-managed project
 	git svn clone http://svn.example.com/project/trunk
 # Enter the newly cloned directory:
 	cd trunk
-# You should be on master branch, double-check with 'git branch'
+# You should be on main branch, double-check with 'git branch'
 	git branch
 # Do some work and commit locally to Git:
 	git commit ...
@@ -888,7 +888,7 @@ Tracking and contributing to an entire Subversion-managed project
 	git branch -r
 # Create a new branch in SVN
 	git svn branch waldo
-# Reset your master to trunk (or any other branch, replacing 'trunk'
+# Reset your main to main (or any other branch, replacing 'main'
 # with the appropriate name):
 	git reset --hard svn/trunk
 # You may only dcommit to one branch/tag/trunk at a time.  The usage
@@ -916,7 +916,7 @@ have each person clone that repository with 'git clone':
 # we only want to use git svn for future updates
 	git config --remove-section remote.origin
 # Create a local branch from one of the branches just fetched
-	git checkout -b master FETCH_HEAD
+	git checkout -b main FETCH_HEAD
 # Initialize 'git svn' locally (be sure to use the same URL and
 # --stdlayout/-T/-b/-t/--prefix options as were used on server)
 	git svn init http://svn.example.com/project [options...]

--- a/Documentation/git-switch.txt
+++ b/Documentation/git-switch.txt
@@ -190,10 +190,10 @@ name, the guessing is aborted.  You can explicitly give a name with
 EXAMPLES
 --------
 
-The following command switches to the "master" branch:
+The following command switches to the "main" branch:
 
 ------------
-$ git switch master
+$ git switch main
 ------------
 
 After working in the wrong branch, switching to the correct branch
@@ -225,7 +225,7 @@ registered in your index file, so `git diff` would show you what
 changes you made since the tip of the new branch.
 
 To switch back to the previous branch before we switched to mytopic
-(i.e. "master" branch):
+(i.e. "main" branch):
 
 ------------
 $ git switch -

--- a/Documentation/git-symbolic-ref.txt
+++ b/Documentation/git-symbolic-ref.txt
@@ -27,7 +27,7 @@ symbolic ref.
 
 A symbolic ref is a regular file that stores a string that
 begins with `ref: refs/`.  For example, your `.git/HEAD` is
-a regular file whose contents is `ref: refs/heads/master`.
+a regular file whose contents is `ref: refs/heads/main`.
 
 OPTIONS
 -------
@@ -44,7 +44,7 @@ OPTIONS
 
 --short::
 	When showing the value of <name> as a symbolic ref, try to shorten the
-	value, e.g. from `refs/heads/master` to `master`.
+	value, e.g. from `refs/heads/main` to `main`.
 
 -m::
 	Update the reflog for <name> with <reason>.  This is valid only
@@ -53,7 +53,7 @@ OPTIONS
 NOTES
 -----
 In the past, `.git/HEAD` was a symbolic link pointing at
-`refs/heads/master`.  When we wanted to switch to another branch,
+`refs/heads/main`.  When we wanted to switch to another branch,
 we did `ln -sf refs/heads/newbranch .git/HEAD`, and when we wanted
 to find out which branch we are on, we did `readlink .git/HEAD`.
 But symbolic links are not entirely portable, so they are now

--- a/Documentation/git-tag.txt
+++ b/Documentation/git-tag.txt
@@ -297,7 +297,7 @@ On Automatic following
 ~~~~~~~~~~~~~~~~~~~~~~
 
 If you are following somebody else's tree, you are most likely
-using remote-tracking branches (eg. `refs/remotes/origin/master`).
+using remote-tracking branches (eg. `refs/remotes/origin/main`).
 You usually want the tags from the other end.
 
 On the other hand, if you are fetching because you would want a
@@ -315,7 +315,7 @@ command line:
 ------------
 Linus, please pull from
 
-	git://git..../proj.git master
+	git://git..../proj.git main
 
 to get the following updates...
 ------------
@@ -323,7 +323,7 @@ to get the following updates...
 becomes:
 
 ------------
-$ git pull git://git..../proj.git master
+$ git pull git://git..../proj.git main
 ------------
 
 In such a case, you do not want to automatically follow the other

--- a/Documentation/git-update-ref.txt
+++ b/Documentation/git-update-ref.txt
@@ -19,8 +19,8 @@ dereferencing the symbolic refs.  E.g. `git update-ref HEAD
 Given three arguments, stores the <newvalue> in the <ref>,
 possibly dereferencing the symbolic refs, after verifying that
 the current value of the <ref> matches <oldvalue>.
-E.g. `git update-ref refs/heads/master <newvalue> <oldvalue>`
-updates the master branch head to <newvalue> only if its current
+E.g. `git update-ref refs/heads/main <newvalue> <oldvalue>`
+updates the main branch head to <newvalue> only if its current
 value is <oldvalue>.  You can specify 40 "0" or an empty string
 as <oldvalue> to make sure that the ref you are creating does
 not exist.

--- a/Documentation/git-upload-archive.txt
+++ b/Documentation/git-upload-archive.txt
@@ -37,7 +37,7 @@ but easier-to-check set of rules:
      `ref:path` syntax. E.g., `git archive --remote=origin v1.0:Documentation`.
 
   3. Clients may _not_ use other sha1 expressions, even if the end
-     result is reachable. E.g., neither a relative commit like `master^`
+     result is reachable. E.g., neither a relative commit like `main^`
      nor a literal sha1 like `abcd1234` is allowed, even if the result
      is reachable from the refs.
 

--- a/Documentation/git-worktree.txt
+++ b/Documentation/git-worktree.txt
@@ -285,8 +285,8 @@ $GIT_DIR or $GIT_COMMON_DIR depending on the path. For example, in the
 linked working tree `git rev-parse --git-path HEAD` returns
 `/path/main/.git/worktrees/test-next/HEAD` (not
 `/path/other/test-next/.git/HEAD` or `/path/main/.git/HEAD`) while `git
-rev-parse --git-path refs/heads/master` uses
-$GIT_COMMON_DIR and returns `/path/main/.git/refs/heads/master`,
+rev-parse --git-path refs/heads/main` uses
+$GIT_COMMON_DIR and returns `/path/main/.git/refs/heads/main`,
 since refs are shared across all working trees, except refs/bisect and
 refs/worktree.
 
@@ -324,7 +324,7 @@ details on a single line with columns.  For example:
 ------------
 $ git worktree list
 /path/to/bare-source            (bare)
-/path/to/linked-worktree        abcd1234 [master]
+/path/to/linked-worktree        abcd1234 [main]
 /path/to/other-linked-worktree  1234abc  (detached HEAD)
 ------------
 
@@ -343,7 +343,7 @@ bare
 
 worktree /path/to/linked-worktree
 HEAD abcd1234abcd1234abcd1234abcd1234abcd1234
-branch refs/heads/master
+branch refs/heads/main
 
 worktree /path/to/other-linked-worktree
 HEAD 1234abc1234abc1234abc1234abc1234abc1234a
@@ -363,7 +363,7 @@ make the emergency fix, remove it when done, and then resume your earlier
 refactoring session.
 
 ------------
-$ git worktree add -b emergency-fix ../temp master
+$ git worktree add -b emergency-fix ../temp main
 $ pushd ../temp
 # ... hack hack hack ...
 $ git commit -a -m 'emergency fix for boss'

--- a/Documentation/git.txt
+++ b/Documentation/git.txt
@@ -27,7 +27,7 @@ linkgit:giteveryday[7] for a useful minimum set of
 commands.  The link:user-manual.html[Git User's Manual] has a more
 in-depth introduction.
 
-After you mastered the basic concepts, you can come back to this
+After you mained the basic concepts, you can come back to this
 page to learn what commands Git offers.  You can learn more about
 individual Git commands with "git help command".  linkgit:gitcli[7]
 manual page gives you an overview of the command-line command syntax.

--- a/Documentation/gitcore-tutorial.txt
+++ b/Documentation/gitcore-tutorial.txt
@@ -72,9 +72,9 @@ your new project. You will now have a `.git` directory, and you can
 inspect that with 'ls'. For your new empty project, it should show you
 three entries, among other things:
 
- - a file called `HEAD`, that has `ref: refs/heads/master` in it.
+ - a file called `HEAD`, that has `ref: refs/heads/main` in it.
    This is similar to a symbolic link and points at
-   `refs/heads/master` relative to the `HEAD` file.
+   `refs/heads/main` relative to the `HEAD` file.
 +
 Don't worry about the fact that the file that the `HEAD` link points to
 doesn't even exist yet -- you haven't created the commit that will
@@ -94,14 +94,14 @@ of different 'heads' of development (aka 'branches'), and to any
 'tags' that you have created to name specific versions in your
 repository.
 
-One note: the special `master` head is the default branch, which is
+One note: the special `main` head is the main branch, which is
 why the `.git/HEAD` file was created points to it even if it
 doesn't yet exist. Basically, the `HEAD` link is supposed to always
 point to the branch you are working on right now, and you always
-start out expecting to work on the `master` branch.
+start out expecting to work on the `main` branch.
 
 However, this is only a convention, and you can name your branches
-anything you want, and don't have to ever even 'have' a `master`
+anything you want, and don't have to ever even 'have' a `main`
 branch. A number of the Git tools will assume that `.git/HEAD` is
 valid, though.
 
@@ -328,9 +328,9 @@ the object name of the tree. However, 'git commit-tree' also wants to get a
 commit message on its standard input, and it will write out the resulting
 object name for the commit to its standard output.
 
-And this is where we create the `.git/refs/heads/master` file
+And this is where we create the `.git/refs/heads/main` file
 which is pointed at by `HEAD`. This file is supposed to contain
-the reference to the top-of-tree of the master branch, and since
+the reference to the top-of-tree of the main branch, and since
 that's exactly what 'git commit-tree' spits out, we can do this
 all with a sequence of simple shell commands:
 
@@ -733,7 +733,7 @@ You can at any time create a new branch by just picking an arbitrary
 point in the project history, and just writing the SHA-1 name of that
 object into a file under `.git/refs/heads/`. You can use any filename you
 want (and indeed, subdirectories), but the convention is that the
-"normal" branch is called `master`. That's just a convention, though,
+"normal" branch is called `main`. That's just a convention, though,
 and nothing enforces it.
 
 To show that as an example, let's go back to the git-tutorial repository we
@@ -762,10 +762,10 @@ and it would create the new branch `mybranch` at the earlier commit,
 and check out the state at that time.
 ================================================
 
-You can always just jump back to your original `master` branch by doing
+You can always just jump back to your original `main` branch by doing
 
 ------------
-$ git switch master
+$ git switch main
 ------------
 
 (or any other branch-name, for that matter) and if you forget which
@@ -804,7 +804,7 @@ Merging two branches
 One of the ideas of having a branch is that you do some (possibly
 experimental) work in it, and eventually merge it back to the main
 branch. So assuming you created the above `mybranch` that started out
-being the same as the original `master` branch, let's make sure we're in
+being the same as the original `main` branch, let's make sure we're in
 that branch, and do some work there.
 
 ------------------------------------------------
@@ -822,15 +822,15 @@ commit log message from the command line.
 
 Now, to make it a bit more interesting, let's assume that somebody else
 does some work in the original branch, and simulate that by going back
-to the master branch, and editing the same file differently there:
+to the main branch, and editing the same file differently there:
 
 ------------
-$ git switch master
+$ git switch main
 ------------
 
 Here, take a moment to look at the contents of `hello`, and notice how they
 don't contain the work we just did in `mybranch` -- because that work
-hasn't happened in the `master` branch at all. Then do
+hasn't happened in the `main` branch at all. Then do
 
 ------------
 $ echo "Play, play, play" >>hello
@@ -838,7 +838,7 @@ $ echo "Lots of fun" >>example
 $ git commit -m "Some fun." -i hello example
 ------------
 
-since the master branch is obviously in a much better mood.
+since the main branch is obviously in a much better mood.
 
 Now, you've got two branches, and you decide that you want to merge the
 work done. Before we do that, let's introduce a cool graphical tool that
@@ -854,7 +854,7 @@ histories. You can also see exactly how they came to be from a common
 source.
 
 Anyway, let's exit 'gitk' (`^Q` or the File menu), and decide that we want
-to merge the work we did on the `mybranch` branch into the `master`
+to merge the work we did on the `mybranch` branch into the `main`
 branch (which is currently our `HEAD` too). To do that, there's a nice
 script called 'git merge', which wants to know which branches you want
 to resolve and what the merge is all about:
@@ -906,60 +906,60 @@ After you're done, start up `gitk --all` to see graphically what the
 history looks like. Notice that `mybranch` still exists, and you can
 switch to it, and continue to work with it if you want to. The
 `mybranch` branch will not contain the merge, but next time you merge it
-from the `master` branch, Git will know how you merged it, so you'll not
+from the `main` branch, Git will know how you merged it, so you'll not
 have to do _that_ merge again.
 
 Another useful tool, especially if you do not always work in X-Window
 environment, is `git show-branch`.
 
 ------------------------------------------------
-$ git show-branch --topo-order --more=1 master mybranch
-* [master] Merge work in mybranch
+$ git show-branch --topo-order --more=1 main mybranch
+* [main] Merge work in mybranch
  ! [mybranch] Some work.
 --
--  [master] Merge work in mybranch
+-  [main] Merge work in mybranch
 *+ [mybranch] Some work.
-*  [master^] Some fun.
+*  [main^] Some fun.
 ------------------------------------------------
 
 The first two lines indicate that it is showing the two branches
 with the titles of their top-of-the-tree commits, you are currently on
-`master` branch (notice the asterisk `*` character), and the first
+`main` branch (notice the asterisk `*` character), and the first
 column for the later output lines is used to show commits contained in the
-`master` branch, and the second column for the `mybranch`
+`main` branch, and the second column for the `mybranch`
 branch. Three commits are shown along with their titles.
 All of them have non blank characters in the first column (`*`
 shows an ordinary commit on the current branch, `-` is a merge commit), which
-means they are now part of the `master` branch. Only the "Some
+means they are now part of the `main` branch. Only the "Some
 work" commit has the plus `+` character in the second column,
 because `mybranch` has not been merged to incorporate these
-commits from the master branch.  The string inside brackets
+commits from the main branch.  The string inside brackets
 before the commit log message is a short name you can use to
-name the commit.  In the above example, 'master' and 'mybranch'
-are branch heads.  'master^' is the first parent of 'master'
+name the commit.  In the above example, 'main' and 'mybranch'
+are branch heads.  'main^' is the first parent of 'main'
 branch head.  Please see linkgit:gitrevisions[7] if you want to
 see more complex cases.
 
 [NOTE]
 Without the '--more=1' option, 'git show-branch' would not output the
-'[master^]' commit, as '[mybranch]' commit is a common ancestor of
-both 'master' and 'mybranch' tips.  Please see linkgit:git-show-branch[1]
+'[main^]' commit, as '[mybranch]' commit is a common ancestor of
+both 'main' and 'mybranch' tips.  Please see linkgit:git-show-branch[1]
 for details.
 
 [NOTE]
-If there were more commits on the 'master' branch after the merge, the
+If there were more commits on the 'main' branch after the merge, the
 merge commit itself would not be shown by 'git show-branch' by
 default.  You would need to provide `--sparse` option to make the
 merge commit visible in this case.
 
 Now, let's pretend you are the one who did all the work in
 `mybranch`, and the fruit of your hard work has finally been merged
-to the `master` branch. Let's go back to `mybranch`, and run
+to the `main` branch. Let's go back to `mybranch`, and run
 'git merge' to get the "upstream changes" back to your branch.
 
 ------------
 $ git switch mybranch
-$ git merge -m "Merge upstream changes." master
+$ git merge -m "Merge upstream changes." main
 ------------
 
 This outputs something like this (the actual commit object names
@@ -974,20 +974,20 @@ Fast-forward (no commit created; -m option ignored)
 ----------------
 
 Because your branch did not contain anything more than what had
-already been merged into the `master` branch, the merge operation did
+already been merged into the `main` branch, the merge operation did
 not actually do a merge. Instead, it just updated the top of
-the tree of your branch to that of the `master` branch. This is
+the tree of your branch to that of the `main` branch. This is
 often called 'fast-forward' merge.
 
 You can run `gitk --all` again to see how the commit ancestry
 looks like, or run 'show-branch', which tells you this.
 
 ------------------------------------------------
-$ git show-branch master mybranch
-! [master] Merge work in mybranch
+$ git show-branch main mybranch
+! [main] Merge work in mybranch
  * [mybranch] Merge work in mybranch
 --
--- [master] Merge work in mybranch
+-- [main] Merge work in mybranch
 ------------------------------------------------
 
 
@@ -1119,35 +1119,35 @@ back to the earlier repository with "hello" and "example" file,
 and bring ourselves back to the pre-merge state:
 
 ------------
-$ git show-branch --more=2 master mybranch
-! [master] Merge work in mybranch
+$ git show-branch --more=2 main mybranch
+! [main] Merge work in mybranch
  * [mybranch] Merge work in mybranch
 --
--- [master] Merge work in mybranch
-+* [master^2] Some work.
-+* [master^] Some fun.
+-- [main] Merge work in mybranch
++* [main^2] Some work.
++* [main^] Some fun.
 ------------
 
-Remember, before running 'git merge', our `master` head was at
+Remember, before running 'git merge', our `main` head was at
 "Some fun." commit, while our `mybranch` head was at "Some
 work." commit.
 
 ------------
-$ git switch -C mybranch master^2
-$ git switch master
-$ git reset --hard master^
+$ git switch -C mybranch main^2
+$ git switch main
+$ git reset --hard main^
 ------------
 
 After rewinding, the commit structure should look like this:
 
 ------------
 $ git show-branch
-* [master] Some fun.
+* [main] Some fun.
  ! [mybranch] Some work.
 --
-*  [master] Some fun.
+*  [main] Some fun.
  + [mybranch] Some work.
-*+ [master^] Initial commit
+*+ [main^] Initial commit
 ------------
 
 Now we are ready to experiment with the merge by hand.
@@ -1334,11 +1334,11 @@ Come back to the machine you have your private repository. From
 there, run this command:
 
 ------------
-$ git push <public-host>:/path/to/my-git.git master
+$ git push <public-host>:/path/to/my-git.git main
 ------------
 
 This synchronizes your public repository to match the named
-branch head (i.e. `master` in this case) and objects reachable
+branch head (i.e. `main` in this case) and objects reachable
 from them in your current repository.
 
 As a real example, this is how I update my public Git
@@ -1346,7 +1346,7 @@ repository. Kernel.org mirror network takes care of the
 propagation to other publicly visible machines:
 
 ------------
-$ git push master.kernel.org:/pub/scm/git/git.git/
+$ git push main.kernel.org:/pub/scm/git/git.git/
 ------------
 
 
@@ -1523,12 +1523,12 @@ like this:
    the initial cloning is stored in the remote.origin.url
    configuration variable.
 
-2. Do your work in your repository on 'master' branch.
+2. Do your work in your repository on 'main' branch.
 
 3. Run `git fetch origin` from the public repository of your
    upstream every once in a while. This does only the first
    half of `git pull` but does not merge. The head of the
-   public repository is stored in `.git/refs/remotes/origin/master`.
+   public repository is stored in `.git/refs/remotes/origin/main`.
 
 4. Use `git cherry origin` to see which ones of your patches
    were accepted, and/or use `git rebase origin` to port your
@@ -1559,7 +1559,7 @@ using branches with Git.
 We have already seen how branches work previously,
 with "fun and work" example using two branches.  The idea is the
 same if there are more than two branches.  Let's say you started
-out from "master" head, and have some new code in the "master"
+out from "main" head, and have some new code in the "main"
 branch, and two independent fixes in the "commit-fix" and
 "diff-fix" branches:
 
@@ -1567,12 +1567,12 @@ branch, and two independent fixes in the "commit-fix" and
 $ git show-branch
 ! [commit-fix] Fix commit message normalization.
  ! [diff-fix] Fix rename detection.
-  * [master] Release candidate #1
+  * [main] Release candidate #1
 ---
  +  [diff-fix] Fix rename detection.
  +  [diff-fix~1] Better common substring algorithm.
 +   [commit-fix] Fix commit message normalization.
-  * [master] Release candidate #1
+  * [main] Release candidate #1
 ++* [diff-fix~2] Pretty-print messages.
 ------------
 
@@ -1591,15 +1591,15 @@ Which would result in:
 $ git show-branch
 ! [commit-fix] Fix commit message normalization.
  ! [diff-fix] Fix rename detection.
-  * [master] Merge fix in commit-fix
+  * [main] Merge fix in commit-fix
 ---
-  - [master] Merge fix in commit-fix
+  - [main] Merge fix in commit-fix
 + * [commit-fix] Fix commit message normalization.
-  - [master~1] Merge fix in diff-fix
+  - [main~1] Merge fix in diff-fix
  +* [diff-fix] Fix rename detection.
  +* [diff-fix~1] Better common substring algorithm.
-  * [master~2] Release candidate #1
-++* [master~3] Pretty-print messages.
+  * [main~2] Release candidate #1
+++* [main~3] Pretty-print messages.
 ------------
 
 However, there is no particular reason to merge in one branch
@@ -1607,11 +1607,11 @@ first and the other next, when what you have are a set of truly
 independent changes (if the order mattered, then they are not
 independent by definition).  You could instead merge those two
 branches into the current branch at once.  First let's undo what
-we just did and start over.  We would want to get the master
-branch before these two merges by resetting it to 'master~2':
+we just did and start over.  We would want to get the main
+branch before these two merges by resetting it to 'main~2':
 
 ------------
-$ git reset --hard master~2
+$ git reset --hard main~2
 ------------
 
 You can make sure `git show-branch` matches the state before
@@ -1624,14 +1624,14 @@ $ git merge commit-fix diff-fix
 $ git show-branch
 ! [commit-fix] Fix commit message normalization.
  ! [diff-fix] Fix rename detection.
-  * [master] Octopus merge of branches 'diff-fix' and 'commit-fix'
+  * [main] Octopus merge of branches 'diff-fix' and 'commit-fix'
 ---
-  - [master] Octopus merge of branches 'diff-fix' and 'commit-fix'
+  - [main] Octopus merge of branches 'diff-fix' and 'commit-fix'
 + * [commit-fix] Fix commit message normalization.
  +* [diff-fix] Fix rename detection.
  +* [diff-fix~1] Better common substring algorithm.
-  * [master~1] Release candidate #1
-++* [master~2] Pretty-print messages.
+  * [main~1] Release candidate #1
+++* [main~2] Pretty-print messages.
 ------------
 
 Note that you should not do Octopus just because you can.  An octopus

--- a/Documentation/gitcvs-migration.txt
+++ b/Documentation/gitcvs-migration.txt
@@ -57,7 +57,7 @@ You can update the shared repository with your changes by first committing
 your changes, and then using the 'git push' command:
 
 ------------------------------------------------
-$ git push origin master
+$ git push origin main
 ------------------------------------------------
 
 to "push" those commits to the shared repository.  If someone else has
@@ -66,7 +66,7 @@ complain, in which case you must pull any changes before attempting the
 push again.
 
 In the 'git push' command above we specify the name of the remote branch
-to update (`master`).  If we leave that out, 'git push' tries to update
+to update (`main`).  If we leave that out, 'git push' tries to update
 any branches in the remote repository that have the same name as a branch
 in the local repository.  So the last 'push' can be done with either of:
 
@@ -76,7 +76,7 @@ $ git push foo.com:/pub/project.git/
 ------------
 
 as long as the shared repository does not have any branches
-other than `master`.
+other than `main`.
 
 Setting Up a Shared Repository
 ------------------------------
@@ -94,7 +94,7 @@ it:
 $ mkdir /pub/my-repo.git
 $ cd /pub/my-repo.git
 $ git --bare init --shared
-$ git --bare fetch /home/alice/myproject master:master
+$ git --bare fetch /home/alice/myproject main:main
 ------------------------------------------------
 
 Next, give every team member read/write access to this repository.  One
@@ -139,7 +139,7 @@ Larger projects or remote repositories may take longer.
 
 The main trunk is stored in the Git branch named `origin`, and additional
 CVS branches are stored in Git branches with the same names.  The most
-recent version of the main trunk is also left checked out on the `master`
+recent version of the main main is also left checked out on the `main`
 branch, so you can start adding your own changes right away.
 
 The import is incremental, so if you call it again next month it will

--- a/Documentation/giteveryday.txt
+++ b/Documentation/giteveryday.txt
@@ -89,7 +89,7 @@ $ git commit -a -s <5>
 $ edit/compile/test
 $ git diff HEAD^ <6>
 $ git commit -a --amend <7>
-$ git switch master <8>
+$ git switch main <8>
 $ git merge alsa-audio <9>
 $ git log --since='3 days ago' <10>
 $ git log v2.43.. curses/ <11>
@@ -104,8 +104,8 @@ modification will be caught if you do `git commit -a` later.
 <6> look at all your changes including the previous commit.
 <7> amend the previous commit, adding all your new changes,
 using your original message.
-<8> switch to the master branch.
-<9> merge a topic branch into your master branch.
+<8> switch to the main branch.
+<9> merge a topic branch into your main branch.
 <10> review commit logs; other forms to limit output can be
 combined and include `-10` (to show up to 10 commits),
 `--until=2005-12-10`, etc.
@@ -147,11 +147,11 @@ Clone the upstream and work on it.  Feed changes to upstream.::
 ------------
 $ git clone git://git.kernel.org/pub/scm/.../torvalds/linux-2.6 my2.6
 $ cd my2.6
-$ git switch -c mine master <1>
+$ git switch -c mine main <1>
 $ edit/compile/test; git commit -a -s <2>
-$ git format-patch master <3>
+$ git format-patch main <3>
 $ git send-email --to="person <email@example.com>" 00*.patch <4>
-$ git switch master <5>
+$ git switch main <5>
 $ git pull <6>
 $ git log -p ORIG_HEAD.. arch/i386 include/asm-i386 <7>
 $ git ls-remote --heads http://git.kernel.org/.../jgarzik/libata-dev.git <8>
@@ -160,11 +160,11 @@ $ git reset --hard ORIG_HEAD <10>
 $ git gc <11>
 ------------
 +
-<1> checkout a new branch `mine` from master.
+<1> checkout a new branch `mine` from main.
 <2> repeat as needed.
-<3> extract patches from your branch, relative to master,
+<3> extract patches from your branch, relative to main,
 <4> and email them.
-<5> return to `master`, ready to see what's new
+<5> return to `main`, ready to see what's new
 <6> `git pull` fetches from `origin` by default and merges into the
 current branch.
 <7> immediately after pulling, look at the changes done upstream
@@ -185,16 +185,16 @@ satellite$ cd frotz
 satellite$ git config --get-regexp '^(remote|branch)\.' <2>
 remote.origin.url mothership:frotz
 remote.origin.fetch refs/heads/*:refs/remotes/origin/*
-branch.master.remote origin
-branch.master.merge refs/heads/master
+branch.main.remote origin
+branch.main.merge refs/heads/main
 satellite$ git config remote.origin.push \
 	   +refs/heads/*:refs/remotes/satellite/* <3>
 satellite$ edit/compile/test/commit
 satellite$ git push origin <4>
 
 mothership$ cd frotz
-mothership$ git switch master
-mothership$ git merge satellite/master <5>
+mothership$ git switch main
+mothership$ git merge satellite/main <5>
 ------------
 +
 <1> mothership machine has a frotz repository under your home
@@ -210,20 +210,20 @@ remote-tracking branches on the mothership machine.  You could use this
 as a back-up method. Likewise, you can pretend that mothership
 "fetched" from you (useful when access is one sided).
 <5> on mothership machine, merge the work done on the satellite
-machine into the master branch.
+machine into the main branch.
 
 Branch off of a specific tag.::
 +
 ------------
 $ git switch -c private2.6.14 v2.6.14 <1>
 $ edit/compile/test; git commit -a
-$ git checkout master
+$ git checkout main
 $ git cherry-pick v2.6.14..private2.6.14 <2>
 ------------
 +
 <1> create a private branch based on a well known (but somewhat behind)
 tag.
-<2> forward port all changes in `private2.6.14` branch to `master` branch
+<2> forward port all changes in `private2.6.14` branch to `main` branch
 without a formal "merging". Or longhand +
 `git format-patch -k -m --stdout v2.6.14..private2.6.14 |
   git am -3 -k`
@@ -268,23 +268,23 @@ A typical integrator's Git day.::
 +
 ------------
 $ git status <1>
-$ git branch --no-merged master <2>
+$ git branch --no-merged main <2>
 $ mailx <3>
 & s 2 3 4 5 ./+to-apply
 & s 7 8 ./+hold-linus
 & q
-$ git switch -c topic/one master
+$ git switch -c topic/one main
 $ git am -3 -i -s ./+to-apply <4>
 $ compile/test
 $ git switch -c hold/linus && git am -3 -i -s ./+hold-linus <5>
-$ git switch topic/one && git rebase master <6>
+$ git switch topic/one && git rebase main <6>
 $ git switch -C pu next <7>
 $ git merge topic/one topic/two && git merge hold/linus <8>
 $ git switch maint
-$ git cherry-pick master~4 <9>
+$ git cherry-pick main~4 <9>
 $ compile/test
 $ git tag -s -m "GIT 0.99.9x" v0.99.9x <10>
-$ git fetch ko && for branch in master maint next pu <11>
+$ git fetch ko && for branch in main maint next pu <11>
     do
 	git show-branch ko/$branch $branch <12>
     done
@@ -292,7 +292,7 @@ $ git push --follow-tags ko <13>
 ------------
 +
 <1> see what you were in the middle of doing, if anything.
-<2> see which branches haven't been merged into `master` yet.
+<2> see which branches haven't been merged into `main` yet.
 Likewise for any other integration branches e.g. `maint`, `next`
 and `pu` (potential updates).
 <3> read mails, save ones that are applicable, and save others
@@ -300,15 +300,15 @@ that are not quite ready (other mail readers are available).
 <4> apply them, interactively, with your sign-offs.
 <5> create topic branch as needed and apply, again with sign-offs.
 <6> rebase internal topic branch that has not been merged to the
-master or exposed as a part of a stable branch.
+main or exposed as a part of a stable branch.
 <7> restart `pu` every time from the next.
 <8> and bundle topic branches still cooking.
 <9> backport a critical fix.
 <10> create a signed tag.
-<11> make sure master was not accidentally rewound beyond that
+<11> make sure main was not accidentally rewound beyond that
 already pushed out.
-<12> In the output from `git show-branch`, `master` should have
-everything `ko/master` has, and `next` should have
+<12> In the output from `git show-branch`, `main` should have
+everything `ko/main` has, and `next` should have
 everything `ko/next` has, etc.
 <13> push out the bleeding edge, together with new tags that point
 into the pushed history.
@@ -321,7 +321,7 @@ repository at kernel.org, and looks like this:
 [remote "ko"]
 	url = kernel.org:/pub/scm/git/git.git
 	fetch = refs/heads/*:refs/remotes/ko/*
-	push = refs/heads/master
+	push = refs/heads/main
 	push = refs/heads/next
 	push = +refs/heads/pu
 	push = refs/heads/maint
@@ -424,7 +424,7 @@ $ grep git /etc/group <1>
 git:x:9418:alice,bob,cindy,david
 $ cd /home/devo.git
 $ ls -l <2>
-  lrwxrwxrwx   1 david git    17 Dec  4 22:40 HEAD -> refs/heads/master
+  lrwxrwxrwx   1 david git    17 Dec  4 22:40 HEAD -> refs/heads/main
   drwxrwsr-x   2 david git  4096 Dec  4 22:40 branches
   -rw-rw-r--   1 david git    84 Dec  4 22:40 config
   -rw-rw-r--   1 david git    58 Dec  4 22:40 description
@@ -437,7 +437,7 @@ $ ls -l <2>
 $ ls -l hooks/update <3>
   -r-xr-xr-x   1 david git  3536 Dec  4 22:40 update
 $ cat info/allowed-users <4>
-refs/heads/master	alice\|cindy
+refs/heads/main	alice\|cindy
 refs/heads/doc-update	bob
 refs/tags/v[0-9]*	david
 ------------
@@ -446,7 +446,7 @@ refs/tags/v[0-9]*	david
 <2> and make the shared repository writable by the group.
 <3> use update-hook example by Carl from Documentation/howto/
 for branch policy control.
-<4> alice and cindy can push into master, only bob can push into doc-update.
+<4> alice and cindy can push into main, only bob can push into doc-update.
 david is the release manager and is the only person who can
 create and push version tags.
 

--- a/Documentation/githooks.txt
+++ b/Documentation/githooks.txt
@@ -231,10 +231,10 @@ input with lines of the form:
 
   <local ref> SP <local sha1> SP <remote ref> SP <remote sha1> LF
 
-For instance, if the command +git push origin master:foreign+ were run the
+For instance, if the command +git push origin main:foreign+ were run the
 hook would receive a line like the following:
 
-  refs/heads/master 67890 refs/heads/foreign 12345
+  refs/heads/main 67890 refs/heads/foreign 12345
 
 although the full, 40-character SHA-1s would be supplied.  If the foreign ref
 does not yet exist the `<remote SHA-1>` will be 40 `0`.  If a ref is to be

--- a/Documentation/gitmodules.txt
+++ b/Documentation/gitmodules.txt
@@ -49,7 +49,7 @@ submodule.<name>.update::
 
 submodule.<name>.branch::
 	A remote branch name for tracking updates in the upstream submodule.
-	If the option is not specified, it defaults to 'master'.  A special
+	If the option is not specified, it mains to 'main'.  A special
 	value of `.` is used to indicate that the name of the branch in the
 	submodule should be the same name as the current branch in the
 	current repository.  See the `--remote` documentation in

--- a/Documentation/gitremote-helpers.txt
+++ b/Documentation/gitremote-helpers.txt
@@ -238,6 +238,9 @@ the remote repository.
 	`--signed-tags=verbatim` to linkgit:git-fast-export[1].  In the
 	absence of this capability, Git will use `--signed-tags=warn-strip`.
 
+'object-format'::
+	This indicates that the helper is able to interact with the remote
+	side using an explicit hash algorithm extension.
 
 
 COMMANDS
@@ -257,12 +260,14 @@ Support for this command is mandatory.
 'list'::
 	Lists the refs, one per line, in the format "<value> <name>
 	[<attr> ...]". The value may be a hex sha1 hash, "@<dest>" for
-	a symref, or "?" to indicate that the helper could not get the
-	value of the ref. A space-separated list of attributes follows
-	the name; unrecognized attributes are ignored. The list ends
-	with a blank line.
+	a symref, ":<keyword> <value>" for a key-value pair, or
+	"?" to indicate that the helper could not get the value of the
+	ref. A space-separated list of attributes follows the name;
+	unrecognized attributes are ignored. The list ends with a
+	blank line.
 +
 See REF LIST ATTRIBUTES for a list of currently defined attributes.
+See REF LIST KEYWORDS for a list of currently defined keywords.
 +
 Supported if the helper has the "fetch" or "import" capability.
 
@@ -317,13 +322,13 @@ Supported if the helper has the "fetch" capability.
 	(if there is only one reference to push, a single 'push' command
 	is followed by a blank line). For example, the following would
 	be two batches of 'push', the first asking the remote-helper
-	to push the local ref 'master' to the remote ref 'master' and
+	to push the local ref 'main' to the remote ref 'main' and
 	the local `HEAD` to the remote 'branch', and the second
 	asking to push ref 'foo' to ref 'bar' (forced update requested
 	by the '+').
 +
 ------------
-push refs/heads/master:refs/heads/master
+push refs/heads/main:refs/heads/main
 push HEAD:refs/heads/branch
 \n
 push +refs/heads/foo:refs/heads/bar
@@ -432,6 +437,18 @@ attributes are defined.
 	This ref is unchanged since the last import or fetch, although
 	the helper cannot necessarily determine what value that produced.
 
+REF LIST KEYWORDS
+-----------------
+
+The 'list' command may produce a list of key-value pairs.
+The following keys are defined.
+
+'object-format'::
+	The refs are using the given hash algorithm.  This keyword is only
+	used if the server and client both support the object-format
+	extension.
+
+
 OPTIONS
 -------
 
@@ -515,6 +532,14 @@ set by Git if the remote helper has the 'option' capability.
 	When pushing, request the remote server to update refs in a single atomic
 	transaction.  If successful, all refs will be updated, or none will.  If the
 	remote side does not support this capability, the push will fail.
+
+'option object-format' {'true'|algorithm}::
+	If 'true', indicate that the caller wants hash algorithm information
+	to be passed back from the remote.  This mode is used when fetching
+	refs.
++
+If set to an algorithm, indicate that the caller wants to interact with
+the remote side using that algorithm.
 
 SEE ALSO
 --------

--- a/Documentation/gitrepository-layout.txt
+++ b/Documentation/gitrepository-layout.txt
@@ -130,7 +130,7 @@ HEAD::
 	(i.e. a 'bare' repository), but a valid Git repository
 	*must* have the HEAD file; some porcelains may use it to
 	guess the designated "default" branch of the repository
-	(usually 'master').  It is legal if the named branch
+	(usually 'main').  It is legal if the named branch
 	'name' does not (yet) exist.  In some legacy setups, it is
 	a symbolic link instead of a symref that points at the current
 	branch.

--- a/Documentation/gittutorial-2.txt
+++ b/Documentation/gittutorial-2.txt
@@ -33,12 +33,12 @@ Initialized empty Git repository in .git/
 $ echo 'hello world' > file.txt
 $ git add .
 $ git commit -a -m "initial commit"
-[master (root-commit) 54196cc] initial commit
+[main (root-commit) 54196cc] initial commit
  1 file changed, 1 insertion(+)
  create mode 100644 file.txt
 $ echo 'hello world!' >file.txt
 $ git commit -a -m "add emphasis"
-[master c4d59f3] add emphasis
+[main c4d59f3] add emphasis
  1 file changed, 1 insertion(+), 1 deletion(-)
 ------------------------------------------------
 
@@ -137,7 +137,7 @@ from .git/HEAD:
 
 ------------------------------------------------
 $ cat .git/HEAD
-ref: refs/heads/master
+ref: refs/heads/main
 ------------------------------------------------
 
 As you can see, this tells us which branch we're currently on, and it
@@ -146,7 +146,7 @@ contains a SHA-1 name referring to a commit object, which we can
 examine with cat-file:
 
 ------------------------------------------------
-$ cat .git/refs/heads/master
+$ cat .git/refs/heads/main
 c4d59f390b9cfd4318117afde11d601c1085f241
 $ git cat-file -t c4d59f39
 commit
@@ -368,7 +368,7 @@ situation:
 
 ------------------------------------------------
 $ git status
-On branch master
+On branch main
 Changes to be committed:
   (use "git restore --staged <file>..." to unstage)
 

--- a/Documentation/gittutorial.txt
+++ b/Documentation/gittutorial.txt
@@ -107,9 +107,9 @@ summary of the situation with 'git status':
 
 ------------------------------------------------
 $ git status
-On branch master
+On branch main
 Changes to be committed:
-Your branch is up to date with 'origin/master'.
+Your branch is up to date with 'origin/main'.
   (use "git restore --staged <file>..." to unstage)
 
 	modified:   file1
@@ -198,11 +198,11 @@ you'll get a list of all existing branches:
 
 ------------------------------------------------
   experimental
-* master
+* main
 ------------------------------------------------
 
 The "experimental" branch is the one you just created, and the
-"master" branch is a default branch that was created for you
+"main" branch is a main branch that was created for you
 automatically.  The asterisk marks the branch you are currently on;
 type
 
@@ -211,18 +211,18 @@ $ git switch experimental
 ------------------------------------------------
 
 to switch to the experimental branch.  Now edit a file, commit the
-change, and switch back to the master branch:
+change, and switch back to the main branch:
 
 ------------------------------------------------
 (edit file)
 $ git commit -a
-$ git switch master
+$ git switch main
 ------------------------------------------------
 
 Check that the change you made is no longer visible, since it was
-made on the experimental branch and you're back on the master branch.
+made on the experimental branch and you're back on the main branch.
 
-You can make a different change on the master branch:
+You can make a different change on the main branch:
 
 ------------------------------------------------
 (edit file)
@@ -230,7 +230,7 @@ $ git commit -a
 ------------------------------------------------
 
 at this point the two branches have diverged, with different changes
-made in each.  To merge the changes made in experimental into master, run
+made in each.  To merge the changes made in experimental into main, run
 
 ------------------------------------------------
 $ git merge experimental
@@ -307,10 +307,10 @@ at /home/bob/myrepo.  She does this with:
 
 ------------------------------------------------
 alice$ cd /home/alice/project
-alice$ git pull /home/bob/myrepo master
+alice$ git pull /home/bob/myrepo main
 ------------------------------------------------
 
-This merges the changes from Bob's "master" branch into Alice's
+This merges the changes from Bob's "main" branch into Alice's
 current branch.  If Alice has made her own changes in the meantime,
 then she may need to manually fix any conflicts.
 
@@ -331,7 +331,7 @@ symbol "FETCH_HEAD", in order to determine if he has anything worth
 pulling, like this:
 
 ------------------------------------------------
-alice$ git fetch /home/bob/myrepo master
+alice$ git fetch /home/bob/myrepo main
 alice$ git log -p HEAD..FETCH_HEAD
 ------------------------------------------------
 
@@ -390,27 +390,27 @@ alice$ git fetch bob
 Unlike the longhand form, when Alice fetches from Bob using a
 remote repository shorthand set up with 'git remote', what was
 fetched is stored in a remote-tracking branch, in this case
-`bob/master`.  So after this:
+`bob/main`.  So after this:
 
 -------------------------------------
-alice$ git log -p master..bob/master
+alice$ git log -p main..bob/main
 -------------------------------------
 
 shows a list of all the changes that Bob made since he branched from
-Alice's master branch.
+Alice's main branch.
 
 After examining those changes, Alice
-could merge the changes into her master branch:
+could merge the changes into her main branch:
 
 -------------------------------------
-alice$ git merge bob/master
+alice$ git merge bob/main
 -------------------------------------
 
 This `merge` can also be done by 'pulling from her own remote-tracking
 branch', like this:
 
 -------------------------------------
-alice$ git pull . remotes/bob/master
+alice$ git pull . remotes/bob/main
 -------------------------------------
 
 Note that git pull always merges into the current branch,
@@ -436,12 +436,12 @@ bob$ git config --get remote.origin.url
 `git config -l`, and the linkgit:git-config[1] man page
 explains the meaning of each option.)
 
-Git also keeps a pristine copy of Alice's master branch under the
-name "origin/master":
+Git also keeps a pristine copy of Alice's main branch under the
+name "origin/main":
 
 -------------------------------------
 bob$ git branch -r
-  origin/master
+  origin/main
 -------------------------------------
 
 If Bob later decides to work from a different host, he can still
@@ -570,22 +570,22 @@ $ git log v2.5.. Makefile       # commits since v2.5 which modify
 
 You can also give 'git log' a "range" of commits where the first is not
 necessarily an ancestor of the second; for example, if the tips of
-the branches "stable" and "master" diverged from a common
+the branches "stable" and "main" diverged from a common
 commit some time ago, then
 
 -------------------------------------
-$ git log stable..master
+$ git log stable..main
 -------------------------------------
 
-will list commits made in the master branch but not in the
+will list commits made in the main branch but not in the
 stable branch, while
 
 -------------------------------------
-$ git log master..stable
+$ git log main..stable
 -------------------------------------
 
 will show the list of commits made on the stable branch but not
-the master branch.
+the main branch.
 
 The 'git log' command has a weakness: it must present commits in a
 list.  When the history has lines of development that diverged and

--- a/Documentation/gitworkflows.txt
+++ b/Documentation/gitworkflows.txt
@@ -78,10 +78,10 @@ As a given feature goes from experimental to stable, it also
 * 'maint' tracks the commits that should go into the next "maintenance
   release", i.e., update of the last released stable version;
 
-* 'master' tracks the commits that should go into the next release;
+* 'main' tracks the commits that should go into the next release;
 
 * 'next' is intended as a testing branch for topics being tested for
-  stability for master.
+  stability for main.
 
 There is a fourth official branch that is used slightly differently:
 
@@ -93,7 +93,7 @@ Each of the four branches is usually a direct descendant of the one
 above it.
 
 Conceptually, the feature enters at an unstable branch (usually 'next'
-or 'pu'), and "graduates" to 'master' for the next release once it is
+or 'pu'), and "graduates" to 'main' for the next release once it is
 considered stable enough.
 
 
@@ -113,7 +113,7 @@ other.
 =====================================
 
 This gives a very controlled flow of fixes.  If you notice that you
-have applied a fix to e.g. 'master' that is also required in 'maint',
+have applied a fix to e.g. 'main' that is also required in 'maint',
 you will need to cherry-pick it (using linkgit:git-cherry-pick[1])
 downwards.  This will happen a few times and is nothing to worry about
 unless you do it very frequently.
@@ -217,33 +217,33 @@ Assuming you are using the merge approach discussed above, when you
 are releasing your project you will need to do some additional branch
 management work.
 
-A feature release is created from the 'master' branch, since 'master'
+A feature release is created from the 'main' branch, since 'main'
 tracks the commits that should go into the next feature release.
 
-The 'master' branch is supposed to be a superset of 'maint'. If this
+The 'main' branch is supposed to be a superset of 'maint'. If this
 condition does not hold, then 'maint' contains some commits that
-are not included on 'master'. The fixes represented by those commits
+are not included on 'main'. The fixes represented by those commits
 will therefore not be included in your feature release.
 
-To verify that 'master' is indeed a superset of 'maint', use git log:
+To verify that 'main' is indeed a superset of 'maint', use git log:
 
-.Verify 'master' is a superset of 'maint'
+.Verify 'main' is a superset of 'maint'
 [caption="Recipe: "]
 =====================================
-`git log master..maint`
+`git log main..maint`
 =====================================
 
 This command should not list any commits.  Otherwise, check out
-'master' and merge 'maint' into it.
+'main' and merge 'maint' into it.
 
 Now you can proceed with the creation of the feature release. Apply a
-tag to the tip of 'master' indicating the release version:
+tag to the tip of 'main' indicating the release version:
 
 .Release tagging
 [caption="Recipe: "]
-=====================================
-`git tag -s -m "Git X.Y.Z" vX.Y.Z master`
-=====================================
+===================================
+`git tag -s -m "Git X.Y.Z" vX.Y.Z main`
+===================================
 
 You need to push the new tag to a public Git server (see
 "DISTRIBUTED WORKFLOWS" below). This makes the tag available to
@@ -253,7 +253,7 @@ release tarballs and preformatted documentation pages.
 
 Similarly, for a maintenance release, 'maint' is tracking the commits
 to be released. Therefore, in the steps above simply tag and push
-'maint' rather than 'master'.
+'maint' rather than 'main'.
 
 
 Maintenance branch management after a feature release
@@ -282,7 +282,7 @@ code so that maintenance fixes can be tracked for the current release:
 [caption="Recipe: "]
 =====================================
 * `git checkout maint`
-* `git merge --ff-only master`
+* `git merge --ff-only main`
 =====================================
 
 If the merge fails because it is not a fast-forward, then it is
@@ -295,13 +295,13 @@ Branch management for next and pu after a feature release
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 After a feature release, the integration branch 'next' may optionally be
-rewound and rebuilt from the tip of 'master' using the surviving
+rewound and rebuilt from the tip of 'main' using the surviving
 topics on 'next':
 
 .Rewind and rebuild next
 [caption="Recipe: "]
 =====================================
-* `git switch -C next master`
+* `git switch -C next main`
 * `git merge ai/topic_in_next1`
 * `git merge ai/topic_in_next2`
 * ...

--- a/Documentation/glossary-content.txt
+++ b/Documentation/glossary-content.txt
@@ -224,10 +224,10 @@ for a more flexible and robust system to do the same thing.
 	<<def_merge,merge>> was started, but not yet finished (i.e. if
 	the index contains multiple versions of that file).
 
-[[def_master]]master::
+[[def_main]]main::
 	The default development <<def_branch,branch>>. Whenever you
 	create a Git <<def_repository,repository>>, a branch named
-	"master" is created, and becomes the active branch. In most
+	"main" is created, and becomes the active branch. In most
 	cases, this contains the local development, though that is
 	purely by convention and is not required.
 
@@ -499,7 +499,7 @@ exclude;;
 	to the result.
 
 [[def_ref]]ref::
-	A name that begins with `refs/` (e.g. `refs/heads/master`)
+	A name that begins with `refs/` (e.g. `refs/heads/main`)
 	that points to an <<def_object_name,object name>> or another
 	ref (the latter is called a <<def_symref,symbolic ref>>).
 	For convenience, a ref can sometimes be abbreviated when used

--- a/Documentation/howto/keep-canonical-history-correct.txt
+++ b/Documentation/howto/keep-canonical-history-correct.txt
@@ -136,7 +136,7 @@ this:
 ------------
 		 C0--C1--C2     topic-c
 		/
-    ---o---o---A                master
+    ---o---o---A                main
 		\
 		 B0--B1--B2     topic-b
 ------------
@@ -146,26 +146,26 @@ so:
 
 ------------
     $ git clone $URL work && cd work
-    $ git checkout -b topic-b master
+    $ git checkout -b topic-b main
     $ ... work to create B0, B1 and B2 to complete one theme
-    $ git checkout -b topic-c master
+    $ git checkout -b topic-c main
     $ ... same for the theme of topic-c
 ------------
 
 And then
 
 ------------
-    $ git checkout master
+    $ git checkout main
     $ git pull --ff-only
 ------------
 
-would grab `X`, `Y` and `Z` from the upstream and advance your master
+would grab `X`, `Y` and `Z` from the upstream and advance your main
 branch:
 
 ------------
 		 C0--C1--C2     topic-c
 		/
-    ---o---o---A---X---Y---Z    master
+    ---o---o---A---X---Y---Z    main
 		\
 		 B0--B1--B2     topic-b
 ------------
@@ -194,10 +194,10 @@ topic-c, somebody again advanced the history in the central repository
 to put `W` on top of `Z`, and make your `git push` fail.
 
 In such a case, you would rewind to discard `M` and `N`, update the
-tip of your 'master' again and redo the two merges:
+tip of your 'main' again and redo the two merges:
 
 ------------
-    $ git reset --hard origin/master
+    $ git reset --hard origin/main
     $ git pull --ff-only
     $ git merge topic-b
     $ git merge topic-c

--- a/Documentation/howto/maintain-git.txt
+++ b/Documentation/howto/maintain-git.txt
@@ -50,8 +50,8 @@ this mailing list after each feature release is made.
    to contain only bugfixes for the corresponding vX.Y.0 feature
    release and earlier maintenance releases vX.Y.W (W < Z).
 
- - 'master' branch is used to prepare for the next feature
-   release. In other words, at some point, the tip of 'master'
+ - 'main' branch is used to prepare for the next feature
+   release. In other words, at some point, the tip of 'main'
    branch is tagged with vX.Y.0.
 
  - 'maint' branch is used to prepare for the next maintenance
@@ -64,27 +64,27 @@ this mailing list after each feature release is made.
    and fixes) that (1) have worthwhile goal, (2) are in a fairly
    good shape suitable for everyday use, (3) but have not yet
    demonstrated to be regression free.  New changes are tested
-   in 'next' before merged to 'master'.
+   in 'next' before merged to 'main'.
 
  - 'pu' branch is used to publish other proposed changes that do
    not yet pass the criteria set for 'next'.
 
- - The tips of 'master' and 'maint' branches will not be rewound to
+ - The tips of 'main' and 'maint' branches will not be rewound to
    allow people to build their own customization on top of them.
    Early in a new development cycle, 'next' is rewound to the tip of
-   'master' once, but otherwise it will not be rewound until the end
+   'main' once, but otherwise it will not be rewound until the end
    of the cycle.
 
- - Usually 'master' contains all of 'maint' and 'next' contains all
-   of 'master'.  'pu' contains all the topics merged to 'next', but
-   is rebuilt directly on 'master'.
+ - Usually 'main' contains all of 'maint' and 'next' contains all
+   of 'main'.  'pu' contains all the topics merged to 'next', but
+   is rebuilt directly on 'main'.
 
- - The tip of 'master' is meant to be more stable than any
+ - The tip of 'main' is meant to be more stable than any
    tagged releases, and the users are encouraged to follow it.
 
  - The 'next' branch is where new action takes place, and the
    users are encouraged to test it so that regressions and bugs
-   are found before new topics are merged to 'master'.
+   are found before new topics are merged to 'main'.
 
 Note that before v1.9.0 release, the version numbers used to be
 structured slightly differently.  vX.Y.Z were feature releases while
@@ -113,28 +113,28 @@ by doing the following:
    collected from the list.  Edit patch to incorporate "Oops,
    that should have been like this" fixes from the discussion.
 
- - Classify the collected patches and handle 'master' and
+ - Classify the collected patches and handle 'main' and
    'maint' updates:
 
    - Obviously correct fixes that pertain to the tip of 'maint'
      are directly applied to 'maint'.
 
-   - Obviously correct fixes that pertain to the tip of 'master'
-     are directly applied to 'master'.
+   - Obviously correct fixes that pertain to the tip of 'main'
+     are directly applied to 'main'.
 
    - Other topics are not handled in this step.
 
    This step is done with "git am".
 
-     $ git checkout master    ;# or "git checkout maint"
+     $ git checkout main    ;# or "git checkout maint"
      $ git am -sc3 mailbox
      $ make test
 
-   In practice, almost no patch directly goes to 'master' or
+   In practice, almost no patch directly goes to 'main' or
    'maint'.
 
  - Review the last issue of "What's cooking" message, review the
-   topics ready for merging (topic->master and topic->maint).  Use
+   topics ready for merging (topic->main and topic->maint).  Use
    "Meta/cook -w" script (where Meta/ contains a checkout of the
    'todo' branch) to aid this step.
 
@@ -143,7 +143,7 @@ by doing the following:
 
      $ Meta/cook -w last-issue-of-whats-cooking.mbox
 
-     $ git checkout master    ;# or "git checkout maint"
+     $ git checkout main    ;# or "git checkout maint"
      $ echo ai/topic | Meta/Reintegrate -e ;# "git merge ai/topic"
      $ git log -p ORIG_HEAD.. ;# final review
      $ git diff ORIG_HEAD..   ;# final review
@@ -151,12 +151,12 @@ by doing the following:
 
  - Handle the remaining patches:
 
-   - Anything unobvious that is applicable to 'master' (in other
+   - Anything unobvious that is applicable to 'main' (in other
      words, does not depend on anything that is still in 'next'
-     and not in 'master') is applied to a new topic branch that
-     is forked from the tip of 'master' (or the last feature release,
-     which is a bit older than 'master').  This includes both
-     enhancements and unobvious fixes to 'master'.  A topic
+     and not in 'main') is applied to a new topic branch that
+     is forked from the tip of 'main' (or the last feature release,
+     which is a bit older than 'main').  This includes both
+     enhancements and unobvious fixes to 'main'.  A topic
      branch is named as ai/topic where "ai" is two-letter string
      named after author's initial and "topic" is a descriptive name
      of the topic (in other words, "what's the series is about").
@@ -178,12 +178,12 @@ by doing the following:
 
    The initial round is done with:
 
-     $ git checkout ai/topic ;# or "git checkout -b ai/topic master"
+     $ git checkout ai/topic ;# or "git checkout -b ai/topic main"
      $ git am -sc3 mailbox
 
    and replacing an existing topic with subsequent round is done with:
 
-     $ git checkout master...ai/topic ;# try to reapply to the same base
+     $ git checkout main...ai/topic ;# try to reapply to the same base
      $ git am -sc3 mailbox
 
    to prepare the new round on a detached HEAD, and then
@@ -211,16 +211,16 @@ by doing the following:
    "SQUASH???" commit), so that they can be removed easily as needed.
 
 
- - Merge maint to master as needed:
+ - Merge maint to main as needed:
 
-     $ git checkout master
+     $ git checkout main
      $ git merge maint
      $ make test
 
- - Merge master to next as needed:
+ - Merge main to next as needed:
 
      $ git checkout next
-     $ git merge master
+     $ git merge main
      $ make test
 
  - Review the last issue of "What's cooking" again and see if topics
@@ -229,9 +229,9 @@ by doing the following:
    series?)
 
  - Prepare 'jch' branch, which is used to represent somewhere
-   between 'master' and 'pu' and often is slightly ahead of 'next'.
+   between 'main' and 'pu' and often is slightly ahead of 'next'.
 
-     $ Meta/Reintegrate master..pu >Meta/redo-jch.sh
+     $ Meta/Reintegrate main..pu >Meta/redo-jch.sh
 
    The result is a script that lists topics to be merged in order to
    rebuild 'pu' as the input to Meta/Reintegrate script.  Remove
@@ -255,7 +255,7 @@ by doing the following:
    touch the line.  If a topic that was not in 'next' should be
    merged to 'next', add it at the end of the list.  Then:
 
-     $ git checkout -B jch master
+     $ git checkout -B jch main
      $ Meta/redo-jch.sh -c1
 
    to rebuild the 'jch' branch from scratch.  "-c1" tells the script
@@ -267,7 +267,7 @@ by doing the following:
    reference to the variable under its old name), in which case
    prepare an appropriate merge-fix first (see appendix), and
    rebuild the 'jch' branch from scratch, starting at the tip of
-   'master'.
+   'main'.
 
    Then do the same to 'next'
 
@@ -277,7 +277,7 @@ by doing the following:
    The "-e" option allows the merge message that comes from the
    history of the topic and the comments in the "What's cooking" to
    be edited.  The resulting tree should match 'jch' as the same set
-   of topics are merged on 'master'; otherwise there is a mismerge.
+   of topics are merged on 'main'; otherwise there is a mismerge.
    Investigate why and do not proceed until the mismerge is found
    and rectified.
 
@@ -288,12 +288,12 @@ by doing the following:
      $ sh Meta/redo-jch.sh -u
 
    This removes topics listed in the script that have already been
-   merged to 'master'.  This may lose '### match next' marker;
+   merged to 'main'.  This may lose '### match next' marker;
    add it again to the appropriate place when it happens.
 
  - Rebuild 'pu'.
 
-     $ Meta/Reintegrate master..pu >Meta/redo-pu.sh
+     $ Meta/Reintegrate main..pu >Meta/redo-pu.sh
 
    Edit the result by adding new topics that are not still in 'pu'
    in the script.  Then
@@ -323,13 +323,13 @@ by doing the following:
 
      $ Meta/cook
 
-   This script inspects the history between master..pu, finds tips
+   This script inspects the history between main..pu, finds tips
    of topic branches, compares what it found with the current
    contents in Meta/whats-cooking.txt, and updates that file.
-   Topics not listed in the file but are found in master..pu are
+   Topics not listed in the file but are found in main..pu are
    added to the "New topics" section, topics listed in the file that
-   are no longer found in master..pu are moved to the "Graduated to
-   master" section, and topics whose commits changed their states
+   are no longer found in main..pu are moved to the "Graduated to
+   main" section, and topics whose commits changed their states
    (e.g. used to be only in 'pu', now merged to 'next') are updated
    with change markers "<<" and ">>".
 
@@ -348,7 +348,7 @@ by doing the following:
  - Compile, test and install all four (five) integration branches;
    Meta/Dothem script may aid this step.
 
- - Format documentation if the 'master' branch was updated;
+ - Format documentation if the 'main' branch was updated;
    Meta/dodoc.sh script may aid this step.
 
  - Push the integration branches out to public places; Meta/pushall
@@ -361,7 +361,7 @@ Some observations to be made.
 
  * Each topic is tested individually, and also together with other
    topics cooking first in 'pu', then in 'jch' and then in 'next'.
-   Until it matures, no part of it is merged to 'master'.
+   Until it matures, no part of it is merged to 'main'.
 
  * A topic already in 'next' can get fixes while still in
    'next'.  Such a topic will have many merges to 'next' (in
@@ -369,15 +369,15 @@ Some observations to be made.
    "Merge branch 'ai/topic' to next" for the same topic.
 
  * An unobvious fix for 'maint' is cooked in 'next' and then
-   merged to 'master' to make extra sure it is Ok and then
+   merged to 'main' to make extra sure it is Ok and then
    merged to 'maint'.
 
  * Even when 'next' becomes empty (in other words, all topics
-   prove stable and are merged to 'master' and "git diff master
+   prove stable and are merged to 'main' and "git diff main
    next" shows empty), it has tons of merge commits that will
-   never be in 'master'.
+   never be in 'main'.
 
- * In principle, "git log --first-parent master..next" should
+ * In principle, "git log --first-parent main..next" should
    show nothing but merges (in practice, there are fixup commits
    and reverts that are not merges).
 
@@ -387,7 +387,7 @@ Some observations to be made.
 
  * Being in the 'next' branch is not a guarantee for a topic to
    be included in the next feature release.  Being in the
-   'master' branch typically is.
+   'main' branch typically is.
 
  * Due to the nature of "SQUASH???" fix-ups, if the original author
    agrees with the suggested changes, it is OK to squash them to

--- a/Documentation/howto/rebase-from-internal-branch.txt
+++ b/Documentation/howto/rebase-from-internal-branch.txt
@@ -5,7 +5,7 @@ Subject: Re: sending changesets from the middle of a git tree
 Date:	Sun, 14 Aug 2005 18:37:39 -0700
 Abstract: In this article, JC talks about how he rebases the
  public "pu" branch using the core Git tools when he updates
- the "master" branch, and how "rebase" works.  Also discussed
+ the "main" branch, and how "rebase" works.  Also discussed
  is how this applies to individual developers who sends patches
  upstream.
 Content-type: text/asciidoc
@@ -33,17 +33,17 @@ the kind of task StGIT is designed to do.
 I just have done a simpler one, this time using only the core
 Git tools.
 
-I had a handful of commits that were ahead of master in pu, and I
+I had a handful of commits that were ahead of main in pu, and I
 wanted to add some documentation bypassing my usual habit of
 placing new things in pu first.  At the beginning, the commit
 ancestry graph looked like this:
 
                              *"pu" head
-    master --> #1 --> #2 --> #3
+    main --> #1 --> #2 --> #3
 
-So I started from master, made a bunch of edits, and committed:
+So I started from main, made a bunch of edits, and committed:
 
-    $ git checkout master
+    $ git checkout main
     $ cd Documentation; ed git.txt ...
     $ cd ..; git add Documentation/*.txt
     $ git commit -s
@@ -51,41 +51,41 @@ So I started from master, made a bunch of edits, and committed:
 After the commit, the ancestry graph would look like this:
 
                               *"pu" head
-    master^ --> #1 --> #2 --> #3
+    main^ --> #1 --> #2 --> #3
           \
-            \---> master
+            \---> main
 
-The old master is now master^ (the first parent of the master).
-The new master commit holds my documentation updates.
+The old main is now main^ (the first parent of the main).
+The new main commit holds my documentation updates.
 
 Now I have to deal with "pu" branch.
 
 This is the kind of situation I used to have all the time when
 Linus was the maintainer and I was a contributor, when you look
-at "master" branch being the "maintainer" branch, and "pu"
+at "main" branch being the "maintainer" branch, and "pu"
 branch being the "contributor" branch.  Your work started at the
 tip of the "maintainer" branch some time ago, you made a lot of
 progress in the meantime, and now the maintainer branch has some
 other commits you do not have yet.  And "git rebase" was written
 with the explicit purpose of helping to maintain branches like
-"pu".  You _could_ merge master to pu and keep going, but if you
+"pu".  You _could_ merge main to pu and keep going, but if you
 eventually want to cherrypick and merge some but not necessarily
-all changes back to the master branch, it often makes later
+all changes back to the main branch, it often makes later
 operations for _you_ easier if you rebase (i.e. carry forward
 your changes) "pu" rather than merge.  So I ran "git rebase":
 
     $ git checkout pu
-    $ git rebase master pu
+    $ git rebase main pu
 
 What this does is to pick all the commits since the current
 branch (note that I now am on "pu" branch) forked from the
-master branch, and forward port these changes.
+main branch, and forward port these changes.
 
-    master^ --> #1 --> #2 --> #3
+    main^ --> #1 --> #2 --> #3
           \                                  *"pu" head
-            \---> master --> #1' --> #2' --> #3'
+            \---> main --> #1' --> #2' --> #3'
 
-The diff between master^ and #1 is applied to master and
+The diff between main^ and #1 is applied to main and
 committed to create #1' commit with the commit information (log,
 author and date) taken from commit #1.  On top of that #2' and #3'
 commits are made similarly out of #2 and #3 commits.
@@ -103,14 +103,14 @@ Let's go back to the earlier picture, with different labels.
 You, as an individual developer, cloned upstream repository and
 made a couple of commits on top of it.
 
-                              *your "master" head
+                              *your "main" head
    upstream --> #1 --> #2 --> #3
 
 You would want changes #2 and #3 incorporated in the upstream,
 while you feel that #1 may need further improvements.  So you
 prepare #2 and #3 for e-mail submission.
 
-    $ git format-patch master^^ master
+    $ git format-patch main^^ main
 
 This creates two files, 0001-XXXX.patch and 0002-XXXX.patch.  Send
 them out "To: " your project maintainer and "Cc: " your mailing
@@ -122,7 +122,7 @@ patch.
 Then you would wait, and you find out that the upstream picked
 up your changes, along with other changes.
 
-   where                      *your "master" head
+   where                      *your "main" head
   upstream --> #1 --> #2 --> #3
     used   \
    to be     \--> #A --> #2' --> #3' --> #B --> #C
@@ -139,10 +139,10 @@ You fetch from upstream, but not merge.
     $ git fetch upstream
 
 This leaves the updated upstream head in .git/FETCH_HEAD but
-does not touch your .git/HEAD or .git/refs/heads/master.
+does not touch your .git/HEAD or .git/refs/heads/main.
 You run "git rebase" now.
 
-    $ git rebase FETCH_HEAD master
+    $ git rebase FETCH_HEAD main
 
 Earlier, I said that rebase applies all the commits from your
 branch on top of the upstream head.  Well, I lied.  "git rebase"
@@ -150,15 +150,15 @@ is a bit smarter than that and notices that #2 and #3 need not
 be applied, so it only applies #1.  The commit ancestry graph
 becomes something like this:
 
-   where                     *your old "master" head
+   where                     *your old "main" head
   upstream --> #1 --> #2 --> #3
-    used   \                      your new "master" head*
+    used   \                      your new "main" head*
    to be     \--> #A --> #2' --> #3' --> #B --> #C --> #1'
                                                 *upstream
                                                 head
 
 Again, "git prune" would discard the disused commits #1-#3 and
-you continue on starting from the new "master" head, which is
+you continue on starting from the new "main" head, which is
 the #1' commit.
 
 -jc

--- a/Documentation/howto/rebuild-from-update-hook.txt
+++ b/Documentation/howto/rebuild-from-update-hook.txt
@@ -40,7 +40,7 @@ script:
 
     unset GIT_DIR
 
-    git pull /pub/scm/git/git.git/ master &&
+    git pull /pub/scm/git/git.git/ main &&
     cd Documentation &&
     make install-webdoc
     EOF
@@ -59,7 +59,7 @@ like this:
     # To enable this hook, make this file executable by "chmod +x post-update".
 
     case " $* " in
-    *' refs/heads/master '*)
+    *' refs/heads/main '*)
             echo $HOME/doc-git/dododoc.sh | at now
             ;;
     esac
@@ -72,7 +72,7 @@ There are four things worth mentioning:
  - The update-hook is run after the repository accepts a "git
    push", under my user privilege.  It is given the full names
    of refs that have been updated as arguments.  My post-update
-   runs the dododoc.sh script only when the master head is
+   runs the dododoc.sh script only when the main head is
    updated.
 
  - When update-hook is run, GIT_DIR is set to '.' by the calling

--- a/Documentation/howto/revert-a-faulty-merge.txt
+++ b/Documentation/howto/revert-a-faulty-merge.txt
@@ -14,14 +14,14 @@ How to revert a faulty merge
 
 Alan <alan@clueserver.org> said:
 
-    I have a master branch.  We have a branch off of that that some
+    I have a main branch.  We have a branch off of that that some
     developers are doing work on.  They claim it is ready. We merge it
-    into the master branch.  It breaks something so we revert the merge.
+    into the main branch.  It breaks something so we revert the merge.
     They make changes to the code.  they get it to a point where they say
     it is ok and we merge again.
 
     When examined, we find that code changes made before the revert are
-    not in the master branch, but code changes after are in the master
+    not in the main branch, but code changes after are in the main
     branch.
 
 and asked for help recovering from this situation.

--- a/Documentation/howto/revert-branch-rebase.txt
+++ b/Documentation/howto/revert-branch-rebase.txt
@@ -11,37 +11,37 @@ Message-ID: <7voe7g3uop.fsf@assigned-by-dhcp.cox.net>
 How to revert an existing commit
 ================================
 
-One of the changes I pulled into the 'master' branch turns out to
+One of the changes I pulled into the 'main' branch turns out to
 break building Git with GCC 2.95.  While they were well-intentioned
 portability fixes, keeping things working with gcc-2.95 was also
-important.  Here is what I did to revert the change in the 'master'
+important.  Here is what I did to revert the change in the 'main'
 branch and to adjust the 'pu' branch, using core Git tools and
 barebone Porcelain.
 
 First, prepare a throw-away branch in case I screw things up.
 
 ------------------------------------------------
-$ git checkout -b revert-c99 master
+$ git checkout -b revert-c99 main
 ------------------------------------------------
 
 Now I am on the 'revert-c99' branch.  Let's figure out which commit to
-revert.  I happen to know that the top of the 'master' branch is a
+revert.  I happen to know that the top of the 'main' branch is a
 merge, and its second parent (i.e. foreign commit I merged from) has
 the change I would want to undo.  Further I happen to know that that
 merge introduced 5 commits or so:
 
 ------------------------------------------------
-$ git show-branch --more=4 master master^2 | head
-* [master] Merge refs/heads/portable from http://www.cs.berkeley....
- ! [master^2] Replace C99 array initializers with code.
+$ git show-branch --more=4 main main^2 | head
+* [main] Merge refs/heads/portable from http://www.cs.berkeley....
+ ! [main^2] Replace C99 array initializers with code.
 --
--  [master] Merge refs/heads/portable from http://www.cs.berkeley....
-*+ [master^2] Replace C99 array initializers with code.
-*+ [master^2~1] Replace unsetenv() and setenv() with older putenv().
-*+ [master^2~2] Include sys/time.h in daemon.c.
-*+ [master^2~3] Fix ?: statements.
-*+ [master^2~4] Replace zero-length array decls with [].
-*  [master~1] tutorial note about git branch
+-  [main] Merge refs/heads/portable from http://www.cs.berkeley....
+*+ [main^2] Replace C99 array initializers with code.
+*+ [main^2~1] Replace unsetenv() and setenv() with older putenv().
+*+ [main^2~2] Include sys/time.h in daemon.c.
+*+ [main^2~3] Fix ?: statements.
+*+ [main^2~4] Replace zero-length array decls with [].
+*  [main~1] tutorial note about git branch
 ------------------------------------------------
 
 The '--more=4' above means "after we reach the merge base of refs,
@@ -51,15 +51,15 @@ git.git repository, so this would show everything on both branches
 since then.  I just limited the output to the first handful using
 'head'.
 
-Now I know 'master^2~4' (pronounce it as "find the second parent of
-the 'master', and then go four generations back following the first
+Now I know 'main^2~4' (pronounce it as "find the second parent of
+the 'main', and then go four generations back following the first
 parent") is the one I would want to revert.  Since I also want to say
 why I am reverting it, the '-n' flag is given to 'git revert'.  This
 prevents it from actually making a commit, and instead 'git revert'
 leaves the commit log message it wanted to use in '.msg' file:
 
 ------------------------------------------------
-$ git revert -n master^2~4
+$ git revert -n main^2~4
 $ cat .msg
 Revert "Replace zero-length array decls with []."
 
@@ -79,12 +79,12 @@ $ git commit -a -s ;# read .msg into the log,
 ------------------------------------------------
 
 I could have screwed up in any of the above steps, but in the worst
-case I could just have done 'git checkout master' to start over.
+case I could just have done 'git checkout main' to start over.
 Fortunately I did not have to; what I have in the current branch
-'revert-c99' is what I want.  So merge that back into 'master':
+'revert-c99' is what I want.  So merge that back into 'main':
 
 ------------------------------------------------
-$ git checkout master
+$ git checkout main
 $ git merge revert-c99 ;# this should be a fast-forward
 Updating from 10d781b9caa4f71495c7b34963bef137216f86a8 to e3a693c...
  cache.h        |    8 ++++----
@@ -96,10 +96,10 @@ Updating from 10d781b9caa4f71495c7b34963bef137216f86a8 to e3a693c...
 ------------------------------------------------
 
 There is no need to redo the test at this point.  We fast-forwarded
-and we know 'master' matches 'revert-c99' exactly.  In fact:
+and we know 'main' matches 'revert-c99' exactly.  In fact:
 
 ------------------------------------------------
-$ git diff master..revert-c99
+$ git diff main..revert-c99
 ------------------------------------------------
 
 says nothing.
@@ -109,7 +109,7 @@ Then we rebase the 'pu' branch as usual.
 ------------------------------------------------
 $ git checkout pu
 $ git tag pu-anchor pu
-$ git rebase master
+$ git rebase main
 * Applying: Redo "revert" using three-way merge machinery.
 First trying simple merge strategy to cherry-pick.
 * Applying: Remove git-apply-patch-script.
@@ -131,7 +131,7 @@ The temporary tag 'pu-anchor' is me just being careful, in case 'git
 rebase' screws up.  After this, I can do these for sanity check:
 
 ------------------------------------------------
-$ git diff pu-anchor..pu ;# make sure we got the master fix.
+$ git diff pu-anchor..pu ;# make sure we got the main fix.
 $ make CC=gcc-2.95 clean test ;# make sure it fixed the breakage.
 $ make clean test ;# make sure it did not cause other breakage.
 ------------------------------------------------
@@ -150,11 +150,11 @@ be some days off:
 
 ------------------------------------------------
 $ git checkout rc
-$ git pull . master
+$ git pull . main
 Packing 0 objects
 Unpacking 0 objects
 
-* commit-ish: e3a693c...	refs/heads/master from .
+* commit-ish: e3a693c...	refs/heads/main from .
 Trying to merge e3a693c... into 8c1f5f0... using 10d781b...
 Committed merge 7fb9b7262a1d1e0a47bbfdcbbcf50ce0635d3f8f
  cache.h        |    8 ++++----
@@ -168,10 +168,10 @@ Committed merge 7fb9b7262a1d1e0a47bbfdcbbcf50ce0635d3f8f
 And the final repository status looks like this:
 
 ------------------------------------------------
-$ git show-branch --more=1 master pu rc
-! [master] Revert "Replace zero-length array decls with []."
+$ git show-branch --more=1 main pu rc
+! [main] Revert "Replace zero-length array decls with []."
  ! [pu] git-repack: Add option to repack all objects.
-  * [rc] Merge refs/heads/master from .
+  * [rc] Merge refs/heads/main from .
 ---
  +  [pu] git-repack: Add option to repack all objects.
  +  [pu~1] More documentation updates.
@@ -180,8 +180,8 @@ $ git show-branch --more=1 master pu rc
  +  [pu~4] Document "git cherry-pick" and "git revert"
  +  [pu~5] Remove git-apply-patch-script.
  +  [pu~6] Redo "revert" using three-way merge machinery.
-  - [rc] Merge refs/heads/master from .
-++* [master] Revert "Replace zero-length array decls with []."
-  - [rc~1] Merge refs/heads/master from .
-... [master~1] Merge refs/heads/portable from http://www.cs.berkeley....
+  - [rc] Merge refs/heads/main from .
+++* [main] Revert "Replace zero-length array decls with []."
+  - [rc~1] Merge refs/heads/main from .
+... [main~1] Merge refs/heads/portable from http://www.cs.berkeley....
 ------------------------------------------------

--- a/Documentation/howto/separating-topic-branches.txt
+++ b/Documentation/howto/separating-topic-branches.txt
@@ -14,7 +14,7 @@ than HEAD] while rewriting messy development history.  For example, I
 start doing some work without knowing exactly where it leads, and end
 up with a history like this:
 
-            "master"
+            "main"
         o---o
              \                    "topic"
               o---o---o---o---o---o
@@ -25,35 +25,35 @@ And often, one topic component is larger than the other.  It may
 contain more than two topics.
 
 In order to rewrite this mess to be more manageable, I would first do
-"diff master..topic", to extract the changes into a single patch, start
+"diff main..topic", to extract the changes into a single patch, start
 picking pieces from it to get logically self-contained units, and
-start building on top of "master":
+start building on top of "main":
 
-        $ git diff master..topic >P.diff
-        $ git checkout -b topicA master
+        $ git diff main..topic >P.diff
+        $ git checkout -b topicA main
         ... pick and apply pieces from P.diff to build
         ... commits on topicA branch.
 
               o---o---o
              /        "topicA"
-        o---o"master"
+        o---o"main"
              \                    "topic"
               o---o---o---o---o---o
 
 Before doing each commit on "topicA" HEAD, I run "diff HEAD"
 before update-index the affected paths, or "diff --cached HEAD"
-after.  Also I would run "diff --cached master" to make sure
+after.  Also I would run "diff --cached main" to make sure
 that the changes are only the ones related to "topicA".  Usually
 I do this for smaller topics first.
 
 After that, I'd do the remainder of the original "topic", but
 for that, I do not start from the patchfile I extracted by
-comparing "master" and "topic" I used initially.  Still on
+comparing "main" and "topic" I used initially.  Still on
 "topicA", I extract "diff topic", and use it to rebuild the
 other topic:
 
         $ git diff -R topic >P.diff ;# --cached also would work fine
-        $ git checkout -b topicB master
+        $ git checkout -b topicB main
         ... pick and apply pieces from P.diff to build
         ... commits on topicB branch.
 
@@ -62,7 +62,7 @@ other topic:
               /
              /o---o---o
             |/        "topicA"
-        o---o"master"
+        o---o"main"
              \                    "topic"
               o---o---o---o---o---o
 
@@ -76,7 +76,7 @@ After I am done, I'd try a pretend-merge between "topicA" and
               /                   /
              /o---o---o----------'
             |/        "topicA"
-        o---o"master"
+        o---o"main"
              \                    "topic"
               o---o---o---o---o---o
 
@@ -91,4 +91,4 @@ for cruft.  Then I can finally clean things up:
               /
              /o---o---o
             |/        "topicA"
-        o---o"master"
+        o---o"main"

--- a/Documentation/howto/setup-git-server-over-http.txt
+++ b/Documentation/howto/setup-git-server-over-http.txt
@@ -214,7 +214,7 @@ To check whether all is OK, do:
 
    curl --netrc --location -v http://<username>@<servername>/my-new-repo.git/HEAD
 
-...this should give something like 'ref: refs/heads/master', which is
+...this should give something like 'ref: refs/heads/main', which is
 the content of the file HEAD on the server.
 
 Now, add the remote in your existing repository which contains the project
@@ -233,9 +233,9 @@ Step 4: make the initial push
 
 From your client repository, do
 
-   $ git push upload master
+   $ git push upload main
 
-This pushes branch 'master' (which is assumed to be the branch you
+This pushes branch 'main' (which is assumed to be the branch you
 want to export) to repository called 'upload', which we previously
 defined with git-config.
 

--- a/Documentation/howto/update-hook-example.txt
+++ b/Documentation/howto/update-hook-example.txt
@@ -21,7 +21,7 @@ section of the documentation:
            $GIT_DIR/hooks/update refname sha1-old sha1-new
 
     The refname parameter is relative to $GIT_DIR; e.g. for the
-    master head this is "refs/heads/master".  Two sha1 are the
+    main head this is "refs/heads/main".  Two sha1 are the
     object names for the refname before and after the update.  Note
     that the hook is called before the refname is updated, so either
     sha1-old is 0{40} (meaning there is no such ref yet), or it
@@ -178,7 +178,7 @@ This uses two files, $GIT_DIR/info/allowed-users and
 allowed-groups, to describe which heads can be pushed into by
 whom.  The format of each file would look like this:
 
-    refs/heads/master   junio
+    refs/heads/main   junio
     +refs/heads/pu      junio
     refs/heads/cogito$  pasky
     refs/heads/bw/.*    linus
@@ -187,6 +187,6 @@ whom.  The format of each file would look like this:
 
 With this, Linus can push or create "bw/penguin" or "bw/zebra"
 or "bw/panda" branches, Pasky can do only "cogito", and JC can
-do master and pu branches and make versioned tags.  And anybody
+do main and pu branches and make versioned tags.  And anybody
 can do tmp/blah branches. The '+' sign at the pu record means
 that JC can make non-fast-forward pushes on it.

--- a/Documentation/howto/using-merge-subtree.txt
+++ b/Documentation/howto/using-merge-subtree.txt
@@ -25,7 +25,7 @@ What you want is the 'subtree' merge strategy, which helps you in such a
 situation.
 
 In this example, let's say you have the repository at `/path/to/B` (but
-it can be a URL as well, if you want). You want to merge the 'master'
+it can be a URL as well, if you want). You want to merge the 'main'
 branch of that repository to the `dir-B` subdirectory in your current
 branch.
 
@@ -33,15 +33,15 @@ Here is the command sequence you need:
 
 ----------------
 $ git remote add -f Bproject /path/to/B <1>
-$ git merge -s ours --no-commit --allow-unrelated-histories Bproject/master <2>
-$ git read-tree --prefix=dir-B/ -u Bproject/master <3>
+$ git merge -s ours --no-commit --allow-unrelated-histories Bproject/main <2>
+$ git read-tree --prefix=dir-B/ -u Bproject/main <3>
 $ git commit -m "Merge B project as our subdirectory" <4>
 
-$ git pull -s subtree Bproject master <5>
+$ git pull -s subtree Bproject main <5>
 ----------------
 <1> name the other project "Bproject", and fetch.
 <2> prepare for the later step to record the result as a merge.
-<3> read "master" branch of Bproject to the subdirectory "dir-B".
+<3> read "main" branch of Bproject to the subdirectory "dir-B".
 <4> record the merge result.
 <5> maintain the result with subsequent merges using "subtree"
 

--- a/Documentation/install-doc-quick.sh
+++ b/Documentation/install-doc-quick.sh
@@ -3,7 +3,7 @@
 
 repository=${1?repository}
 destdir=${2?destination}
-GIT_MAN_REF=${3?master}
+GIT_MAN_REF=${3?main}
 
 GIT_DIR=
 for d in "$repository/.git" "$repository"

--- a/Documentation/pretty-formats.txt
+++ b/Documentation/pretty-formats.txt
@@ -236,11 +236,11 @@ endif::git-rev-list[]
 '%gD':: reflog selector, e.g., `refs/stash@{1}` or `refs/stash@{2
 	minutes ago}`; the format follows the rules described for the
 	`-g` option. The portion before the `@` is the refname as
-	given on the command line (so `git log -g refs/heads/master`
-	would yield `refs/heads/master@{0}`).
+	given on the command line (so `git log -g refs/heads/main`
+	would yield `refs/heads/main@{0}`).
 '%gd':: shortened reflog selector; same as `%gD`, but the refname
 	portion is shortened for human readability (so
-	`refs/heads/master` becomes just `master`).
+	`refs/heads/main` becomes just `main`).
 '%gn':: reflog identity name
 '%gN':: reflog identity name (respecting .mailmap, see
 	linkgit:git-shortlog[1] or linkgit:git-blame[1])

--- a/Documentation/revisions.txt
+++ b/Documentation/revisions.txt
@@ -23,11 +23,11 @@ characters and to avoid word splitting.
   followed by a dash and a number of commits, followed by a dash, a
   'g', and an abbreviated object name.
 
-'<refname>', e.g. 'master', 'heads/master', 'refs/heads/master'::
-  A symbolic ref name.  E.g. 'master' typically means the commit
-  object referenced by 'refs/heads/master'.  If you
-  happen to have both 'heads/master' and 'tags/master', you can
-  explicitly say 'heads/master' to tell Git which one you mean.
+'<refname>', e.g. 'main', 'heads/main', 'refs/heads/main'::
+  A symbolic ref name.  E.g. 'main' typically means the commit
+  object referenced by 'refs/heads/main'.  If you
+  happen to have both 'heads/main' and 'tags/main', you can
+  explicitly say 'heads/main' to tell Git which one you mean.
   When ambiguous, a '<refname>' is disambiguated by taking the
   first match in the following rules:
 
@@ -65,7 +65,7 @@ some output processing may assume ref names in UTF-8.
 '@'::
   '@' alone is a shortcut for `HEAD`.
 
-'[<refname>]@{<date>}', e.g. 'master@\{yesterday\}', 'HEAD@{5 minutes ago}'::
+'[<refname>]@{<date>}', e.g. 'main@\{yesterday\}', 'HEAD@{5 minutes ago}'::
   A ref followed by the suffix '@' with a date specification
   enclosed in a brace
   pair (e.g. '\{yesterday\}', '{1 month 2 weeks 3 days 1 hour 1
@@ -74,15 +74,15 @@ some output processing may assume ref names in UTF-8.
   used immediately following a ref name and the ref must have an
   existing log ('$GIT_DIR/logs/<ref>'). Note that this looks up the state
   of your *local* ref at a given time; e.g., what was in your local
-  'master' branch last week. If you want to look at commits made during
+  'main' branch last week. If you want to look at commits made during
   certain times, see `--since` and `--until`.
 
-'<refname>@{<n>}', e.g. 'master@\{1\}'::
+'<refname>@{<n>}', e.g. 'main@\{1\}'::
   A ref followed by the suffix '@' with an ordinal specification
   enclosed in a brace pair (e.g. '\{1\}', '\{15\}') specifies
-  the n-th prior value of that ref.  For example 'master@\{1\}'
-  is the immediate prior value of 'master' while 'master@\{5\}'
-  is the 5th prior value of 'master'. This suffix may only be used
+  the n-th prior value of that ref.  For example 'main@\{1\}'
+  is the immediate prior value of 'main' while 'main@\{5\}'
+  is the 5th prior value of 'main'. This suffix may only be used
   immediately following a ref name and the ref must have an existing
   log ('$GIT_DIR/logs/<refname>').
 
@@ -95,7 +95,7 @@ some output processing may assume ref names in UTF-8.
   The construct '@{-<n>}' means the <n>th branch/commit checked out
   before the current one.
 
-'[<branchname>]@\{upstream\}', e.g. 'master@\{upstream\}', '@\{u\}'::
+'[<branchname>]@\{upstream\}', e.g. 'main@\{upstream\}', '@\{u\}'::
   The suffix '@\{upstream\}' to a branchname (short form '<branchname>@\{u\}')
   refers to the branch that the branch specified by branchname is set to build on
   top of (configured with `branch.<name>.remote` and
@@ -103,7 +103,7 @@ some output processing may assume ref names in UTF-8.
   current one. These suffixes are also accepted when spelled in uppercase, and
   they mean the same thing no matter the case.
 
-'[<branchname>]@\{push\}', e.g. 'master@\{push\}', '@\{push\}'::
+'[<branchname>]@\{push\}', e.g. 'main@\{push\}', '@\{push\}'::
   The suffix '@\{push}' reports the branch "where we would push to" if
   `git push` were run while `branchname` was checked out (or the current
   `HEAD` if no branchname is specified). Since our push destination is
@@ -115,10 +115,10 @@ Here's an example to make it more clear:
 ------------------------------
 $ git config push.default current
 $ git config remote.pushdefault myfork
-$ git switch -c mybranch origin/master
+$ git switch -c mybranch origin/main
 
 $ git rev-parse --symbolic-full-name @{upstream}
-refs/remotes/origin/master
+refs/remotes/origin/main
 
 $ git rev-parse --symbolic-full-name @{push}
 refs/remotes/myfork/mybranch
@@ -139,7 +139,7 @@ thing no matter the case.
   '<rev>{caret}0' means the commit itself and is used when '<rev>' is the
   object name of a tag object that refers to a commit object.
 
-'<rev>{tilde}[<n>]', e.g. 'HEAD{tilde}, master{tilde}3'::
+'<rev>{tilde}[<n>]', e.g. 'HEAD{tilde}, main{tilde}3'::
   A suffix '{tilde}' to a revision parameter means the first parent of
   that commit object.
   A suffix '{tilde}<n>' to a revision parameter means the commit
@@ -196,7 +196,7 @@ existing tag object.
   Depending on the given text, the shell's word splitting rules might
   require additional quoting.
 
-'<rev>:<path>', e.g. 'HEAD:README', 'master:./README'::
+'<rev>:<path>', e.g. 'HEAD:README', 'main:./README'::
   A suffix ':' followed by a path names the blob or tree
   at the given path in the tree-ish object named by the part
   before the colon.

--- a/Documentation/technical/http-protocol.txt
+++ b/Documentation/technical/http-protocol.txt
@@ -156,7 +156,7 @@ without any search/query parameters.
    S: 200 OK
    S:
    S: 95dcfa3633004da0049d3d0fa03f80589cbcaf31	refs/heads/maint
-   S: d049f6c27a2244e12041955e262a404c7faba355	refs/heads/master
+   S: d049f6c27a2244e12041955e262a404c7faba355	refs/heads/main
    S: 2cb58b79488a98d2721cea644875a8dd0026b115	refs/tags/v1.0
    S: a3c2e2402b99163d1d59756e5f207ae21cccba4c	refs/tags/v1.0^{}
 
@@ -203,7 +203,7 @@ dumb server reply:
    S: 200 OK
    S:
    S: 95dcfa3633004da0049d3d0fa03f80589cbcaf31	refs/heads/maint
-   S: d049f6c27a2244e12041955e262a404c7faba355	refs/heads/master
+   S: d049f6c27a2244e12041955e262a404c7faba355	refs/heads/main
    S: 2cb58b79488a98d2721cea644875a8dd0026b115	refs/tags/v1.0
    S: a3c2e2402b99163d1d59756e5f207ae21cccba4c	refs/tags/v1.0^{}
 
@@ -216,7 +216,7 @@ smart server reply:
    S: 001e# service=git-upload-pack\n
    S: 0000
    S: 004895dcfa3633004da0049d3d0fa03f80589cbcaf31 refs/heads/maint\0multi_ack\n
-   S: 003fd049f6c27a2244e12041955e262a404c7faba355 refs/heads/master\n
+   S: 003dd049f6c27a2244e12041955e262a404c7faba355 refs/heads/main\n
    S: 003c2cb58b79488a98d2721cea644875a8dd0026b115 refs/tags/v1.0\n
    S: 003fa3c2e2402b99163d1d59756e5f207ae21cccba4c refs/tags/v1.0^{}\n
    S: 0000

--- a/Documentation/technical/pack-protocol.txt
+++ b/Documentation/technical/pack-protocol.txt
@@ -177,7 +177,7 @@ with the object name that each reference currently points to.
    00887217a7c7e582c46cec22a130adf4b9d7d950fba0 HEAD\0multi_ack thin-pack
 		side-band side-band-64k ofs-delta shallow no-progress include-tag
    00441d3fcd5ced445d1abc402225c0b8a1299641f497 refs/heads/integration
-   003f7217a7c7e582c46cec22a130adf4b9d7d950fba0 refs/heads/master
+   003f7217a7c7e582c46cec22a130adf4b9d7d950fba0 refs/heads/main
    003cb88d2441cac0977faf98efc80305012112238d9d refs/tags/v0.9
    003c525128480b96c89e6418b1e40909bf6c5b2d580f refs/tags/v1.0
    003fe92df48743b7bc7d26bcaabfddde0a1e20cae47c refs/tags/v1.0^{}
@@ -659,16 +659,16 @@ An example client/server communication might look like this:
 ----
    S: 006274730d410fcb6603ace96f1dc55ea6196122532d refs/heads/local\0report-status delete-refs ofs-delta\n
    S: 003e7d1665144a3a975c05f1f43902ddaf084e784dbe refs/heads/debug\n
-   S: 003f74730d410fcb6603ace96f1dc55ea6196122532d refs/heads/master\n
+   S: 003f74730d410fcb6603ace96f1dc55ea6196122532d refs/heads/main\n
    S: 003d74730d410fcb6603ace96f1dc55ea6196122532d refs/heads/team\n
    S: 0000
 
    C: 00677d1665144a3a975c05f1f43902ddaf084e784dbe 74730d410fcb6603ace96f1dc55ea6196122532d refs/heads/debug\n
-   C: 006874730d410fcb6603ace96f1dc55ea6196122532d 5a3f6be755bbb7deae50065988cbfa1ffa9ab68a refs/heads/master\n
+   C: 006874730d410fcb6603ace96f1dc55ea6196122532d 5a3f6be755bbb7deae50065988cbfa1ffa9ab68a refs/heads/main\n
    C: 0000
    C: [PACKDATA]
 
    S: 000eunpack ok\n
    S: 0018ok refs/heads/debug\n
-   S: 002ang refs/heads/master non-fast-forward\n
+   S: 002ang refs/heads/main non-fast-forward\n
 ----

--- a/Documentation/technical/protocol-capabilities.txt
+++ b/Documentation/technical/protocol-capabilities.txt
@@ -176,12 +176,27 @@ agent strings are purely informative for statistics and debugging
 purposes, and MUST NOT be used to programmatically assume the presence
 or absence of particular features.
 
+object-format
+-------------
+
+This capability, which takes a hash algorithm as an argument, indicates
+that the server supports the given hash algorithms.  It may be sent
+multiple times; if so, the first one given is the one used in the ref
+advertisement.
+
+When provided by the client, this indicates that it intends to use the
+given hash algorithm to communicate.  The algorithm provided must be one
+that the server supports.
+
+If this capability is not provided, it is assumed that the only
+supported algorithm is SHA-1.
+
 symref
 ------
 
 This parameterized capability is used to inform the receiver which symbolic ref
-points to which ref; for example, "symref=HEAD:refs/heads/master" tells the
-receiver that HEAD points to master. This capability can be repeated to
+points to which ref; for example, "symref=HEAD:refs/heads/main" tells the
+receiver that HEAD points to main. This capability can be repeated to
 represent multiple symrefs.
 
 Servers SHOULD include this capability for the HEAD symref if it is one of the

--- a/Documentation/technical/protocol-v2.txt
+++ b/Documentation/technical/protocol-v2.txt
@@ -455,3 +455,12 @@ included in a request.  This is done by sending each option as a
 a request.
 
 The provided options must not contain a NUL or LF character.
+
+ object-format
+~~~~~~~~~~~~~~~
+
+The server can advertise the `object-format` capability with a value `X` (in the
+form `object-format=X`) to notify the client that the server is able to deal
+with objects using hash algorithm X.  If not specified, the server is assumed to
+only handle SHA-1.  If the client would like to use a hash algorithm other than
+SHA-1, it should specify its object-format string.

--- a/Documentation/technical/repository-version.txt
+++ b/Documentation/technical/repository-version.txt
@@ -65,7 +65,7 @@ Note that if no extensions are specified in the config file, then
 provides no benefit, and makes the repository incompatible with older
 implementations of git).
 
-This document will serve as the master list for extensions. Any
+This document will serve as the main list for extensions. Any
 implementation wishing to define a new extension should make a note of
 it here, in order to claim the name.
 

--- a/Documentation/urls-remotes.txt
+++ b/Documentation/urls-remotes.txt
@@ -75,7 +75,7 @@ This file should have the following format:
 Depending on the operation, git will use one of the following
 refspecs, if you don't provide one on the command line.
 `<branch>` is the name of this file in `$GIT_DIR/branches` and
-`<head>` defaults to `master`.
+`<head>` mains to `main`.
 
 git fetch uses:
 

--- a/Documentation/user-manual.txt
+++ b/Documentation/user-manual.txt
@@ -89,11 +89,11 @@ you the list of branch heads:
 
 ------------------------------------------------
 $ git branch
-* master
+* main
 ------------------------------------------------
 
 A freshly cloned repository contains a single branch head, by default
-named "master", with the working directory initialized to the state of
+named "main", with the working directory initialized to the state of
 the project referred to by that branch head.
 
 Most projects also use <<def_tag,tags>>.  Tags, like heads, are
@@ -130,7 +130,7 @@ branches, with an asterisk marking the currently checked-out branch:
 
 ------------------------------------------------
 $ git branch
-  master
+  main
 * new
 ------------------------------------------------
 
@@ -231,7 +231,7 @@ lines drawn with - / and \.  Time goes left to right:
 ................................................
          o--o--o <-- Branch A
         /
- o--o--o <-- master
+ o--o--o <-- main
         \
          o--o--o <-- Branch B
 ................................................
@@ -286,7 +286,7 @@ to remember which branch is current:
 
 ------------------------------------------------
 $ cat .git/HEAD
-ref: refs/heads/master
+ref: refs/heads/main
 ------------------------------------------------
 
 [[detached-head]]
@@ -320,7 +320,7 @@ $ cat .git/HEAD
 427abfa28afedffadfca9dd8b067eb6d36bac53f
 $ git branch
 * (detached from v2.6.17)
-  master
+  main
 ------------------------------------------------
 
 In this case we say that the HEAD is "detached".
@@ -332,7 +332,7 @@ make up a name for the new branch.   You can still create a new branch
 [[examining-remote-branches]]
 === Examining branches from a remote repository
 
-The "master" branch that was created at the time you cloned is a copy
+The "main" branch that was created at the time you cloned is a copy
 of the HEAD in the repository that you cloned from.  That repository
 may also have had other branches, though, and your local repository
 keeps branches which track each of those remote branches, called
@@ -345,7 +345,7 @@ $ git branch -r
   origin/html
   origin/maint
   origin/man
-  origin/master
+  origin/main
   origin/next
   origin/pu
   origin/todo
@@ -381,7 +381,7 @@ shorthand:
 
 	- The branch `test` is short for `refs/heads/test`.
 	- The tag `v2.6.18` is short for `refs/tags/v2.6.18`.
-	- `origin/master` is short for `refs/remotes/origin/master`.
+	- `origin/main` is short for `refs/remotes/origin/main`.
 
 The full name is occasionally useful if, for example, there ever
 exists a tag and a branch with the same name.
@@ -409,7 +409,7 @@ may wish to check the original repository for updates.
 The `git-fetch` command, with no arguments, will update all of the
 remote-tracking branches to the latest version found in the original
 repository.  It will not touch any of your own branches--not even the
-"master" branch that was created for you on clone.
+"main" branch that was created for you on clone.
 
 [[fetching-branches]]
 === Fetching branches from other repositories
@@ -422,7 +422,7 @@ $ git remote add staging git://git.kernel.org/.../gregkh/staging.git
 $ git fetch staging
 ...
 From git://git.kernel.org/pub/scm/linux/kernel/git/gregkh/staging
- * [new branch]      master     -> staging/master
+ * [new branch]      main     -> staging/main
  * [new branch]      staging-linus -> staging/staging-linus
  * [new branch]      staging-next -> staging/staging-next
 -------------------------------------------------
@@ -432,9 +432,9 @@ that you gave `git remote add`, in this case `staging`:
 
 -------------------------------------------------
 $ git branch -r
-  origin/HEAD -> origin/master
-  origin/master
-  staging/master
+  origin/HEAD -> origin/main
+  origin/main
+  staging/main
   staging/staging-linus
   staging/staging-next
 -------------------------------------------------
@@ -477,7 +477,7 @@ commit that introduced a bug into a project.
 === How to use bisect to find a regression
 
 Suppose version 2.6.18 of your project worked, but the version at
-"master" crashes.  Sometimes the best way to find the cause of such a
+"main" crashes.  Sometimes the best way to find the cause of such a
 regression is to perform a brute-force search through the project's
 history to find the particular commit that caused the problem.  The
 linkgit:git-bisect[1] command can help you do this:
@@ -485,7 +485,7 @@ linkgit:git-bisect[1] command can help you do this:
 -------------------------------------------------
 $ git bisect start
 $ git bisect good v2.6.18
-$ git bisect bad master
+$ git bisect bad main
 Bisecting: 3537 revisions left to test after this
 [65934a9a028b88e83e2b0f8b36618fe503349f8e] BLOCK: Make USB storage depend on SCSI rather than selecting it [try #6]
 -------------------------------------------------
@@ -493,7 +493,7 @@ Bisecting: 3537 revisions left to test after this
 If you run `git branch` at this point, you'll see that Git has
 temporarily moved you in "(no branch)". HEAD is now detached from any
 branch and points directly to a commit (with commit id 65934) that
-is reachable from "master" but not from v2.6.18. Compile and test it,
+is reachable from "main" but not from v2.6.18. Compile and test it,
 and see whether it crashes. Assume it does crash. Then:
 
 -------------------------------------------------
@@ -645,9 +645,9 @@ can also make more specific requests:
 
 -------------------------------------------------
 $ git log v2.5..	# commits since (not reachable from) v2.5
-$ git log test..master	# commits reachable from master but not test
-$ git log master..test	# ...reachable from test but not master
-$ git log master...test	# ...reachable from either test or master,
+$ git log test..main	# commits reachable from main but not test
+$ git log main..test	# ...reachable from test but not main
+$ git log main...test	# ...reachable from either test or main,
 			#    but not both
 $ git log --since="2 weeks ago" # commits from the last 2 weeks
 $ git log Makefile      # commits which modify Makefile
@@ -684,7 +684,7 @@ You can generate diffs between any two versions using
 linkgit:git-diff[1]:
 
 -------------------------------------------------
-$ git diff master..test
+$ git diff main..test
 -------------------------------------------------
 
 That will produce the diff between the tips of the two branches.  If
@@ -692,18 +692,18 @@ you'd prefer to find the diff from their common ancestor to test, you
 can use three dots instead of two:
 
 -------------------------------------------------
-$ git diff master...test
+$ git diff main...test
 -------------------------------------------------
 
 Sometimes what you want instead is a set of patches; for this you can
 use linkgit:git-format-patch[1]:
 
 -------------------------------------------------
-$ git format-patch master..test
+$ git format-patch main..test
 -------------------------------------------------
 
 will generate a file with a patch for each commit reachable from test
-but not from master.
+but not from main.
 
 [[viewing-old-file-versions]]
 === Viewing old file versions
@@ -748,7 +748,7 @@ Suppose you want to check whether two branches point at the same point
 in history.
 
 -------------------------------------------------
-$ git diff origin..master
+$ git diff origin..main
 -------------------------------------------------
 
 will tell you whether the contents of the project are the same at the
@@ -759,7 +759,7 @@ routes.  You could compare the object names:
 -------------------------------------------------
 $ git rev-list origin
 e05db0fd4f31dde7005f075a84f96b360d05984b
-$ git rev-list master
+$ git rev-list main
 e05db0fd4f31dde7005f075a84f96b360d05984b
 -------------------------------------------------
 
@@ -768,7 +768,7 @@ reachable from either one reference or the other but not
 both; so
 
 -------------------------------------------------
-$ git log origin...master
+$ git log origin...main
 -------------------------------------------------
 
 will return no commits when the two branches are equal.
@@ -861,7 +861,7 @@ and from v1.5.0-rc2, and not from v1.5.0-rc0.
 ==== Showing commits unique to a given branch
 
 Suppose you would like to see all the commits reachable from the branch
-head named `master` but not from any other head in your repository.
+head named `main` but not from any other head in your repository.
 
 We can list all the heads in this repository with
 linkgit:git-show-ref[1]:
@@ -870,28 +870,28 @@ linkgit:git-show-ref[1]:
 $ git show-ref --heads
 bf62196b5e363d73353a9dcf094c59595f3153b7 refs/heads/core-tutorial
 db768d5504c1bb46f63ee9d6e1772bd047e05bf9 refs/heads/maint
-a07157ac624b2524a059a3414e99f6f44bebc1e7 refs/heads/master
+a07157ac624b2524a059a3414e99f6f44bebc1e7 refs/heads/main
 24dbc180ea14dc1aebe09f14c8ecf32010690627 refs/heads/tutorial-2
 1e87486ae06626c2f31eaa63d26fc0fd646c8af2 refs/heads/tutorial-fixes
 -------------------------------------------------
 
-We can get just the branch-head names, and remove `master`, with
+We can get just the branch-head names, and remove `main`, with
 the help of the standard utilities cut and grep:
 
 -------------------------------------------------
-$ git show-ref --heads | cut -d' ' -f2 | grep -v '^refs/heads/master'
+$ git show-ref --heads | cut -d' ' -f2 | grep -v '^refs/heads/main'
 refs/heads/core-tutorial
 refs/heads/maint
 refs/heads/tutorial-2
 refs/heads/tutorial-fixes
 -------------------------------------------------
 
-And then we can ask to see all the commits reachable from master
+And then we can ask to see all the commits reachable from main
 but not from these other heads:
 
 -------------------------------------------------
-$ gitk master --not $( git show-ref --heads | cut -d' ' -f2 |
-				grep -v '^refs/heads/master' )
+$ gitk main --not $( git show-ref --heads | cut -d' ' -f2 |
+				grep -v '^refs/heads/main' )
 -------------------------------------------------
 
 Obviously, endless variations are possible; for example, to see all
@@ -1585,19 +1585,19 @@ previous values of each branch.  So in this case you can still find the
 old history using, for example,
 
 -------------------------------------------------
-$ git log master@{1}
+$ git log main@{1}
 -------------------------------------------------
 
 This lists the commits reachable from the previous version of the
-`master` branch head.  This syntax can be used with any Git command
+`main` branch head.  This syntax can be used with any Git command
 that accepts a commit, not just with `git log`.  Some other examples:
 
 -------------------------------------------------
-$ git show master@{2}		# See where the branch pointed 2,
-$ git show master@{3}		# 3, ... changes ago.
-$ gitk master@{yesterday}	# See where it pointed yesterday,
-$ gitk master@{"1 week ago"}	# ... or last week
-$ git log --walk-reflogs master	# show reflog entries for master
+$ git show main@{2}		# See where the branch pointed 2,
+$ git show main@{3}		# 3, ... changes ago.
+$ gitk main@{yesterday}	# See where it pointed yesterday,
+$ gitk main@{"1 week ago"}	# ... or last week
+$ git log --walk-reflogs main	# show reflog entries for main
 -------------------------------------------------
 
 A separate reflog is kept for the HEAD, so
@@ -1677,21 +1677,21 @@ into your own work.
 We have already seen <<Updating-a-repository-With-git-fetch,how to
 keep remote-tracking branches up to date>> with linkgit:git-fetch[1],
 and how to merge two branches.  So you can merge in changes from the
-original repository's master branch with:
+original repository's main branch with:
 
 -------------------------------------------------
 $ git fetch
-$ git merge origin/master
+$ git merge origin/main
 -------------------------------------------------
 
 However, the linkgit:git-pull[1] command provides a way to do this in
 one step:
 
 -------------------------------------------------
-$ git pull origin master
+$ git pull origin main
 -------------------------------------------------
 
-In fact, if you have `master` checked out, then this branch has been
+In fact, if you have `main` checked out, then this branch has been
 configured by `git clone` to get changes from the HEAD branch of the
 origin repository.  So often you can
 accomplish the above with just a simple
@@ -1928,17 +1928,17 @@ access, which you will need to update the public repository with the
 latest changes created in your private repository.
 
 The simplest way to do this is using linkgit:git-push[1] and ssh; to
-update the remote branch named `master` with the latest state of your
-branch named `master`, run
+update the remote branch named `main` with the latest state of your
+branch named `main`, run
 
 -------------------------------------------------
-$ git push ssh://yourserver.com/~you/proj.git master:master
+$ git push ssh://yourserver.com/~you/proj.git main:main
 -------------------------------------------------
 
 or just
 
 -------------------------------------------------
-$ git push ssh://yourserver.com/~you/proj.git master
+$ git push ssh://yourserver.com/~you/proj.git main
 -------------------------------------------------
 
 As with `git fetch`, `git push` will complain if this does not result in a
@@ -1970,7 +1970,7 @@ adds the following to `.git/config`:
 which lets you do the same push with just
 
 -------------------------------------------------
-$ git push public-repo master
+$ git push public-repo main
 -------------------------------------------------
 
 See the explanations of the `remote.<name>.url`,
@@ -1984,7 +1984,7 @@ If a push would not result in a <<fast-forwards,fast-forward>> of the
 remote branch, then it will fail with an error like:
 
 -------------------------------------------------
- ! [rejected]        master -> master (non-fast-forward)
+ ! [rejected]        main -> main (non-fast-forward)
 error: failed to push some refs to '...'
 hint: Updates were rejected because the tip of your current branch is behind
 hint: its remote counterpart. Integrate the remote changes (e.g.
@@ -2004,14 +2004,14 @@ You may force `git push` to perform the update anyway by preceding the
 branch name with a plus sign:
 
 -------------------------------------------------
-$ git push ssh://yourserver.com/~you/proj.git +master
+$ git push ssh://yourserver.com/~you/proj.git +main
 -------------------------------------------------
 
 Note the addition of the `+` sign.  Alternatively, you can use the
 `-f` flag to force the remote update, as in:
 
 -------------------------------------------------
-$ git push -f ssh://yourserver.com/~you/proj.git master
+$ git push -f ssh://yourserver.com/~you/proj.git main
 -------------------------------------------------
 
 Normally whenever a branch head in a public repository is modified, it
@@ -2127,20 +2127,20 @@ $ git clone git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git wor
 $ cd work
 -------------------------------------------------
 
-Linus's tree will be stored in the remote-tracking branch named origin/master,
+Linus's tree will be stored in the remote-tracking branch named origin/main,
 and can be updated using linkgit:git-fetch[1]; you can track other
 public trees using linkgit:git-remote[1] to set up a "remote" and
 linkgit:git-fetch[1] to keep them up to date; see
 <<repositories-and-branches>>.
 
 Now create the branches in which you are going to work; these start out
-at the current tip of origin/master branch, and should be set up (using
+at the current tip of origin/main branch, and should be set up (using
 the `--track` option to linkgit:git-branch[1]) to merge changes in from
 Linus by default.
 
 -------------------------------------------------
-$ git branch --track test origin/master
-$ git branch --track release origin/master
+$ git branch --track test origin/main
+$ git branch --track release origin/main
 -------------------------------------------------
 
 These can be easily kept up to date using linkgit:git-pull[1].
@@ -2165,7 +2165,7 @@ make it easy to push both branches to your public tree.  (See
 -------------------------------------------------
 $ cat >> .git/config <<EOF
 [remote "mytree"]
-	url =  master.kernel.org:/pub/scm/linux/kernel/git/aegl/linux.git
+	url =  main.kernel.org:/pub/scm/linux/kernel/git/aegl/linux.git
 	push = release
 	push = test
 EOF
@@ -2256,7 +2256,7 @@ If it has been merged, then there will be no output.)
 
 Once a patch completes the great cycle (moving from test to release,
 then pulled by Linus, and finally coming back into your local
-`origin/master` branch), the branch for this change is no longer needed.
+`origin/main` branch), the branch for this change is no longer needed.
 You detect this when the output from:
 
 -------------------------------------------------
@@ -2289,16 +2289,16 @@ Here are some of the scripts that simplify all this even further.
 ==== update script ====
 # Update a branch in my Git tree.  If the branch to be updated
 # is origin, then pull from kernel.org.  Otherwise merge
-# origin/master branch into test|release branch
+# origin/main branch into test|release branch
 
 case "$1" in
 test|release)
 	git checkout $1 && git pull . origin
 	;;
 origin)
-	before=$(git rev-parse refs/remotes/origin/master)
+	before=$(git rev-parse refs/remotes/origin/main)
 	git fetch origin
-	after=$(git rev-parse refs/remotes/origin/master)
+	after=$(git rev-parse refs/remotes/origin/main)
 	if [ $before != $after ]
 	then
 		git log $before..$after | git shortlog
@@ -2366,7 +2366,7 @@ do
 
 	echo -n $gb ======= $branch ====== $restore " "
 	status=
-	for ref in test release origin/master
+	for ref in test release origin/main
 	do
 		if [ `git rev-list $ref..$branch | wc -c` -gt 0 ]
 		then
@@ -2390,7 +2390,7 @@ do
 		echo $rb "<$status>" $restore
 		;;
 	esac
-	git log origin/master..$branch | git shortlog
+	git log origin/main..$branch | git shortlog
 done
 -------------------------------------------------
 
@@ -2760,14 +2760,14 @@ store it locally under the name `refs/heads/my-todo-work`.
 You can also fetch branches from other repositories; so
 
 -------------------------------------------------
-$ git fetch git://example.com/proj.git master:example-master
+$ git fetch git://example.com/proj.git main:example-main
 -------------------------------------------------
 
-will create a new branch named `example-master` and store in it the
-branch named `master` from the repository at the given URL.  If you
-already have a branch named example-master, it will attempt to
+will create a new branch named `example-main` and store in it the
+branch named `main` from the repository at the given URL.  If you
+already have a branch named example-main, it will attempt to
 <<fast-forwards,fast-forward>> to the commit given by example.com's
-master branch.  In more detail:
+main branch.  In more detail:
 
 [[fetch-fast-forwards]]
 === git fetch and fast-forwards
@@ -2813,7 +2813,7 @@ If git fetch fails because the new head of a branch is not a
 descendant of the old head, you may force the update with:
 
 -------------------------------------------------
-$ git fetch git://example.com/proj.git +master:refs/remotes/example/master
+$ git fetch git://example.com/proj.git +main:refs/remotes/example/main
 -------------------------------------------------
 
 Note the addition of the `+` sign.  Alternatively, you can use the `-f`
@@ -2823,7 +2823,7 @@ flag to force updates of all the fetched branches, as in:
 $ git fetch -f origin
 -------------------------------------------------
 
-Be aware that commits that the old version of example/master pointed at
+Be aware that commits that the old version of example/main pointed at
 may be lost, as we saw in the previous section.
 
 [[remote-branch-configuration]]
@@ -2841,8 +2841,8 @@ core.filemode=true
 core.logallrefupdates=true
 remote.origin.url=git://git.kernel.org/pub/scm/git/git.git
 remote.origin.fetch=+refs/heads/*:refs/remotes/origin/*
-branch.master.remote=origin
-branch.master.merge=refs/heads/master
+branch.main.remote=origin
+branch.main.merge=refs/heads/main
 -------------------------------------------------
 
 If there are other repositories that you also use frequently, you can
@@ -3507,7 +3507,7 @@ $ ls -a
 The `git submodule add <repo> <path>` command does a couple of things:
 
 - It clones the submodule from `<repo>` to the given `<path>` under the
-  current directory and by default checks out the master branch.
+  current directory and by main checks out the main branch.
 - It adds the submodule's clone path to the linkgit:gitmodules[5] file and
   adds this file to the index, ready to be committed.
 - It adds the submodule's current commit ID to the index, ready to be
@@ -3568,7 +3568,7 @@ working on a branch.
 -------------------------------------------------
 $ git branch
 * (detached from d266b98)
-  master
+  main
 -------------------------------------------------
 
 If you want to make a change within a submodule and you have a detached head,
@@ -3577,7 +3577,7 @@ change within the submodule, and then update the superproject to reference the
 new commit:
 
 -------------------------------------------------
-$ git switch master
+$ git switch main
 -------------------------------------------------
 
 or
@@ -4355,10 +4355,10 @@ Update and examine branches from the repository you cloned from:
 -----------------------------------------------
 $ git fetch		# update
 $ git branch -r		# list
-  origin/master
+  origin/main
   origin/next
   ...
-$ git switch -c masterwork origin/master
+$ git switch -c mainwork origin/main
 -----------------------------------------------
 
 Fetch a branch from a different repository, and give it a new
@@ -4380,7 +4380,7 @@ $ git remote show example	# get details
 * remote example
   URL: git://example.com/project.git
   Tracked remote branches
-    master
+    main
     next
     ...
 $ git fetch example		# update branches from example
@@ -4396,9 +4396,9 @@ $ gitk			    # visualize and browse history
 $ git log		    # list all commits
 $ git log src/		    # ...modifying src/
 $ git log v2.6.15..v2.6.16  # ...in v2.6.16, not in v2.6.15
-$ git log master..test	    # ...in branch test, not in branch master
-$ git log test..master	    # ...in branch master, but not in test
-$ git log test...master	    # ...in one branch, not in both
+$ git log main..test	    # ...in branch test, not in branch main
+$ git log test..main	    # ...in branch main, but not in test
+$ git log test...main	    # ...in one branch, not in both
 $ git log -S'foo()'	    # ...where difference contain "foo()"
 $ git log --since="2 weeks ago"
 $ git log -p		    # show patches as well
@@ -4458,7 +4458,7 @@ $ git commit -a	   # use latest content of all tracked files
 
 -----------------------------------------------
 $ git merge test   # merge branch "test" into the current branch
-$ git pull git://example.com/project.git master
+$ git pull git://example.com/project.git main
 		   # fetch and merge in remote branch
 $ git pull . test  # equivalent to git merge test
 -----------------------------------------------


### PR DESCRIPTION
TODO better commit message.

This is part of a split of https://github.com/gitgitgadget/git/pull/655 into reasonable chunks.

Thanks for taking the time to contribute to Git! Please be advised that the
Git community does not use github.com for their contributions. Instead, we use
a mailing list (git@vger.kernel.org) for code submissions, code reviews, and
bug reports. Nevertheless, you can use GitGitGadget (https://gitgitgadget.github.io/)
to conveniently send your Pull Requests commits to our mailing list.

Please read the "guidelines for contributing" linked above!
