### PR TITLE
Accelerate "git merge-base --is-ancestor"

### DIFF
--- a/commit-reach.c
+++ b/commit-reach.c
@@ -283,7 +283,9 @@ struct commit_list *repo_get_merge_bases(struct repository *r,
 /*
  * Is "commit" a descendant of one of the elements on the "with_commit" list?
  */
-int is_descendant_of(struct commit *commit, struct commit_list *with_commit)
+static int repo_is_descendant_of(struct repository *r,
+				 struct commit *commit,
+				 struct commit_list *with_commit)
 {
 	if (!with_commit)
 		return 1;
@@ -301,11 +303,16 @@ int is_descendant_of(struct commit *commit, struct commit_list *with_commit)
 
 			other = with_commit->item;
 			with_commit = with_commit->next;
-			if (in_merge_bases(other, commit))
+			if (repo_in_merge_bases(r, other, commit))
 				return 1;
 		}
 		return 0;
 	}
+}
+
+int is_descendant_of(struct commit *commit, struct commit_list *with_commit)
+{
+	return repo_is_descendant_of(the_repository, commit, with_commit);
 }
 
 /*

--- a/commit-reach.c
+++ b/commit-reach.c
@@ -303,7 +303,7 @@ static int repo_is_descendant_of(struct repository *r,
 
 			other = with_commit->item;
 			with_commit = with_commit->next;
-			if (repo_in_merge_bases(r, other, commit))
+			if (repo_in_merge_bases_many(r, other, 1, &commit))
 				return 1;
 		}
 		return 0;
@@ -355,7 +355,15 @@ int repo_in_merge_bases(struct repository *r,
 			struct commit *commit,
 			struct commit *reference)
 {
-	return repo_in_merge_bases_many(r, commit, 1, &reference);
+	int res;
+	struct commit_list *list = NULL;
+	struct commit_list **next = &list;
+
+	next = commit_list_append(commit, next);
+	res = repo_is_descendant_of(r, reference, list);
+	free_commit_list(list);
+
+	return res;
 }
 
 struct commit_list *reduce_heads(struct commit_list *heads)


### PR DESCRIPTION
It was recently [1] reported (and not-so-recently [2] reported) that "git merge-base --is-ancestor" can be pretty slow. In fact, it is regularly slower than "git branch --contains" or "git tag --contains", which are answering a "harder" query.

[1] https://lore.kernel.org/git/20200607195347.GA8232@szeder.dev/

[2] https://lore.kernel.org/git/87608bawoa.fsf@evledraar.gmail.com/

The root cause is that the in_merge_base() implementation is skipping the fast can_all_from_reach() implementation and using paint_down_to_common() instead. Note that these are equivalent: a commit A is in the set of merge-bases between A and B if and only if B can reach A.

This fixes the issue, and makes the performance degradation reported by Szeder a non-issue.

Thanks,
-Stolee

Cc: szeder.dev@gmail.com, avarab@gmail.com, abhishekkumar8222@gmail.com, me@ttaylorr.com