### PR TITLE
diff: teach --stat to ignore uninteresting modifications

### DIFF
--- a/diff.c
+++ b/diff.c
@@ -3153,16 +3153,19 @@ static void show_dirstat_by_line(struct diffstat_t *data, struct diff_options *o
 	gather_dirstat(options, &dir, changed, "", 0);
 }
 
+static void free_diffstat_file(struct diffstat_file *f)
+{
+	free(f->print_name);
+	free(f->name);
+	free(f->from_name);
+	free(f);
+}
+
 void free_diffstat_info(struct diffstat_t *diffstat)
 {
 	int i;
-	for (i = 0; i < diffstat->nr; i++) {
-		struct diffstat_file *f = diffstat->files[i];
-		free(f->print_name);
-		free(f->name);
-		free(f->from_name);
-		free(f);
-	}
+	for (i = 0; i < diffstat->nr; i++)
+		free_diffstat_file(diffstat->files[i]);
 	free(diffstat->files);
 }
 
@@ -3718,6 +3721,27 @@ static void builtin_diffstat(const char *name_a, const char *name_b,
 		if (xdi_diff_outf(&mf1, &mf2, discard_hunk_line,
 				  diffstat_consume, diffstat, &xpp, &xecfg))
 			die("unable to generate diffstat for %s", one->path);
+
+		if (DIFF_FILE_VALID(one) && DIFF_FILE_VALID(two)) {
+			struct diffstat_file *file = 
+				diffstat->files[diffstat->nr - 1];
+			/*
+			 * Omit diffstats of modified files where nothing changed. 
+			 * Even if !same_contents, this might be the case due to
+			 * ignoring whitespace changes, etc.
+			 * 
+			 * But note that we special-case additions, deletions,
+			 * renames, and mode changes as adding an empty file, 
+			 * for example is still of interest.
+			 */
+			if ((p->status == DIFF_STATUS_MODIFIED) 
+				&& !file->added
+				&& !file->deleted
+				&& one->mode == two->mode) {
+				free_diffstat_file(file);
+				diffstat->nr--;
+			}
+		}
 	}
 
 	diff_free_filespec_data(one);


### PR DESCRIPTION
This patch is based on the discussion these email threads:

https://lore.kernel.org/git/1484704915.2096.16.camel@mattmccutchen.net/
https://lore.kernel.org/git/CAOjrSZtQPQ8Xxuz+7SGykR8Q-gFDEZANSE5yQASqKjpbUAq_5Q@mail.gmail.com/

With the code mostly taken from this specific message:
https://lore.kernel.org/git/20170118111705.6bqzkklluikda3r5@sigill.intra.peff.net/

The summary is that when running `git diff --stat` in combination with --ignore-all-space or similar options, you'll see many lines of the form:

some-file.txt | 0

which can be misleading when you are explicitly telling git to "ignore all space" or something similar.  To rectify this issue, this patch categorizes all files that are modified but have no effective changes as not fit to display to the user.

New in V2:
* I've added a test covering the rename case with whitespace-changes and permissions changes
* I've also updated the logic in builtin_diffstat to include that logic as well

CC: peff@peff.net
