### PR TITLE
setup: warn if extensions exist on old format

### DIFF
--- a/builtin/config.c
+++ b/builtin/config.c
@@ -678,8 +678,9 @@ int cmd_config(int argc, const char **argv, const char *prefix)
 		else if (worktrees[0] && worktrees[1])
 			die(_("--worktree cannot be used with multiple "
 			      "working trees unless the config\n"
-			      "extension worktreeConfig is enabled. "
-			      "Please read \"CONFIGURATION FILE\"\n"
+			      "extension worktreeConfig is enabled "
+			      "and core.repositoryFormatVersion is at least\n"
+			      "1. Please read \"CONFIGURATION FILE\""
 			      "section in \"git help worktree\" for details"));
 		else
 			given_config_source.file = git_pathdup("config");

--- a/cache.h
+++ b/cache.h
@@ -1042,8 +1042,8 @@ struct repository_format {
 	int worktree_config;
 	int is_bare;
 	int hash_algo;
-	int has_extensions;
 	char *work_tree;
+	int has_unallowed_extensions;
 	struct string_list unknown_extensions;
 };
 

--- a/t/t1091-sparse-checkout-builtin.sh
+++ b/t/t1091-sparse-checkout-builtin.sh
@@ -68,6 +68,18 @@ test_expect_success 'git sparse-checkout init' '
 	check_files repo a
 '
 
+test_expect_success 'git sparse-checkout works if repository format is wrong' '
+	test_when_finished git -C repo config core.repositoryFormatVersion 1 &&
+	git -C repo config --unset core.repositoryFormatVersion &&
+	git -C repo sparse-checkout init &&
+	git -C repo config core.repositoryFormatVersion >actual &&
+	echo 1 >expect &&
+	git -C repo config core.repositoryFormatVersion 0 &&
+	git -C repo sparse-checkout init &&
+	git -C repo config core.repositoryFormatVersion >actual &&
+	test_cmp expect actual
+'
+
 test_expect_success 'git sparse-checkout list after init' '
 	git -C repo sparse-checkout list >actual &&
 	cat >expect <<-\EOF &&

--- a/t/t2404-worktree-config.sh
+++ b/t/t2404-worktree-config.sh
@@ -77,5 +77,17 @@ test_expect_success 'config.worktree no longer read without extension' '
 	test_cmp_config -C wt1 shared this.is &&
 	test_cmp_config -C wt2 shared this.is
 '
+test_expect_success 'show advice when extensions.* are not enabled' '
+	test_config core.repositoryformatversion 1 &&
+	test_config extensions.worktreeConfig true &&
+	git config --worktree test.one true &&
+	test_cmp_config true test.one &&
+	test_config core.repositoryformatversion 0 &&
+	test_must_fail git config --worktree test.two true 2>err &&
+	test_i18ngrep "extension worktreeConfig is enabled" err &&
+	git config --unset core.repositoryformatversion &&
+	test_must_fail git config --worktree test.three true 2>err &&
+	test_i18ngrep "core.repositoryFormatVersion is at least" err
+'
 
 test_done


### PR DESCRIPTION
This is based on xl/upgrade-repo-format.

Thanks, Taylor and Junio for jumping in with helpful review.

Updates in v2:

1. My initial patch is essentially dropped in its entirety, with Junio's patch here instead. I added an extra test and kept some of my commit message.

2. A second patch has joined the fray, hopefully answering the concerned raise by Johannes [1].

[1] https://lore.kernel.org/git/pull.675.git.1594677321039.gitgitgadget@gmail.com/

Thanks,
-Stolee

Cc: newren@gmail.com, delphij@google.com, peff@peff.net, johannes.schindelin@gmx.de, me@ttaylorr.com