### PR TITLE
Inclusive naming, part II

### DIFF
--- a/builtin/fast-export.c
+++ b/builtin/fast-export.c
@@ -1026,7 +1026,7 @@ static void handle_tags_and_duplicates(struct string_list *extras)
 				/*
 				 * Getting here means we have a commit which
 				 * was excluded by a negative refspec (e.g.
-				 * fast-export ^master master).  If we are
+				 * fast-export ^HEAD HEAD).  If we are
 				 * referencing excluded commits, set the ref
 				 * to the exact commit.  Otherwise, the user
 				 * wants the branch exported but every commit

--- a/t/t3200-branch.sh
+++ b/t/t3200-branch.sh
@@ -234,10 +234,10 @@ test_expect_success 'git branch -M master master should work when master is chec
 	git branch -M master master
 '
 
-test_expect_success 'git branch -M master2 master2 should work when master is checked out' '
+test_expect_success 'git branch -M topic topic should work when master is checked out' '
 	git checkout master &&
-	git branch master2 &&
-	git branch -M master2 master2
+	git branch topic &&
+	git branch -M topic topic
 '
 
 test_expect_success 'git branch -v -d t should work' '
@@ -324,8 +324,8 @@ test_expect_success 'git branch --list -v with --abbrev' '
 test_expect_success 'git branch --column' '
 	COLUMNS=81 git branch --column=column >actual &&
 	cat >expect <<\EOF &&
-  a/b/c     bam       foo       l       * master    mb        o/o       q
-  abc       bar       j/k       m/m       master2   n         o/p       r
+  a/b/c    bam      foo      l      * master   n        o/p      r
+  abc      bar      j/k      m/m      mb       o/o      q        topic
 EOF
 	test_cmp expect actual
 '
@@ -346,13 +346,13 @@ test_expect_success 'git branch --column with an extremely long branch name' '
   l
   m/m
 * master
-  master2
   mb
   n
   o/o
   o/p
   q
   r
+  topic
   $long
 EOF
 	test_cmp expect actual
@@ -365,8 +365,8 @@ test_expect_success 'git branch with column.*' '
 	git config --unset column.branch &&
 	git config --unset column.ui &&
 	cat >expect <<\EOF &&
-  a/b/c   bam   foo   l   * master    mb   o/o   q
-  abc     bar   j/k   m/m   master2   n    o/p   r
+  a/b/c   bam   foo   l   * master   n     o/p   r
+  abc     bar   j/k   m/m   mb       o/o   q     topic
 EOF
 	test_cmp expect actual
 '
@@ -377,7 +377,7 @@ test_expect_success 'git branch --column -v should fail' '
 
 test_expect_success 'git branch -v with column.ui ignored' '
 	git config column.ui column &&
-	COLUMNS=80 git branch -v | cut -c -10 | sed "s/ *$//" >actual &&
+	COLUMNS=80 git branch -v | cut -c -9 | sed "s/ *$//" >actual &&
 	git config --unset column.ui &&
 	cat >expect <<\EOF &&
   a/b/c
@@ -389,13 +389,13 @@ test_expect_success 'git branch -v with column.ui ignored' '
   l
   m/m
 * master
-  master2
   mb
   n
   o/o
   o/p
   q
   r
+  topic
 EOF
 	test_cmp expect actual
 '
@@ -597,10 +597,10 @@ test_expect_success 'git branch -C master master should work when master is chec
 	git branch -C master master
 '
 
-test_expect_success 'git branch -C master5 master5 should work when master is checked out' '
+test_expect_success 'git branch -C main5 main5 should work when master is checked out' '
 	git checkout master &&
-	git branch master5 &&
-	git branch -C master5 master5
+	git branch main5 &&
+	git branch -C main5 main5
 '
 
 test_expect_success 'git branch -C ab cd should overwrite existing config for cd' '
@@ -711,11 +711,11 @@ test_expect_success 'deleting a self-referential symref' '
 '
 
 test_expect_success 'renaming a symref is not allowed' '
-	git symbolic-ref refs/heads/master2 refs/heads/master &&
-	test_must_fail git branch -m master2 master3 &&
-	git symbolic-ref refs/heads/master2 &&
+	git symbolic-ref refs/heads/topic refs/heads/master &&
+	test_must_fail git branch -m topic new-topic &&
+	git symbolic-ref refs/heads/topic &&
 	test_path_is_file .git/refs/heads/master &&
-	test_path_is_missing .git/refs/heads/master3
+	test_path_is_missing .git/refs/heads/new-topic
 '
 
 test_expect_success SYMLINKS 'git branch -m u v should fail when the reflog for u is a symlink' '

--- a/t/t3427-rebase-subtree.sh
+++ b/t/t3427-rebase-subtree.sh
@@ -15,12 +15,12 @@ commit_message() {
 # this test script tries to document them.  First, the following commit history
 # is generated (the onelines are shown, time flows from left to right):
 #
-# master1 - master2 - master3
+# topic_1 - topic_2 - topic_3
 #                             \
-# README ---------------------- Add subproject master - master4 - files_subtree/master5
+# README ---------------------- Add subproject master - topic_4 - files_subtree/topic_5
 #
 # Where the merge moves the files master[123].t into the subdirectory
-# files_subtree/ and master4 as well as files_subtree/master5 add files to that
+# files_subtree/ and topic_4 as well as files_subtree/topic_5 add files to that
 # directory directly.
 #
 # Then, in subsequent test cases, `git filter-branch` is used to distill just
@@ -28,11 +28,11 @@ commit_message() {
 # an empty commit is added on top. The pre-rebase commit history looks like
 # this:
 #
-# Add subproject master - master4 - files_subtree/master5 - Empty commit
+# Add subproject master - topic_4 - files_subtree/topic_5 - Empty commit
 #
-# where the root commit adds three files: master1.t, master2.t and master3.t.
+# where the root commit adds three files: topic_1.t, topic_2.t and topic_3.t.
 #
-# This commit history is then rebased onto `master3` with the
+# This commit history is then rebased onto `topic_3` with the
 # `-Xsubtree=files_subtree` option in three different ways:
 #
 # 1. using `--preserve-merges`
@@ -43,9 +43,9 @@ test_expect_success 'setup' '
 	test_commit README &&
 
 	git init files &&
-	test_commit -C files master1 &&
-	test_commit -C files master2 &&
-	test_commit -C files master3 &&
+	test_commit -C files topic_1 &&
+	test_commit -C files topic_2 &&
+	test_commit -C files topic_3 &&
 
 	: perform subtree merge into files_subtree/ &&
 	git fetch files refs/heads/master:refs/heads/files-master &&
@@ -55,8 +55,8 @@ test_expect_success 'setup' '
 	git commit -m "Add subproject master" &&
 
 	: add two extra commits to rebase &&
-	test_commit -C files_subtree master4 &&
-	test_commit files_subtree/master5 &&
+	test_commit -C files_subtree topic_4 &&
+	test_commit files_subtree/topic_5 &&
 
 	git checkout -b to-rebase &&
 	git fast-export --no-data HEAD -- files_subtree/ |
@@ -66,22 +66,22 @@ test_expect_success 'setup' '
 	git commit -m "Empty commit" --allow-empty
 '
 
-# FAILURE: Does not preserve master4.
+# FAILURE: Does not preserve topic_4.
 test_expect_failure REBASE_P 'Rebase -Xsubtree --preserve-merges --onto commit' '
 	reset_rebase &&
 	git checkout -b rebase-preserve-merges to-rebase &&
 	git rebase -Xsubtree=files_subtree --preserve-merges --onto files-master master &&
-	verbose test "$(commit_message HEAD~)" = "master4" &&
-	verbose test "$(commit_message HEAD)" = "files_subtree/master5"
+	verbose test "$(commit_message HEAD~)" = "topic_4" &&
+	verbose test "$(commit_message HEAD)" = "files_subtree/topic_5"
 '
 
-# FAILURE: Does not preserve master4.
+# FAILURE: Does not preserve topic_4.
 test_expect_failure REBASE_P 'Rebase -Xsubtree --keep-empty --preserve-merges --onto commit' '
 	reset_rebase &&
 	git checkout -b rebase-keep-empty to-rebase &&
 	git rebase -Xsubtree=files_subtree --keep-empty --preserve-merges --onto files-master master &&
-	verbose test "$(commit_message HEAD~2)" = "master4" &&
-	verbose test "$(commit_message HEAD~)" = "files_subtree/master5" &&
+	verbose test "$(commit_message HEAD~2)" = "topic_4" &&
+	verbose test "$(commit_message HEAD~)" = "files_subtree/topic_5" &&
 	verbose test "$(commit_message HEAD)" = "Empty commit"
 '
 
@@ -91,8 +91,8 @@ test_expect_success 'Rebase -Xsubtree --empty=ask --onto commit' '
 	test_must_fail git rebase -Xsubtree=files_subtree --empty=ask --onto files-master master &&
 	: first pick results in no changes &&
 	git rebase --skip &&
-	verbose test "$(commit_message HEAD~2)" = "master4" &&
-	verbose test "$(commit_message HEAD~)" = "files_subtree/master5" &&
+	verbose test "$(commit_message HEAD~2)" = "topic_4" &&
+	verbose test "$(commit_message HEAD~)" = "files_subtree/topic_5" &&
 	verbose test "$(commit_message HEAD)" = "Empty commit"
 '
 
@@ -102,8 +102,8 @@ test_expect_success 'Rebase -Xsubtree --empty=ask --rebase-merges --onto commit'
 	test_must_fail git rebase -Xsubtree=files_subtree --empty=ask --rebase-merges --onto files-master --root &&
 	: first pick results in no changes &&
 	git rebase --skip &&
-	verbose test "$(commit_message HEAD~2)" = "master4" &&
-	verbose test "$(commit_message HEAD~)" = "files_subtree/master5" &&
+	verbose test "$(commit_message HEAD~2)" = "topic_4" &&
+	verbose test "$(commit_message HEAD~)" = "files_subtree/topic_5" &&
 	verbose test "$(commit_message HEAD)" = "Empty commit"
 '
 

--- a/t/t4150-am.sh
+++ b/t/t4150-am.sh
@@ -465,7 +465,7 @@ test_expect_success 'am changes committer and keeps author' '
 test_expect_success 'am --signoff adds Signed-off-by: line' '
 	rm -fr .git/rebase-apply &&
 	git reset --hard &&
-	git checkout -b master2 first &&
+	git checkout -b topic_2 first &&
 	git am --signoff <patch2 &&
 	{
 		printf "third\n\nSigned-off-by: %s <%s>\n\n" \
@@ -479,7 +479,7 @@ test_expect_success 'am --signoff adds Signed-off-by: line' '
 '
 
 test_expect_success 'am stays in branch' '
-	echo refs/heads/master2 >expected &&
+	echo refs/heads/topic_2 >expected &&
 	git symbolic-ref HEAD >actual &&
 	test_cmp expected actual
 '
@@ -540,7 +540,7 @@ test_expect_success 'am without --keep removes Re: and [PATCH] stuff' '
 	git reset --hard HEAD^ &&
 	git am <patch4 &&
 	git rev-parse HEAD >expected &&
-	git rev-parse master2 >actual &&
+	git rev-parse topic_2 >actual &&
 	test_cmp expected actual
 '
 
@@ -567,7 +567,7 @@ test_expect_success 'am --keep-non-patch really keeps the non-patch part' '
 test_expect_success 'setup am -3' '
 	rm -fr .git/rebase-apply &&
 	git reset --hard &&
-	git checkout -b base3way master2 &&
+	git checkout -b base3way topic_2 &&
 	sed -n -e "3,\$p" msg >file &&
 	head -n 9 msg >>file &&
 	git add file &&

--- a/t/t5515-fetch-merge-logic.sh
+++ b/t/t5515-fetch-merge-logic.sh
@@ -15,7 +15,7 @@ export GIT_TEST_PROTOCOL_VERSION
 
 build_script () {
 	script="$1" &&
-	for i in one three_file master master2 one_tree three two two2 three2
+	for i in one three_file master topic_2 one_tree three two two2 three2
 	do
 		echo "s/$(test_oid --hash=sha1 "$i")/$(test_oid "$i")/g" >>"$script"
 	done
@@ -52,8 +52,8 @@ test_expect_success setup '
 	two sha1:525b7fb068d59950d185a8779dc957c77eed73ba
 	two sha256:3b21de3440cd38c2a9e9b464adb923f7054949ed4c918e1a0ac4c95cd52774db
 
-	master2 sha1:754b754407bf032e9a2f9d5a9ad05ca79a6b228f
-	master2 sha256:6c7abaea8a6d8ef4d89877e68462758dc6774690fbbbb0e6d7dd57415c9abde0
+	topic_2 sha1:754b754407bf032e9a2f9d5a9ad05ca79a6b228f
+	topic_2 sha256:6c7abaea8a6d8ef4d89877e68462758dc6774690fbbbb0e6d7dd57415c9abde0
 
 	two2 sha1:6134ee8f857693b96ff1cc98d3e2fd62b199e5a8
 	two2 sha256:87a2d3ee29c83a3dc7afd41c0606b11f67603120b910a7be7840accdc18344d4

--- a/t/t5523-push-upstream.sh
+++ b/t/t5523-push-upstream.sh
@@ -41,20 +41,20 @@ test_expect_success 'push -u --dry-run master:otherX' '
 	check_config master upstream refs/heads/other
 '
 
-test_expect_success 'push -u master2:master2' '
-	git branch master2 &&
-	git push -u upstream master2:master2 &&
-	check_config master2 upstream refs/heads/master2
+test_expect_success 'push -u topic_2:topic_2' '
+	git branch topic_2 &&
+	git push -u upstream topic_2:topic_2 &&
+	check_config topic_2 upstream refs/heads/topic_2
 '
 
-test_expect_success 'push -u master2:other2' '
-	git push -u upstream master2:other2 &&
-	check_config master2 upstream refs/heads/other2
+test_expect_success 'push -u topic_2:other2' '
+	git push -u upstream topic_2:other2 &&
+	check_config topic_2 upstream refs/heads/other2
 '
 
-test_expect_success 'push -u :master2' '
-	git push -u upstream :master2 &&
-	check_config master2 upstream refs/heads/other2
+test_expect_success 'push -u :topic_2' '
+	git push -u upstream :topic_2 &&
+	check_config topic_2 upstream refs/heads/other2
 '
 
 test_expect_success 'push -u --all' '

--- a/t/t6018-rev-list-glob.sh
+++ b/t/t6018-rev-list-glob.sh
@@ -32,11 +32,11 @@ test_expect_success 'setup' '
 	git checkout -b someref master &&
 	commit some &&
 	git checkout master &&
-	commit master2 &&
+	commit topic_2 &&
 	git tag foo/bar master &&
-	commit master3 &&
+	commit topic_3 &&
 	git update-ref refs/remotes/foo/baz master &&
-	commit master4 &&
+	commit topic_4 &&
 	git update-ref refs/remotes/upstream/one subspace/one &&
 	git update-ref refs/remotes/upstream/two subspace/two &&
 	git update-ref refs/remotes/upstream/x subspace-x &&

--- a/t/t6040-tracking-info.sh
+++ b/t/t6040-tracking-info.sh
@@ -264,25 +264,25 @@ test_expect_success 'fail to track annotated tags' '
 test_expect_success '--set-upstream-to does not change branch' '
 	git branch from-master master &&
 	git branch --set-upstream-to master from-master &&
-	git branch from-master2 master &&
-	test_must_fail git config branch.from-master2.merge > actual &&
-	git rev-list from-master2 &&
-	git update-ref refs/heads/from-master2 from-master2^ &&
-	git rev-parse from-master2 >expect2 &&
-	git branch --set-upstream-to master from-master2 &&
+	git branch from-topic_2 master &&
+	test_must_fail git config branch.from-topic_2.merge > actual &&
+	git rev-list from-topic_2 &&
+	git update-ref refs/heads/from-topic_2 from-topic_2^ &&
+	git rev-parse from-topic_2 >expect2 &&
+	git branch --set-upstream-to master from-topic_2 &&
 	git config branch.from-master.merge > actual &&
-	git rev-parse from-master2 >actual2 &&
+	git rev-parse from-topic_2 >actual2 &&
 	grep -q "^refs/heads/master$" actual &&
 	cmp expect2 actual2
 '
 
 test_expect_success '--set-upstream-to @{-1}' '
 	git checkout follower &&
-	git checkout from-master2 &&
-	git config branch.from-master2.merge > expect2 &&
+	git checkout from-topic_2 &&
+	git config branch.from-topic_2.merge > expect2 &&
 	git branch --set-upstream-to @{-1} from-master &&
 	git config branch.from-master.merge > actual &&
-	git config branch.from-master2.merge > actual2 &&
+	git config branch.from-topic_2.merge > actual2 &&
 	git branch --set-upstream-to follower from-master &&
 	git config branch.from-master.merge > expect &&
 	test_cmp expect2 actual2 &&

--- a/t/t6409-merge-subtree.sh
+++ b/t/t6409-merge-subtree.sh
@@ -94,10 +94,10 @@ test_expect_success 'merge update' '
 	echo git-gui2 > git-gui.sh &&
 	o3=$(git hash-object git-gui.sh) &&
 	git add git-gui.sh &&
-	git checkout -b master2 &&
+	git checkout -b topic_2 &&
 	git commit -m "update git-gui" &&
 	cd ../git &&
-	git pull -s subtree gui master2 &&
+	git pull -s subtree gui topic_2 &&
 	git ls-files -s >actual &&
 	(
 		echo "100644 $o3 0	git-gui/git-gui.sh" &&
@@ -109,7 +109,7 @@ test_expect_success 'merge update' '
 test_expect_success 'initial ambiguous subtree' '
 	cd ../git &&
 	git reset --hard master &&
-	git checkout -b master2 &&
+	git checkout -b topic_2 &&
 	git merge -s ours --no-commit gui/master &&
 	git read-tree --prefix=git-gui2/ -u gui/master &&
 	git commit -m "Merge git-gui2 as our subdirectory" &&
@@ -125,8 +125,8 @@ test_expect_success 'initial ambiguous subtree' '
 
 test_expect_success 'merge using explicit' '
 	cd ../git &&
-	git reset --hard master2 &&
-	git pull -Xsubtree=git-gui gui master2 &&
+	git reset --hard topic_2 &&
+	git pull -Xsubtree=git-gui gui topic_2 &&
 	git ls-files -s >actual &&
 	(
 		echo "100644 $o3 0	git-gui/git-gui.sh" &&
@@ -138,8 +138,8 @@ test_expect_success 'merge using explicit' '
 
 test_expect_success 'merge2 using explicit' '
 	cd ../git &&
-	git reset --hard master2 &&
-	git pull -Xsubtree=git-gui2 gui master2 &&
+	git reset --hard topic_2 &&
+	git pull -Xsubtree=git-gui2 gui topic_2 &&
 	git ls-files -s >actual &&
 	(
 		echo "100644 $o1 0	git-gui/git-gui.sh" &&

--- a/t/t9902-completion.sh
+++ b/t/t9902-completion.sh
@@ -542,37 +542,37 @@ test_expect_success '__gitcomp - doesnt fail because of invalid variable name' '
 '
 
 read -r -d "" refs <<-\EOF
+main
 maint
-master
 next
 seen
 EOF
 
 test_expect_success '__gitcomp_nl - trailing space' '
 	test_gitcomp_nl "m" "$refs" <<-EOF
+	main Z
 	maint Z
-	master Z
 	EOF
 '
 
 test_expect_success '__gitcomp_nl - prefix' '
 	test_gitcomp_nl "--fixup=m" "$refs" "--fixup=" "m" <<-EOF
+	--fixup=main Z
 	--fixup=maint Z
-	--fixup=master Z
 	EOF
 '
 
 test_expect_success '__gitcomp_nl - suffix' '
 	test_gitcomp_nl "branch.ma" "$refs" "branch." "ma" "." <<-\EOF
+	branch.main.Z
 	branch.maint.Z
-	branch.master.Z
 	EOF
 '
 
 test_expect_success '__gitcomp_nl - no suffix' '
 	test_gitcomp_nl "ma" "$refs" "" "ma" "" <<-\EOF
+	mainZ
 	maintZ
-	masterZ
 	EOF
 '
 

--- a/t/test-terminal.perl
+++ b/t/test-terminal.perl
@@ -81,24 +81,24 @@ if ($#ARGV < 1) {
 	die "usage: test-terminal program args";
 }
 $ENV{TERM} = 'vt100';
-my $master_in = new IO::Pty;
-my $master_out = new IO::Pty;
-my $master_err = new IO::Pty;
-$master_in->set_raw();
-$master_out->set_raw();
-$master_err->set_raw();
-$master_in->slave->set_raw();
-$master_out->slave->set_raw();
-$master_err->slave->set_raw();
-my $pid = start_child(\@ARGV, $master_in->slave, $master_out->slave, $master_err->slave);
-close $master_in->slave;
-close $master_out->slave;
-close $master_err->slave;
-my $in_pid = copy_stdin($master_in);
-copy_stdio($master_out, $master_err);
+my $parent_in = new IO::Pty;
+my $parent_out = new IO::Pty;
+my $parent_err = new IO::Pty;
+$parent_in->set_raw();
+$parent_out->set_raw();
+$parent_err->set_raw();
+$parent_in->slave->set_raw();
+$parent_out->slave->set_raw();
+$parent_err->slave->set_raw();
+my $pid = start_child(\@ARGV, $parent_in->slave, $parent_out->slave, $parent_err->slave);
+close $parent_in->slave;
+close $parent_out->slave;
+close $parent_err->slave;
+my $in_pid = copy_stdin($parent_in);
+copy_stdio($parent_out, $parent_err);
 my $ret = finish_child($pid);
 # If the child process terminates before our copy_stdin() process is able to
-# write all of its data to $master_in, the copy_stdin() process could stall.
+# write all of its data to $parent_in, the copy_stdin() process could stall.
 # Send SIGTERM to it to ensure it terminates.
 kill 'TERM', $in_pid;
 finish_child($in_pid);


### PR DESCRIPTION
This patch series represents the logical next step on the journey begun with introducing `init.defaultBranch`: in these patches, we avoid a couple unnecessary mentions of the branch name "master".

This patch series does _not_ try to change the default branch name, although I have that patch series ready to go. You can see the overall idea here: https://github.com/gitgitgadget/git/pull/655. Concretely, I plan on submitting three more patch series after this one:

1. a relatively small patch series to avoid using the branch name `main` in the test suite. This is necessary because my plan is to change the default branch name to that name, therefore it cannot be used as the name of a topic branch any longer.
2. a relatively large patch series (currently consisting of 18 patches) to change the default branch name to `main`. Most of the patches provide non-trivial (read: non-scriptable) adjustments to the test suite in an incremental fashion, with a big patch toward the end that reflects a fully-automated search-and-replace of all the trivial cases.
3. a very small patch series with fall-out patches that are not necessary to pass the test suite, but are still required to complete the rename (adjusted code comment, file rename).

(Note: I am still debating whether I should move one or two patches from the second to the third patch series)

Changes since v2:

- Extended the idea of using `topic` instead of `main` to patch 4/5.
- Explained in the commit message of patch 5/5 why we cannot use `topic` instead of `main` here.

Changes since v1:

- Instead of using the name `primary` for the adjustments to `t/test-terminal.perl`, we follow Python's lead (which uses the parent/child nomenclature).
- The changes to t3200 no longer use variations of the name `main` as branch names; Instead, the renamed branches are independent from any current or future default branch name.

cc: Jeff King <peff@peff.net>
cc: Johannes Schindelin <Johannes.Schindelin@gmx.de>