### PR TITLE
ci: avoid ugly "failure" annotation in the GitHub workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,6 @@ jobs:
       enabled: ${{ steps.check-ref.outputs.enabled }}
     steps:
       - name: try to clone ci-config branch
-        continue-on-error: true
         run: |
           git -c protocol.version=2 clone \
             --no-tags \
@@ -24,7 +23,7 @@ jobs:
             https://github.com/${{ github.repository }} \
             config-repo &&
           cd config-repo &&
-          git checkout HEAD -- ci/config
+          git checkout HEAD -- ci/config || : ignore
       - id: check-ref
         name: check whether CI is enabled for ref
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,8 +23,8 @@ jobs:
             --filter=blob:none \
             https://github.com/${{ github.repository }} \
             config-repo &&
-            cd config-repo &&
-            git checkout HEAD -- ci/config
+          cd config-repo &&
+          git checkout HEAD -- ci/config
       - id: check-ref
         name: check whether CI is enabled for ref
         run: |


### PR DESCRIPTION
Whenever the GitHub workflow runs in a fork that does _not_ contain the special-purpose `ci-config` branch, a big fat failure annotation greets the casual reader. See e.g. https://github.com/gitgitgadget/git/actions/runs/233438295

This is caused by the (non-fatal) failure to clone said branch. Let's avoid that. It's distracting.

cc: Jeff King <peff@peff.net>