### PR TITLE
maintenance: core.commitGraph=false prevents writes

### DIFF
--- a/builtin/gc.c
+++ b/builtin/gc.c
@@ -813,6 +813,10 @@ static int run_write_commit_graph(struct maintenance_run_opts *opts)
 
 static int maintenance_task_commit_graph(struct maintenance_run_opts *opts)
 {
+	prepare_repo_settings(the_repository);
+	if (!the_repository->settings.core_commit_graph)
+		return 0;
+
 	close_object_store(the_repository->objects);
 	if (run_write_commit_graph(opts)) {
 		error(_("failed to write commit-graph"));

--- a/t/t7900-maintenance.sh
+++ b/t/t7900-maintenance.sh
@@ -52,6 +52,14 @@ test_expect_success 'run --task=<task>' '
 	test_subcommand git commit-graph write --split --reachable --no-progress <run-both.txt
 '
 
+test_expect_success 'core.commitGraph=false prevents write process' '
+	GIT_TRACE2_EVENT="$(pwd)/no-commit-graph.txt" \
+		git -c core.commitGraph=false maintenance run \
+		--task=commit-graph 2>/dev/null &&
+	test_subcommand ! git commit-graph write --split --reachable --no-progress \
+		<no-commit-graph.txt
+'
+
 test_expect_success 'commit-graph auto condition' '
 	COMMAND="maintenance run --task=commit-graph --auto --quiet" &&
 


### PR DESCRIPTION
As requested [1], this prevents the extra process when core.commitGraph is disabled.

This is based on ds/maintenance-commit-graph-auto-fix.

[1] https://lore.kernel.org/git/xmqqft6nrtlw.fsf@gitster.c.googlers.com/

Thanks,
-Stolee

cc: Derrick Stolee <stolee@gmail.com>