### PR TITLE
Fix the command list with SKIP_DASHED_BUILT_INS=YesPlease

### DIFF
--- a/git.c
+++ b/git.c
@@ -641,6 +641,25 @@ static void list_builtins(struct string_list *out, unsigned int exclude_option)
 	}
 }
 
+void load_builtin_commands(const char *prefix, struct cmdnames *cmds)
+{
+	const char *name;
+	int i;
+
+	/*
+	 * Callers can ask for a subset of the commands based on a certain
+	 * prefix, which is then dropped from the added names. The names in
+	 * the `commands[]` array do not have the `git-` prefix, though,
+	 * therefore we must expect the `prefix` to at least start with `git-`.
+	 */
+	if (!skip_prefix(prefix, "git-", &prefix))
+		BUG("prefix '%s' must start with 'git-'", prefix);
+
+	for (i = 0; i < ARRAY_SIZE(commands); i++)
+		if (skip_prefix(commands[i].cmd, prefix, &name))
+			add_cmdname(cmds, name, strlen(name));
+}
+
 #ifdef STRIP_EXTENSION
 static void strip_extension(const char **argv)
 {

--- a/help.c
+++ b/help.c
@@ -263,6 +263,8 @@ void load_command_list(const char *prefix,
 	const char *env_path = getenv("PATH");
 	const char *exec_path = git_exec_path();
 
+	load_builtin_commands(prefix, main_cmds);
+
 	if (exec_path) {
 		list_commands_in_dir(main_cmds, exec_path, prefix);
 		QSORT(main_cmds->names, main_cmds->cnt, cmdname_compare);

--- a/help.h
+++ b/help.h
@@ -32,6 +32,7 @@ const char *help_unknown_cmd(const char *cmd);
 void load_command_list(const char *prefix,
 		       struct cmdnames *main_cmds,
 		       struct cmdnames *other_cmds);
+void load_builtin_commands(const char *prefix, struct cmdnames *cmds);
 void add_cmdname(struct cmdnames *cmds, const char *name, int len);
 /* Here we require that excludes is a sorted list. */
 void exclude_cmds(struct cmdnames *cmds, struct cmdnames *excludes);


### PR DESCRIPTION
In [a recent patch series](https://lore.kernel.org/git/20201005122646.27994-12-alban.gruin@gmail.com/#r), the merge strategies were converted into built-ins, which is good.

Together with the change where we stop hard-linking the built-in commands in CI builds, this broke t9902.199.

The _actual_ root cause is that `git merge -s help` relies on `load_command_list()` to find all available Git commands, and that function expected to find the built-in commands to on the `PATH`.

Changes since v1:

- Clarified the prefix skipping.

Cc: Alban Gruin <alban.gruin@gmail.com>
cc: Johannes Schindelin <Johannes.Schindelin@gmx.de>