### PR TITLE
submodule: suppress checking for file name and ref ambiguity for object ids

### DIFF
--- a/submodule.c
+++ b/submodule.c
@@ -840,9 +840,16 @@ static void collect_changed_submodules(struct repository *r,
 {
 	struct rev_info rev;
 	const struct commit *commit;
+	int save_warning;
+	struct setup_revision_opt s_r_opt = {
+		.assume_dashdash = 1,
+	};
 
+	save_warning = warn_on_object_refname_ambiguity;
+	warn_on_object_refname_ambiguity = 0;
 	repo_init_revisions(r, &rev, NULL);
-	setup_revisions(argv->nr, argv->v, &rev, NULL);
+	setup_revisions(argv->nr, argv->v, &rev, &s_r_opt);
+	warn_on_object_refname_ambiguity = save_warning;
 	if (prepare_revision_walk(&rev))
 		die(_("revision walk setup failed"));
 


### PR DESCRIPTION
The argv argument of collect_changed_submodules() contains obly object ids
(submodule references).

Notify setup_revisions() that the input is not filenames by passing
assume_dashdash, so it can avoid redundant stat for each ref.

A better improvement would be to pass oid_array instead of stringified argv,
but that will require a larger change, which can be done later.

cc: Orgad Shaneh <orgads@gmail.com>
cc: Ramsay Jones <ramsay@ramsayjones.plus.com>