### PR TITLE
Commit-Graph: Verify bloom filter

### DIFF
--- a/builtin/commit-graph.c
+++ b/builtin/commit-graph.c
@@ -18,7 +18,8 @@ static char const * const builtin_commit_graph_usage[] = {
 };
 
 static const char * const builtin_commit_graph_verify_usage[] = {
-	N_("git commit-graph verify [--object-dir <objdir>] [--shallow] [--[no-]progress]"),
+	N_("git commit-graph verify [--object-dir <objdir>] [--shallow] "
+	    "[--has-changed-paths] [--[no-]progress]"),
 	NULL
 };
 
@@ -37,6 +38,7 @@ static struct opts_commit_graph {
 	int append;
 	int split;
 	int shallow;
+	int has_changed_paths;
 	int progress;
 	int enable_changed_paths;
 } opts;
@@ -71,12 +73,14 @@ static int graph_verify(int argc, const char **argv)
 	int open_ok;
 	int fd;
 	struct stat st;
-	int flags = 0;
+	enum commit_graph_verify_flags flags = 0;
 
 	static struct option builtin_commit_graph_verify_options[] = {
 		OPT_STRING(0, "object-dir", &opts.obj_dir,
 			   N_("dir"),
 			   N_("The object directory to store the graph")),
+		OPT_BOOL(0, "has-changed-paths", &opts.has_changed_paths,
+			 N_("verify that the commit-graph includes changed paths")),
 		OPT_BOOL(0, "shallow", &opts.shallow,
 			 N_("if the commit-graph is split, only verify the tip file")),
 		OPT_BOOL(0, "progress", &opts.progress, N_("force progress reporting")),
@@ -94,8 +98,10 @@ static int graph_verify(int argc, const char **argv)
 		opts.obj_dir = get_object_directory();
 	if (opts.shallow)
 		flags |= COMMIT_GRAPH_VERIFY_SHALLOW;
+	if (opts.has_changed_paths)
+		flags |= COMMIT_GRAPH_VERIFY_CHANGED_PATHS;
 	if (opts.progress)
-		flags |= COMMIT_GRAPH_WRITE_PROGRESS;
+		flags |= COMMIT_GRAPH_VERIFY_PROGRESS;
 
 	odb = find_odb(the_repository, opts.obj_dir);
 	graph_name = get_commit_graph_filename(odb);

--- a/commit-graph.h
+++ b/commit-graph.h
@@ -94,6 +94,12 @@ enum commit_graph_write_flags {
 	COMMIT_GRAPH_WRITE_BLOOM_FILTERS = (1 << 3),
 };
 
+enum commit_graph_verify_flags {
+	COMMIT_GRAPH_VERIFY_SHALLOW       = (1 << 0),
+	COMMIT_GRAPH_VERIFY_CHANGED_PATHS = (1 << 1),
+	COMMIT_GRAPH_VERIFY_PROGRESS      = (1 << 2),
+};
+
 enum commit_graph_split_flags {
 	COMMIT_GRAPH_SPLIT_UNSPECIFIED      = 0,
 	COMMIT_GRAPH_SPLIT_MERGE_PROHIBITED = 1,
@@ -122,9 +128,9 @@ int write_commit_graph(struct object_directory *odb,
 		       enum commit_graph_write_flags flags,
 		       const struct split_commit_graph_opts *split_opts);
 
-#define COMMIT_GRAPH_VERIFY_SHALLOW	(1 << 0)
-
-int verify_commit_graph(struct repository *r, struct commit_graph *g, int flags);
+int verify_commit_graph(struct repository *r,
+			struct commit_graph *g,
+			enum commit_graph_verify_flags flags);
 
 void close_commit_graph(struct raw_object_store *);
 void free_commit_graph(struct commit_graph *);


### PR DESCRIPTION
When I was working on git-care(1) and Gitaly(2), the need to check whether a commit-graph (split or non-split) were built with Bloom filter.
This is needed especially when a repository primary commit-graph write strategy is '--split' and the bottom chains might rarely be re-written (or never) thus Bloom filter is never applied to the graph.

Provides users with a straight forward way to validate the existence of Bloom filter chunks to save user having to read the commit-graph manually as show in (1) and (2).

References:

1. https://github.com/sluongng/git-care/commit/d0feaa381ea3ec7b0e617c6596ad6e3cf16b884a
2. https://gitlab.com/sluongng/gitaly/-/commit/78dba8b73e720b11500482b19b755346ec853025

---

It's probably going to take me a bit more time to write up some tests for this, so I want to send it out first for comments.