### PR TITLE
fetch: do not look for submodule changes in unchanged refs

### DIFF
--- a/builtin/fetch.c
+++ b/builtin/fetch.c
@@ -958,8 +958,10 @@ static int store_updated_refs(const char *raw_url, const char *remote_name,
 				ref->force = rm->peer_ref->force;
 			}
 
-			if (recurse_submodules != RECURSE_SUBMODULES_OFF)
+			if (recurse_submodules != RECURSE_SUBMODULES_OFF &&
+			    (!rm->peer_ref || !oideq(&ref->old_oid, &ref->new_oid))) {
 				check_for_new_submodule_commits(&rm->old_oid);
+			}
 
 			if (!strcmp(rm->name, "HEAD")) {
 				kind = "";


### PR DESCRIPTION
This operation is very expensive, as it scans all the refs using
setup_revisions, which resolves each ref, including checking if it
is ambiguous, or if it is a file name etc.

There is no reason to do all that for refs that hasn't changed in this
fetch.

Reported here:
https://public-inbox.org/git/CAGHpTBKSUJzFSWc=uznSu2zB33qCSmKXM-iAjxRCpqNK5bnhRg@mail.gmail.com/


cc: Orgad Shaneh <orgads@gmail.com>