### PR TITLE
Clean up and improve git-imap-send.txt

### DIFF
--- a/Documentation/git-imap-send.txt
+++ b/Documentation/git-imap-send.txt
@@ -110,6 +110,10 @@ Using Gmail's IMAP interface:
 You might need to instead use: `folder = "[Google Mail]/Drafts"` if you get an error
 that the "Folder doesn't exist".
 
+[NOTE]
+If your Gmail account is set to another language than English, the name of the "Drafts"
+folder will be localized.
+
 Once the commits are ready to be sent, run the following command:
 
   $ git format-patch --cover-letter -M --stdout origin/master | git imap-send

--- a/Documentation/git-imap-send.txt
+++ b/Documentation/git-imap-send.txt
@@ -85,9 +85,16 @@ Using direct mode with SSL:
     user = bob
     pass = p4ssw0rd
     port = 123
-    sslverify = false
+    ; sslVerify = false
 .........................
 
+
+[NOTE]
+You may want to use `sslVerify=false`
+while troubleshooting, if you suspect that the reason you are
+having trouble connecting is because the certificate you use at
+the private server `example.com` you are trying to set up (or
+have set up) may not be verified correctly.
 
 Using Gmail's IMAP interface:
 
@@ -97,9 +104,9 @@ Using Gmail's IMAP interface:
 	host = imaps://imap.gmail.com
 	user = user@gmail.com
 	port = 993
-	sslverify = false
 ---------
 
+[NOTE]
 You might need to instead use: `folder = "[Google Mail]/Drafts"` if you get an error
 that the "Folder doesn't exist".
 

--- a/Documentation/git-imap-send.txt
+++ b/Documentation/git-imap-send.txt
@@ -51,17 +51,13 @@ OPTIONS
 CONFIGURATION
 -------------
 
-To use the tool, imap.folder and either imap.tunnel or imap.host must be set
+To use the tool, `imap.folder` and either `imap.tunnel` or `imap.host` must be set
 to appropriate values.
-
-Variables
-~~~~~~~~~
 
 include::config/imap.txt[]
 
-Examples
-~~~~~~~~
-
+EXAMPLES
+--------
 Using tunnel mode:
 
 ..........................
@@ -93,10 +89,7 @@ Using direct mode with SSL:
 .........................
 
 
-EXAMPLES
---------
-To submit patches using GMail's IMAP interface, first, edit your ~/.gitconfig
-to specify your account settings:
+Using Gmail's IMAP interface:
 
 ---------
 [imap]
@@ -107,14 +100,14 @@ to specify your account settings:
 	sslverify = false
 ---------
 
-You might need to instead use: folder = "[Google Mail]/Drafts" if you get an error
+You might need to instead use: `folder = "[Google Mail]/Drafts"` if you get an error
 that the "Folder doesn't exist".
 
 Once the commits are ready to be sent, run the following command:
 
   $ git format-patch --cover-letter -M --stdout origin/master | git imap-send
 
-Just make sure to disable line wrapping in the email client (GMail's web
+Just make sure to disable line wrapping in the email client (Gmail's web
 interface will wrap lines no matter what, so you need to use a real
 IMAP client).
 


### PR DESCRIPTION
This series cleans up the documentation page for 'git imap-send',
removes the `sslVerify` config from the Gmail example, and uses more 
appropriate Asciidoc syntax.

It is a rework of [1], incorporating Junio's suggestions
from [2]. 

I split the suggestions in 2 commits to make reviewing the patches easier.
The third commit adds a note about localized Gmail folder names, 
which bit me when I was configuring 'git imap-send' myself.

[1] https://lore.kernel.org/git/51758EE8.7030800@gmail.com/
[2] https://lore.kernel.org/git/7vr4hzetki.fsf@alter.siamese.dyndns.org/
