### PR TITLE
GitHub workflow: automatically follow minor updates of setup-msbuild

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -154,7 +154,7 @@ jobs:
         Expand-Archive compat.zip -DestinationPath . -Force
         Remove-Item compat.zip
     - name: add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1.0.0
+      uses: microsoft/setup-msbuild@v1
     - name: copy dlls to root
       shell: powershell
       run: |


### PR DESCRIPTION
This patch was based on `dd/ci-swap-azure-pipelines-with-github-actions`, but due to changes outside of Git, that GitHub workflow does not even begin to work anymore. Therefore, the patch is now actually based on `master`.

cc: Jeff King <peff@peff.net>