### PR TITLE
multi-pack-index: repack batches below --batch-size

### DIFF
--- a/Documentation/git-multi-pack-index.txt
+++ b/Documentation/git-multi-pack-index.txt
@@ -51,11 +51,12 @@ repack::
 	multi-pack-index, then divide by the total number of objects in
 	the pack and multiply by the pack size. We select packs with
 	expected size below the batch size until the set of packs have
-	total expected size at least the batch size. If the total size
-	does not reach the batch size, then do nothing. If a new pack-
-	file is created, rewrite the multi-pack-index to reference the
-	new pack-file. A later run of 'git multi-pack-index expire' will
-	delete the pack-files that were part of this batch.
+	total expected size at least the batch size, or all pack-files
+	are considered. If only one pack-file is selected, then do
+	nothing. If a new pack-file is created, rewrite the
+	multi-pack-index to reference the new pack-file. A later run of
+	'git multi-pack-index expire' will delete the pack-files that
+	were part of this batch.
 +
 If `repack.packKeptObjects` is `false`, then any pack-files with an
 associated `.keep` file will not be selected for the batch to repack.

--- a/midx.c
+++ b/midx.c
@@ -1371,7 +1371,7 @@ static int fill_included_packs_batch(struct repository *r,
 
 	free(pack_info);
 
-	if (total_size < batch_size || packs_to_repack < 2)
+	if (packs_to_repack < 2)
 		return 1;
 
 	return 0;

--- a/t/t5319-multi-pack-index.sh
+++ b/t/t5319-multi-pack-index.sh
@@ -643,6 +643,7 @@ test_expect_success 'expire respects .keep files' '
 '
 
 test_expect_success 'repack --batch-size=0 repacks everything' '
+	cp -r dup dup2 &&
 	(
 		cd dup &&
 		rm .git/objects/pack/*.keep &&
@@ -659,6 +660,23 @@ test_expect_success 'repack --batch-size=0 repacks everything' '
 		git multi-pack-index repack --batch-size=0 &&
 		ls -al .git/objects/pack/*idx >new-idx-list &&
 		test_cmp idx-list new-idx-list
+	)
+'
+
+test_expect_success 'repack --batch-size=<large> repacks everything' '
+	(
+		cd dup2 &&
+		rm .git/objects/pack/*.keep &&
+		ls .git/objects/pack/*idx >idx-list &&
+		test_line_count = 2 idx-list &&
+		git multi-pack-index repack --batch-size=2000000 &&
+		ls .git/objects/pack/*idx >idx-list &&
+		test_line_count = 3 idx-list &&
+		test-tool read-midx .git/objects | grep idx >midx-list &&
+		test_line_count = 3 midx-list &&
+		git multi-pack-index expire &&
+		ls -al .git/objects/pack/*idx >idx-list &&
+		test_line_count = 1 idx-list
 	)
 '
 


### PR DESCRIPTION
As reported [1], the 'git multi-pack-index repack' command has some unexpected behavior due to the nature of "expected size" for un-thinned fetch packs and the fact that the batch size requires the total size to be at least as large as that batch-size. By removing this minimum size restriction, we will repack more frequently and prevent this "many pack-file" problems.

[1] https://lore.kernel.org/git/6FA8F54A-C92D-497B-895F-AC6E8287AACD@gmail.com/

Cc: sluongng@gmail.com