### PR TITLE
Avoid main as branch name in the test suite

### DIFF
--- a/t/t1415-worktree-refs.sh
+++ b/t/t1415-worktree-refs.sh
@@ -76,24 +76,24 @@ test_expect_success 'reflog of worktrees/xx/HEAD' '
 	test_cmp expected actual.wt2
 '
 
-test_expect_success 'for-each-ref from main repo' '
+test_expect_success 'for-each-ref from main worktree' '
 	mkdir fer1 &&
 	git -C fer1 init repo &&
 	test_commit -C fer1/repo initial &&
 	git -C fer1/repo worktree add ../second &&
-	git -C fer1/repo update-ref refs/bisect/main HEAD &&
-	git -C fer1/repo update-ref refs/rewritten/main HEAD &&
-	git -C fer1/repo update-ref refs/worktree/main HEAD &&
-	git -C fer1/repo for-each-ref --format="%(refname)" | grep main >actual &&
+	git -C fer1/repo update-ref refs/bisect/first HEAD &&
+	git -C fer1/repo update-ref refs/rewritten/first HEAD &&
+	git -C fer1/repo update-ref refs/worktree/first HEAD &&
+	git -C fer1/repo for-each-ref --format="%(refname)" | grep first >actual &&
 	cat >expected <<-\EOF &&
-	refs/bisect/main
-	refs/rewritten/main
-	refs/worktree/main
+	refs/bisect/first
+	refs/rewritten/first
+	refs/worktree/first
 	EOF
 	test_cmp expected actual
 '
 
-test_expect_success 'for-each-ref from linked repo' '
+test_expect_success 'for-each-ref from linked worktree' '
 	mkdir fer2 &&
 	git -C fer2 init repo &&
 	test_commit -C fer2/repo initial &&

--- a/t/t6012-rev-list-simplify.sh
+++ b/t/t6012-rev-list-simplify.sh
@@ -171,7 +171,7 @@ test_expect_success '--full-diff is not affected by --parents' '
 test_expect_success 'rebuild repo' '
 	rm -rf .git * &&
 	git init &&
-	git switch -c main &&
+	git switch -c topic &&
 
 	echo base >file &&
 	git add file &&
@@ -186,7 +186,7 @@ test_expect_success 'rebuild repo' '
 	git add file &&
 	test_commit B &&
 
-	git switch main &&
+	git switch topic &&
 	test_must_fail git merge -m "M" B &&
 	echo A >file &&
 	echo B >>file &&
@@ -207,7 +207,7 @@ test_expect_success 'rebuild repo' '
 	git merge -m R -Xtheirs X &&
 	note R &&
 
-	git switch main &&
+	git switch topic &&
 	git merge -m N R &&
 	note N &&
 
@@ -221,7 +221,7 @@ test_expect_success 'rebuild repo' '
 	git add z &&
 	test_commit Z &&
 
-	git switch main &&
+	git switch topic &&
 	git merge -m O Z &&
 	note O &&
 

--- a/t/t6400-merge-df.sh
+++ b/t/t6400-merge-df.sh
@@ -124,7 +124,7 @@ test_expect_success 'Simple merge in repo with interesting pathnames' '
 		git add . &&
 		git commit -m initial &&
 
-		git branch main &&
+		git branch topic &&
 		git branch other &&
 
 		git checkout other &&
@@ -132,10 +132,10 @@ test_expect_success 'Simple merge in repo with interesting pathnames' '
 		git add -u &&
 		git commit -m other &&
 
-		git checkout main &&
-		echo main >foo/bar/baz &&
+		git checkout topic &&
+		echo topic >foo/bar/baz &&
 		git add -u &&
-		git commit -m main &&
+		git commit -m topic &&
 
 		git merge other &&
 		git ls-files -s >out &&

--- a/t/t6409-merge-subtree.sh
+++ b/t/t6409-merge-subtree.sh
@@ -35,11 +35,11 @@ test_expect_success 'setup branch sub' '
 	test_commit foo
 '
 
-test_expect_success 'setup branch main' '
-	git checkout -b main master &&
+test_expect_success 'setup topic branch' '
+	git checkout -b topic master &&
 	git merge -s ours --no-commit --allow-unrelated-histories sub &&
 	git read-tree --prefix=dir/ -u sub &&
-	git commit -m "initial merge of sub into main" &&
+	git commit -m "initial merge of sub into topic" &&
 	test_path_is_file dir/foo.t &&
 	test_path_is_file hello
 '
@@ -49,9 +49,9 @@ test_expect_success 'update branch sub' '
 	test_commit bar
 '
 
-test_expect_success 'update branch main' '
-	git checkout main &&
-	git merge -s subtree sub -m "second merge of sub into main" &&
+test_expect_success 'update topic branch' '
+	git checkout topic &&
+	git merge -s subtree sub -m "second merge of sub into topic" &&
 	test_path_is_file dir/bar.t &&
 	test_path_is_file dir/foo.t &&
 	test_path_is_file hello

--- a/t/t6430-merge-recursive.sh
+++ b/t/t6430-merge-recursive.sh
@@ -663,7 +663,7 @@ test_expect_failure 'merge-recursive rename vs. rename/symlink' '
 
 test_expect_success 'merging with triple rename across D/F conflict' '
 	git reset --hard HEAD &&
-	git checkout -b main &&
+	git checkout -b topic &&
 	git rm -rf . &&
 
 	echo "just a file" >sub1 &&
@@ -682,7 +682,7 @@ test_expect_success 'merging with triple rename across D/F conflict' '
 	test_tick &&
 	git commit -a -m changesimplefile &&
 
-	git checkout main &&
+	git checkout topic &&
 	git rm sub1 &&
 	git mv sub2 sub1 &&
 	test_tick &&


### PR DESCRIPTION
In preparation for changing the default branch name to `main`, let's stop using it as non-default branch name in the test suite.

This is the last preparatory step before the patch series that intends to change the default branch name to `main`. See https://github.com/gitgitgadget/git/pull/655 for the entire game plan.

Changes since v1:

- The commit message of the `t1415` patch elaborates a but more about the rationale for the change.
- Instead of `primary`, the second patch renames all of those branches to `topic`, imitating b6211b89eb3 (tests: avoid variations of the `master` branch name, 2020-09-26).

cc: Jonathan Nieder <jrnieder@gmail.com>
cc: Johannes Schindelin <Johannes.Schindelin@gmx.de>
cc: Derrick Stolee <stolee@gmail.com>