### PR TITLE
Adjust t5411 for the upcoming change of the default branch name

### DIFF
--- a/t/t5411-proc-receive-hook.sh
+++ b/t/t5411-proc-receive-hook.sh
@@ -5,13 +5,21 @@
 
 test_description='Test proc-receive hook'
 
+GIT_TEST_DEFAULT_INITIAL_BRANCH_NAME=master
+export GIT_TEST_DEFAULT_INITIAL_BRANCH_NAME
+
 . ./test-lib.sh
+
+test_have_prereq PREPARE_FOR_MAIN_BRANCH || {
+	test_skip="In transit for the default branch name 'main'"
+	test_done
+}
 
 . "$TEST_DIRECTORY"/t5411/common-functions.sh
 
 setup_upstream_and_workbench () {
-	# Refs of upstream : master(A)
-	# Refs of workbench: master(A)  tags/v123
+	# Refs of upstream : main(A)
+	# Refs of workbench: main(A)  tags/v123
 	test_expect_success "setup upstream and workbench" '
 		rm -rf upstream.git &&
 		rm -rf workbench &&
@@ -25,10 +33,10 @@ setup_upstream_and_workbench () {
 			git config core.abbrev 7 &&
 			git tag -m "v123" v123 $A &&
 			git remote add origin ../upstream.git &&
-			git push origin master &&
-			git update-ref refs/heads/master $A $B &&
+			git push origin main &&
+			git update-ref refs/heads/main $A $B &&
 			git -C ../upstream.git update-ref \
-				refs/heads/master $A $B
+				refs/heads/main $A $B
 		) &&
 		TAG=$(git -C workbench rev-parse v123) &&
 
@@ -99,8 +107,8 @@ start_httpd
 # Re-initialize the upstream repository and local workbench.
 setup_upstream_and_workbench
 
-# Refs of upstream : master(A)
-# Refs of workbench: master(A)  tags/v123
+# Refs of upstream : main(A)
+# Refs of workbench: main(A)  tags/v123
 test_expect_success "setup for HTTP protocol" '
 	git -C upstream.git config http.receivepack true &&
 	upstream="$HTTPD_DOCUMENT_ROOT_PATH/upstream.git" &&

--- a/t/t5411-proc-receive-hook.sh
+++ b/t/t5411-proc-receive-hook.sh
@@ -5,15 +5,10 @@
 
 test_description='Test proc-receive hook'
 
-GIT_TEST_DEFAULT_INITIAL_BRANCH_NAME=master
+GIT_TEST_DEFAULT_INITIAL_BRANCH_NAME=main
 export GIT_TEST_DEFAULT_INITIAL_BRANCH_NAME
 
 . ./test-lib.sh
-
-test_have_prereq PREPARE_FOR_MAIN_BRANCH || {
-	test_skip="In transit for the default branch name 'main'"
-	test_done
-}
 
 . "$TEST_DIRECTORY"/t5411/common-functions.sh
 

--- a/t/t5411/common-functions.sh
+++ b/t/t5411/common-functions.sh
@@ -28,7 +28,7 @@ create_commits_in () {
 		shift ||
 		return 1
 	done &&
-	git -C "$repo" update-ref refs/heads/master $oid
+	git -C "$repo" update-ref refs/heads/main $oid
 }
 
 # Format the output of git-push, git-show-ref and other commands to make a

--- a/t/t5411/once-0010-report-status-v1.sh
+++ b/t/t5411/once-0010-report-status-v1.sh
@@ -6,12 +6,12 @@ test_expect_success "setup proc-receive hook" '
 	write_script "$upstream/hooks/proc-receive" <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
-		-r "ok refs/for/master/topic1" \
+		-r "ok refs/for/main/topic1" \
 		-r "option fall-through" \
-		-r "ok refs/for/master/topic2" \
+		-r "ok refs/for/main/topic2" \
 		-r "option refname refs/for/changes/23/123/1" \
 		-r "option new-oid $A" \
-		-r "ok refs/for/master/topic2" \
+		-r "ok refs/for/main/topic2" \
 		-r "option refname refs/for/changes/24/124/2" \
 		-r "option old-oid $B" \
 		-r "option new-oid $A" \
@@ -20,26 +20,26 @@ test_expect_success "setup proc-receive hook" '
 	EOF
 '
 
-# Refs of upstream : master(A)
-# Refs of workbench: master(A)  tags/v123
-# git push         : (B)                   refs/for/master/topic1(A)  foo(A)  refs/for/next/topic(A)  refs/for/master/topic2(A)
+# Refs of upstream : main(A)
+# Refs of workbench: main(A)  tags/v123
+# git push         : (B)                   refs/for/main/topic1(A)  foo(A)  refs/for/next/topic(A)  refs/for/main/topic2(A)
 test_expect_success "proc-receive: report status v1" '
 	{
 		if test -z "$GIT_DEFAULT_HASH" || test "$GIT_DEFAULT_HASH" = "sha1"
 		then
-			printf "%s %s refs/heads/master\0report-status\n" \
+			printf "%s %s refs/heads/main\0report-status\n" \
 				$A $B | packetize
 		else
-			printf "%s %s refs/heads/master\0report-status object-format=$GIT_DEFAULT_HASH\n" \
+			printf "%s %s refs/heads/main\0report-status object-format=$GIT_DEFAULT_HASH\n" \
 				$A $B | packetize
 		fi &&
-		printf "%s %s refs/for/master/topic1\n" \
+		printf "%s %s refs/for/main/topic1\n" \
 			$ZERO_OID $A | packetize &&
 		printf "%s %s refs/heads/foo\n" \
 			$ZERO_OID $A | packetize &&
 		printf "%s %s refs/for/next/topic\n" \
 			$ZERO_OID $A | packetize &&
-		printf "%s %s refs/for/master/topic2\n" \
+		printf "%s %s refs/for/main/topic2\n" \
 			$ZERO_OID $A | packetize &&
 		printf 0000 &&
 		printf "" | git -C "$upstream" pack-objects --stdout
@@ -48,35 +48,35 @@ test_expect_success "proc-receive: report status v1" '
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
 	# pre-receive hook
-	pre-receive< <COMMIT-A> <COMMIT-B> refs/heads/master
-	pre-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic1
+	pre-receive< <COMMIT-A> <COMMIT-B> refs/heads/main
+	pre-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic1
 	pre-receive< <ZERO-OID> <COMMIT-A> refs/heads/foo
 	pre-receive< <ZERO-OID> <COMMIT-A> refs/for/next/topic
-	pre-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic2
+	pre-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic2
 	# proc-receive hook
-	proc-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic1
+	proc-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic1
 	proc-receive< <ZERO-OID> <COMMIT-A> refs/for/next/topic
-	proc-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic2
-	proc-receive> ok refs/for/master/topic1
+	proc-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic2
+	proc-receive> ok refs/for/main/topic1
 	proc-receive> option fall-through
-	proc-receive> ok refs/for/master/topic2
+	proc-receive> ok refs/for/main/topic2
 	proc-receive> option refname refs/for/changes/23/123/1
 	proc-receive> option new-oid <COMMIT-A>
-	proc-receive> ok refs/for/master/topic2
+	proc-receive> ok refs/for/main/topic2
 	proc-receive> option refname refs/for/changes/24/124/2
 	proc-receive> option old-oid <COMMIT-B>
 	proc-receive> option new-oid <COMMIT-A>
 	proc-receive> option forced-update
 	proc-receive> ng refs/for/next/topic target branch not exist
 	000eunpack ok
-	0019ok refs/heads/master
-	001eok refs/for/master/topic1
+	0019ok refs/heads/main
+	001eok refs/for/main/topic1
 	0016ok refs/heads/foo
 	0033ng refs/for/next/topic target branch not exist
-	001eok refs/for/master/topic2
+	001eok refs/for/main/topic2
 	0000# post-receive hook
-	post-receive< <COMMIT-A> <COMMIT-B> refs/heads/master
-	post-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic1
+	post-receive< <COMMIT-A> <COMMIT-B> refs/heads/main
+	post-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic1
 	post-receive< <ZERO-OID> <COMMIT-A> refs/heads/foo
 	post-receive< <ZERO-OID> <COMMIT-A> refs/for/changes/23/123/1
 	post-receive< <COMMIT-B> <COMMIT-A> refs/for/changes/24/124/2
@@ -86,9 +86,9 @@ test_expect_success "proc-receive: report status v1" '
 	git -C "$upstream" show-ref >out &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
-	<COMMIT-A> refs/for/master/topic1
+	<COMMIT-A> refs/for/main/topic1
 	<COMMIT-A> refs/heads/foo
-	<COMMIT-B> refs/heads/master
+	<COMMIT-B> refs/heads/main
 	EOF
 	test_cmp expect actual
 '

--- a/t/t5411/once-0010-report-status-v1.sh
+++ b/t/t5411/once-0010-report-status-v1.sh
@@ -69,11 +69,11 @@ test_expect_success "proc-receive: report status v1" '
 	proc-receive> option forced-update
 	proc-receive> ng refs/for/next/topic target branch not exist
 	000eunpack ok
-	0019ok refs/heads/main
-	001eok refs/for/main/topic1
+	0017ok refs/heads/main
+	001cok refs/for/main/topic1
 	0016ok refs/heads/foo
 	0033ng refs/for/next/topic target branch not exist
-	001eok refs/for/main/topic2
+	001cok refs/for/main/topic2
 	0000# post-receive hook
 	post-receive< <COMMIT-A> <COMMIT-B> refs/heads/main
 	post-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic1

--- a/t/t5411/test-0000-standard-git-push.sh
+++ b/t/t5411/test-0000-standard-git-push.sh
@@ -1,39 +1,39 @@
-# Refs of upstream : master(A)  
-# Refs of workbench: master(A)  tags/v123
-# git-push         : master(B)             next(A)
+# Refs of upstream : main(A)  
+# Refs of workbench: main(A)  tags/v123
+# git-push         : main(B)             next(A)
 test_expect_success "git-push ($PROTOCOL)" '
 	git -C workbench push origin \
-		$B:refs/heads/master \
+		$B:refs/heads/main \
 		HEAD:refs/heads/next \
 		>out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
 	remote: # pre-receive hook
-	remote: pre-receive< <COMMIT-A> <COMMIT-B> refs/heads/master
+	remote: pre-receive< <COMMIT-A> <COMMIT-B> refs/heads/main
 	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/heads/next
 	remote: # post-receive hook
-	remote: post-receive< <COMMIT-A> <COMMIT-B> refs/heads/master
+	remote: post-receive< <COMMIT-A> <COMMIT-B> refs/heads/main
 	remote: post-receive< <ZERO-OID> <COMMIT-A> refs/heads/next
 	To <URL/of/upstream.git>
-	 <OID-A>..<OID-B> <COMMIT-B> -> master
+	 <OID-A>..<OID-B> <COMMIT-B> -> main
 	 * [new branch] HEAD -> next
 	EOF
 	test_cmp expect actual &&
 	git -C "$upstream" show-ref >out &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
-	<COMMIT-B> refs/heads/master
+	<COMMIT-B> refs/heads/main
 	<COMMIT-A> refs/heads/next
 	EOF
 	test_cmp expect actual
 '
 
-# Refs of upstream : master(B)  next(A)
-# Refs of workbench: master(A)           tags/v123
-# git-push --atomic: master(A)  next(B)
+# Refs of upstream : main(B)  next(A)
+# Refs of workbench: main(A)           tags/v123
+# git-push --atomic: main(A)  next(B)
 test_expect_success "git-push --atomic ($PROTOCOL)" '
 	test_must_fail git -C workbench push --atomic origin \
-		master \
+		main \
 		$B:refs/heads/next \
 		>out 2>&1 &&
 	make_user_friendly_and_stable_output <out |
@@ -43,28 +43,28 @@ test_expect_success "git-push --atomic ($PROTOCOL)" '
 			>actual &&
 	cat >expect <<-EOF &&
 	To <URL/of/upstream.git>
-	 ! [rejected] master -> master (non-fast-forward)
+	 ! [rejected] main -> main (non-fast-forward)
 	 ! [rejected] <COMMIT-B> -> next (atomic push failed)
 	EOF
 	test_cmp expect actual &&
 	git -C "$upstream" show-ref >out &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
-	<COMMIT-B> refs/heads/master
+	<COMMIT-B> refs/heads/main
 	<COMMIT-A> refs/heads/next
 	EOF
 	test_cmp expect actual
 '
 
-# Refs of upstream : master(B)  next(A)
-# Refs of workbench: master(A)           tags/v123
-# git-push         : master(A)  next(B)
+# Refs of upstream : main(B)  next(A)
+# Refs of workbench: main(A)           tags/v123
+# git-push         : main(A)  next(B)
 test_expect_success "non-fast-forward git-push ($PROTOCOL)" '
 	test_must_fail git \
 		-C workbench \
 		-c advice.pushUpdateRejected=false \
 		push origin \
-		master \
+		main \
 		$B:refs/heads/next \
 		>out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
@@ -75,48 +75,48 @@ test_expect_success "non-fast-forward git-push ($PROTOCOL)" '
 	remote: post-receive< <COMMIT-A> <COMMIT-B> refs/heads/next
 	To <URL/of/upstream.git>
 	 <OID-A>..<OID-B> <COMMIT-B> -> next
-	 ! [rejected] master -> master (non-fast-forward)
+	 ! [rejected] main -> main (non-fast-forward)
 	EOF
 	test_cmp expect actual &&
 	git -C "$upstream" show-ref >out &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
-	<COMMIT-B> refs/heads/master
+	<COMMIT-B> refs/heads/main
 	<COMMIT-B> refs/heads/next
 	EOF
 	test_cmp expect actual
 '
 
-# Refs of upstream : master(B)  next(B)
-# Refs of workbench: master(A)           tags/v123
-# git-push -f      : master(A)  NULL     tags/v123  refs/review/master/topic(A)  a/b/c(A)
+# Refs of upstream : main(B)  next(B)
+# Refs of workbench: main(A)           tags/v123
+# git-push -f      : main(A)  NULL     tags/v123  refs/review/main/topic(A)  a/b/c(A)
 test_expect_success "git-push -f ($PROTOCOL)" '
 	git -C workbench push -f origin \
 		refs/tags/v123 \
 		:refs/heads/next \
-		master \
-		master:refs/review/master/topic \
+		main \
+		main:refs/review/main/topic \
 		HEAD:refs/heads/a/b/c \
 		>out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
 	remote: # pre-receive hook
-	remote: pre-receive< <COMMIT-B> <COMMIT-A> refs/heads/master
+	remote: pre-receive< <COMMIT-B> <COMMIT-A> refs/heads/main
 	remote: pre-receive< <COMMIT-B> <ZERO-OID> refs/heads/next
 	remote: pre-receive< <ZERO-OID> <TAG-v123> refs/tags/v123
-	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/review/master/topic
+	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/review/main/topic
 	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/heads/a/b/c
 	remote: # post-receive hook
-	remote: post-receive< <COMMIT-B> <COMMIT-A> refs/heads/master
+	remote: post-receive< <COMMIT-B> <COMMIT-A> refs/heads/main
 	remote: post-receive< <COMMIT-B> <ZERO-OID> refs/heads/next
 	remote: post-receive< <ZERO-OID> <TAG-v123> refs/tags/v123
-	remote: post-receive< <ZERO-OID> <COMMIT-A> refs/review/master/topic
+	remote: post-receive< <ZERO-OID> <COMMIT-A> refs/review/main/topic
 	remote: post-receive< <ZERO-OID> <COMMIT-A> refs/heads/a/b/c
 	To <URL/of/upstream.git>
-	 + <OID-B>...<OID-A> master -> master (forced update)
+	 + <OID-B>...<OID-A> main -> main (forced update)
 	 - [deleted] next
 	 * [new tag] v123 -> v123
-	 * [new reference] master -> refs/review/master/topic
+	 * [new reference] main -> refs/review/main/topic
 	 * [new branch] HEAD -> a/b/c
 	EOF
 	test_cmp expect actual &&
@@ -124,19 +124,19 @@ test_expect_success "git-push -f ($PROTOCOL)" '
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
 	<COMMIT-A> refs/heads/a/b/c
-	<COMMIT-A> refs/heads/master
-	<COMMIT-A> refs/review/master/topic
+	<COMMIT-A> refs/heads/main
+	<COMMIT-A> refs/review/main/topic
 	<TAG-v123> refs/tags/v123
 	EOF
 	test_cmp expect actual
 '
 
-# Refs of upstream : master(A)  tags/v123  refs/review/master/topic(A)  a/b/c(A)
-# Refs of workbench: master(A)  tags/v123
+# Refs of upstream : main(A)  tags/v123  refs/review/main/topic(A)  a/b/c(A)
+# Refs of workbench: main(A)  tags/v123
 test_expect_success "cleanup ($PROTOCOL)" '
 	(
 		cd "$upstream" &&
-		git update-ref -d refs/review/master/topic &&
+		git update-ref -d refs/review/main/topic &&
 		git update-ref -d refs/tags/v123 &&
 		git update-ref -d refs/heads/a/b/c
 	)

--- a/t/t5411/test-0001-standard-git-push--porcelain.sh
+++ b/t/t5411/test-0001-standard-git-push--porcelain.sh
@@ -1,21 +1,21 @@
-# Refs of upstream : master(A)  
-# Refs of workbench: master(A)  tags/v123
-# git-push         : master(B)             next(A)
+# Refs of upstream : main(A)  
+# Refs of workbench: main(A)  tags/v123
+# git-push         : main(B)             next(A)
 test_expect_success "git-push ($PROTOCOL/porcelain)" '
 	git -C workbench push --porcelain origin \
-		$B:refs/heads/master \
+		$B:refs/heads/main \
 		HEAD:refs/heads/next \
 		>out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
 	remote: # pre-receive hook
-	remote: pre-receive< <COMMIT-A> <COMMIT-B> refs/heads/master
+	remote: pre-receive< <COMMIT-A> <COMMIT-B> refs/heads/main
 	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/heads/next
 	remote: # post-receive hook
-	remote: post-receive< <COMMIT-A> <COMMIT-B> refs/heads/master
+	remote: post-receive< <COMMIT-A> <COMMIT-B> refs/heads/main
 	remote: post-receive< <ZERO-OID> <COMMIT-A> refs/heads/next
 	To <URL/of/upstream.git>
-	     <COMMIT-B>:refs/heads/master    <OID-A>..<OID-B>
+	     <COMMIT-B>:refs/heads/main    <OID-A>..<OID-B>
 	*    HEAD:refs/heads/next    [new branch]
 	Done
 	EOF
@@ -23,18 +23,18 @@ test_expect_success "git-push ($PROTOCOL/porcelain)" '
 	git -C "$upstream" show-ref >out &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
-	<COMMIT-B> refs/heads/master
+	<COMMIT-B> refs/heads/main
 	<COMMIT-A> refs/heads/next
 	EOF
 	test_cmp expect actual
 '
 
-# Refs of upstream : master(B)  next(A)
-# Refs of workbench: master(A)           tags/v123
-# git-push --atomic: master(A)  next(B)
+# Refs of upstream : main(B)  next(A)
+# Refs of workbench: main(A)           tags/v123
+# git-push --atomic: main(A)  next(B)
 test_expect_success "git-push --atomic ($PROTOCOL/porcelain)" '
 	test_must_fail git -C workbench push --atomic --porcelain origin \
-		master \
+		main \
 		$B:refs/heads/next \
 		>out 2>&1 &&
 	make_user_friendly_and_stable_output <out |
@@ -45,28 +45,28 @@ test_expect_success "git-push --atomic ($PROTOCOL/porcelain)" '
 			>actual &&
 	cat >expect <<-EOF &&
 	To <URL/of/upstream.git>
-	! refs/heads/master:refs/heads/master [rejected] (non-fast-forward)
+	! refs/heads/main:refs/heads/main [rejected] (non-fast-forward)
 	! <COMMIT-B>:refs/heads/next [rejected] (atomic push failed)
 	EOF
 	test_cmp expect actual &&
 	git -C "$upstream" show-ref >out &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
-	<COMMIT-B> refs/heads/master
+	<COMMIT-B> refs/heads/main
 	<COMMIT-A> refs/heads/next
 	EOF
 	test_cmp expect actual
 '
 
-# Refs of upstream : master(B)  next(A)
-# Refs of workbench: master(A)           tags/v123
-# git-push         : master(A)  next(B)
+# Refs of upstream : main(B)  next(A)
+# Refs of workbench: main(A)           tags/v123
+# git-push         : main(A)  next(B)
 test_expect_success "non-fast-forward git-push ($PROTOCOL/porcelain)" '
 	test_must_fail git \
 		-C workbench \
 		-c advice.pushUpdateRejected=false \
 		push --porcelain origin \
-		master \
+		main \
 		$B:refs/heads/next \
 		>out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
@@ -77,49 +77,49 @@ test_expect_success "non-fast-forward git-push ($PROTOCOL/porcelain)" '
 	remote: post-receive< <COMMIT-A> <COMMIT-B> refs/heads/next
 	To <URL/of/upstream.git>
 	     <COMMIT-B>:refs/heads/next    <OID-A>..<OID-B>
-	!    refs/heads/master:refs/heads/master    [rejected] (non-fast-forward)
+	!    refs/heads/main:refs/heads/main    [rejected] (non-fast-forward)
 	Done
 	EOF
 	test_cmp expect actual &&
 	git -C "$upstream" show-ref >out &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
-	<COMMIT-B> refs/heads/master
+	<COMMIT-B> refs/heads/main
 	<COMMIT-B> refs/heads/next
 	EOF
 	test_cmp expect actual
 '
 
-# Refs of upstream : master(B)  next(B)
-# Refs of workbench: master(A)           tags/v123
-# git-push -f      : master(A)  NULL     tags/v123  refs/review/master/topic(A)  a/b/c(A)
+# Refs of upstream : main(B)  next(B)
+# Refs of workbench: main(A)           tags/v123
+# git-push -f      : main(A)  NULL     tags/v123  refs/review/main/topic(A)  a/b/c(A)
 test_expect_success "git-push -f ($PROTOCOL/porcelain)" '
 	git -C workbench push --porcelain -f origin \
 		refs/tags/v123 \
 		:refs/heads/next \
-		master \
-		master:refs/review/master/topic \
+		main \
+		main:refs/review/main/topic \
 		HEAD:refs/heads/a/b/c \
 		>out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
 	remote: # pre-receive hook
-	remote: pre-receive< <COMMIT-B> <COMMIT-A> refs/heads/master
+	remote: pre-receive< <COMMIT-B> <COMMIT-A> refs/heads/main
 	remote: pre-receive< <COMMIT-B> <ZERO-OID> refs/heads/next
 	remote: pre-receive< <ZERO-OID> <TAG-v123> refs/tags/v123
-	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/review/master/topic
+	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/review/main/topic
 	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/heads/a/b/c
 	remote: # post-receive hook
-	remote: post-receive< <COMMIT-B> <COMMIT-A> refs/heads/master
+	remote: post-receive< <COMMIT-B> <COMMIT-A> refs/heads/main
 	remote: post-receive< <COMMIT-B> <ZERO-OID> refs/heads/next
 	remote: post-receive< <ZERO-OID> <TAG-v123> refs/tags/v123
-	remote: post-receive< <ZERO-OID> <COMMIT-A> refs/review/master/topic
+	remote: post-receive< <ZERO-OID> <COMMIT-A> refs/review/main/topic
 	remote: post-receive< <ZERO-OID> <COMMIT-A> refs/heads/a/b/c
 	To <URL/of/upstream.git>
-	+    refs/heads/master:refs/heads/master    <OID-B>...<OID-A> (forced update)
+	+    refs/heads/main:refs/heads/main    <OID-B>...<OID-A> (forced update)
 	-    :refs/heads/next    [deleted]
 	*    refs/tags/v123:refs/tags/v123    [new tag]
-	*    refs/heads/master:refs/review/master/topic    [new reference]
+	*    refs/heads/main:refs/review/main/topic    [new reference]
 	*    HEAD:refs/heads/a/b/c    [new branch]
 	Done
 	EOF
@@ -128,19 +128,19 @@ test_expect_success "git-push -f ($PROTOCOL/porcelain)" '
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
 	<COMMIT-A> refs/heads/a/b/c
-	<COMMIT-A> refs/heads/master
-	<COMMIT-A> refs/review/master/topic
+	<COMMIT-A> refs/heads/main
+	<COMMIT-A> refs/review/main/topic
 	<TAG-v123> refs/tags/v123
 	EOF
 	test_cmp expect actual
 '
 
-# Refs of upstream : master(A)  tags/v123  refs/review/master/topic(A)  a/b/c(A)
-# Refs of workbench: master(A)  tags/v123
+# Refs of upstream : main(A)  tags/v123  refs/review/main/topic(A)  a/b/c(A)
+# Refs of workbench: main(A)  tags/v123
 test_expect_success "cleanup ($PROTOCOL/porcelain)" '
 	(
 		cd "$upstream" &&
-		git update-ref -d refs/review/master/topic &&
+		git update-ref -d refs/review/main/topic &&
 		git update-ref -d refs/tags/v123 &&
 		git update-ref -d refs/heads/a/b/c
 	)

--- a/t/t5411/test-0002-pre-receive-declined.sh
+++ b/t/t5411/test-0002-pre-receive-declined.sh
@@ -5,25 +5,25 @@ test_expect_success "setup pre-receive hook ($PROTOCOL)" '
 	EOF
 '
 
-# Refs of upstream : master(A)
-# Refs of workbench: master(A)  tags/v123
-# git-push         : master(B)             next(A)
+# Refs of upstream : main(A)
+# Refs of workbench: main(A)  tags/v123
+# git-push         : main(B)             next(A)
 test_expect_success "git-push is declined ($PROTOCOL)" '
 	test_must_fail git -C workbench push origin \
-		$B:refs/heads/master \
+		$B:refs/heads/main \
 		HEAD:refs/heads/next \
 		>out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
 	To <URL/of/upstream.git>
-	 ! [remote rejected] <COMMIT-B> -> master (pre-receive hook declined)
+	 ! [remote rejected] <COMMIT-B> -> main (pre-receive hook declined)
 	 ! [remote rejected] HEAD -> next (pre-receive hook declined)
 	EOF
 	test_cmp expect actual &&
 	git -C "$upstream" show-ref >out &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
-	<COMMIT-A> refs/heads/master
+	<COMMIT-A> refs/heads/main
 	EOF
 	test_cmp expect actual
 '

--- a/t/t5411/test-0003-pre-receive-declined--porcelain.sh
+++ b/t/t5411/test-0003-pre-receive-declined--porcelain.sh
@@ -5,18 +5,18 @@ test_expect_success "setup pre-receive hook ($PROTOCOL/porcelain)" '
 	EOF
 '
 
-# Refs of upstream : master(A)
-# Refs of workbench: master(A)  tags/v123
-# git-push         : master(B)             next(A)
+# Refs of upstream : main(A)
+# Refs of workbench: main(A)  tags/v123
+# git-push         : main(B)             next(A)
 test_expect_success "git-push is declined ($PROTOCOL/porcelain)" '
 	test_must_fail git -C workbench push --porcelain origin \
-		$B:refs/heads/master \
+		$B:refs/heads/main \
 		HEAD:refs/heads/next \
 		>out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
 	To <URL/of/upstream.git>
-	!    <COMMIT-B>:refs/heads/master    [remote rejected] (pre-receive hook declined)
+	!    <COMMIT-B>:refs/heads/main    [remote rejected] (pre-receive hook declined)
 	!    HEAD:refs/heads/next    [remote rejected] (pre-receive hook declined)
 	Done
 	EOF
@@ -24,7 +24,7 @@ test_expect_success "git-push is declined ($PROTOCOL/porcelain)" '
 	git -C "$upstream" show-ref >out &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
-	<COMMIT-A> refs/heads/master
+	<COMMIT-A> refs/heads/main
 	EOF
 	test_cmp expect actual
 '

--- a/t/t5411/test-0011-no-hook-error.sh
+++ b/t/t5411/test-0011-no-hook-error.sh
@@ -1,64 +1,64 @@
-# Refs of upstream : master(A)
-# Refs of workbench: master(A)  tags/v123
-# git push         :                       next(A)  refs/for/master/topic(A)
+# Refs of upstream : main(A)
+# Refs of workbench: main(A)  tags/v123
+# git push         :                       next(A)  refs/for/main/topic(A)
 test_expect_success "proc-receive: no hook, fail to push special ref ($PROTOCOL)" '
 	test_must_fail git -C workbench push origin \
 		HEAD:next \
-		HEAD:refs/for/master/topic \
+		HEAD:refs/for/main/topic \
 		>out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
 	remote: # pre-receive hook
 	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/heads/next
-	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	remote: error: cannot find hook "proc-receive"
 	remote: # post-receive hook
 	remote: post-receive< <ZERO-OID> <COMMIT-A> refs/heads/next
 	To <URL/of/upstream.git>
 	 * [new branch] HEAD -> next
-	 ! [remote rejected] HEAD -> refs/for/master/topic (fail to run proc-receive hook)
+	 ! [remote rejected] HEAD -> refs/for/main/topic (fail to run proc-receive hook)
 	EOF
 	test_cmp expect actual &&
 	git -C "$upstream" show-ref >out &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
-	<COMMIT-A> refs/heads/master
+	<COMMIT-A> refs/heads/main
 	<COMMIT-A> refs/heads/next
 	EOF
 	test_cmp expect actual
 '
 
-# Refs of upstream : master(A)             next(A)
-# Refs of workbench: master(A)  tags/v123
+# Refs of upstream : main(A)             next(A)
+# Refs of workbench: main(A)  tags/v123
 test_expect_success "cleanup ($PROTOCOL)" '
 	git -C "$upstream" update-ref -d refs/heads/next
 '
 
-# Refs of upstream : master(A)
-# Refs of workbench: master(A)  tags/v123
-# git push --atomic: (B)                   next(A)  refs/for/master/topic(A)
+# Refs of upstream : main(A)
+# Refs of workbench: main(A)  tags/v123
+# git push --atomic: (B)                   next(A)  refs/for/main/topic(A)
 test_expect_success "proc-receive: no hook, all failed for atomic push ($PROTOCOL)" '
 	test_must_fail git -C workbench push --atomic origin \
-		$B:master \
+		$B:main \
 		HEAD:next \
-		HEAD:refs/for/master/topic >out 2>&1 &&
+		HEAD:refs/for/main/topic >out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
 	remote: # pre-receive hook
-	remote: pre-receive< <COMMIT-A> <COMMIT-B> refs/heads/master
+	remote: pre-receive< <COMMIT-A> <COMMIT-B> refs/heads/main
 	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/heads/next
-	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	remote: error: cannot find hook "proc-receive"
 	To <URL/of/upstream.git>
-	 ! [remote rejected] <COMMIT-B> -> master (fail to run proc-receive hook)
+	 ! [remote rejected] <COMMIT-B> -> main (fail to run proc-receive hook)
 	 ! [remote rejected] HEAD -> next (fail to run proc-receive hook)
-	 ! [remote rejected] HEAD -> refs/for/master/topic (fail to run proc-receive hook)
+	 ! [remote rejected] HEAD -> refs/for/main/topic (fail to run proc-receive hook)
 	EOF
 	test_cmp expect actual &&
 	git -C "$upstream" show-ref >out &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
-	<COMMIT-A> refs/heads/master
+	<COMMIT-A> refs/heads/main
 	EOF
 	test_cmp expect actual
 '

--- a/t/t5411/test-0012-no-hook-error--porcelain.sh
+++ b/t/t5411/test-0012-no-hook-error--porcelain.sh
@@ -1,66 +1,66 @@
-# Refs of upstream : master(A)
-# Refs of workbench: master(A)  tags/v123
-# git push         :                       next(A)  refs/for/master/topic(A)
+# Refs of upstream : main(A)
+# Refs of workbench: main(A)  tags/v123
+# git push         :                       next(A)  refs/for/main/topic(A)
 test_expect_success "proc-receive: no hook, fail to push special ref ($PROTOCOL/porcelain)" '
 	test_must_fail git -C workbench push --porcelain origin \
 		HEAD:next \
-		HEAD:refs/for/master/topic \
+		HEAD:refs/for/main/topic \
 		>out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
 	remote: # pre-receive hook
 	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/heads/next
-	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	remote: error: cannot find hook "proc-receive"
 	remote: # post-receive hook
 	remote: post-receive< <ZERO-OID> <COMMIT-A> refs/heads/next
 	To <URL/of/upstream.git>
 	*    HEAD:refs/heads/next    [new branch]
-	!    HEAD:refs/for/master/topic    [remote rejected] (fail to run proc-receive hook)
+	!    HEAD:refs/for/main/topic    [remote rejected] (fail to run proc-receive hook)
 	Done
 	EOF
 	test_cmp expect actual &&
 	git -C "$upstream" show-ref >out &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
-	<COMMIT-A> refs/heads/master
+	<COMMIT-A> refs/heads/main
 	<COMMIT-A> refs/heads/next
 	EOF
 	test_cmp expect actual
 '
 
-# Refs of upstream : master(A)             next(A)
-# Refs of workbench: master(A)  tags/v123
+# Refs of upstream : main(A)             next(A)
+# Refs of workbench: main(A)  tags/v123
 test_expect_success "cleanup ($PROTOCOL/porcelain)" '
 	git -C "$upstream" update-ref -d refs/heads/next
 '
 
-# Refs of upstream : master(A)
-# Refs of workbench: master(A)  tags/v123
-# git push --atomic: (B)                   next(A)  refs/for/master/topic(A)
+# Refs of upstream : main(A)
+# Refs of workbench: main(A)  tags/v123
+# git push --atomic: (B)                   next(A)  refs/for/main/topic(A)
 test_expect_success "proc-receive: no hook, all failed for atomic push ($PROTOCOL/porcelain)" '
 	test_must_fail git -C workbench push --porcelain --atomic origin \
-		$B:master \
+		$B:main \
 		HEAD:next \
-		HEAD:refs/for/master/topic >out 2>&1 &&
+		HEAD:refs/for/main/topic >out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
 	remote: # pre-receive hook
-	remote: pre-receive< <COMMIT-A> <COMMIT-B> refs/heads/master
+	remote: pre-receive< <COMMIT-A> <COMMIT-B> refs/heads/main
 	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/heads/next
-	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	remote: error: cannot find hook "proc-receive"
 	To <URL/of/upstream.git>
-	!    <COMMIT-B>:refs/heads/master    [remote rejected] (fail to run proc-receive hook)
+	!    <COMMIT-B>:refs/heads/main    [remote rejected] (fail to run proc-receive hook)
 	!    HEAD:refs/heads/next    [remote rejected] (fail to run proc-receive hook)
-	!    HEAD:refs/for/master/topic    [remote rejected] (fail to run proc-receive hook)
+	!    HEAD:refs/for/main/topic    [remote rejected] (fail to run proc-receive hook)
 	Done
 	EOF
 	test_cmp expect actual &&
 	git -C "$upstream" show-ref >out &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
-	<COMMIT-A> refs/heads/master
+	<COMMIT-A> refs/heads/main
 	EOF
 	test_cmp expect actual
 '

--- a/t/t5411/test-0013-bad-protocol.sh
+++ b/t/t5411/test-0013-bad-protocol.sh
@@ -5,12 +5,12 @@ test_expect_success "setup proc-receive hook (unknown version, $PROTOCOL)" '
 	EOF
 '
 
-# Refs of upstream : master(A)
-# Refs of workbench: master(A)  tags/v123
-# git push         :                       refs/for/master/topic(A)
+# Refs of upstream : main(A)
+# Refs of workbench: main(A)  tags/v123
+# git push         :                       refs/for/main/topic(A)
 test_expect_success "proc-receive: bad protocol (unknown version, $PROTOCOL)" '
 	test_must_fail git -C workbench push origin \
-		HEAD:refs/for/master/topic \
+		HEAD:refs/for/main/topic \
 		>out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
 
@@ -20,7 +20,7 @@ test_expect_success "proc-receive: bad protocol (unknown version, $PROTOCOL)" '
 		<actual >actual-report &&
 	cat >expect <<-EOF &&
 	To <URL/of/upstream.git>
-	 ! [remote rejected] HEAD -> refs/for/master/topic (fail to run proc-receive hook)
+	 ! [remote rejected] HEAD -> refs/for/main/topic (fail to run proc-receive hook)
 	EOF
 	test_cmp expect actual-report &&
 
@@ -36,7 +36,7 @@ test_expect_success "proc-receive: bad protocol (unknown version, $PROTOCOL)" '
 	git -C "$upstream" show-ref >out &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
-	<COMMIT-A> refs/heads/master
+	<COMMIT-A> refs/heads/main
 	EOF
 	test_cmp expect actual
 '
@@ -48,30 +48,30 @@ test_expect_success "setup proc-receive hook (hook --die-version, $PROTOCOL)" '
 	EOF
 '
 
-# Refs of upstream : master(A)
-# Refs of workbench: master(A)  tags/v123
-# git push         :                       refs/for/master/topic(A)
+# Refs of upstream : main(A)
+# Refs of workbench: main(A)  tags/v123
+# git push         :                       refs/for/main/topic(A)
 test_expect_success "proc-receive: bad protocol (hook --die-version, $PROTOCOL)" '
 	test_must_fail git -C workbench push origin \
-		HEAD:refs/for/master/topic \
+		HEAD:refs/for/main/topic \
 		>out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
 
 	cat >expect <<-EOF &&
 	remote: # pre-receive hook
-	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	remote: # proc-receive hook
 	remote: fatal: bad protocol version: 1
 	remote: error: proc-receive version "0" is not supported
 	To <URL/of/upstream.git>
-	 ! [remote rejected] HEAD -> refs/for/master/topic (fail to run proc-receive hook)
+	 ! [remote rejected] HEAD -> refs/for/main/topic (fail to run proc-receive hook)
 	EOF
 	test_cmp expect actual &&
 
 	git -C "$upstream" show-ref >out &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
-	<COMMIT-A> refs/heads/master
+	<COMMIT-A> refs/heads/main
 	EOF
 	test_cmp expect actual
 '
@@ -83,21 +83,21 @@ test_expect_success "setup proc-receive hook (hook --die-readline, $PROTOCOL)" '
 	EOF
 '
 
-# Refs of upstream : master(A)
-# Refs of workbench: master(A)  tags/v123
-# git push         :                       refs/for/master/topic(A)
+# Refs of upstream : main(A)
+# Refs of workbench: main(A)  tags/v123
+# git push         :                       refs/for/main/topic(A)
 test_expect_success "proc-receive: bad protocol (hook --die-readline, $PROTOCOL)" '
 	test_must_fail git -C workbench push origin \
-		HEAD:refs/for/master/topic \
+		HEAD:refs/for/main/topic \
 		>out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
 
-	grep "remote: fatal: protocol error: expected \"old new ref\", got \"<ZERO-OID> <COMMIT-A> refs/for/master/topic\"" actual &&
+	grep "remote: fatal: protocol error: expected \"old new ref\", got \"<ZERO-OID> <COMMIT-A> refs/for/main/topic\"" actual &&
 
 	git -C "$upstream" show-ref >out &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
-	<COMMIT-A> refs/heads/master
+	<COMMIT-A> refs/heads/main
 	EOF
 	test_cmp expect actual
 '
@@ -109,38 +109,38 @@ test_expect_success "setup proc-receive hook (no report, $PROTOCOL)" '
 	EOF
 '
 
-# Refs of upstream : master(A)
-# Refs of workbench: master(A)  tags/v123
-# git push         :                       next(A)  refs/for/master/topic(A)
+# Refs of upstream : main(A)
+# Refs of workbench: main(A)  tags/v123
+# git push         :                       next(A)  refs/for/main/topic(A)
 test_expect_success "proc-receive: bad protocol (no report, $PROTOCOL)" '
 	test_must_fail git -C workbench push origin \
 		HEAD:refs/heads/next \
-		HEAD:refs/for/master/topic >out 2>&1 &&
+		HEAD:refs/for/main/topic >out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
 	remote: # pre-receive hook
 	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/heads/next
-	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	remote: # proc-receive hook
-	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	remote: # post-receive hook
 	remote: post-receive< <ZERO-OID> <COMMIT-A> refs/heads/next
 	To <URL/of/upstream.git>
 	 * [new branch] HEAD -> next
-	 ! [remote rejected] HEAD -> refs/for/master/topic (proc-receive failed to report status)
+	 ! [remote rejected] HEAD -> refs/for/main/topic (proc-receive failed to report status)
 	EOF
 	test_cmp expect actual &&
 	git -C "$upstream" show-ref >out &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
-	<COMMIT-A> refs/heads/master
+	<COMMIT-A> refs/heads/main
 	<COMMIT-A> refs/heads/next
 	EOF
 	test_cmp expect actual
 '
 
-# Refs of upstream : master(A)             next(A)
-# Refs of workbench: master(A)  tags/v123
+# Refs of upstream : main(A)             next(A)
+# Refs of workbench: main(A)  tags/v123
 test_expect_success "cleanup ($PROTOCOL)" '
 	git -C "$upstream" update-ref -d refs/heads/next
 
@@ -154,29 +154,29 @@ test_expect_success "setup proc-receive hook (no ref, $PROTOCOL)" '
 	EOF
 '
 
-# Refs of upstream : master(A)
-# Refs of workbench: master(A)  tags/v123
-# git push         :                       refs/for/master/topic
+# Refs of upstream : main(A)
+# Refs of workbench: main(A)  tags/v123
+# git push         :                       refs/for/main/topic
 test_expect_success "proc-receive: bad protocol (no ref, $PROTOCOL)" '
 	test_must_fail git -C workbench push origin \
-		HEAD:refs/for/master/topic\
+		HEAD:refs/for/main/topic\
 		>out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
 	remote: # pre-receive hook
-	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	remote: # proc-receive hook
-	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	remote: proc-receive> ok
 	remote: error: proc-receive reported incomplete status line: "ok"
 	To <URL/of/upstream.git>
-	 ! [remote rejected] HEAD -> refs/for/master/topic (proc-receive failed to report status)
+	 ! [remote rejected] HEAD -> refs/for/main/topic (proc-receive failed to report status)
 	EOF
 	test_cmp expect actual &&
 	git -C "$upstream" show-ref >out &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
-	<COMMIT-A> refs/heads/master
+	<COMMIT-A> refs/heads/main
 	EOF
 	test_cmp expect actual
 '
@@ -185,33 +185,33 @@ test_expect_success "setup proc-receive hook (unknown status, $PROTOCOL)" '
 	write_script "$upstream/hooks/proc-receive" <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
-		-r "xx refs/for/master/topic"
+		-r "xx refs/for/main/topic"
 	EOF
 '
 
-# Refs of upstream : master(A)
-# Refs of workbench: master(A)  tags/v123
-# git push         :                       refs/for/master/topic
+# Refs of upstream : main(A)
+# Refs of workbench: main(A)  tags/v123
+# git push         :                       refs/for/main/topic
 test_expect_success "proc-receive: bad protocol (unknown status, $PROTOCOL)" '
 	test_must_fail git -C workbench push origin \
-			HEAD:refs/for/master/topic \
+			HEAD:refs/for/main/topic \
 			>out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
 	remote: # pre-receive hook
-	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	remote: # proc-receive hook
-	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
-	remote: proc-receive> xx refs/for/master/topic
-	remote: error: proc-receive reported bad status "xx" on ref "refs/for/master/topic"
+	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
+	remote: proc-receive> xx refs/for/main/topic
+	remote: error: proc-receive reported bad status "xx" on ref "refs/for/main/topic"
 	To <URL/of/upstream.git>
-	 ! [remote rejected] HEAD -> refs/for/master/topic (proc-receive failed to report status)
+	 ! [remote rejected] HEAD -> refs/for/main/topic (proc-receive failed to report status)
 	EOF
 	test_cmp expect actual &&
 	git -C "$upstream" show-ref >out &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
-	<COMMIT-A> refs/heads/master
+	<COMMIT-A> refs/heads/main
 	EOF
 	test_cmp expect actual
 '

--- a/t/t5411/test-0014-bad-protocol--porcelain.sh
+++ b/t/t5411/test-0014-bad-protocol--porcelain.sh
@@ -5,12 +5,12 @@ test_expect_success "setup proc-receive hook (unknown version, $PROTOCOL/porcela
 	EOF
 '
 
-# Refs of upstream : master(A)
-# Refs of workbench: master(A)  tags/v123
-# git push         :                       refs/for/master/topic(A)
+# Refs of upstream : main(A)
+# Refs of workbench: main(A)  tags/v123
+# git push         :                       refs/for/main/topic(A)
 test_expect_success "proc-receive: bad protocol (unknown version, $PROTOCOL/porcelain)" '
 	test_must_fail git -C workbench push --porcelain origin \
-		HEAD:refs/for/master/topic \
+		HEAD:refs/for/main/topic \
 		>out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
 
@@ -20,7 +20,7 @@ test_expect_success "proc-receive: bad protocol (unknown version, $PROTOCOL/porc
 		<actual >actual-report &&
 	cat >expect <<-EOF &&
 	To <URL/of/upstream.git>
-	!    HEAD:refs/for/master/topic    [remote rejected] (fail to run proc-receive hook)
+	!    HEAD:refs/for/main/topic    [remote rejected] (fail to run proc-receive hook)
 	Done
 	EOF
 	test_cmp expect actual-report &&
@@ -37,7 +37,7 @@ test_expect_success "proc-receive: bad protocol (unknown version, $PROTOCOL/porc
 	git -C "$upstream" show-ref >out &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
-	<COMMIT-A> refs/heads/master
+	<COMMIT-A> refs/heads/main
 	EOF
 	test_cmp expect actual
 '
@@ -49,39 +49,39 @@ test_expect_success "setup proc-receive hook (no report, $PROTOCOL/porcelain)" '
 	EOF
 '
 
-# Refs of upstream : master(A)
-# Refs of workbench: master(A)  tags/v123
-# git push         :                       next(A)  refs/for/master/topic(A)
+# Refs of upstream : main(A)
+# Refs of workbench: main(A)  tags/v123
+# git push         :                       next(A)  refs/for/main/topic(A)
 test_expect_success "proc-receive: bad protocol (no report, $PROTOCOL/porcelain)" '
 	test_must_fail git -C workbench push --porcelain origin \
 		HEAD:refs/heads/next \
-		HEAD:refs/for/master/topic >out 2>&1 &&
+		HEAD:refs/for/main/topic >out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
 	remote: # pre-receive hook
 	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/heads/next
-	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	remote: # proc-receive hook
-	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	remote: # post-receive hook
 	remote: post-receive< <ZERO-OID> <COMMIT-A> refs/heads/next
 	To <URL/of/upstream.git>
 	*    HEAD:refs/heads/next    [new branch]
-	!    HEAD:refs/for/master/topic    [remote rejected] (proc-receive failed to report status)
+	!    HEAD:refs/for/main/topic    [remote rejected] (proc-receive failed to report status)
 	Done
 	EOF
 	test_cmp expect actual &&
 	git -C "$upstream" show-ref >out &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
-	<COMMIT-A> refs/heads/master
+	<COMMIT-A> refs/heads/main
 	<COMMIT-A> refs/heads/next
 	EOF
 	test_cmp expect actual
 '
 
-# Refs of upstream : master(A)             next(A)
-# Refs of workbench: master(A)  tags/v123
+# Refs of upstream : main(A)             next(A)
+# Refs of workbench: main(A)  tags/v123
 test_expect_success "cleanup ($PROTOCOL/porcelain)" '
 	git -C "$upstream" update-ref -d refs/heads/next
 
@@ -95,30 +95,30 @@ test_expect_success "setup proc-receive hook (no ref, $PROTOCOL/porcelain)" '
 	EOF
 '
 
-# Refs of upstream : master(A)
-# Refs of workbench: master(A)  tags/v123
-# git push         :                       refs/for/master/topic
+# Refs of upstream : main(A)
+# Refs of workbench: main(A)  tags/v123
+# git push         :                       refs/for/main/topic
 test_expect_success "proc-receive: bad protocol (no ref, $PROTOCOL/porcelain)" '
 	test_must_fail git -C workbench push --porcelain origin \
-		HEAD:refs/for/master/topic\
+		HEAD:refs/for/main/topic\
 		>out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
 	remote: # pre-receive hook
-	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	remote: # proc-receive hook
-	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	remote: proc-receive> ok
 	remote: error: proc-receive reported incomplete status line: "ok"
 	To <URL/of/upstream.git>
-	!    HEAD:refs/for/master/topic    [remote rejected] (proc-receive failed to report status)
+	!    HEAD:refs/for/main/topic    [remote rejected] (proc-receive failed to report status)
 	Done
 	EOF
 	test_cmp expect actual &&
 	git -C "$upstream" show-ref >out &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
-	<COMMIT-A> refs/heads/master
+	<COMMIT-A> refs/heads/main
 	EOF
 	test_cmp expect actual
 '
@@ -127,34 +127,34 @@ test_expect_success "setup proc-receive hook (unknown status, $PROTOCOL/porcelai
 	write_script "$upstream/hooks/proc-receive" <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
-		-r "xx refs/for/master/topic"
+		-r "xx refs/for/main/topic"
 	EOF
 '
 
-# Refs of upstream : master(A)
-# Refs of workbench: master(A)  tags/v123
-# git push         :                       refs/for/master/topic
+# Refs of upstream : main(A)
+# Refs of workbench: main(A)  tags/v123
+# git push         :                       refs/for/main/topic
 test_expect_success "proc-receive: bad protocol (unknown status, $PROTOCOL/porcelain)" '
 	test_must_fail git -C workbench push --porcelain origin \
-			HEAD:refs/for/master/topic \
+			HEAD:refs/for/main/topic \
 			>out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
 	remote: # pre-receive hook
-	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	remote: # proc-receive hook
-	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
-	remote: proc-receive> xx refs/for/master/topic
-	remote: error: proc-receive reported bad status "xx" on ref "refs/for/master/topic"
+	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
+	remote: proc-receive> xx refs/for/main/topic
+	remote: error: proc-receive reported bad status "xx" on ref "refs/for/main/topic"
 	To <URL/of/upstream.git>
-	!    HEAD:refs/for/master/topic    [remote rejected] (proc-receive failed to report status)
+	!    HEAD:refs/for/main/topic    [remote rejected] (proc-receive failed to report status)
 	Done
 	EOF
 	test_cmp expect actual &&
 	git -C "$upstream" show-ref >out &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
-	<COMMIT-A> refs/heads/master
+	<COMMIT-A> refs/heads/main
 	EOF
 	test_cmp expect actual
 '

--- a/t/t5411/test-0020-report-ng.sh
+++ b/t/t5411/test-0020-report-ng.sh
@@ -2,32 +2,32 @@ test_expect_success "setup proc-receive hook (ng, no message, $PROTOCOL)" '
 	write_script "$upstream/hooks/proc-receive" <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
-		-r "ng refs/for/master/topic"
+		-r "ng refs/for/main/topic"
 	EOF
 '
 
-# Refs of upstream : master(A)
-# Refs of workbench: master(A)  tags/v123
-# git push         :                       refs/for/master/topic
+# Refs of upstream : main(A)
+# Refs of workbench: main(A)  tags/v123
+# git push         :                       refs/for/main/topic
 test_expect_success "proc-receive: fail to update (ng, no message, $PROTOCOL)" '
 	test_must_fail git -C workbench push origin \
-		HEAD:refs/for/master/topic \
+		HEAD:refs/for/main/topic \
 		>out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
 	remote: # pre-receive hook
-	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	remote: # proc-receive hook
-	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
-	remote: proc-receive> ng refs/for/master/topic
+	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
+	remote: proc-receive> ng refs/for/main/topic
 	To <URL/of/upstream.git>
-	 ! [remote rejected] HEAD -> refs/for/master/topic (failed)
+	 ! [remote rejected] HEAD -> refs/for/main/topic (failed)
 	EOF
 	test_cmp expect actual &&
 	git -C "$upstream" show-ref >out &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
-	<COMMIT-A> refs/heads/master
+	<COMMIT-A> refs/heads/main
 	EOF
 	test_cmp expect actual
 '
@@ -36,32 +36,32 @@ test_expect_success "setup proc-receive hook (ng message, $PROTOCOL)" '
 	write_script "$upstream/hooks/proc-receive" <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
-		-r "ng refs/for/master/topic error msg"
+		-r "ng refs/for/main/topic error msg"
 	EOF
 '
 
-# Refs of upstream : master(A)
-# Refs of workbench: master(A)  tags/v123
-# git push         :                       refs/for/master/topic
+# Refs of upstream : main(A)
+# Refs of workbench: main(A)  tags/v123
+# git push         :                       refs/for/main/topic
 test_expect_success "proc-receive: fail to update (ng, with message, $PROTOCOL)" '
 	test_must_fail git -C workbench push origin \
-		HEAD:refs/for/master/topic \
+		HEAD:refs/for/main/topic \
 		>out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
 	remote: # pre-receive hook
-	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	remote: # proc-receive hook
-	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
-	remote: proc-receive> ng refs/for/master/topic error msg
+	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
+	remote: proc-receive> ng refs/for/main/topic error msg
 	To <URL/of/upstream.git>
-	 ! [remote rejected] HEAD -> refs/for/master/topic (error msg)
+	 ! [remote rejected] HEAD -> refs/for/main/topic (error msg)
 	EOF
 	test_cmp expect actual &&
 	git -C "$upstream" show-ref >out &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
-	<COMMIT-A> refs/heads/master
+	<COMMIT-A> refs/heads/main
 	EOF
 	test_cmp expect actual
 '

--- a/t/t5411/test-0021-report-ng--porcelain.sh
+++ b/t/t5411/test-0021-report-ng--porcelain.sh
@@ -2,33 +2,33 @@ test_expect_success "setup proc-receive hook (ng, no message, $PROTOCOL/porcelai
 	write_script "$upstream/hooks/proc-receive" <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
-		-r "ng refs/for/master/topic"
+		-r "ng refs/for/main/topic"
 	EOF
 '
 
-# Refs of upstream : master(A)
-# Refs of workbench: master(A)  tags/v123
-# git push         :                       refs/for/master/topic
+# Refs of upstream : main(A)
+# Refs of workbench: main(A)  tags/v123
+# git push         :                       refs/for/main/topic
 test_expect_success "proc-receive: fail to update (ng, no message, $PROTOCOL/porcelain)" '
 	test_must_fail git -C workbench push --porcelain origin \
-		HEAD:refs/for/master/topic \
+		HEAD:refs/for/main/topic \
 		>out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
 	remote: # pre-receive hook
-	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	remote: # proc-receive hook
-	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
-	remote: proc-receive> ng refs/for/master/topic
+	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
+	remote: proc-receive> ng refs/for/main/topic
 	To <URL/of/upstream.git>
-	!    HEAD:refs/for/master/topic    [remote rejected] (failed)
+	!    HEAD:refs/for/main/topic    [remote rejected] (failed)
 	Done
 	EOF
 	test_cmp expect actual &&
 	git -C "$upstream" show-ref >out &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
-	<COMMIT-A> refs/heads/master
+	<COMMIT-A> refs/heads/main
 	EOF
 	test_cmp expect actual
 '
@@ -37,33 +37,33 @@ test_expect_success "setup proc-receive hook (ng message, $PROTOCOL/porcelain)" 
 	write_script "$upstream/hooks/proc-receive" <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
-		-r "ng refs/for/master/topic error msg"
+		-r "ng refs/for/main/topic error msg"
 	EOF
 '
 
-# Refs of upstream : master(A)
-# Refs of workbench: master(A)  tags/v123
-# git push         :                       refs/for/master/topic
+# Refs of upstream : main(A)
+# Refs of workbench: main(A)  tags/v123
+# git push         :                       refs/for/main/topic
 test_expect_success "proc-receive: fail to update (ng, with message, $PROTOCOL/porcelain)" '
 	test_must_fail git -C workbench push --porcelain origin \
-		HEAD:refs/for/master/topic \
+		HEAD:refs/for/main/topic \
 		>out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
 	remote: # pre-receive hook
-	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	remote: # proc-receive hook
-	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
-	remote: proc-receive> ng refs/for/master/topic error msg
+	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
+	remote: proc-receive> ng refs/for/main/topic error msg
 	To <URL/of/upstream.git>
-	!    HEAD:refs/for/master/topic    [remote rejected] (error msg)
+	!    HEAD:refs/for/main/topic    [remote rejected] (error msg)
 	Done
 	EOF
 	test_cmp expect actual &&
 	git -C "$upstream" show-ref >out &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
-	<COMMIT-A> refs/heads/master
+	<COMMIT-A> refs/heads/main
 	EOF
 	test_cmp expect actual
 '

--- a/t/t5411/test-0022-report-unexpect-ref.sh
+++ b/t/t5411/test-0022-report-unexpect-ref.sh
@@ -2,44 +2,44 @@ test_expect_success "setup proc-receive hook (unexpected ref, $PROTOCOL)" '
 	write_script "$upstream/hooks/proc-receive" <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
-		-r "ok refs/heads/master"
+		-r "ok refs/heads/main"
 	EOF
 '
 
-# Refs of upstream : master(A)
-# Refs of workbench: master(A)  tags/v123
-# git push         : (B)                   refs/for/master/topic
+# Refs of upstream : main(A)
+# Refs of workbench: main(A)  tags/v123
+# git push         : (B)                   refs/for/main/topic
 test_expect_success "proc-receive: report unexpected ref ($PROTOCOL)" '
 	test_must_fail git -C workbench push origin \
-		$B:refs/heads/master \
-		HEAD:refs/for/master/topic \
+		$B:refs/heads/main \
+		HEAD:refs/for/main/topic \
 		>out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
 	remote: # pre-receive hook
-	remote: pre-receive< <COMMIT-A> <COMMIT-B> refs/heads/master
-	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: pre-receive< <COMMIT-A> <COMMIT-B> refs/heads/main
+	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	remote: # proc-receive hook
-	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
-	remote: proc-receive> ok refs/heads/master
-	remote: error: proc-receive reported status on unexpected ref: refs/heads/master
+	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
+	remote: proc-receive> ok refs/heads/main
+	remote: error: proc-receive reported status on unexpected ref: refs/heads/main
 	remote: # post-receive hook
-	remote: post-receive< <COMMIT-A> <COMMIT-B> refs/heads/master
+	remote: post-receive< <COMMIT-A> <COMMIT-B> refs/heads/main
 	To <URL/of/upstream.git>
-	 <OID-A>..<OID-B> <COMMIT-B> -> master
-	 ! [remote rejected] HEAD -> refs/for/master/topic (proc-receive failed to report status)
+	 <OID-A>..<OID-B> <COMMIT-B> -> main
+	 ! [remote rejected] HEAD -> refs/for/main/topic (proc-receive failed to report status)
 	EOF
 	test_cmp expect actual &&
 	git -C "$upstream" show-ref >out &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
-	<COMMIT-B> refs/heads/master
+	<COMMIT-B> refs/heads/main
 	EOF
 	test_cmp expect actual
 '
 
-# Refs of upstream : master(B)
-# Refs of workbench: master(A)  tags/v123
+# Refs of upstream : main(B)
+# Refs of workbench: main(A)  tags/v123
 test_expect_success "cleanup ($PROTOCOL)" '
-	git -C "$upstream" update-ref refs/heads/master $A
+	git -C "$upstream" update-ref refs/heads/main $A
 '

--- a/t/t5411/test-0023-report-unexpect-ref--porcelain.sh
+++ b/t/t5411/test-0023-report-unexpect-ref--porcelain.sh
@@ -2,45 +2,45 @@ test_expect_success "setup proc-receive hook (unexpected ref, $PROTOCOL/porcelai
 	write_script "$upstream/hooks/proc-receive" <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
-		-r "ok refs/heads/master"
+		-r "ok refs/heads/main"
 	EOF
 '
 
-# Refs of upstream : master(A)
-# Refs of workbench: master(A)  tags/v123
-# git push         : (B)                   refs/for/master/topic
+# Refs of upstream : main(A)
+# Refs of workbench: main(A)  tags/v123
+# git push         : (B)                   refs/for/main/topic
 test_expect_success "proc-receive: report unexpected ref ($PROTOCOL/porcelain)" '
 	test_must_fail git -C workbench push --porcelain origin \
-		$B:refs/heads/master \
-		HEAD:refs/for/master/topic \
+		$B:refs/heads/main \
+		HEAD:refs/for/main/topic \
 		>out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
 	remote: # pre-receive hook
-	remote: pre-receive< <COMMIT-A> <COMMIT-B> refs/heads/master
-	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: pre-receive< <COMMIT-A> <COMMIT-B> refs/heads/main
+	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	remote: # proc-receive hook
-	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
-	remote: proc-receive> ok refs/heads/master
-	remote: error: proc-receive reported status on unexpected ref: refs/heads/master
+	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
+	remote: proc-receive> ok refs/heads/main
+	remote: error: proc-receive reported status on unexpected ref: refs/heads/main
 	remote: # post-receive hook
-	remote: post-receive< <COMMIT-A> <COMMIT-B> refs/heads/master
+	remote: post-receive< <COMMIT-A> <COMMIT-B> refs/heads/main
 	To <URL/of/upstream.git>
-	     <COMMIT-B>:refs/heads/master    <OID-A>..<OID-B>
-	!    HEAD:refs/for/master/topic    [remote rejected] (proc-receive failed to report status)
+	     <COMMIT-B>:refs/heads/main    <OID-A>..<OID-B>
+	!    HEAD:refs/for/main/topic    [remote rejected] (proc-receive failed to report status)
 	Done
 	EOF
 	test_cmp expect actual &&
 	git -C "$upstream" show-ref >out &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
-	<COMMIT-B> refs/heads/master
+	<COMMIT-B> refs/heads/main
 	EOF
 	test_cmp expect actual
 '
 
-# Refs of upstream : master(B)
-# Refs of workbench: master(A)  tags/v123
+# Refs of upstream : main(B)
+# Refs of workbench: main(A)  tags/v123
 test_expect_success "cleanup ($PROTOCOL/porcelain)" '
-	git -C "$upstream" update-ref refs/heads/master $A
+	git -C "$upstream" update-ref refs/heads/main $A
 '

--- a/t/t5411/test-0024-report-unknown-ref.sh
+++ b/t/t5411/test-0024-report-unknown-ref.sh
@@ -2,12 +2,12 @@ test_expect_success "setup proc-receive hook (unexpected ref, $PROTOCOL)" '
 	write_script "$upstream/hooks/proc-receive" <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
-		-r "ok refs/for/master/topic"
+		-r "ok refs/for/main/topic"
 	EOF
 '
 
-# Refs of upstream : master(A)
-# Refs of workbench: master(A)  tags/v123
+# Refs of upstream : main(A)
+# Refs of workbench: main(A)  tags/v123
 # git push         :                       refs/for/a/b/c/my/topic
 test_expect_success "proc-receive: report unknown reference ($PROTOCOL)" '
 	test_must_fail git -C workbench push origin \
@@ -19,8 +19,8 @@ test_expect_success "proc-receive: report unknown reference ($PROTOCOL)" '
 	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/a/b/c/my/topic
 	remote: # proc-receive hook
 	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/a/b/c/my/topic
-	remote: proc-receive> ok refs/for/master/topic
-	remote: error: proc-receive reported status on unknown ref: refs/for/master/topic
+	remote: proc-receive> ok refs/for/main/topic
+	remote: error: proc-receive reported status on unknown ref: refs/for/main/topic
 	To <URL/of/upstream.git>
 	 ! [remote rejected] HEAD -> refs/for/a/b/c/my/topic (proc-receive failed to report status)
 	EOF
@@ -28,7 +28,7 @@ test_expect_success "proc-receive: report unknown reference ($PROTOCOL)" '
 	git -C "$upstream" show-ref >out &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
-	<COMMIT-A> refs/heads/master
+	<COMMIT-A> refs/heads/main
 	EOF
 	test_cmp expect actual
 '

--- a/t/t5411/test-0025-report-unknown-ref--porcelain.sh
+++ b/t/t5411/test-0025-report-unknown-ref--porcelain.sh
@@ -2,12 +2,12 @@ test_expect_success "setup proc-receive hook (unexpected ref, $PROTOCOL/porcelai
 	write_script "$upstream/hooks/proc-receive" <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
-		-r "ok refs/for/master/topic"
+		-r "ok refs/for/main/topic"
 	EOF
 '
 
-# Refs of upstream : master(A)
-# Refs of workbench: master(A)  tags/v123
+# Refs of upstream : main(A)
+# Refs of workbench: main(A)  tags/v123
 # git push         :                       refs/for/a/b/c/my/topic
 test_expect_success "proc-receive: report unknown reference ($PROTOCOL/porcelain)" '
 	test_must_fail git -C workbench push --porcelain origin \
@@ -19,8 +19,8 @@ test_expect_success "proc-receive: report unknown reference ($PROTOCOL/porcelain
 	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/a/b/c/my/topic
 	remote: # proc-receive hook
 	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/a/b/c/my/topic
-	remote: proc-receive> ok refs/for/master/topic
-	remote: error: proc-receive reported status on unknown ref: refs/for/master/topic
+	remote: proc-receive> ok refs/for/main/topic
+	remote: error: proc-receive reported status on unknown ref: refs/for/main/topic
 	To <URL/of/upstream.git>
 	!    HEAD:refs/for/a/b/c/my/topic    [remote rejected] (proc-receive failed to report status)
 	Done
@@ -29,7 +29,7 @@ test_expect_success "proc-receive: report unknown reference ($PROTOCOL/porcelain
 	git -C "$upstream" show-ref >out &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
-	<COMMIT-A> refs/heads/master
+	<COMMIT-A> refs/heads/main
 	EOF
 	test_cmp expect actual
 '

--- a/t/t5411/test-0026-push-options.sh
+++ b/t/t5411/test-0026-push-options.sh
@@ -3,19 +3,19 @@ test_expect_success "setup proc-receive hook and disable push-options ($PROTOCOL
 	write_script "$upstream/hooks/proc-receive" <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
-		-r "ok refs/for/master/topic"
+		-r "ok refs/for/main/topic"
 	EOF
 '
 
-# Refs of upstream : master(A)
-# Refs of workbench: master(A)  tags/v123
-# git push -o ...  :                       refs/for/master/topic
+# Refs of upstream : main(A)
+# Refs of workbench: main(A)  tags/v123
+# git push -o ...  :                       refs/for/main/topic
 test_expect_success "proc-receive: not support push options ($PROTOCOL)" '
 	test_must_fail git -C workbench push \
 		-o issue=123 \
 		-o reviewer=user1 \
 		origin \
-		HEAD:refs/for/master/topic \
+		HEAD:refs/for/main/topic \
 		>out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
 	test_i18ngrep "fatal: the receiving end does not support push options" \
@@ -23,7 +23,7 @@ test_expect_success "proc-receive: not support push options ($PROTOCOL)" '
 	git -C "$upstream" show-ref >out &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
-	<COMMIT-A> refs/heads/master
+	<COMMIT-A> refs/heads/main
 	EOF
 	test_cmp expect actual
 '
@@ -32,9 +32,9 @@ test_expect_success "enable push options ($PROTOCOL)" '
 	git -C "$upstream" config receive.advertisePushOptions true
 '
 
-# Refs of upstream : master(A)
-# Refs of workbench: master(A)  tags/v123
-# git push -o ...  :                       next(A)  refs/for/master/topic
+# Refs of upstream : main(A)
+# Refs of workbench: main(A)  tags/v123
+# git push -o ...  :                       next(A)  refs/for/main/topic
 test_expect_success "proc-receive: push with options ($PROTOCOL)" '
 	git -C workbench push \
 		--atomic \
@@ -42,38 +42,38 @@ test_expect_success "proc-receive: push with options ($PROTOCOL)" '
 		-o reviewer=user1 \
 		origin \
 		HEAD:refs/heads/next \
-		HEAD:refs/for/master/topic \
+		HEAD:refs/for/main/topic \
 		>out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
 	remote: # pre-receive hook
 	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/heads/next
-	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	remote: # proc-receive hook
 	remote: proc-receive: atomic push_options
-	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	remote: proc-receive< issue=123
 	remote: proc-receive< reviewer=user1
-	remote: proc-receive> ok refs/for/master/topic
+	remote: proc-receive> ok refs/for/main/topic
 	remote: # post-receive hook
 	remote: post-receive< <ZERO-OID> <COMMIT-A> refs/heads/next
-	remote: post-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: post-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	To <URL/of/upstream.git>
 	 * [new branch] HEAD -> next
-	 * [new reference] HEAD -> refs/for/master/topic
+	 * [new reference] HEAD -> refs/for/main/topic
 	EOF
 	test_cmp expect actual &&
 	git -C "$upstream" show-ref >out &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
-	<COMMIT-A> refs/heads/master
+	<COMMIT-A> refs/heads/main
 	<COMMIT-A> refs/heads/next
 	EOF
 	test_cmp expect actual
 '
 
-# Refs of upstream : master(A)             next(A)
-# Refs of workbench: master(A)  tags/v123
+# Refs of upstream : main(A)             next(A)
+# Refs of workbench: main(A)  tags/v123
 test_expect_success "cleanup ($PROTOCOL)" '
 	git -C "$upstream" update-ref -d refs/heads/next
 '

--- a/t/t5411/test-0027-push-options--porcelain.sh
+++ b/t/t5411/test-0027-push-options--porcelain.sh
@@ -3,20 +3,20 @@ test_expect_success "setup proc-receive hook and disable push-options ($PROTOCOL
 	write_script "$upstream/hooks/proc-receive" <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
-		-r "ok refs/for/master/topic"
+		-r "ok refs/for/main/topic"
 	EOF
 '
 
-# Refs of upstream : master(A)
-# Refs of workbench: master(A)  tags/v123
-# git push -o ...  :                       refs/for/master/topic
+# Refs of upstream : main(A)
+# Refs of workbench: main(A)  tags/v123
+# git push -o ...  :                       refs/for/main/topic
 test_expect_success "proc-receive: not support push options ($PROTOCOL/porcelain)" '
 	test_must_fail git -C workbench push \
 		--porcelain \
 		-o issue=123 \
 		-o reviewer=user1 \
 		origin \
-		HEAD:refs/for/master/topic \
+		HEAD:refs/for/main/topic \
 		>out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
 	test_i18ngrep "fatal: the receiving end does not support push options" \
@@ -24,7 +24,7 @@ test_expect_success "proc-receive: not support push options ($PROTOCOL/porcelain
 	git -C "$upstream" show-ref >out &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
-	<COMMIT-A> refs/heads/master
+	<COMMIT-A> refs/heads/main
 	EOF
 	test_cmp expect actual
 '
@@ -33,9 +33,9 @@ test_expect_success "enable push options ($PROTOCOL/porcelain)" '
 	git -C "$upstream" config receive.advertisePushOptions true
 '
 
-# Refs of upstream : master(A)
-# Refs of workbench: master(A)  tags/v123
-# git push -o ...  :                       next(A)  refs/for/master/topic
+# Refs of upstream : main(A)
+# Refs of workbench: main(A)  tags/v123
+# git push -o ...  :                       next(A)  refs/for/main/topic
 test_expect_success "proc-receive: push with options ($PROTOCOL/porcelain)" '
 	git -C workbench push \
 		--porcelain \
@@ -44,39 +44,39 @@ test_expect_success "proc-receive: push with options ($PROTOCOL/porcelain)" '
 		-o reviewer=user1 \
 		origin \
 		HEAD:refs/heads/next \
-		HEAD:refs/for/master/topic \
+		HEAD:refs/for/main/topic \
 		>out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
 	remote: # pre-receive hook
 	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/heads/next
-	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	remote: # proc-receive hook
 	remote: proc-receive: atomic push_options
-	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	remote: proc-receive< issue=123
 	remote: proc-receive< reviewer=user1
-	remote: proc-receive> ok refs/for/master/topic
+	remote: proc-receive> ok refs/for/main/topic
 	remote: # post-receive hook
 	remote: post-receive< <ZERO-OID> <COMMIT-A> refs/heads/next
-	remote: post-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: post-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	To <URL/of/upstream.git>
 	*    HEAD:refs/heads/next    [new branch]
-	*    HEAD:refs/for/master/topic    [new reference]
+	*    HEAD:refs/for/main/topic    [new reference]
 	Done
 	EOF
 	test_cmp expect actual &&
 	git -C "$upstream" show-ref >out &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
-	<COMMIT-A> refs/heads/master
+	<COMMIT-A> refs/heads/main
 	<COMMIT-A> refs/heads/next
 	EOF
 	test_cmp expect actual
 '
 
-# Refs of upstream : master(A)             next(A)
-# Refs of workbench: master(A)  tags/v123
+# Refs of upstream : main(A)             next(A)
+# Refs of workbench: main(A)  tags/v123
 test_expect_success "cleanup ($PROTOCOL/porcelain)" '
 	git -C "$upstream" update-ref -d refs/heads/next
 '

--- a/t/t5411/test-0030-report-ok.sh
+++ b/t/t5411/test-0030-report-ok.sh
@@ -2,34 +2,34 @@ test_expect_success "setup proc-receive hook (ok, $PROTOCOL)" '
 	write_script "$upstream/hooks/proc-receive" <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
-		-r "ok refs/for/master/topic"
+		-r "ok refs/for/main/topic"
 	EOF
 '
 
-# Refs of upstream : master(A)
-# Refs of workbench: master(A)  tags/v123
-# git push         :                       refs/for/master/topic
+# Refs of upstream : main(A)
+# Refs of workbench: main(A)  tags/v123
+# git push         :                       refs/for/main/topic
 test_expect_success "proc-receive: ok ($PROTOCOL)" '
 	git -C workbench push origin \
-		HEAD:refs/for/master/topic \
+		HEAD:refs/for/main/topic \
 		>out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
 	remote: # pre-receive hook
-	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	remote: # proc-receive hook
-	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
-	remote: proc-receive> ok refs/for/master/topic
+	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
+	remote: proc-receive> ok refs/for/main/topic
 	remote: # post-receive hook
-	remote: post-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: post-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	To <URL/of/upstream.git>
-	 * [new reference] HEAD -> refs/for/master/topic
+	 * [new reference] HEAD -> refs/for/main/topic
 	EOF
 	test_cmp expect actual &&
 	git -C "$upstream" show-ref >out &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
-	<COMMIT-A> refs/heads/master
+	<COMMIT-A> refs/heads/main
 	EOF
 	test_cmp expect actual
 '

--- a/t/t5411/test-0031-report-ok--porcelain.sh
+++ b/t/t5411/test-0031-report-ok--porcelain.sh
@@ -2,35 +2,35 @@ test_expect_success "setup proc-receive hook (ok, $PROTOCOL/porcelain)" '
 	write_script "$upstream/hooks/proc-receive" <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
-		-r "ok refs/for/master/topic"
+		-r "ok refs/for/main/topic"
 	EOF
 '
 
-# Refs of upstream : master(A)
-# Refs of workbench: master(A)  tags/v123
-# git push         :                       refs/for/master/topic
+# Refs of upstream : main(A)
+# Refs of workbench: main(A)  tags/v123
+# git push         :                       refs/for/main/topic
 test_expect_success "proc-receive: ok ($PROTOCOL/porcelain)" '
 	git -C workbench push --porcelain origin \
-		HEAD:refs/for/master/topic \
+		HEAD:refs/for/main/topic \
 		>out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
 	remote: # pre-receive hook
-	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	remote: # proc-receive hook
-	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
-	remote: proc-receive> ok refs/for/master/topic
+	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
+	remote: proc-receive> ok refs/for/main/topic
 	remote: # post-receive hook
-	remote: post-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: post-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	To <URL/of/upstream.git>
-	*    HEAD:refs/for/master/topic    [new reference]
+	*    HEAD:refs/for/main/topic    [new reference]
 	Done
 	EOF
 	test_cmp expect actual &&
 	git -C "$upstream" show-ref >out &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
-	<COMMIT-A> refs/heads/master
+	<COMMIT-A> refs/heads/main
 	EOF
 	test_cmp expect actual
 '

--- a/t/t5411/test-0032-report-with-options.sh
+++ b/t/t5411/test-0032-report-with-options.sh
@@ -7,24 +7,24 @@ test_expect_success "setup proc-receive hook (option without matching ok, $PROTO
 	EOF
 '
 
-# Refs of upstream : master(A)
-# Refs of workbench: master(A)  tags/v123
-# git push         :                       refs/for/next/topic(A)  refs/for/a/b/c/topic(A)  refs/for/master/topic(A)
+# Refs of upstream : main(A)
+# Refs of workbench: main(A)  tags/v123
+# git push         :                       refs/for/next/topic(A)  refs/for/a/b/c/topic(A)  refs/for/main/topic(A)
 test_expect_success "proc-receive: report option without matching ok ($PROTOCOL)" '
 	test_must_fail git -C workbench push origin \
-		HEAD:refs/for/master/topic \
+		HEAD:refs/for/main/topic \
 		>out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
 	remote: # pre-receive hook
-	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	remote: # proc-receive hook
-	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	remote: proc-receive> option refname refs/pull/123/head
 	remote: proc-receive> option old-oid <COMMIT-B>
 	remote: error: proc-receive reported "option" without a matching "ok/ng" directive
 	To <URL/of/upstream.git>
-	 ! [remote rejected] HEAD -> refs/for/master/topic (proc-receive failed to report status)
+	 ! [remote rejected] HEAD -> refs/for/main/topic (proc-receive failed to report status)
 	EOF
 	test_cmp expect actual
 '
@@ -33,25 +33,25 @@ test_expect_success "setup proc-receive hook (option refname, $PROTOCOL)" '
 	write_script "$upstream/hooks/proc-receive" <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
-		-r "ok refs/for/master/topic" \
+		-r "ok refs/for/main/topic" \
 		-r "option refname refs/pull/123/head"
 	EOF
 '
 
-# Refs of upstream : master(A)
-# Refs of workbench: master(A)  tags/v123
-# git push         :                       refs/for/next/topic(A)  refs/for/a/b/c/topic(A)  refs/for/master/topic(A)
+# Refs of upstream : main(A)
+# Refs of workbench: main(A)  tags/v123
+# git push         :                       refs/for/next/topic(A)  refs/for/a/b/c/topic(A)  refs/for/main/topic(A)
 test_expect_success "proc-receive: report option refname ($PROTOCOL)" '
 	git -C workbench push origin \
-		HEAD:refs/for/master/topic \
+		HEAD:refs/for/main/topic \
 		>out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
 	remote: # pre-receive hook
-	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	remote: # proc-receive hook
-	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
-	remote: proc-receive> ok refs/for/master/topic
+	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
+	remote: proc-receive> ok refs/for/main/topic
 	remote: proc-receive> option refname refs/pull/123/head
 	remote: # post-receive hook
 	remote: post-receive< <ZERO-OID> <COMMIT-A> refs/pull/123/head
@@ -65,25 +65,25 @@ test_expect_success "setup proc-receive hook (option refname and forced-update, 
 	write_script "$upstream/hooks/proc-receive" <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
-		-r "ok refs/for/master/topic" \
+		-r "ok refs/for/main/topic" \
 		-r "option refname refs/pull/123/head" \
 		-r "option forced-update"
 	EOF
 '
-# Refs of upstream : master(A)
-# Refs of workbench: master(A)  tags/v123
-# git push         :                       refs/for/next/topic(A)  refs/for/a/b/c/topic(A)  refs/for/master/topic(A)
+# Refs of upstream : main(A)
+# Refs of workbench: main(A)  tags/v123
+# git push         :                       refs/for/next/topic(A)  refs/for/a/b/c/topic(A)  refs/for/main/topic(A)
 test_expect_success "proc-receive: report option refname and forced-update ($PROTOCOL)" '
 	git -C workbench push origin \
-		HEAD:refs/for/master/topic \
+		HEAD:refs/for/main/topic \
 		>out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
 	remote: # pre-receive hook
-	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	remote: # proc-receive hook
-	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
-	remote: proc-receive> ok refs/for/master/topic
+	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
+	remote: proc-receive> ok refs/for/main/topic
 	remote: proc-receive> option refname refs/pull/123/head
 	remote: proc-receive> option forced-update
 	remote: # post-receive hook
@@ -98,26 +98,26 @@ test_expect_success "setup proc-receive hook (option refname and old-oid, $PROTO
 	write_script "$upstream/hooks/proc-receive" <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
-		-r "ok refs/for/master/topic" \
+		-r "ok refs/for/main/topic" \
 		-r "option refname refs/pull/123/head" \
 		-r "option old-oid $B"
 	EOF
 '
 
-# Refs of upstream : master(A)
-# Refs of workbench: master(A)  tags/v123
-# git push         :                       refs/for/next/topic(A)  refs/for/a/b/c/topic(A)  refs/for/master/topic(A)
+# Refs of upstream : main(A)
+# Refs of workbench: main(A)  tags/v123
+# git push         :                       refs/for/next/topic(A)  refs/for/a/b/c/topic(A)  refs/for/main/topic(A)
 test_expect_success "proc-receive: report option refname and old-oid ($PROTOCOL)" '
 	git -C workbench push origin \
-		HEAD:refs/for/master/topic \
+		HEAD:refs/for/main/topic \
 		>out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
 	remote: # pre-receive hook
-	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	remote: # proc-receive hook
-	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
-	remote: proc-receive> ok refs/for/master/topic
+	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
+	remote: proc-receive> ok refs/for/main/topic
 	remote: proc-receive> option refname refs/pull/123/head
 	remote: proc-receive> option old-oid <COMMIT-B>
 	remote: # post-receive hook
@@ -132,30 +132,30 @@ test_expect_success "setup proc-receive hook (option old-oid, $PROTOCOL)" '
 	write_script "$upstream/hooks/proc-receive" <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
-		-r "ok refs/for/master/topic" \
+		-r "ok refs/for/main/topic" \
 		-r "option old-oid $B"
 	EOF
 '
 
-# Refs of upstream : master(A)
-# Refs of workbench: master(A)  tags/v123
-# git push         :                       refs/for/next/topic(A)  refs/for/a/b/c/topic(A)  refs/for/master/topic(A)
+# Refs of upstream : main(A)
+# Refs of workbench: main(A)  tags/v123
+# git push         :                       refs/for/next/topic(A)  refs/for/a/b/c/topic(A)  refs/for/main/topic(A)
 test_expect_success "proc-receive: report option old-oid ($PROTOCOL)" '
 	git -C workbench push origin \
-		HEAD:refs/for/master/topic \
+		HEAD:refs/for/main/topic \
 		>out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
 	remote: # pre-receive hook
-	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	remote: # proc-receive hook
-	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
-	remote: proc-receive> ok refs/for/master/topic
+	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
+	remote: proc-receive> ok refs/for/main/topic
 	remote: proc-receive> option old-oid <COMMIT-B>
 	remote: # post-receive hook
-	remote: post-receive< <COMMIT-B> <COMMIT-A> refs/for/master/topic
+	remote: post-receive< <COMMIT-B> <COMMIT-A> refs/for/main/topic
 	To <URL/of/upstream.git>
-	 <OID-B>..<OID-A> HEAD -> refs/for/master/topic
+	 <OID-B>..<OID-A> HEAD -> refs/for/main/topic
 	EOF
 	test_cmp expect actual
 '
@@ -164,32 +164,32 @@ test_expect_success "setup proc-receive hook (option old-oid and new-oid, $PROTO
 	write_script "$upstream/hooks/proc-receive" <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
-		-r "ok refs/for/master/topic" \
+		-r "ok refs/for/main/topic" \
 		-r "option old-oid $A" \
 		-r "option new-oid $B"
 	EOF
 '
 
-# Refs of upstream : master(A)
-# Refs of workbench: master(A)  tags/v123
-# git push         :                       refs/for/next/topic(A)  refs/for/a/b/c/topic(A)  refs/for/master/topic(A)
+# Refs of upstream : main(A)
+# Refs of workbench: main(A)  tags/v123
+# git push         :                       refs/for/next/topic(A)  refs/for/a/b/c/topic(A)  refs/for/main/topic(A)
 test_expect_success "proc-receive: report option old-oid and new-oid ($PROTOCOL)" '
 	git -C workbench push origin \
-		HEAD:refs/for/master/topic \
+		HEAD:refs/for/main/topic \
 		>out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
 	remote: # pre-receive hook
-	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	remote: # proc-receive hook
-	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
-	remote: proc-receive> ok refs/for/master/topic
+	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
+	remote: proc-receive> ok refs/for/main/topic
 	remote: proc-receive> option old-oid <COMMIT-A>
 	remote: proc-receive> option new-oid <COMMIT-B>
 	remote: # post-receive hook
-	remote: post-receive< <COMMIT-A> <COMMIT-B> refs/for/master/topic
+	remote: post-receive< <COMMIT-A> <COMMIT-B> refs/for/main/topic
 	To <URL/of/upstream.git>
-	 <OID-A>..<OID-B> HEAD -> refs/for/master/topic
+	 <OID-A>..<OID-B> HEAD -> refs/for/main/topic
 	EOF
 	test_cmp expect actual
 '
@@ -201,7 +201,7 @@ test_expect_success "setup proc-receive hook (report with multiple rewrites, $PR
 		-r "ok refs/for/a/b/c/topic" \
 		-r "ok refs/for/next/topic" \
 		-r "option refname refs/pull/123/head" \
-		-r "ok refs/for/master/topic" \
+		-r "ok refs/for/main/topic" \
 		-r "option refname refs/pull/124/head" \
 		-r "option old-oid $B" \
 		-r "option forced-update" \
@@ -209,29 +209,29 @@ test_expect_success "setup proc-receive hook (report with multiple rewrites, $PR
 	EOF
 '
 
-# Refs of upstream : master(A)
-# Refs of workbench: master(A)  tags/v123
-# git push         :                       refs/for/next/topic(A)  refs/for/a/b/c/topic(A)  refs/for/master/topic(A)
+# Refs of upstream : main(A)
+# Refs of workbench: main(A)  tags/v123
+# git push         :                       refs/for/next/topic(A)  refs/for/a/b/c/topic(A)  refs/for/main/topic(A)
 test_expect_success "proc-receive: report with multiple rewrites ($PROTOCOL)" '
 	git -C workbench push origin \
 		HEAD:refs/for/next/topic \
 		HEAD:refs/for/a/b/c/topic \
-		HEAD:refs/for/master/topic \
+		HEAD:refs/for/main/topic \
 		>out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
 	remote: # pre-receive hook
 	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/next/topic
 	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/a/b/c/topic
-	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	remote: # proc-receive hook
 	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/next/topic
 	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/a/b/c/topic
-	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	remote: proc-receive> ok refs/for/a/b/c/topic
 	remote: proc-receive> ok refs/for/next/topic
 	remote: proc-receive> option refname refs/pull/123/head
-	remote: proc-receive> ok refs/for/master/topic
+	remote: proc-receive> ok refs/for/main/topic
 	remote: proc-receive> option refname refs/pull/124/head
 	remote: proc-receive> option old-oid <COMMIT-B>
 	remote: proc-receive> option forced-update
@@ -250,7 +250,7 @@ test_expect_success "proc-receive: report with multiple rewrites ($PROTOCOL)" '
 	git -C "$upstream" show-ref >out &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
-	<COMMIT-A> refs/heads/master
+	<COMMIT-A> refs/heads/main
 	EOF
 	test_cmp expect actual
 '

--- a/t/t5411/test-0033-report-with-options--porcelain.sh
+++ b/t/t5411/test-0033-report-with-options--porcelain.sh
@@ -7,24 +7,24 @@ test_expect_success "setup proc-receive hook (option without matching ok, $PROTO
 	EOF
 '
 
-# Refs of upstream : master(A)
-# Refs of workbench: master(A)  tags/v123
-# git push         :                       refs/for/next/topic(A)  refs/for/a/b/c/topic(A)  refs/for/master/topic(A)
+# Refs of upstream : main(A)
+# Refs of workbench: main(A)  tags/v123
+# git push         :                       refs/for/next/topic(A)  refs/for/a/b/c/topic(A)  refs/for/main/topic(A)
 test_expect_success "proc-receive: report option without matching ok ($PROTOCOL/porcelain)" '
 	test_must_fail git -C workbench push --porcelain origin \
-		HEAD:refs/for/master/topic \
+		HEAD:refs/for/main/topic \
 		>out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
 	remote: # pre-receive hook
-	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	remote: # proc-receive hook
-	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	remote: proc-receive> option refname refs/pull/123/head
 	remote: proc-receive> option old-oid <COMMIT-B>
 	remote: error: proc-receive reported "option" without a matching "ok/ng" directive
 	To <URL/of/upstream.git>
-	!    HEAD:refs/for/master/topic    [remote rejected] (proc-receive failed to report status)
+	!    HEAD:refs/for/main/topic    [remote rejected] (proc-receive failed to report status)
 	Done
 	EOF
 	test_cmp expect actual
@@ -34,25 +34,25 @@ test_expect_success "setup proc-receive hook (option refname, $PROTOCOL/porcelai
 	write_script "$upstream/hooks/proc-receive" <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
-		-r "ok refs/for/master/topic" \
+		-r "ok refs/for/main/topic" \
 		-r "option refname refs/pull/123/head"
 	EOF
 '
 
-# Refs of upstream : master(A)
-# Refs of workbench: master(A)  tags/v123
-# git push         :                       refs/for/next/topic(A)  refs/for/a/b/c/topic(A)  refs/for/master/topic(A)
+# Refs of upstream : main(A)
+# Refs of workbench: main(A)  tags/v123
+# git push         :                       refs/for/next/topic(A)  refs/for/a/b/c/topic(A)  refs/for/main/topic(A)
 test_expect_success "proc-receive: report option refname ($PROTOCOL/porcelain)" '
 	git -C workbench push --porcelain origin \
-		HEAD:refs/for/master/topic \
+		HEAD:refs/for/main/topic \
 		>out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
 	remote: # pre-receive hook
-	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	remote: # proc-receive hook
-	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
-	remote: proc-receive> ok refs/for/master/topic
+	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
+	remote: proc-receive> ok refs/for/main/topic
 	remote: proc-receive> option refname refs/pull/123/head
 	remote: # post-receive hook
 	remote: post-receive< <ZERO-OID> <COMMIT-A> refs/pull/123/head
@@ -67,26 +67,26 @@ test_expect_success "setup proc-receive hook (option refname and forced-update, 
 	write_script "$upstream/hooks/proc-receive" <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
-		-r "ok refs/for/master/topic" \
+		-r "ok refs/for/main/topic" \
 		-r "option refname refs/pull/123/head" \
 		-r "option forced-update"
 	EOF
 '
 
-# Refs of upstream : master(A)
-# Refs of workbench: master(A)  tags/v123
-# git push         :                       refs/for/next/topic(A)  refs/for/a/b/c/topic(A)  refs/for/master/topic(A)
+# Refs of upstream : main(A)
+# Refs of workbench: main(A)  tags/v123
+# git push         :                       refs/for/next/topic(A)  refs/for/a/b/c/topic(A)  refs/for/main/topic(A)
 test_expect_success "proc-receive: report option refname and forced-update ($PROTOCOL/porcelain)" '
 	git -C workbench push --porcelain origin \
-		HEAD:refs/for/master/topic \
+		HEAD:refs/for/main/topic \
 		>out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
 	remote: # pre-receive hook
-	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	remote: # proc-receive hook
-	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
-	remote: proc-receive> ok refs/for/master/topic
+	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
+	remote: proc-receive> ok refs/for/main/topic
 	remote: proc-receive> option refname refs/pull/123/head
 	remote: proc-receive> option forced-update
 	remote: # post-receive hook
@@ -102,26 +102,26 @@ test_expect_success "setup proc-receive hook (option refname and old-oid, $PROTO
 	write_script "$upstream/hooks/proc-receive" <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
-		-r "ok refs/for/master/topic" \
+		-r "ok refs/for/main/topic" \
 		-r "option refname refs/pull/123/head" \
 		-r "option old-oid $B"
 	EOF
 '
 
-# Refs of upstream : master(A)
-# Refs of workbench: master(A)  tags/v123
-# git push         :                       refs/for/next/topic(A)  refs/for/a/b/c/topic(A)  refs/for/master/topic(A)
+# Refs of upstream : main(A)
+# Refs of workbench: main(A)  tags/v123
+# git push         :                       refs/for/next/topic(A)  refs/for/a/b/c/topic(A)  refs/for/main/topic(A)
 test_expect_success "proc-receive: report option refname and old-oid ($PROTOCOL/porcelain)" '
 	git -C workbench push --porcelain origin \
-		HEAD:refs/for/master/topic \
+		HEAD:refs/for/main/topic \
 		>out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
 	remote: # pre-receive hook
-	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	remote: # proc-receive hook
-	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
-	remote: proc-receive> ok refs/for/master/topic
+	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
+	remote: proc-receive> ok refs/for/main/topic
 	remote: proc-receive> option refname refs/pull/123/head
 	remote: proc-receive> option old-oid <COMMIT-B>
 	remote: # post-receive hook
@@ -137,30 +137,30 @@ test_expect_success "setup proc-receive hook (option old-oid, $PROTOCOL/porcelai
 	write_script "$upstream/hooks/proc-receive" <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
-		-r "ok refs/for/master/topic" \
+		-r "ok refs/for/main/topic" \
 		-r "option old-oid $B"
 	EOF
 '
 
-# Refs of upstream : master(A)
-# Refs of workbench: master(A)  tags/v123
-# git push         :                       refs/for/next/topic(A)  refs/for/a/b/c/topic(A)  refs/for/master/topic(A)
+# Refs of upstream : main(A)
+# Refs of workbench: main(A)  tags/v123
+# git push         :                       refs/for/next/topic(A)  refs/for/a/b/c/topic(A)  refs/for/main/topic(A)
 test_expect_success "proc-receive: report option old-oid ($PROTOCOL/porcelain)" '
 	git -C workbench push --porcelain origin \
-		HEAD:refs/for/master/topic \
+		HEAD:refs/for/main/topic \
 		>out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
 	remote: # pre-receive hook
-	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	remote: # proc-receive hook
-	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
-	remote: proc-receive> ok refs/for/master/topic
+	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
+	remote: proc-receive> ok refs/for/main/topic
 	remote: proc-receive> option old-oid <COMMIT-B>
 	remote: # post-receive hook
-	remote: post-receive< <COMMIT-B> <COMMIT-A> refs/for/master/topic
+	remote: post-receive< <COMMIT-B> <COMMIT-A> refs/for/main/topic
 	To <URL/of/upstream.git>
-	     HEAD:refs/for/master/topic    <OID-B>..<OID-A>
+	     HEAD:refs/for/main/topic    <OID-B>..<OID-A>
 	Done
 	EOF
 	test_cmp expect actual
@@ -170,32 +170,32 @@ test_expect_success "setup proc-receive hook (option old-oid and new-oid, $PROTO
 	write_script "$upstream/hooks/proc-receive" <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
-		-r "ok refs/for/master/topic" \
+		-r "ok refs/for/main/topic" \
 		-r "option old-oid $A" \
 		-r "option new-oid $B"
 	EOF
 '
 
-# Refs of upstream : master(A)
-# Refs of workbench: master(A)  tags/v123
-# git push         :                       refs/for/next/topic(A)  refs/for/a/b/c/topic(A)  refs/for/master/topic(A)
+# Refs of upstream : main(A)
+# Refs of workbench: main(A)  tags/v123
+# git push         :                       refs/for/next/topic(A)  refs/for/a/b/c/topic(A)  refs/for/main/topic(A)
 test_expect_success "proc-receive: report option old-oid and new-oid ($PROTOCOL/porcelain)" '
 	git -C workbench push --porcelain origin \
-		HEAD:refs/for/master/topic \
+		HEAD:refs/for/main/topic \
 		>out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
 	remote: # pre-receive hook
-	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	remote: # proc-receive hook
-	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
-	remote: proc-receive> ok refs/for/master/topic
+	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
+	remote: proc-receive> ok refs/for/main/topic
 	remote: proc-receive> option old-oid <COMMIT-A>
 	remote: proc-receive> option new-oid <COMMIT-B>
 	remote: # post-receive hook
-	remote: post-receive< <COMMIT-A> <COMMIT-B> refs/for/master/topic
+	remote: post-receive< <COMMIT-A> <COMMIT-B> refs/for/main/topic
 	To <URL/of/upstream.git>
-	     HEAD:refs/for/master/topic    <OID-A>..<OID-B>
+	     HEAD:refs/for/main/topic    <OID-A>..<OID-B>
 	Done
 	EOF
 	test_cmp expect actual
@@ -208,7 +208,7 @@ test_expect_success "setup proc-receive hook (report with multiple rewrites, $PR
 		-r "ok refs/for/a/b/c/topic" \
 		-r "ok refs/for/next/topic" \
 		-r "option refname refs/pull/123/head" \
-		-r "ok refs/for/master/topic" \
+		-r "ok refs/for/main/topic" \
 		-r "option refname refs/pull/124/head" \
 		-r "option old-oid $B" \
 		-r "option forced-update" \
@@ -217,29 +217,29 @@ test_expect_success "setup proc-receive hook (report with multiple rewrites, $PR
 	EOF
 '
 
-# Refs of upstream : master(A)
-# Refs of workbench: master(A)  tags/v123
-# git push         :                       refs/for/next/topic(A)  refs/for/a/b/c/topic(A)  refs/for/master/topic(A)
+# Refs of upstream : main(A)
+# Refs of workbench: main(A)  tags/v123
+# git push         :                       refs/for/next/topic(A)  refs/for/a/b/c/topic(A)  refs/for/main/topic(A)
 test_expect_success "proc-receive: report with multiple rewrites ($PROTOCOL/porcelain)" '
 	git -C workbench push --porcelain origin \
 		HEAD:refs/for/next/topic \
 		HEAD:refs/for/a/b/c/topic \
-		HEAD:refs/for/master/topic \
+		HEAD:refs/for/main/topic \
 		>out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
 	remote: # pre-receive hook
 	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/next/topic
 	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/a/b/c/topic
-	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	remote: # proc-receive hook
 	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/next/topic
 	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/a/b/c/topic
-	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	remote: proc-receive> ok refs/for/a/b/c/topic
 	remote: proc-receive> ok refs/for/next/topic
 	remote: proc-receive> option refname refs/pull/123/head
-	remote: proc-receive> ok refs/for/master/topic
+	remote: proc-receive> ok refs/for/main/topic
 	remote: proc-receive> option refname refs/pull/124/head
 	remote: proc-receive> option old-oid <COMMIT-B>
 	remote: proc-receive> option forced-update
@@ -259,7 +259,7 @@ test_expect_success "proc-receive: report with multiple rewrites ($PROTOCOL/porc
 	git -C "$upstream" show-ref >out &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
-	<COMMIT-A> refs/heads/master
+	<COMMIT-A> refs/heads/main
 	EOF
 	test_cmp expect actual
 '

--- a/t/t5411/test-0034-report-ft.sh
+++ b/t/t5411/test-0034-report-ft.sh
@@ -2,43 +2,43 @@ test_expect_success "setup proc-receive hook (ft, $PROTOCOL)" '
 	write_script "$upstream/hooks/proc-receive" <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
-		-r "ok refs/for/master/topic" \
+		-r "ok refs/for/main/topic" \
 		-r "option fall-through"
 	EOF
 '
 
-# Refs of upstream : master(A)
-# Refs of workbench: master(A)  tags/v123
-# git push         :                       refs/for/master/topic(B)
+# Refs of upstream : main(A)
+# Refs of workbench: main(A)  tags/v123
+# git push         :                       refs/for/main/topic(B)
 test_expect_success "proc-receive: fall throught, let receive-pack to execute ($PROTOCOL)" '
 	git -C workbench push origin \
-		$B:refs/for/master/topic \
+		$B:refs/for/main/topic \
 		>out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
 	remote: # pre-receive hook
-	remote: pre-receive< <ZERO-OID> <COMMIT-B> refs/for/master/topic
+	remote: pre-receive< <ZERO-OID> <COMMIT-B> refs/for/main/topic
 	remote: # proc-receive hook
-	remote: proc-receive< <ZERO-OID> <COMMIT-B> refs/for/master/topic
-	remote: proc-receive> ok refs/for/master/topic
+	remote: proc-receive< <ZERO-OID> <COMMIT-B> refs/for/main/topic
+	remote: proc-receive> ok refs/for/main/topic
 	remote: proc-receive> option fall-through
 	remote: # post-receive hook
-	remote: post-receive< <ZERO-OID> <COMMIT-B> refs/for/master/topic
+	remote: post-receive< <ZERO-OID> <COMMIT-B> refs/for/main/topic
 	To <URL/of/upstream.git>
-	 * [new reference] <COMMIT-B> -> refs/for/master/topic
+	 * [new reference] <COMMIT-B> -> refs/for/main/topic
 	EOF
 	test_cmp expect actual &&
 	git -C "$upstream" show-ref >out &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
-	<COMMIT-B> refs/for/master/topic
-	<COMMIT-A> refs/heads/master
+	<COMMIT-B> refs/for/main/topic
+	<COMMIT-A> refs/heads/main
 	EOF
 	test_cmp expect actual
 '
 
-# Refs of upstream : master(A)             refs/for/master/topic(A)
-# Refs of workbench: master(A)  tags/v123
+# Refs of upstream : main(A)             refs/for/main/topic(A)
+# Refs of workbench: main(A)  tags/v123
 test_expect_success "cleanup ($PROTOCOL)" '
-	git -C "$upstream" update-ref -d refs/for/master/topic
+	git -C "$upstream" update-ref -d refs/for/main/topic
 '

--- a/t/t5411/test-0035-report-ft--porcelain.sh
+++ b/t/t5411/test-0035-report-ft--porcelain.sh
@@ -2,44 +2,44 @@ test_expect_success "setup proc-receive hook (fall-through, $PROTOCOL/porcelain)
 	write_script "$upstream/hooks/proc-receive" <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
-		-r "ok refs/for/master/topic" \
+		-r "ok refs/for/main/topic" \
 		-r "option fall-through"
 	EOF
 '
 
-# Refs of upstream : master(A)
-# Refs of workbench: master(A)  tags/v123
-# git push         :                       refs/for/master/topic(B)
+# Refs of upstream : main(A)
+# Refs of workbench: main(A)  tags/v123
+# git push         :                       refs/for/main/topic(B)
 test_expect_success "proc-receive: fall throught, let receive-pack to execute ($PROTOCOL/porcelain)" '
 	git -C workbench push --porcelain origin \
-		$B:refs/for/master/topic \
+		$B:refs/for/main/topic \
 		>out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
 	remote: # pre-receive hook
-	remote: pre-receive< <ZERO-OID> <COMMIT-B> refs/for/master/topic
+	remote: pre-receive< <ZERO-OID> <COMMIT-B> refs/for/main/topic
 	remote: # proc-receive hook
-	remote: proc-receive< <ZERO-OID> <COMMIT-B> refs/for/master/topic
-	remote: proc-receive> ok refs/for/master/topic
+	remote: proc-receive< <ZERO-OID> <COMMIT-B> refs/for/main/topic
+	remote: proc-receive> ok refs/for/main/topic
 	remote: proc-receive> option fall-through
 	remote: # post-receive hook
-	remote: post-receive< <ZERO-OID> <COMMIT-B> refs/for/master/topic
+	remote: post-receive< <ZERO-OID> <COMMIT-B> refs/for/main/topic
 	To <URL/of/upstream.git>
-	*    <COMMIT-B>:refs/for/master/topic    [new reference]
+	*    <COMMIT-B>:refs/for/main/topic    [new reference]
 	Done
 	EOF
 	test_cmp expect actual &&
 	git -C "$upstream" show-ref >out &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
-	<COMMIT-B> refs/for/master/topic
-	<COMMIT-A> refs/heads/master
+	<COMMIT-B> refs/for/main/topic
+	<COMMIT-A> refs/heads/main
 	EOF
 	test_cmp expect actual
 '
 
-# Refs of upstream : master(A)             refs/for/master/topic(A)
-# Refs of workbench: master(A)  tags/v123
+# Refs of upstream : main(A)             refs/for/main/topic(A)
+# Refs of workbench: main(A)  tags/v123
 test_expect_success "cleanup ($PROTOCOL/porcelain)" '
-	git -C "$upstream" update-ref -d refs/for/master/topic
+	git -C "$upstream" update-ref -d refs/for/main/topic
 '

--- a/t/t5411/test-0036-report-multi-rewrite-for-one-ref.sh
+++ b/t/t5411/test-0036-report-multi-rewrite-for-one-ref.sh
@@ -17,50 +17,50 @@ test_expect_success "setup proc-receive hook (multiple rewrites for one ref, no 
 	write_script "$upstream/hooks/proc-receive" <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
-		-r "ok refs/for/master/topic" \
+		-r "ok refs/for/main/topic" \
 		-r "option old-oid $A" \
 		-r "option new-oid $B" \
-		-r "ok refs/for/master/topic" \
+		-r "ok refs/for/main/topic" \
 		-r "option refname refs/changes/24/124/1" \
 		-r "option old-oid $ZERO_OID" \
 		-r "option new-oid $A" \
-		-r "ok refs/for/master/topic" \
+		-r "ok refs/for/main/topic" \
 		-r "option refname refs/changes/25/125/1" \
 		-r "option old-oid $A" \
 		-r "option new-oid $B"
 	EOF
 '
 
-# Refs of upstream : master(A)
-# Refs of workbench: master(A)  tags/v123
-# git push         :                       refs/for/master/topic(A)
+# Refs of upstream : main(A)
+# Refs of workbench: main(A)  tags/v123
+# git push         :                       refs/for/main/topic(A)
 test_expect_success "proc-receive: multiple rewrite for one ref, no refname for the 1st rewrite ($PROTOCOL)" '
 	git -C workbench push origin \
-		HEAD:refs/for/master/topic \
+		HEAD:refs/for/main/topic \
 		>out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
 	remote: # pre-receive hook
-	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	remote: # proc-receive hook
-	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
-	remote: proc-receive> ok refs/for/master/topic
+	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
+	remote: proc-receive> ok refs/for/main/topic
 	remote: proc-receive> option old-oid <COMMIT-A>
 	remote: proc-receive> option new-oid <COMMIT-B>
-	remote: proc-receive> ok refs/for/master/topic
+	remote: proc-receive> ok refs/for/main/topic
 	remote: proc-receive> option refname refs/changes/24/124/1
 	remote: proc-receive> option old-oid <ZERO-OID>
 	remote: proc-receive> option new-oid <COMMIT-A>
-	remote: proc-receive> ok refs/for/master/topic
+	remote: proc-receive> ok refs/for/main/topic
 	remote: proc-receive> option refname refs/changes/25/125/1
 	remote: proc-receive> option old-oid <COMMIT-A>
 	remote: proc-receive> option new-oid <COMMIT-B>
 	remote: # post-receive hook
-	remote: post-receive< <COMMIT-A> <COMMIT-B> refs/for/master/topic
+	remote: post-receive< <COMMIT-A> <COMMIT-B> refs/for/main/topic
 	remote: post-receive< <ZERO-OID> <COMMIT-A> refs/changes/24/124/1
 	remote: post-receive< <COMMIT-A> <COMMIT-B> refs/changes/25/125/1
 	To <URL/of/upstream.git>
-	 <OID-A>..<OID-B> HEAD -> refs/for/master/topic
+	 <OID-A>..<OID-B> HEAD -> refs/for/main/topic
 	 * [new reference] HEAD -> refs/changes/24/124/1
 	 <OID-A>..<OID-B> HEAD -> refs/changes/25/125/1
 	EOF
@@ -68,7 +68,7 @@ test_expect_success "proc-receive: multiple rewrite for one ref, no refname for 
 	git -C "$upstream" show-ref >out &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
-	<COMMIT-A> refs/heads/master
+	<COMMIT-A> refs/heads/main
 	EOF
 	test_cmp expect actual
 '
@@ -80,10 +80,10 @@ test_expect_success "proc-receive: check remote-tracking #1 ($PROTOCOL)" '
 	cat >expect <<-EOF &&
 	<COMMIT-A> refs/t/changes/24/124/1
 	<COMMIT-B> refs/t/changes/25/125/1
-	<COMMIT-B> refs/t/for/master/topic
+	<COMMIT-B> refs/t/for/main/topic
 	EOF
 	test_cmp expect actual &&
-	git -C workbench update-ref -d refs/t/for/master/topic &&
+	git -C workbench update-ref -d refs/t/for/main/topic &&
 	git -C workbench update-ref -d refs/t/changes/24/124/1 &&
 	git -C workbench update-ref -d refs/t/changes/25/125/1
 '
@@ -92,14 +92,14 @@ test_expect_success "setup proc-receive hook (multiple rewrites for one ref, no 
 	write_script "$upstream/hooks/proc-receive" <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
-		-r "ok refs/for/master/topic" \
+		-r "ok refs/for/main/topic" \
 		-r "option refname refs/changes/24/124/1" \
 		-r "option old-oid $ZERO_OID" \
 		-r "option new-oid $A" \
-		-r "ok refs/for/master/topic" \
+		-r "ok refs/for/main/topic" \
 		-r "option old-oid $A" \
 		-r "option new-oid $B" \
-		-r "ok refs/for/master/topic" \
+		-r "ok refs/for/main/topic" \
 		-r "option refname refs/changes/25/125/1" \
 		-r "option old-oid $B" \
 		-r "option new-oid $A" \
@@ -107,45 +107,45 @@ test_expect_success "setup proc-receive hook (multiple rewrites for one ref, no 
 	EOF
 '
 
-# Refs of upstream : master(A)
-# Refs of workbench: master(A)  tags/v123
-# git push         :                       refs/for/master/topic(A)
+# Refs of upstream : main(A)
+# Refs of workbench: main(A)  tags/v123
+# git push         :                       refs/for/main/topic(A)
 test_expect_success "proc-receive: multiple rewrites for one ref, no refname for the 2nd rewrite ($PROTOCOL)" '
 	git -C workbench push origin \
-		HEAD:refs/for/master/topic \
+		HEAD:refs/for/main/topic \
 		>out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
 	remote: # pre-receive hook
-	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	remote: # proc-receive hook
-	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
-	remote: proc-receive> ok refs/for/master/topic
+	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
+	remote: proc-receive> ok refs/for/main/topic
 	remote: proc-receive> option refname refs/changes/24/124/1
 	remote: proc-receive> option old-oid <ZERO-OID>
 	remote: proc-receive> option new-oid <COMMIT-A>
-	remote: proc-receive> ok refs/for/master/topic
+	remote: proc-receive> ok refs/for/main/topic
 	remote: proc-receive> option old-oid <COMMIT-A>
 	remote: proc-receive> option new-oid <COMMIT-B>
-	remote: proc-receive> ok refs/for/master/topic
+	remote: proc-receive> ok refs/for/main/topic
 	remote: proc-receive> option refname refs/changes/25/125/1
 	remote: proc-receive> option old-oid <COMMIT-B>
 	remote: proc-receive> option new-oid <COMMIT-A>
 	remote: proc-receive> option forced-update
 	remote: # post-receive hook
 	remote: post-receive< <ZERO-OID> <COMMIT-A> refs/changes/24/124/1
-	remote: post-receive< <COMMIT-A> <COMMIT-B> refs/for/master/topic
+	remote: post-receive< <COMMIT-A> <COMMIT-B> refs/for/main/topic
 	remote: post-receive< <COMMIT-B> <COMMIT-A> refs/changes/25/125/1
 	To <URL/of/upstream.git>
 	 * [new reference] HEAD -> refs/changes/24/124/1
-	 <OID-A>..<OID-B> HEAD -> refs/for/master/topic
+	 <OID-A>..<OID-B> HEAD -> refs/for/main/topic
 	 + <OID-B>...<OID-A> HEAD -> refs/changes/25/125/1 (forced update)
 	EOF
 	test_cmp expect actual &&
 	git -C "$upstream" show-ref >out &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
-	<COMMIT-A> refs/heads/master
+	<COMMIT-A> refs/heads/main
 	EOF
 	test_cmp expect actual
 '
@@ -157,10 +157,10 @@ test_expect_success "proc-receive: check remote-tracking #2 ($PROTOCOL)" '
 	cat >expect <<-EOF &&
 	<COMMIT-A> refs/t/changes/24/124/1
 	<COMMIT-A> refs/t/changes/25/125/1
-	<COMMIT-B> refs/t/for/master/topic
+	<COMMIT-B> refs/t/for/main/topic
 	EOF
 	test_cmp expect actual &&
-	git -C workbench update-ref -d refs/t/for/master/topic &&
+	git -C workbench update-ref -d refs/t/for/main/topic &&
 	git -C workbench update-ref -d refs/t/changes/24/124/1 &&
 	git -C workbench update-ref -d refs/t/changes/25/125/1
 '
@@ -169,31 +169,31 @@ test_expect_success "setup proc-receive hook (multiple rewrites for one ref, $PR
 	write_script "$upstream/hooks/proc-receive" <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
-		-r "ok refs/for/master/topic" \
+		-r "ok refs/for/main/topic" \
 		-r "option refname refs/changes/23/123/1" \
-		-r "ok refs/for/master/topic" \
+		-r "ok refs/for/main/topic" \
 		-r "option refname refs/changes/24/124/2" \
 		-r "option old-oid $A" \
 		-r "option new-oid $B"
 	EOF
 '
 
-# Refs of upstream : master(A)
-# Refs of workbench: master(A)  tags/v123
-# git push         :                       refs/for/master/topic(A)
+# Refs of upstream : main(A)
+# Refs of workbench: main(A)  tags/v123
+# git push         :                       refs/for/main/topic(A)
 test_expect_success "proc-receive: multiple rewrites for one ref ($PROTOCOL)" '
 	git -C workbench push origin \
-		HEAD:refs/for/master/topic \
+		HEAD:refs/for/main/topic \
 		>out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
 	remote: # pre-receive hook
-	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	remote: # proc-receive hook
-	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
-	remote: proc-receive> ok refs/for/master/topic
+	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
+	remote: proc-receive> ok refs/for/main/topic
 	remote: proc-receive> option refname refs/changes/23/123/1
-	remote: proc-receive> ok refs/for/master/topic
+	remote: proc-receive> ok refs/for/main/topic
 	remote: proc-receive> option refname refs/changes/24/124/2
 	remote: proc-receive> option old-oid <COMMIT-A>
 	remote: proc-receive> option new-oid <COMMIT-B>
@@ -208,7 +208,7 @@ test_expect_success "proc-receive: multiple rewrites for one ref ($PROTOCOL)" '
 	git -C "$upstream" show-ref >out &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
-	<COMMIT-A> refs/heads/master
+	<COMMIT-A> refs/heads/main
 	EOF
 	test_cmp expect actual
 '

--- a/t/t5411/test-0037-report-multi-rewrite-for-one-ref--porcelain.sh
+++ b/t/t5411/test-0037-report-multi-rewrite-for-one-ref--porcelain.sh
@@ -2,50 +2,50 @@ test_expect_success "setup proc-receive hook (multiple rewrites for one ref, no 
 	write_script "$upstream/hooks/proc-receive" <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
-		-r "ok refs/for/master/topic" \
+		-r "ok refs/for/main/topic" \
 		-r "option old-oid $A" \
 		-r "option new-oid $B" \
-		-r "ok refs/for/master/topic" \
+		-r "ok refs/for/main/topic" \
 		-r "option refname refs/changes/24/124/1" \
 		-r "option old-oid $ZERO_OID" \
 		-r "option new-oid $A" \
-		-r "ok refs/for/master/topic" \
+		-r "ok refs/for/main/topic" \
 		-r "option refname refs/changes/25/125/1" \
 		-r "option old-oid $A" \
 		-r "option new-oid $B"
 	EOF
 '
 
-# Refs of upstream : master(A)
-# Refs of workbench: master(A)  tags/v123
-# git push         :                       refs/for/master/topic(A)
+# Refs of upstream : main(A)
+# Refs of workbench: main(A)  tags/v123
+# git push         :                       refs/for/main/topic(A)
 test_expect_success "proc-receive: multiple rewrite for one ref, no refname for the 1st rewrite ($PROTOCOL/porcelain)" '
 	git -C workbench push --porcelain origin \
-		HEAD:refs/for/master/topic \
+		HEAD:refs/for/main/topic \
 		>out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
 	remote: # pre-receive hook
-	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	remote: # proc-receive hook
-	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
-	remote: proc-receive> ok refs/for/master/topic
+	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
+	remote: proc-receive> ok refs/for/main/topic
 	remote: proc-receive> option old-oid <COMMIT-A>
 	remote: proc-receive> option new-oid <COMMIT-B>
-	remote: proc-receive> ok refs/for/master/topic
+	remote: proc-receive> ok refs/for/main/topic
 	remote: proc-receive> option refname refs/changes/24/124/1
 	remote: proc-receive> option old-oid <ZERO-OID>
 	remote: proc-receive> option new-oid <COMMIT-A>
-	remote: proc-receive> ok refs/for/master/topic
+	remote: proc-receive> ok refs/for/main/topic
 	remote: proc-receive> option refname refs/changes/25/125/1
 	remote: proc-receive> option old-oid <COMMIT-A>
 	remote: proc-receive> option new-oid <COMMIT-B>
 	remote: # post-receive hook
-	remote: post-receive< <COMMIT-A> <COMMIT-B> refs/for/master/topic
+	remote: post-receive< <COMMIT-A> <COMMIT-B> refs/for/main/topic
 	remote: post-receive< <ZERO-OID> <COMMIT-A> refs/changes/24/124/1
 	remote: post-receive< <COMMIT-A> <COMMIT-B> refs/changes/25/125/1
 	To <URL/of/upstream.git>
-	     HEAD:refs/for/master/topic    <OID-A>..<OID-B>
+	     HEAD:refs/for/main/topic    <OID-A>..<OID-B>
 	*    HEAD:refs/changes/24/124/1    [new reference]
 	     HEAD:refs/changes/25/125/1    <OID-A>..<OID-B>
 	Done
@@ -54,7 +54,7 @@ test_expect_success "proc-receive: multiple rewrite for one ref, no refname for 
 	git -C "$upstream" show-ref >out &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
-	<COMMIT-A> refs/heads/master
+	<COMMIT-A> refs/heads/main
 	EOF
 	test_cmp expect actual
 '
@@ -63,14 +63,14 @@ test_expect_success "setup proc-receive hook (multiple rewrites for one ref, no 
 	write_script "$upstream/hooks/proc-receive" <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
-		-r "ok refs/for/master/topic" \
+		-r "ok refs/for/main/topic" \
 		-r "option refname refs/changes/24/124/1" \
 		-r "option old-oid $ZERO_OID" \
 		-r "option new-oid $A" \
-		-r "ok refs/for/master/topic" \
+		-r "ok refs/for/main/topic" \
 		-r "option old-oid $A" \
 		-r "option new-oid $B" \
-		-r "ok refs/for/master/topic" \
+		-r "ok refs/for/main/topic" \
 		-r "option refname refs/changes/25/125/1" \
 		-r "option old-oid $B" \
 		-r "option new-oid $A" \
@@ -78,38 +78,38 @@ test_expect_success "setup proc-receive hook (multiple rewrites for one ref, no 
 	EOF
 '
 
-# Refs of upstream : master(A)
-# Refs of workbench: master(A)  tags/v123
-# git push         :                       refs/for/master/topic(A)
+# Refs of upstream : main(A)
+# Refs of workbench: main(A)  tags/v123
+# git push         :                       refs/for/main/topic(A)
 test_expect_success "proc-receive: multiple rewrites for one ref, no refname for the 2nd rewrite ($PROTOCOL/porcelain)" '
 	git -C workbench push --porcelain origin \
-		HEAD:refs/for/master/topic \
+		HEAD:refs/for/main/topic \
 		>out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
 	remote: # pre-receive hook
-	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	remote: # proc-receive hook
-	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
-	remote: proc-receive> ok refs/for/master/topic
+	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
+	remote: proc-receive> ok refs/for/main/topic
 	remote: proc-receive> option refname refs/changes/24/124/1
 	remote: proc-receive> option old-oid <ZERO-OID>
 	remote: proc-receive> option new-oid <COMMIT-A>
-	remote: proc-receive> ok refs/for/master/topic
+	remote: proc-receive> ok refs/for/main/topic
 	remote: proc-receive> option old-oid <COMMIT-A>
 	remote: proc-receive> option new-oid <COMMIT-B>
-	remote: proc-receive> ok refs/for/master/topic
+	remote: proc-receive> ok refs/for/main/topic
 	remote: proc-receive> option refname refs/changes/25/125/1
 	remote: proc-receive> option old-oid <COMMIT-B>
 	remote: proc-receive> option new-oid <COMMIT-A>
 	remote: proc-receive> option forced-update
 	remote: # post-receive hook
 	remote: post-receive< <ZERO-OID> <COMMIT-A> refs/changes/24/124/1
-	remote: post-receive< <COMMIT-A> <COMMIT-B> refs/for/master/topic
+	remote: post-receive< <COMMIT-A> <COMMIT-B> refs/for/main/topic
 	remote: post-receive< <COMMIT-B> <COMMIT-A> refs/changes/25/125/1
 	To <URL/of/upstream.git>
 	*    HEAD:refs/changes/24/124/1    [new reference]
-	     HEAD:refs/for/master/topic    <OID-A>..<OID-B>
+	     HEAD:refs/for/main/topic    <OID-A>..<OID-B>
 	+    HEAD:refs/changes/25/125/1    <OID-B>...<OID-A> (forced update)
 	Done
 	EOF
@@ -117,7 +117,7 @@ test_expect_success "proc-receive: multiple rewrites for one ref, no refname for
 	git -C "$upstream" show-ref >out &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
-	<COMMIT-A> refs/heads/master
+	<COMMIT-A> refs/heads/main
 	EOF
 	test_cmp expect actual
 '
@@ -126,31 +126,31 @@ test_expect_success "setup proc-receive hook (multiple rewrites for one ref, $PR
 	write_script "$upstream/hooks/proc-receive" <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
-		-r "ok refs/for/master/topic" \
+		-r "ok refs/for/main/topic" \
 		-r "option refname refs/changes/23/123/1" \
-		-r "ok refs/for/master/topic" \
+		-r "ok refs/for/main/topic" \
 		-r "option refname refs/changes/24/124/2" \
 		-r "option old-oid $A" \
 		-r "option new-oid $B"
 	EOF
 '
 
-# Refs of upstream : master(A)
-# Refs of workbench: master(A)  tags/v123
-# git push         :                       refs/for/master/topic(A)
+# Refs of upstream : main(A)
+# Refs of workbench: main(A)  tags/v123
+# git push         :                       refs/for/main/topic(A)
 test_expect_success "proc-receive: multiple rewrites for one ref ($PROTOCOL/porcelain)" '
 	git -C workbench push --porcelain origin \
-		HEAD:refs/for/master/topic \
+		HEAD:refs/for/main/topic \
 		>out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
 	remote: # pre-receive hook
-	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	remote: # proc-receive hook
-	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
-	remote: proc-receive> ok refs/for/master/topic
+	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
+	remote: proc-receive> ok refs/for/main/topic
 	remote: proc-receive> option refname refs/changes/23/123/1
-	remote: proc-receive> ok refs/for/master/topic
+	remote: proc-receive> ok refs/for/main/topic
 	remote: proc-receive> option refname refs/changes/24/124/2
 	remote: proc-receive> option old-oid <COMMIT-A>
 	remote: proc-receive> option new-oid <COMMIT-B>
@@ -166,7 +166,7 @@ test_expect_success "proc-receive: multiple rewrites for one ref ($PROTOCOL/porc
 	git -C "$upstream" show-ref >out &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
-	<COMMIT-A> refs/heads/master
+	<COMMIT-A> refs/heads/main
 	EOF
 	test_cmp expect actual
 '

--- a/t/t5411/test-0038-report-mixed-refs.sh
+++ b/t/t5411/test-0038-report-mixed-refs.sh
@@ -4,63 +4,63 @@ test_expect_success "setup proc-receive hook ($PROTOCOL)" '
 	test-tool proc-receive -v \
 		-r "ok refs/for/next/topic2" \
 		-r "ng refs/for/next/topic1 fail to call Web API" \
-		-r "ok refs/for/master/topic" \
-		-r "option refname refs/for/master/topic" \
+		-r "ok refs/for/main/topic" \
+		-r "option refname refs/for/main/topic" \
 		-r "option old-oid $A" \
 		-r "option new-oid $B"
 	EOF
 '
 
-# Refs of upstream : master(A)
-# Refs of workbench: master(A)  tags/v123
-# git push         : (B)                   bar(A)  baz(A)  refs/for/next/topic(A)  foo(A)  refs/for/master/topic(A)
+# Refs of upstream : main(A)
+# Refs of workbench: main(A)  tags/v123
+# git push         : (B)                   bar(A)  baz(A)  refs/for/next/topic(A)  foo(A)  refs/for/main/topic(A)
 test_expect_success "proc-receive: report update of mixed refs ($PROTOCOL)" '
 	test_must_fail git -C workbench push origin \
-		$B:refs/heads/master \
+		$B:refs/heads/main \
 		HEAD:refs/heads/bar \
 		HEAD:refs/heads/baz \
 		HEAD:refs/for/next/topic2 \
 		HEAD:refs/for/next/topic1 \
 		HEAD:refs/heads/foo \
-		HEAD:refs/for/master/topic \
+		HEAD:refs/for/main/topic \
 		HEAD:refs/for/next/topic3 \
 		>out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
 	remote: # pre-receive hook
-	remote: pre-receive< <COMMIT-A> <COMMIT-B> refs/heads/master
+	remote: pre-receive< <COMMIT-A> <COMMIT-B> refs/heads/main
 	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/heads/bar
 	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/heads/baz
 	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/next/topic2
 	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/next/topic1
 	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/heads/foo
-	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/next/topic3
 	remote: # proc-receive hook
 	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/next/topic2
 	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/next/topic1
-	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/next/topic3
 	remote: proc-receive> ok refs/for/next/topic2
 	remote: proc-receive> ng refs/for/next/topic1 fail to call Web API
-	remote: proc-receive> ok refs/for/master/topic
-	remote: proc-receive> option refname refs/for/master/topic
+	remote: proc-receive> ok refs/for/main/topic
+	remote: proc-receive> option refname refs/for/main/topic
 	remote: proc-receive> option old-oid <COMMIT-A>
 	remote: proc-receive> option new-oid <COMMIT-B>
 	remote: # post-receive hook
-	remote: post-receive< <COMMIT-A> <COMMIT-B> refs/heads/master
+	remote: post-receive< <COMMIT-A> <COMMIT-B> refs/heads/main
 	remote: post-receive< <ZERO-OID> <COMMIT-A> refs/heads/bar
 	remote: post-receive< <ZERO-OID> <COMMIT-A> refs/heads/baz
 	remote: post-receive< <ZERO-OID> <COMMIT-A> refs/for/next/topic2
 	remote: post-receive< <ZERO-OID> <COMMIT-A> refs/heads/foo
-	remote: post-receive< <COMMIT-A> <COMMIT-B> refs/for/master/topic
+	remote: post-receive< <COMMIT-A> <COMMIT-B> refs/for/main/topic
 	To <URL/of/upstream.git>
-	 <OID-A>..<OID-B> <COMMIT-B> -> master
+	 <OID-A>..<OID-B> <COMMIT-B> -> main
 	 * [new branch] HEAD -> bar
 	 * [new branch] HEAD -> baz
 	 * [new reference] HEAD -> refs/for/next/topic2
 	 * [new branch] HEAD -> foo
-	 <OID-A>..<OID-B> HEAD -> refs/for/master/topic
+	 <OID-A>..<OID-B> HEAD -> refs/for/main/topic
 	 ! [remote rejected] HEAD -> refs/for/next/topic1 (fail to call Web API)
 	 ! [remote rejected] HEAD -> refs/for/next/topic3 (proc-receive failed to report status)
 	EOF
@@ -71,17 +71,17 @@ test_expect_success "proc-receive: report update of mixed refs ($PROTOCOL)" '
 	<COMMIT-A> refs/heads/bar
 	<COMMIT-A> refs/heads/baz
 	<COMMIT-A> refs/heads/foo
-	<COMMIT-B> refs/heads/master
+	<COMMIT-B> refs/heads/main
 	EOF
 	test_cmp expect actual
 '
 
-# Refs of upstream : master(B)             foo(A)  bar(A))  baz(A)
-# Refs of workbench: master(A)  tags/v123
+# Refs of upstream : main(B)             foo(A)  bar(A))  baz(A)
+# Refs of workbench: main(A)  tags/v123
 test_expect_success "cleanup ($PROTOCOL)" '
 	(
 		cd "$upstream" &&
-		git update-ref refs/heads/master $A &&
+		git update-ref refs/heads/main $A &&
 		git update-ref -d refs/heads/foo &&
 		git update-ref -d refs/heads/bar &&
 		git update-ref -d refs/heads/baz

--- a/t/t5411/test-0039-report-mixed-refs--porcelain.sh
+++ b/t/t5411/test-0039-report-mixed-refs--porcelain.sh
@@ -4,63 +4,63 @@ test_expect_success "setup proc-receive hook ($PROTOCOL/porcelain)" '
 	test-tool proc-receive -v \
 		-r "ok refs/for/next/topic2" \
 		-r "ng refs/for/next/topic1 fail to call Web API" \
-		-r "ok refs/for/master/topic" \
-		-r "option refname refs/for/master/topic" \
+		-r "ok refs/for/main/topic" \
+		-r "option refname refs/for/main/topic" \
 		-r "option old-oid $A" \
 		-r "option new-oid $B"
 	EOF
 '
 
-# Refs of upstream : master(A)
-# Refs of workbench: master(A)  tags/v123
-# git push         : (B)                   bar(A)  baz(A)  refs/for/next/topic(A)  foo(A)  refs/for/master/topic(A)
+# Refs of upstream : main(A)
+# Refs of workbench: main(A)  tags/v123
+# git push         : (B)                   bar(A)  baz(A)  refs/for/next/topic(A)  foo(A)  refs/for/main/topic(A)
 test_expect_success "proc-receive: report update of mixed refs ($PROTOCOL/porcelain)" '
 	test_must_fail git -C workbench push --porcelain origin \
-		$B:refs/heads/master \
+		$B:refs/heads/main \
 		HEAD:refs/heads/bar \
 		HEAD:refs/heads/baz \
 		HEAD:refs/for/next/topic2 \
 		HEAD:refs/for/next/topic1 \
 		HEAD:refs/heads/foo \
-		HEAD:refs/for/master/topic \
+		HEAD:refs/for/main/topic \
 		HEAD:refs/for/next/topic3 \
 		>out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
 	remote: # pre-receive hook
-	remote: pre-receive< <COMMIT-A> <COMMIT-B> refs/heads/master
+	remote: pre-receive< <COMMIT-A> <COMMIT-B> refs/heads/main
 	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/heads/bar
 	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/heads/baz
 	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/next/topic2
 	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/next/topic1
 	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/heads/foo
-	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/next/topic3
 	remote: # proc-receive hook
 	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/next/topic2
 	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/next/topic1
-	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/next/topic3
 	remote: proc-receive> ok refs/for/next/topic2
 	remote: proc-receive> ng refs/for/next/topic1 fail to call Web API
-	remote: proc-receive> ok refs/for/master/topic
-	remote: proc-receive> option refname refs/for/master/topic
+	remote: proc-receive> ok refs/for/main/topic
+	remote: proc-receive> option refname refs/for/main/topic
 	remote: proc-receive> option old-oid <COMMIT-A>
 	remote: proc-receive> option new-oid <COMMIT-B>
 	remote: # post-receive hook
-	remote: post-receive< <COMMIT-A> <COMMIT-B> refs/heads/master
+	remote: post-receive< <COMMIT-A> <COMMIT-B> refs/heads/main
 	remote: post-receive< <ZERO-OID> <COMMIT-A> refs/heads/bar
 	remote: post-receive< <ZERO-OID> <COMMIT-A> refs/heads/baz
 	remote: post-receive< <ZERO-OID> <COMMIT-A> refs/for/next/topic2
 	remote: post-receive< <ZERO-OID> <COMMIT-A> refs/heads/foo
-	remote: post-receive< <COMMIT-A> <COMMIT-B> refs/for/master/topic
+	remote: post-receive< <COMMIT-A> <COMMIT-B> refs/for/main/topic
 	To <URL/of/upstream.git>
-	     <COMMIT-B>:refs/heads/master    <OID-A>..<OID-B>
+	     <COMMIT-B>:refs/heads/main    <OID-A>..<OID-B>
 	*    HEAD:refs/heads/bar    [new branch]
 	*    HEAD:refs/heads/baz    [new branch]
 	*    HEAD:refs/for/next/topic2    [new reference]
 	*    HEAD:refs/heads/foo    [new branch]
-	     HEAD:refs/for/master/topic    <OID-A>..<OID-B>
+	     HEAD:refs/for/main/topic    <OID-A>..<OID-B>
 	!    HEAD:refs/for/next/topic1    [remote rejected] (fail to call Web API)
 	!    HEAD:refs/for/next/topic3    [remote rejected] (proc-receive failed to report status)
 	Done
@@ -72,17 +72,17 @@ test_expect_success "proc-receive: report update of mixed refs ($PROTOCOL/porcel
 	<COMMIT-A> refs/heads/bar
 	<COMMIT-A> refs/heads/baz
 	<COMMIT-A> refs/heads/foo
-	<COMMIT-B> refs/heads/master
+	<COMMIT-B> refs/heads/main
 	EOF
 	test_cmp expect actual
 '
 
-# Refs of upstream : master(B)             foo(A)  bar(A))  baz(A)
-# Refs of workbench: master(A)  tags/v123
+# Refs of upstream : main(B)             foo(A)  bar(A))  baz(A)
+# Refs of workbench: main(A)  tags/v123
 test_expect_success "cleanup ($PROTOCOL/porcelain)" '
 	(
 		cd "$upstream" &&
-		git update-ref refs/heads/master $A &&
+		git update-ref refs/heads/main $A &&
 		git update-ref -d refs/heads/foo &&
 		git update-ref -d refs/heads/bar &&
 		git update-ref -d refs/heads/baz

--- a/t/t5411/test-0040-process-all-refs.sh
+++ b/t/t5411/test-0040-process-all-refs.sh
@@ -3,12 +3,12 @@ test_expect_success "config receive.procReceiveRefs = refs ($PROTOCOL)" '
 	git -C "$upstream" config --add receive.procReceiveRefs refs
 '
 
-# Refs of upstream : master(A)
-# Refs of workbench: master(A)  tags/v123
+# Refs of upstream : main(A)
+# Refs of workbench: main(A)  tags/v123
 test_expect_success "setup upstream branches ($PROTOCOL)" '
 	(
 		cd "$upstream" &&
-		git update-ref refs/heads/master $B &&
+		git update-ref refs/heads/main $B &&
 		git update-ref refs/heads/foo $A &&
 		git update-ref refs/heads/bar $A &&
 		git update-ref refs/heads/baz $A
@@ -20,13 +20,13 @@ test_expect_success "setup proc-receive hook ($PROTOCOL)" '
 	write_script "$upstream/hooks/proc-receive" <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
-		-r "ok refs/heads/master" \
+		-r "ok refs/heads/main" \
 		-r "option fall-through" \
 		-r "ok refs/heads/foo" \
 		-r "option fall-through" \
 		-r "ok refs/heads/bar" \
 		-r "option fall-through" \
-		-r "ok refs/for/master/topic" \
+		-r "ok refs/for/main/topic" \
 		-r "option refname refs/pull/123/head" \
 		-r "option old-oid $A" \
 		-r "option new-oid $B" \
@@ -38,15 +38,15 @@ test_expect_success "setup proc-receive hook ($PROTOCOL)" '
 	EOF
 '
 
-# Refs of upstream : master(B)             foo(A)  bar(A))  baz(A)
-# Refs of workbench: master(A)  tags/v123
-# git push -f      : master(A)             (NULL)  (B)              refs/for/master/topic(A)  refs/for/next/topic(A)
+# Refs of upstream : main(B)             foo(A)  bar(A))  baz(A)
+# Refs of workbench: main(A)  tags/v123
+# git push -f      : main(A)             (NULL)  (B)              refs/for/main/topic(A)  refs/for/next/topic(A)
 test_expect_success "proc-receive: process all refs ($PROTOCOL)" '
 	git -C workbench push -f origin \
-		HEAD:refs/heads/master \
+		HEAD:refs/heads/main \
 		:refs/heads/foo \
 		$B:refs/heads/bar \
-		HEAD:refs/for/master/topic \
+		HEAD:refs/for/main/topic \
 		HEAD:refs/for/next/topic \
 		>out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
@@ -54,22 +54,22 @@ test_expect_success "proc-receive: process all refs ($PROTOCOL)" '
 	remote: # pre-receive hook
 	remote: pre-receive< <COMMIT-A> <COMMIT-B> refs/heads/bar
 	remote: pre-receive< <COMMIT-A> <ZERO-OID> refs/heads/foo
-	remote: pre-receive< <COMMIT-B> <COMMIT-A> refs/heads/master
-	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: pre-receive< <COMMIT-B> <COMMIT-A> refs/heads/main
+	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/next/topic
 	remote: # proc-receive hook
 	remote: proc-receive< <COMMIT-A> <COMMIT-B> refs/heads/bar
 	remote: proc-receive< <COMMIT-A> <ZERO-OID> refs/heads/foo
-	remote: proc-receive< <COMMIT-B> <COMMIT-A> refs/heads/master
-	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: proc-receive< <COMMIT-B> <COMMIT-A> refs/heads/main
+	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/next/topic
-	remote: proc-receive> ok refs/heads/master
+	remote: proc-receive> ok refs/heads/main
 	remote: proc-receive> option fall-through
 	remote: proc-receive> ok refs/heads/foo
 	remote: proc-receive> option fall-through
 	remote: proc-receive> ok refs/heads/bar
 	remote: proc-receive> option fall-through
-	remote: proc-receive> ok refs/for/master/topic
+	remote: proc-receive> ok refs/for/main/topic
 	remote: proc-receive> option refname refs/pull/123/head
 	remote: proc-receive> option old-oid <COMMIT-A>
 	remote: proc-receive> option new-oid <COMMIT-B>
@@ -81,13 +81,13 @@ test_expect_success "proc-receive: process all refs ($PROTOCOL)" '
 	remote: # post-receive hook
 	remote: post-receive< <COMMIT-A> <COMMIT-B> refs/heads/bar
 	remote: post-receive< <COMMIT-A> <ZERO-OID> refs/heads/foo
-	remote: post-receive< <COMMIT-B> <COMMIT-A> refs/heads/master
+	remote: post-receive< <COMMIT-B> <COMMIT-A> refs/heads/main
 	remote: post-receive< <COMMIT-A> <COMMIT-B> refs/pull/123/head
 	remote: post-receive< <COMMIT-B> <COMMIT-A> refs/pull/124/head
 	To <URL/of/upstream.git>
 	 <OID-A>..<OID-B> <COMMIT-B> -> bar
 	 - [deleted] foo
-	 + <OID-B>...<OID-A> HEAD -> master (forced update)
+	 + <OID-B>...<OID-A> HEAD -> main (forced update)
 	 <OID-A>..<OID-B> HEAD -> refs/pull/123/head
 	 + <OID-B>...<OID-A> HEAD -> refs/pull/124/head (forced update)
 	EOF
@@ -97,13 +97,13 @@ test_expect_success "proc-receive: process all refs ($PROTOCOL)" '
 	cat >expect <<-EOF &&
 	<COMMIT-B> refs/heads/bar
 	<COMMIT-A> refs/heads/baz
-	<COMMIT-A> refs/heads/master
+	<COMMIT-A> refs/heads/main
 	EOF
 	test_cmp expect actual
 '
 
-# Refs of upstream : master(A)             bar(A)  baz(B)
-# Refs of workbench: master(A)  tags/v123
+# Refs of upstream : main(A)             bar(A)  baz(B)
+# Refs of workbench: main(A)  tags/v123
 test_expect_success "cleanup ($PROTOCOL)" '
 	(
 		cd "$upstream" &&

--- a/t/t5411/test-0041-process-all-refs--porcelain.sh
+++ b/t/t5411/test-0041-process-all-refs--porcelain.sh
@@ -3,12 +3,12 @@ test_expect_success "config receive.procReceiveRefs = refs ($PROTOCOL/porcelain)
 	git -C "$upstream" config --add receive.procReceiveRefs refs
 '
 
-# Refs of upstream : master(A)
-# Refs of workbench: master(A)  tags/v123
+# Refs of upstream : main(A)
+# Refs of workbench: main(A)  tags/v123
 test_expect_success "setup upstream branches ($PROTOCOL/porcelain)" '
 	(
 		cd "$upstream" &&
-		git update-ref refs/heads/master $B &&
+		git update-ref refs/heads/main $B &&
 		git update-ref refs/heads/foo $A &&
 		git update-ref refs/heads/bar $A &&
 		git update-ref refs/heads/baz $A
@@ -20,13 +20,13 @@ test_expect_success "setup proc-receive hook ($PROTOCOL/porcelain)" '
 	write_script "$upstream/hooks/proc-receive" <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
-		-r "ok refs/heads/master" \
+		-r "ok refs/heads/main" \
 		-r "option fall-through" \
 		-r "ok refs/heads/foo" \
 		-r "option fall-through" \
 		-r "ok refs/heads/bar" \
 		-r "option fall-through" \
-		-r "ok refs/for/master/topic" \
+		-r "ok refs/for/main/topic" \
 		-r "option refname refs/pull/123/head" \
 		-r "option old-oid $A" \
 		-r "option new-oid $B" \
@@ -38,15 +38,15 @@ test_expect_success "setup proc-receive hook ($PROTOCOL/porcelain)" '
 	EOF
 '
 
-# Refs of upstream : master(B)             foo(A)  bar(A))  baz(A)
-# Refs of workbench: master(A)  tags/v123
-# git push -f      : master(A)             (NULL)  (B)              refs/for/master/topic(A)  refs/for/next/topic(A)
+# Refs of upstream : main(B)             foo(A)  bar(A))  baz(A)
+# Refs of workbench: main(A)  tags/v123
+# git push -f      : main(A)             (NULL)  (B)              refs/for/main/topic(A)  refs/for/next/topic(A)
 test_expect_success "proc-receive: process all refs ($PROTOCOL/porcelain)" '
 	git -C workbench push --porcelain -f origin \
-		HEAD:refs/heads/master \
+		HEAD:refs/heads/main \
 		:refs/heads/foo \
 		$B:refs/heads/bar \
-		HEAD:refs/for/master/topic \
+		HEAD:refs/for/main/topic \
 		HEAD:refs/for/next/topic \
 		>out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
@@ -54,22 +54,22 @@ test_expect_success "proc-receive: process all refs ($PROTOCOL/porcelain)" '
 	remote: # pre-receive hook
 	remote: pre-receive< <COMMIT-A> <COMMIT-B> refs/heads/bar
 	remote: pre-receive< <COMMIT-A> <ZERO-OID> refs/heads/foo
-	remote: pre-receive< <COMMIT-B> <COMMIT-A> refs/heads/master
-	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: pre-receive< <COMMIT-B> <COMMIT-A> refs/heads/main
+	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/for/next/topic
 	remote: # proc-receive hook
 	remote: proc-receive< <COMMIT-A> <COMMIT-B> refs/heads/bar
 	remote: proc-receive< <COMMIT-A> <ZERO-OID> refs/heads/foo
-	remote: proc-receive< <COMMIT-B> <COMMIT-A> refs/heads/master
-	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/master/topic
+	remote: proc-receive< <COMMIT-B> <COMMIT-A> refs/heads/main
+	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/main/topic
 	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/for/next/topic
-	remote: proc-receive> ok refs/heads/master
+	remote: proc-receive> ok refs/heads/main
 	remote: proc-receive> option fall-through
 	remote: proc-receive> ok refs/heads/foo
 	remote: proc-receive> option fall-through
 	remote: proc-receive> ok refs/heads/bar
 	remote: proc-receive> option fall-through
-	remote: proc-receive> ok refs/for/master/topic
+	remote: proc-receive> ok refs/for/main/topic
 	remote: proc-receive> option refname refs/pull/123/head
 	remote: proc-receive> option old-oid <COMMIT-A>
 	remote: proc-receive> option new-oid <COMMIT-B>
@@ -81,13 +81,13 @@ test_expect_success "proc-receive: process all refs ($PROTOCOL/porcelain)" '
 	remote: # post-receive hook
 	remote: post-receive< <COMMIT-A> <COMMIT-B> refs/heads/bar
 	remote: post-receive< <COMMIT-A> <ZERO-OID> refs/heads/foo
-	remote: post-receive< <COMMIT-B> <COMMIT-A> refs/heads/master
+	remote: post-receive< <COMMIT-B> <COMMIT-A> refs/heads/main
 	remote: post-receive< <COMMIT-A> <COMMIT-B> refs/pull/123/head
 	remote: post-receive< <COMMIT-B> <COMMIT-A> refs/pull/124/head
 	To <URL/of/upstream.git>
 	     <COMMIT-B>:refs/heads/bar    <OID-A>..<OID-B>
 	-    :refs/heads/foo    [deleted]
-	+    HEAD:refs/heads/master    <OID-B>...<OID-A> (forced update)
+	+    HEAD:refs/heads/main    <OID-B>...<OID-A> (forced update)
 	     HEAD:refs/pull/123/head    <OID-A>..<OID-B>
 	+    HEAD:refs/pull/124/head    <OID-B>...<OID-A> (forced update)
 	Done
@@ -98,13 +98,13 @@ test_expect_success "proc-receive: process all refs ($PROTOCOL/porcelain)" '
 	cat >expect <<-EOF &&
 	<COMMIT-B> refs/heads/bar
 	<COMMIT-A> refs/heads/baz
-	<COMMIT-A> refs/heads/master
+	<COMMIT-A> refs/heads/main
 	EOF
 	test_cmp expect actual
 '
 
-# Refs of upstream : master(A)             bar(A)  baz(B)
-# Refs of workbench: master(A)  tags/v123
+# Refs of upstream : main(A)             bar(A)  baz(B)
+# Refs of workbench: main(A)  tags/v123
 test_expect_success "cleanup ($PROTOCOL/porcelain)" '
 	(
 		cd "$upstream" &&

--- a/t/t5411/test-0050-proc-receive-refs-with-modifiers.sh
+++ b/t/t5411/test-0050-proc-receive-refs-with-modifiers.sh
@@ -2,7 +2,7 @@ test_expect_success "config receive.procReceiveRefs with modifiers ($PROTOCOL)" 
 	(
 		cd "$upstream" &&
 		git config --unset-all receive.procReceiveRefs &&
-		git config --add receive.procReceiveRefs m:refs/heads/master &&
+		git config --add receive.procReceiveRefs m:refs/heads/main &&
 		git config --add receive.procReceiveRefs ad:refs/heads &&
 		git config --add receive.procReceiveRefs "a!:refs/heads"
 	)
@@ -12,7 +12,7 @@ test_expect_success "setup proc-receive hook ($PROTOCOL)" '
 	write_script "$upstream/hooks/proc-receive" <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
-		-r "ok refs/heads/master" \
+		-r "ok refs/heads/main" \
 		-r "option refname refs/pull/123/head" \
 		-r "option old-oid $A" \
 		-r "option new-oid $B" \
@@ -21,22 +21,22 @@ test_expect_success "setup proc-receive hook ($PROTOCOL)" '
 	EOF
 '
 
-# Refs of upstream : master(A)
-# Refs of workbench: master(A)  tags/v123
-# git push         : master(B)  tags/v123
+# Refs of upstream : main(A)
+# Refs of workbench: main(A)  tags/v123
+# git push         : main(B)  tags/v123
 test_expect_success "proc-receive: update branch and new tag ($PROTOCOL)" '
 	git -C workbench push origin \
-		$B:refs/heads/master \
+		$B:refs/heads/main \
 		v123 >out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
 	remote: # pre-receive hook
-	remote: pre-receive< <COMMIT-A> <COMMIT-B> refs/heads/master
+	remote: pre-receive< <COMMIT-A> <COMMIT-B> refs/heads/main
 	remote: pre-receive< <ZERO-OID> <TAG-v123> refs/tags/v123
 	remote: # proc-receive hook
-	remote: proc-receive< <COMMIT-A> <COMMIT-B> refs/heads/master
+	remote: proc-receive< <COMMIT-A> <COMMIT-B> refs/heads/main
 	remote: proc-receive< <ZERO-OID> <TAG-v123> refs/tags/v123
-	remote: proc-receive> ok refs/heads/master
+	remote: proc-receive> ok refs/heads/main
 	remote: proc-receive> option refname refs/pull/123/head
 	remote: proc-receive> option old-oid <COMMIT-A>
 	remote: proc-receive> option new-oid <COMMIT-B>
@@ -53,20 +53,20 @@ test_expect_success "proc-receive: update branch and new tag ($PROTOCOL)" '
 	git -C "$upstream" show-ref >out &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
-	<COMMIT-A> refs/heads/master
+	<COMMIT-A> refs/heads/main
 	EOF
 	test_cmp expect actual
 '
 
-# Refs of upstream : master(A)
-# Refs of workbench: master(A)  tags/v123
+# Refs of upstream : main(A)
+# Refs of workbench: main(A)  tags/v123
 test_expect_success "setup upstream: create tags/v123 ($PROTOCOL)" '
 	git -C "$upstream" update-ref refs/heads/topic $A &&
 	git -C "$upstream" update-ref refs/tags/v123 $TAG &&
 	git -C "$upstream" show-ref >out &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
-	<COMMIT-A> refs/heads/master
+	<COMMIT-A> refs/heads/main
 	<COMMIT-A> refs/heads/topic
 	<TAG-v123> refs/tags/v123
 	EOF
@@ -77,7 +77,7 @@ test_expect_success "setup proc-receive hook ($PROTOCOL)" '
 	write_script "$upstream/hooks/proc-receive" <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
-		-r "ok refs/heads/master" \
+		-r "ok refs/heads/main" \
 		-r "option refname refs/pull/123/head" \
 		-r "option old-oid $A" \
 		-r "option new-oid $ZERO_OID" \
@@ -87,26 +87,26 @@ test_expect_success "setup proc-receive hook ($PROTOCOL)" '
 	EOF
 '
 
-# Refs of upstream : master(A)  topic(A)  tags/v123
-# Refs of workbench: master(A)            tags/v123
+# Refs of upstream : main(A)  topic(A)  tags/v123
+# Refs of workbench: main(A)            tags/v123
 # git push         : NULL       topic(B)  NULL       next(A)
 test_expect_success "proc-receive: create/delete branch, and delete tag ($PROTOCOL)" '
 	git -C workbench push origin \
-		:refs/heads/master \
+		:refs/heads/main \
 		$B:refs/heads/topic \
 		$A:refs/heads/next \
 		:refs/tags/v123 >out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
 	remote: # pre-receive hook
-	remote: pre-receive< <COMMIT-A> <ZERO-OID> refs/heads/master
+	remote: pre-receive< <COMMIT-A> <ZERO-OID> refs/heads/main
 	remote: pre-receive< <COMMIT-A> <COMMIT-B> refs/heads/topic
 	remote: pre-receive< <TAG-v123> <ZERO-OID> refs/tags/v123
 	remote: pre-receive< <ZERO-OID> <COMMIT-A> refs/heads/next
 	remote: # proc-receive hook
-	remote: proc-receive< <COMMIT-A> <ZERO-OID> refs/heads/master
+	remote: proc-receive< <COMMIT-A> <ZERO-OID> refs/heads/main
 	remote: proc-receive< <ZERO-OID> <COMMIT-A> refs/heads/next
-	remote: proc-receive> ok refs/heads/master
+	remote: proc-receive> ok refs/heads/main
 	remote: proc-receive> option refname refs/pull/123/head
 	remote: proc-receive> option old-oid <COMMIT-A>
 	remote: proc-receive> option new-oid <ZERO-OID>
@@ -128,7 +128,7 @@ test_expect_success "proc-receive: create/delete branch, and delete tag ($PROTOC
 	git -C "$upstream" show-ref >out &&
 	make_user_friendly_and_stable_output <out >actual &&
 	cat >expect <<-EOF &&
-	<COMMIT-A> refs/heads/master
+	<COMMIT-A> refs/heads/main
 	<COMMIT-B> refs/heads/topic
 	EOF
 	test_cmp expect actual


### PR DESCRIPTION
The test script `t5411-proc-receive-hook.sh` is an interesting case: it not only requires _tons_ of mostly straight-forward changes that amount to an automated search-and-replace, but it also requires a few adjustments due to the change of the default branch name's _length_.

This patch series is part of the over-all effort tracked in https://github.com/gitgitgadget/git/pull/655.

Changes since v1:

- We now set `GIT_TEST_DEFAULT_INITIAL_BRANCH_NAME` explicitly to `master` in patch 1/4, effectively disabling the test due to the use of the `PREPARE_FOR_MAIN_BRANCH` prereq until we switch it over to setting the initial branch name to `main` with patch 4/4.

cc: Johannes Schindelin <Johannes.Schindelin@gmx.de>