### PR TITLE
Change == to = for zsh's sake in git-prompt.sh

### DIFF
--- a/contrib/completion/git-prompt.sh
+++ b/contrib/completion/git-prompt.sh
@@ -433,7 +433,7 @@ __git_ps1 ()
 	local sparse=""
 	if [ -z "${GIT_PS1_COMPRESSSPARSESTATE}" ] &&
 	   [ -z "${GIT_PS1_OMITSPARSESTATE}" ] &&
-	   [ "$(git config --bool core.sparseCheckout)" == "true" ]; then
+	   [ "$(git config --bool core.sparseCheckout)" = "true" ]; then
 		sparse="|SPARSE"
 	fi
 
@@ -542,7 +542,7 @@ __git_ps1 ()
 		fi
 
 		if [ -n "${GIT_PS1_COMPRESSSPARSESTATE}" ] &&
-		   [ "$(git config --bool core.sparseCheckout)" == "true" ]; then
+		   [ "$(git config --bool core.sparseCheckout)" = "true" ]; then
 			h="?"
 		fi
 


### PR DESCRIPTION
Upon installing [`git-prompt.sh`](https://github.com/gitgitgadget/git/blob/master/contrib/completion/git-prompt.sh) on macOS Catalina, I noticed that https://github.com/gitgitgadget/git/commit/afda36dbf3b4f5a489ab44c00d5210c1fa894a40 seems to have introduced an issue for Zsh whereby `__git_ps1` errs with

```
__git_ps1:96: = not found
```

when inside a repo. Changing `==` to `=` would seem to address for both Bash and Zsh.

Changes since v1:
- Commit message rewritten to use imperative mood.
- Commit message rewritten to elaborate on reason for change.

CC: Elijah Newren <newren@gmail.com>, Junio C Hamano <gitster@pobox.com>