### PR TITLE
Windows: improve checkout performance with large numbers of files

### DIFF
--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -290,6 +290,9 @@ int mingw_unlink(const char *pathname)
 	if (xutftowcs_path(wpathname, pathname) < 0)
 		return -1;
 
+	if (DeleteFileW(wpathname))
+		return 0;
+
 	/* read-only files cannot be removed */
 	_wchmod(wpathname, 0666);
 	while ((ret = _wunlink(wpathname)) == -1 && tries < ARRAY_SIZE(delay)) {


### PR DESCRIPTION
Jeff Hostetler contributed this patch to Git for Windows a while ago after [measuring ~15% improvement](https://github.com/microsoft/git/pull/264#issuecomment-617216583) with a very, very large worktree:

> I ran a series of timing tests on the Office repo on my Z440 desktop. This was a full enlistment at HEAD. I ran `git sparse-checkout disable` to populate the entire worktree and then `git sparse-checkout init --cone` to delete everything except the files at root. I repeated that sequence 3 times.
> 
> Each init needed to delete about 2.1M files.
> 
> `git sparse-checkout init`
>
> old: 636.1s, 638.3s, 637.2s, 637.2s
> new: 535.9s, 544.8s, 533.3s, 538.0s
> 
> In this example, run time was decreased by 15%.