### PR TITLE
Update commit.template to add info on paths

### DIFF
--- a/Documentation/config/commit.txt
+++ b/Documentation/config/commit.txt
@@ -22,7 +22,12 @@ commit.status::
 
 commit.template::
 	Specify the pathname of a file to use as the template for
-	new commit messages.
+    	new commit messages. Use an absolute path, such as
+  	$HOME/.git/gitmessage, to use the template for all repos on the
+  	machine. Use a relative path, such as .git/gitmessage, to use a
+  	different template for each repo. Note that using a relative path
+  	requires creating a template for every repo, otherwise committing
+    	will throw an error. A blank template is acceptable.
 
 commit.verbose::
 	A boolean or int to specify the level of verbose with `git commit`.


### PR DESCRIPTION
commit.template can take an absolute path or a relative path, and those
do different things. However, this is not explained in the man pages.
This commit adds information so users can discover this functionality.