### PR TITLE
vcbuild: fix library name for expat with make MSVC=1

### DIFF
--- a/compat/vcbuild/scripts/clink.pl
+++ b/compat/vcbuild/scripts/clink.pl
@@ -66,7 +66,7 @@ while (@ARGV) {
 		}
 		push(@args, $lib);
 	} elsif ("$arg" eq "-lexpat") {
-		push(@args, "expat.lib");
+		push(@args, "libexpat.lib");
 	} elsif ("$arg" =~ /^-L/ && "$arg" ne "-LTCG") {
 		$arg =~ s/^-L/-LIBPATH:/;
 		push(@lflags, $arg);


### PR DESCRIPTION
Signed-off-by: Orgad Shaneh <orgads@gmail.com>

cc: Jonathan Nieder <jrnieder@gmail.com>
cc: Johannes Schindelin <Johannes.Schindelin@gmx.de>