### PR TITLE
Work around flakiness in t5500.43

### DIFF
--- a/pkt-line.c
+++ b/pkt-line.c
@@ -471,6 +471,9 @@ int recv_sideband(const char *me, int in_stream, int out)
 			write_or_die(out, buf + 1, len - 1);
 			break;
 		default: /* errors: message already written */
+			if (scratch.len > 0)
+				BUG("unhandled incomplete sideband: '%s'",
+				    scratch.buf);
 			return sideband_type;
 		}
 	}

--- a/sideband.c
+++ b/sideband.c
@@ -190,7 +190,7 @@ int demultiplex_sideband(const char *me, char *buf, int len,
 		return 0;
 	case 1:
 		*sideband_type = SIDEBAND_PRIMARY;
-		break;
+		return 1;
 	default:
 		strbuf_addf(scratch, "%s%s: protocol error: bad band #%d",
 			    scratch->len ? "\n" : "", me, band);

--- a/t/helper/test-pkt-line.c
+++ b/t/helper/test-pkt-line.c
@@ -84,6 +84,25 @@ static void unpack_sideband(void)
 	}
 }
 
+static int send_split_sideband(void)
+{
+	const char *part1 = "Hello,";
+	const char *primary = "\001primary: regular output\n";
+	const char *part2 = " world!\n";
+
+	send_sideband(1, 2, part1, strlen(part1), LARGE_PACKET_MAX);
+	packet_write(1, primary, strlen(primary));
+	send_sideband(1, 2, part2, strlen(part2), LARGE_PACKET_MAX);
+	packet_response_end(1);
+
+	return 0;
+}
+
+static int receive_sideband(void)
+{
+	return recv_sideband("sideband: ", 0, 1);
+}
+
 int cmd__pkt_line(int argc, const char **argv)
 {
 	if (argc < 2)
@@ -95,6 +114,10 @@ int cmd__pkt_line(int argc, const char **argv)
 		unpack();
 	else if (!strcmp(argv[1], "unpack-sideband"))
 		unpack_sideband();
+	else if (!strcmp(argv[1], "send-split-sideband"))
+		send_split_sideband();
+	else if (!strcmp(argv[1], "receive-sideband"))
+		receive_sideband();
 	else
 		die("invalid argument '%s'", argv[1]);
 

--- a/t/t0070-fundamental.sh
+++ b/t/t0070-fundamental.sh
@@ -34,4 +34,10 @@ test_expect_success 'check for a bug in the regex routines' '
 	test-tool regex --bug
 '
 
+test_expect_success 'incomplete sideband messages are reassembled' '
+	test-tool pkt-line send-split-sideband >split-sideband &&
+	test-tool pkt-line receive-sideband <split-sideband 2>err &&
+	grep "Hello, world" err
+'
+
 test_done


### PR DESCRIPTION
It seems that this test became flaky only recently, although I have to admit that I have no idea why: the involved code does not seem to have changed recently at all. It _should_ have been fixed by https://lore.kernel.org/git/20200506220741.71021-1-jonathantanmy@google.com/, but apparently wasn't completely fixed, despite what I said in that thread.

Changes since v2:

- Dropped patch 3/3 because it was only intended to be defensive programming, but turned out to be too hard without layering violations.

Changes since v1:

- Instead of papering over the underlying cause, the patch was completely changed to actually fix the bug and add a proper regression test for it (originally, I wanted to act according to the common notion that good programmers are lazy, oh my, see how well _that_ worked out for me).
- We now specifically watch out for future bugs where incomplete sideband messages would be dropped inadvertently rather than being reported at EOF or at encountering a flush/error packet.
- Before sending 0-length data to `demultiplex_sideband()`, we now make sure that it is _not_ marked as a data packet; Otherwise we now complain loudly about a bug.

Cc: Jonathan Tan <jonathantanmy@google.com>
cc: Jeff King <peff@peff.net>
cc: Johannes Schindelin <Johannes.Schindelin@gmx.de>