### PR TITLE
 Adjust t5515 for the upcoming change of the default branch name

### DIFF
--- a/t/t5515-fetch-merge-logic.sh
+++ b/t/t5515-fetch-merge-logic.sh
@@ -11,15 +11,10 @@ test_description='Merge logic in fetch'
 GIT_TEST_PROTOCOL_VERSION=0
 export GIT_TEST_PROTOCOL_VERSION
 
-GIT_TEST_DEFAULT_INITIAL_BRANCH_NAME=master
+GIT_TEST_DEFAULT_INITIAL_BRANCH_NAME=main
 export GIT_TEST_DEFAULT_INITIAL_BRANCH_NAME
 
 . ./test-lib.sh
-
-test_have_prereq PREPARE_FOR_MAIN_BRANCH || {
-	test_skip="In transit for the default branch name 'main'"
-	test_done
-}
 
 build_script () {
 	script="$1" &&

--- a/t/t5515-fetch-merge-logic.sh
+++ b/t/t5515-fetch-merge-logic.sh
@@ -11,11 +11,19 @@ test_description='Merge logic in fetch'
 GIT_TEST_PROTOCOL_VERSION=0
 export GIT_TEST_PROTOCOL_VERSION
 
+GIT_TEST_DEFAULT_INITIAL_BRANCH_NAME=master
+export GIT_TEST_DEFAULT_INITIAL_BRANCH_NAME
+
 . ./test-lib.sh
+
+test_have_prereq PREPARE_FOR_MAIN_BRANCH || {
+	test_skip="In transit for the default branch name 'main'"
+	test_done
+}
 
 build_script () {
 	script="$1" &&
-	for i in one three_file master topic_2 one_tree three two two2 three2
+	for i in one three_file main topic_2 one_tree three two two2 three2
 	do
 		echo "s/$(test_oid --hash=sha1 "$i")/$(test_oid "$i")/g" >>"$script"
 	done
@@ -40,8 +48,8 @@ test_expect_success setup '
 	three_file sha1:0e3b14047d3ee365f4f2a1b673db059c3972589c
 	three_file sha256:bc4447d50c07497a8bfe6eef817f2364ecca9d471452e43b52756cc1a908bd32
 
-	master sha1:6c9dec2b923228c9ff994c6cfe4ae16c12408dc5
-	master sha256:8521c3072461fcfe8f32d67f95cc6e6b832a2db2fa29769ffc788bce85ebcd75
+	main sha1:ecf3b3627b498bdcb735cc4343bf165f76964e9a
+	main sha256:fff666109892bb4b1c80cd1649d2d8762a0663db8b5d46c8be98360b64fbba5f
 
 	one_tree sha1:22feea448b023a2d864ef94b013735af34d238ba
 	one_tree sha256:6e4743f4ef2356b881dda5e91f5c7cdffe870faf350bf7b312f80a20935f5d83
@@ -52,8 +60,8 @@ test_expect_success setup '
 	two sha1:525b7fb068d59950d185a8779dc957c77eed73ba
 	two sha256:3b21de3440cd38c2a9e9b464adb923f7054949ed4c918e1a0ac4c95cd52774db
 
-	topic_2 sha1:754b754407bf032e9a2f9d5a9ad05ca79a6b228f
-	topic_2 sha256:6c7abaea8a6d8ef4d89877e68462758dc6774690fbbbb0e6d7dd57415c9abde0
+	topic_2 sha1:b4ab76b1a01ea602209932134a44f1e6bd610832
+	topic_2 sha256:380ebae0113f877ce46fcdf39d5bc33e4dc0928db5c5a4d5fdc78381c4d55ae3
 
 	two2 sha1:6134ee8f857693b96ff1cc98d3e2fd62b199e5a8
 	two2 sha256:87a2d3ee29c83a3dc7afd41c0606b11f67603120b910a7be7840accdc18344d4
@@ -80,9 +88,9 @@ test_expect_success setup '
 	git tag -a -m "Tag Three file" tag-three-file HEAD^{tree}:file &&
 	git branch three &&
 
-	echo master >> file &&
-	git commit -a -m Master &&
-	git tag -a -m "Tag Master" tag-master &&
+	echo main >> file &&
+	git commit -a -m Main &&
+	git tag -a -m "Tag Main" tag-main &&
 
 	git checkout three &&
 
@@ -91,7 +99,7 @@ test_expect_success setup '
 	git config remote.origin.url ../.git/ &&
 
 	git config remote.config-explicit.url ../.git/ &&
-	git config remote.config-explicit.fetch refs/heads/master:remotes/rem/master &&
+	git config remote.config-explicit.fetch refs/heads/main:remotes/rem/main &&
 	git config --add remote.config-explicit.fetch refs/heads/one:remotes/rem/one &&
 	git config --add remote.config-explicit.fetch two:remotes/rem/two &&
 	git config --add remote.config-explicit.fetch refs/heads/three:remotes/rem/three &&
@@ -104,7 +112,7 @@ test_expect_success setup '
 	mkdir -p .git/remotes &&
 	{
 		echo "URL: ../.git/"
-		echo "Pull: refs/heads/master:remotes/rem/master"
+		echo "Pull: refs/heads/main:remotes/rem/main"
 		echo "Pull: refs/heads/one:remotes/rem/one"
 		echo "Pull: two:remotes/rem/two"
 		echo "Pull: refs/heads/three:remotes/rem/three"
@@ -149,7 +157,7 @@ done > tests
 # but does depend on Pull: or fetch lines.
 # Use two branches completely unrelated from the arguments,
 # the clone default and one without branch properties
-for branch in master br-unconfig ; do
+for branch in main br-unconfig ; do
     echo $branch
     for remote in $remotes ; do
 	echo $branch $remote
@@ -158,7 +166,7 @@ done >> tests
 
 # Merge logic does not depend on branch properties
 # neither in the Pull: or .fetch config
-for branch in master br-unconfig ; do
+for branch in main br-unconfig ; do
     cat <<EOF
 $branch ../.git
 $branch ../.git one

--- a/t/t5515/fetch.br-branches-default
+++ b/t/t5515/fetch.br-branches-default
@@ -1,6 +1,6 @@
 # br-branches-default
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f		branch 'master' of ../
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5	not-for-merge	tag 'tag-master' of ../
+b4ab76b1a01ea602209932134a44f1e6bd610832		branch 'main' of ../
+ecf3b3627b498bdcb735cc4343bf165f76964e9a	not-for-merge	tag 'tag-main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	tag 'tag-one' of ../
 22feea448b023a2d864ef94b013735af34d238ba	not-for-merge	tag 'tag-one-tree' of ../
 c61a82b60967180544e3c19f819ddbd0c9f89899	not-for-merge	tag 'tag-three' of ../

--- a/t/t5515/fetch.br-branches-default-merge
+++ b/t/t5515/fetch.br-branches-default-merge
@@ -1,7 +1,7 @@
 # br-branches-default-merge
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b		branch 'three' of ../
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f	not-for-merge	branch 'master' of ../
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5	not-for-merge	tag 'tag-master' of ../
+b4ab76b1a01ea602209932134a44f1e6bd610832	not-for-merge	branch 'main' of ../
+ecf3b3627b498bdcb735cc4343bf165f76964e9a	not-for-merge	tag 'tag-main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	tag 'tag-one' of ../
 22feea448b023a2d864ef94b013735af34d238ba	not-for-merge	tag 'tag-one-tree' of ../
 c61a82b60967180544e3c19f819ddbd0c9f89899	not-for-merge	tag 'tag-three' of ../

--- a/t/t5515/fetch.br-branches-default-merge_branches-default
+++ b/t/t5515/fetch.br-branches-default-merge_branches-default
@@ -1,7 +1,7 @@
 # br-branches-default-merge branches-default
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b		branch 'three' of ../
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f	not-for-merge	branch 'master' of ../
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5	not-for-merge	tag 'tag-master' of ../
+b4ab76b1a01ea602209932134a44f1e6bd610832	not-for-merge	branch 'main' of ../
+ecf3b3627b498bdcb735cc4343bf165f76964e9a	not-for-merge	tag 'tag-main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	tag 'tag-one' of ../
 22feea448b023a2d864ef94b013735af34d238ba	not-for-merge	tag 'tag-one-tree' of ../
 c61a82b60967180544e3c19f819ddbd0c9f89899	not-for-merge	tag 'tag-three' of ../

--- a/t/t5515/fetch.br-branches-default-octopus
+++ b/t/t5515/fetch.br-branches-default-octopus
@@ -1,8 +1,8 @@
 # br-branches-default-octopus
 8e32a6d901327a23ef831511badce7bf3bf46689		branch 'one' of ../
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8		branch 'two' of ../
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f	not-for-merge	branch 'master' of ../
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5	not-for-merge	tag 'tag-master' of ../
+b4ab76b1a01ea602209932134a44f1e6bd610832	not-for-merge	branch 'main' of ../
+ecf3b3627b498bdcb735cc4343bf165f76964e9a	not-for-merge	tag 'tag-main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	tag 'tag-one' of ../
 22feea448b023a2d864ef94b013735af34d238ba	not-for-merge	tag 'tag-one-tree' of ../
 c61a82b60967180544e3c19f819ddbd0c9f89899	not-for-merge	tag 'tag-three' of ../

--- a/t/t5515/fetch.br-branches-default-octopus_branches-default
+++ b/t/t5515/fetch.br-branches-default-octopus_branches-default
@@ -1,8 +1,8 @@
 # br-branches-default-octopus branches-default
 8e32a6d901327a23ef831511badce7bf3bf46689		branch 'one' of ../
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8		branch 'two' of ../
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f	not-for-merge	branch 'master' of ../
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5	not-for-merge	tag 'tag-master' of ../
+b4ab76b1a01ea602209932134a44f1e6bd610832	not-for-merge	branch 'main' of ../
+ecf3b3627b498bdcb735cc4343bf165f76964e9a	not-for-merge	tag 'tag-main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	tag 'tag-one' of ../
 22feea448b023a2d864ef94b013735af34d238ba	not-for-merge	tag 'tag-one-tree' of ../
 c61a82b60967180544e3c19f819ddbd0c9f89899	not-for-merge	tag 'tag-three' of ../

--- a/t/t5515/fetch.br-branches-default_branches-default
+++ b/t/t5515/fetch.br-branches-default_branches-default
@@ -1,6 +1,6 @@
 # br-branches-default branches-default
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f		branch 'master' of ../
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5	not-for-merge	tag 'tag-master' of ../
+b4ab76b1a01ea602209932134a44f1e6bd610832		branch 'main' of ../
+ecf3b3627b498bdcb735cc4343bf165f76964e9a	not-for-merge	tag 'tag-main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	tag 'tag-one' of ../
 22feea448b023a2d864ef94b013735af34d238ba	not-for-merge	tag 'tag-one-tree' of ../
 c61a82b60967180544e3c19f819ddbd0c9f89899	not-for-merge	tag 'tag-three' of ../

--- a/t/t5515/fetch.br-branches-one
+++ b/t/t5515/fetch.br-branches-one
@@ -1,6 +1,6 @@
 # br-branches-one
 8e32a6d901327a23ef831511badce7bf3bf46689		branch 'one' of ../
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5	not-for-merge	tag 'tag-master' of ../
+ecf3b3627b498bdcb735cc4343bf165f76964e9a	not-for-merge	tag 'tag-main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	tag 'tag-one' of ../
 22feea448b023a2d864ef94b013735af34d238ba	not-for-merge	tag 'tag-one-tree' of ../
 c61a82b60967180544e3c19f819ddbd0c9f89899	not-for-merge	tag 'tag-three' of ../

--- a/t/t5515/fetch.br-branches-one-merge
+++ b/t/t5515/fetch.br-branches-one-merge
@@ -1,7 +1,7 @@
 # br-branches-one-merge
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b		branch 'three' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	branch 'one' of ../
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5	not-for-merge	tag 'tag-master' of ../
+ecf3b3627b498bdcb735cc4343bf165f76964e9a	not-for-merge	tag 'tag-main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	tag 'tag-one' of ../
 22feea448b023a2d864ef94b013735af34d238ba	not-for-merge	tag 'tag-one-tree' of ../
 c61a82b60967180544e3c19f819ddbd0c9f89899	not-for-merge	tag 'tag-three' of ../

--- a/t/t5515/fetch.br-branches-one-merge_branches-one
+++ b/t/t5515/fetch.br-branches-one-merge_branches-one
@@ -1,7 +1,7 @@
 # br-branches-one-merge branches-one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b		branch 'three' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	branch 'one' of ../
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5	not-for-merge	tag 'tag-master' of ../
+ecf3b3627b498bdcb735cc4343bf165f76964e9a	not-for-merge	tag 'tag-main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	tag 'tag-one' of ../
 22feea448b023a2d864ef94b013735af34d238ba	not-for-merge	tag 'tag-one-tree' of ../
 c61a82b60967180544e3c19f819ddbd0c9f89899	not-for-merge	tag 'tag-three' of ../

--- a/t/t5515/fetch.br-branches-one-octopus
+++ b/t/t5515/fetch.br-branches-one-octopus
@@ -1,7 +1,7 @@
 # br-branches-one-octopus
 8e32a6d901327a23ef831511badce7bf3bf46689		branch 'one' of ../
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8		branch 'two' of ../
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5	not-for-merge	tag 'tag-master' of ../
+ecf3b3627b498bdcb735cc4343bf165f76964e9a	not-for-merge	tag 'tag-main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	tag 'tag-one' of ../
 22feea448b023a2d864ef94b013735af34d238ba	not-for-merge	tag 'tag-one-tree' of ../
 c61a82b60967180544e3c19f819ddbd0c9f89899	not-for-merge	tag 'tag-three' of ../

--- a/t/t5515/fetch.br-branches-one-octopus_branches-one
+++ b/t/t5515/fetch.br-branches-one-octopus_branches-one
@@ -1,7 +1,7 @@
 # br-branches-one-octopus branches-one
 8e32a6d901327a23ef831511badce7bf3bf46689		branch 'one' of ../
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8		branch 'two' of ../
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5	not-for-merge	tag 'tag-master' of ../
+ecf3b3627b498bdcb735cc4343bf165f76964e9a	not-for-merge	tag 'tag-main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	tag 'tag-one' of ../
 22feea448b023a2d864ef94b013735af34d238ba	not-for-merge	tag 'tag-one-tree' of ../
 c61a82b60967180544e3c19f819ddbd0c9f89899	not-for-merge	tag 'tag-three' of ../

--- a/t/t5515/fetch.br-branches-one_branches-one
+++ b/t/t5515/fetch.br-branches-one_branches-one
@@ -1,6 +1,6 @@
 # br-branches-one branches-one
 8e32a6d901327a23ef831511badce7bf3bf46689		branch 'one' of ../
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5	not-for-merge	tag 'tag-master' of ../
+ecf3b3627b498bdcb735cc4343bf165f76964e9a	not-for-merge	tag 'tag-main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	tag 'tag-one' of ../
 22feea448b023a2d864ef94b013735af34d238ba	not-for-merge	tag 'tag-one-tree' of ../
 c61a82b60967180544e3c19f819ddbd0c9f89899	not-for-merge	tag 'tag-three' of ../

--- a/t/t5515/fetch.br-config-explicit
+++ b/t/t5515/fetch.br-config-explicit
@@ -1,9 +1,9 @@
 # br-config-explicit
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f		branch 'master' of ../
+b4ab76b1a01ea602209932134a44f1e6bd610832		branch 'main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	branch 'one' of ../
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8	not-for-merge	branch 'two' of ../
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b	not-for-merge	branch 'three' of ../
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5	not-for-merge	tag 'tag-master' of ../
+ecf3b3627b498bdcb735cc4343bf165f76964e9a	not-for-merge	tag 'tag-main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	tag 'tag-one' of ../
 22feea448b023a2d864ef94b013735af34d238ba	not-for-merge	tag 'tag-one-tree' of ../
 c61a82b60967180544e3c19f819ddbd0c9f89899	not-for-merge	tag 'tag-three' of ../

--- a/t/t5515/fetch.br-config-explicit-merge
+++ b/t/t5515/fetch.br-config-explicit-merge
@@ -1,9 +1,9 @@
 # br-config-explicit-merge
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b		branch 'three' of ../
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f	not-for-merge	branch 'master' of ../
+b4ab76b1a01ea602209932134a44f1e6bd610832	not-for-merge	branch 'main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	branch 'one' of ../
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8	not-for-merge	branch 'two' of ../
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5	not-for-merge	tag 'tag-master' of ../
+ecf3b3627b498bdcb735cc4343bf165f76964e9a	not-for-merge	tag 'tag-main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	tag 'tag-one' of ../
 22feea448b023a2d864ef94b013735af34d238ba	not-for-merge	tag 'tag-one-tree' of ../
 c61a82b60967180544e3c19f819ddbd0c9f89899	not-for-merge	tag 'tag-three' of ../

--- a/t/t5515/fetch.br-config-explicit-merge_config-explicit
+++ b/t/t5515/fetch.br-config-explicit-merge_config-explicit
@@ -1,9 +1,9 @@
 # br-config-explicit-merge config-explicit
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b		branch 'three' of ../
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f	not-for-merge	branch 'master' of ../
+b4ab76b1a01ea602209932134a44f1e6bd610832	not-for-merge	branch 'main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	branch 'one' of ../
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8	not-for-merge	branch 'two' of ../
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5	not-for-merge	tag 'tag-master' of ../
+ecf3b3627b498bdcb735cc4343bf165f76964e9a	not-for-merge	tag 'tag-main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	tag 'tag-one' of ../
 22feea448b023a2d864ef94b013735af34d238ba	not-for-merge	tag 'tag-one-tree' of ../
 c61a82b60967180544e3c19f819ddbd0c9f89899	not-for-merge	tag 'tag-three' of ../

--- a/t/t5515/fetch.br-config-explicit-octopus
+++ b/t/t5515/fetch.br-config-explicit-octopus
@@ -1,9 +1,9 @@
 # br-config-explicit-octopus
 8e32a6d901327a23ef831511badce7bf3bf46689		branch 'one' of ../
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8		branch 'two' of ../
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f	not-for-merge	branch 'master' of ../
+b4ab76b1a01ea602209932134a44f1e6bd610832	not-for-merge	branch 'main' of ../
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b	not-for-merge	branch 'three' of ../
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5	not-for-merge	tag 'tag-master' of ../
+ecf3b3627b498bdcb735cc4343bf165f76964e9a	not-for-merge	tag 'tag-main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	tag 'tag-one' of ../
 22feea448b023a2d864ef94b013735af34d238ba	not-for-merge	tag 'tag-one-tree' of ../
 c61a82b60967180544e3c19f819ddbd0c9f89899	not-for-merge	tag 'tag-three' of ../

--- a/t/t5515/fetch.br-config-explicit-octopus_config-explicit
+++ b/t/t5515/fetch.br-config-explicit-octopus_config-explicit
@@ -1,9 +1,9 @@
 # br-config-explicit-octopus config-explicit
 8e32a6d901327a23ef831511badce7bf3bf46689		branch 'one' of ../
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8		branch 'two' of ../
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f	not-for-merge	branch 'master' of ../
+b4ab76b1a01ea602209932134a44f1e6bd610832	not-for-merge	branch 'main' of ../
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b	not-for-merge	branch 'three' of ../
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5	not-for-merge	tag 'tag-master' of ../
+ecf3b3627b498bdcb735cc4343bf165f76964e9a	not-for-merge	tag 'tag-main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	tag 'tag-one' of ../
 22feea448b023a2d864ef94b013735af34d238ba	not-for-merge	tag 'tag-one-tree' of ../
 c61a82b60967180544e3c19f819ddbd0c9f89899	not-for-merge	tag 'tag-three' of ../

--- a/t/t5515/fetch.br-config-explicit_config-explicit
+++ b/t/t5515/fetch.br-config-explicit_config-explicit
@@ -1,9 +1,9 @@
 # br-config-explicit config-explicit
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f		branch 'master' of ../
+b4ab76b1a01ea602209932134a44f1e6bd610832		branch 'main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	branch 'one' of ../
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8	not-for-merge	branch 'two' of ../
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b	not-for-merge	branch 'three' of ../
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5	not-for-merge	tag 'tag-master' of ../
+ecf3b3627b498bdcb735cc4343bf165f76964e9a	not-for-merge	tag 'tag-main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	tag 'tag-one' of ../
 22feea448b023a2d864ef94b013735af34d238ba	not-for-merge	tag 'tag-one-tree' of ../
 c61a82b60967180544e3c19f819ddbd0c9f89899	not-for-merge	tag 'tag-three' of ../

--- a/t/t5515/fetch.br-config-glob
+++ b/t/t5515/fetch.br-config-glob
@@ -1,9 +1,9 @@
 # br-config-glob
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f	not-for-merge	branch 'master' of ../
+b4ab76b1a01ea602209932134a44f1e6bd610832	not-for-merge	branch 'main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	branch 'one' of ../
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b	not-for-merge	branch 'three' of ../
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8	not-for-merge	branch 'two' of ../
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5	not-for-merge	tag 'tag-master' of ../
+ecf3b3627b498bdcb735cc4343bf165f76964e9a	not-for-merge	tag 'tag-main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	tag 'tag-one' of ../
 22feea448b023a2d864ef94b013735af34d238ba	not-for-merge	tag 'tag-one-tree' of ../
 c61a82b60967180544e3c19f819ddbd0c9f89899	not-for-merge	tag 'tag-three' of ../

--- a/t/t5515/fetch.br-config-glob-merge
+++ b/t/t5515/fetch.br-config-glob-merge
@@ -1,9 +1,9 @@
 # br-config-glob-merge
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b		branch 'three' of ../
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f	not-for-merge	branch 'master' of ../
+b4ab76b1a01ea602209932134a44f1e6bd610832	not-for-merge	branch 'main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	branch 'one' of ../
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8	not-for-merge	branch 'two' of ../
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5	not-for-merge	tag 'tag-master' of ../
+ecf3b3627b498bdcb735cc4343bf165f76964e9a	not-for-merge	tag 'tag-main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	tag 'tag-one' of ../
 22feea448b023a2d864ef94b013735af34d238ba	not-for-merge	tag 'tag-one-tree' of ../
 c61a82b60967180544e3c19f819ddbd0c9f89899	not-for-merge	tag 'tag-three' of ../

--- a/t/t5515/fetch.br-config-glob-merge_config-glob
+++ b/t/t5515/fetch.br-config-glob-merge_config-glob
@@ -1,9 +1,9 @@
 # br-config-glob-merge config-glob
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b		branch 'three' of ../
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f	not-for-merge	branch 'master' of ../
+b4ab76b1a01ea602209932134a44f1e6bd610832	not-for-merge	branch 'main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	branch 'one' of ../
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8	not-for-merge	branch 'two' of ../
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5	not-for-merge	tag 'tag-master' of ../
+ecf3b3627b498bdcb735cc4343bf165f76964e9a	not-for-merge	tag 'tag-main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	tag 'tag-one' of ../
 22feea448b023a2d864ef94b013735af34d238ba	not-for-merge	tag 'tag-one-tree' of ../
 c61a82b60967180544e3c19f819ddbd0c9f89899	not-for-merge	tag 'tag-three' of ../

--- a/t/t5515/fetch.br-config-glob-octopus
+++ b/t/t5515/fetch.br-config-glob-octopus
@@ -1,9 +1,9 @@
 # br-config-glob-octopus
 8e32a6d901327a23ef831511badce7bf3bf46689		branch 'one' of ../
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8		branch 'two' of ../
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f	not-for-merge	branch 'master' of ../
+b4ab76b1a01ea602209932134a44f1e6bd610832	not-for-merge	branch 'main' of ../
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b	not-for-merge	branch 'three' of ../
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5	not-for-merge	tag 'tag-master' of ../
+ecf3b3627b498bdcb735cc4343bf165f76964e9a	not-for-merge	tag 'tag-main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	tag 'tag-one' of ../
 22feea448b023a2d864ef94b013735af34d238ba	not-for-merge	tag 'tag-one-tree' of ../
 c61a82b60967180544e3c19f819ddbd0c9f89899	not-for-merge	tag 'tag-three' of ../

--- a/t/t5515/fetch.br-config-glob-octopus_config-glob
+++ b/t/t5515/fetch.br-config-glob-octopus_config-glob
@@ -1,9 +1,9 @@
 # br-config-glob-octopus config-glob
 8e32a6d901327a23ef831511badce7bf3bf46689		branch 'one' of ../
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8		branch 'two' of ../
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f	not-for-merge	branch 'master' of ../
+b4ab76b1a01ea602209932134a44f1e6bd610832	not-for-merge	branch 'main' of ../
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b	not-for-merge	branch 'three' of ../
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5	not-for-merge	tag 'tag-master' of ../
+ecf3b3627b498bdcb735cc4343bf165f76964e9a	not-for-merge	tag 'tag-main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	tag 'tag-one' of ../
 22feea448b023a2d864ef94b013735af34d238ba	not-for-merge	tag 'tag-one-tree' of ../
 c61a82b60967180544e3c19f819ddbd0c9f89899	not-for-merge	tag 'tag-three' of ../

--- a/t/t5515/fetch.br-config-glob_config-glob
+++ b/t/t5515/fetch.br-config-glob_config-glob
@@ -1,9 +1,9 @@
 # br-config-glob config-glob
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f	not-for-merge	branch 'master' of ../
+b4ab76b1a01ea602209932134a44f1e6bd610832	not-for-merge	branch 'main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	branch 'one' of ../
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b	not-for-merge	branch 'three' of ../
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8	not-for-merge	branch 'two' of ../
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5	not-for-merge	tag 'tag-master' of ../
+ecf3b3627b498bdcb735cc4343bf165f76964e9a	not-for-merge	tag 'tag-main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	tag 'tag-one' of ../
 22feea448b023a2d864ef94b013735af34d238ba	not-for-merge	tag 'tag-one-tree' of ../
 c61a82b60967180544e3c19f819ddbd0c9f89899	not-for-merge	tag 'tag-three' of ../

--- a/t/t5515/fetch.br-remote-explicit
+++ b/t/t5515/fetch.br-remote-explicit
@@ -1,9 +1,9 @@
 # br-remote-explicit
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f		branch 'master' of ../
+b4ab76b1a01ea602209932134a44f1e6bd610832		branch 'main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	branch 'one' of ../
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8	not-for-merge	branch 'two' of ../
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b	not-for-merge	branch 'three' of ../
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5	not-for-merge	tag 'tag-master' of ../
+ecf3b3627b498bdcb735cc4343bf165f76964e9a	not-for-merge	tag 'tag-main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	tag 'tag-one' of ../
 22feea448b023a2d864ef94b013735af34d238ba	not-for-merge	tag 'tag-one-tree' of ../
 c61a82b60967180544e3c19f819ddbd0c9f89899	not-for-merge	tag 'tag-three' of ../

--- a/t/t5515/fetch.br-remote-explicit-merge
+++ b/t/t5515/fetch.br-remote-explicit-merge
@@ -1,9 +1,9 @@
 # br-remote-explicit-merge
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b		branch 'three' of ../
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f	not-for-merge	branch 'master' of ../
+b4ab76b1a01ea602209932134a44f1e6bd610832	not-for-merge	branch 'main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	branch 'one' of ../
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8	not-for-merge	branch 'two' of ../
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5	not-for-merge	tag 'tag-master' of ../
+ecf3b3627b498bdcb735cc4343bf165f76964e9a	not-for-merge	tag 'tag-main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	tag 'tag-one' of ../
 22feea448b023a2d864ef94b013735af34d238ba	not-for-merge	tag 'tag-one-tree' of ../
 c61a82b60967180544e3c19f819ddbd0c9f89899	not-for-merge	tag 'tag-three' of ../

--- a/t/t5515/fetch.br-remote-explicit-merge_remote-explicit
+++ b/t/t5515/fetch.br-remote-explicit-merge_remote-explicit
@@ -1,9 +1,9 @@
 # br-remote-explicit-merge remote-explicit
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b		branch 'three' of ../
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f	not-for-merge	branch 'master' of ../
+b4ab76b1a01ea602209932134a44f1e6bd610832	not-for-merge	branch 'main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	branch 'one' of ../
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8	not-for-merge	branch 'two' of ../
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5	not-for-merge	tag 'tag-master' of ../
+ecf3b3627b498bdcb735cc4343bf165f76964e9a	not-for-merge	tag 'tag-main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	tag 'tag-one' of ../
 22feea448b023a2d864ef94b013735af34d238ba	not-for-merge	tag 'tag-one-tree' of ../
 c61a82b60967180544e3c19f819ddbd0c9f89899	not-for-merge	tag 'tag-three' of ../

--- a/t/t5515/fetch.br-remote-explicit-octopus
+++ b/t/t5515/fetch.br-remote-explicit-octopus
@@ -1,9 +1,9 @@
 # br-remote-explicit-octopus
 8e32a6d901327a23ef831511badce7bf3bf46689		branch 'one' of ../
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8		branch 'two' of ../
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f	not-for-merge	branch 'master' of ../
+b4ab76b1a01ea602209932134a44f1e6bd610832	not-for-merge	branch 'main' of ../
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b	not-for-merge	branch 'three' of ../
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5	not-for-merge	tag 'tag-master' of ../
+ecf3b3627b498bdcb735cc4343bf165f76964e9a	not-for-merge	tag 'tag-main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	tag 'tag-one' of ../
 22feea448b023a2d864ef94b013735af34d238ba	not-for-merge	tag 'tag-one-tree' of ../
 c61a82b60967180544e3c19f819ddbd0c9f89899	not-for-merge	tag 'tag-three' of ../

--- a/t/t5515/fetch.br-remote-explicit-octopus_remote-explicit
+++ b/t/t5515/fetch.br-remote-explicit-octopus_remote-explicit
@@ -1,9 +1,9 @@
 # br-remote-explicit-octopus remote-explicit
 8e32a6d901327a23ef831511badce7bf3bf46689		branch 'one' of ../
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8		branch 'two' of ../
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f	not-for-merge	branch 'master' of ../
+b4ab76b1a01ea602209932134a44f1e6bd610832	not-for-merge	branch 'main' of ../
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b	not-for-merge	branch 'three' of ../
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5	not-for-merge	tag 'tag-master' of ../
+ecf3b3627b498bdcb735cc4343bf165f76964e9a	not-for-merge	tag 'tag-main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	tag 'tag-one' of ../
 22feea448b023a2d864ef94b013735af34d238ba	not-for-merge	tag 'tag-one-tree' of ../
 c61a82b60967180544e3c19f819ddbd0c9f89899	not-for-merge	tag 'tag-three' of ../

--- a/t/t5515/fetch.br-remote-explicit_remote-explicit
+++ b/t/t5515/fetch.br-remote-explicit_remote-explicit
@@ -1,9 +1,9 @@
 # br-remote-explicit remote-explicit
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f		branch 'master' of ../
+b4ab76b1a01ea602209932134a44f1e6bd610832		branch 'main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	branch 'one' of ../
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8	not-for-merge	branch 'two' of ../
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b	not-for-merge	branch 'three' of ../
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5	not-for-merge	tag 'tag-master' of ../
+ecf3b3627b498bdcb735cc4343bf165f76964e9a	not-for-merge	tag 'tag-main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	tag 'tag-one' of ../
 22feea448b023a2d864ef94b013735af34d238ba	not-for-merge	tag 'tag-one-tree' of ../
 c61a82b60967180544e3c19f819ddbd0c9f89899	not-for-merge	tag 'tag-three' of ../

--- a/t/t5515/fetch.br-remote-glob
+++ b/t/t5515/fetch.br-remote-glob
@@ -1,9 +1,9 @@
 # br-remote-glob
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f	not-for-merge	branch 'master' of ../
+b4ab76b1a01ea602209932134a44f1e6bd610832	not-for-merge	branch 'main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	branch 'one' of ../
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b	not-for-merge	branch 'three' of ../
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8	not-for-merge	branch 'two' of ../
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5	not-for-merge	tag 'tag-master' of ../
+ecf3b3627b498bdcb735cc4343bf165f76964e9a	not-for-merge	tag 'tag-main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	tag 'tag-one' of ../
 22feea448b023a2d864ef94b013735af34d238ba	not-for-merge	tag 'tag-one-tree' of ../
 c61a82b60967180544e3c19f819ddbd0c9f89899	not-for-merge	tag 'tag-three' of ../

--- a/t/t5515/fetch.br-remote-glob-merge
+++ b/t/t5515/fetch.br-remote-glob-merge
@@ -1,9 +1,9 @@
 # br-remote-glob-merge
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b		branch 'three' of ../
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f	not-for-merge	branch 'master' of ../
+b4ab76b1a01ea602209932134a44f1e6bd610832	not-for-merge	branch 'main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	branch 'one' of ../
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8	not-for-merge	branch 'two' of ../
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5	not-for-merge	tag 'tag-master' of ../
+ecf3b3627b498bdcb735cc4343bf165f76964e9a	not-for-merge	tag 'tag-main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	tag 'tag-one' of ../
 22feea448b023a2d864ef94b013735af34d238ba	not-for-merge	tag 'tag-one-tree' of ../
 c61a82b60967180544e3c19f819ddbd0c9f89899	not-for-merge	tag 'tag-three' of ../

--- a/t/t5515/fetch.br-remote-glob-merge_remote-glob
+++ b/t/t5515/fetch.br-remote-glob-merge_remote-glob
@@ -1,9 +1,9 @@
 # br-remote-glob-merge remote-glob
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b		branch 'three' of ../
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f	not-for-merge	branch 'master' of ../
+b4ab76b1a01ea602209932134a44f1e6bd610832	not-for-merge	branch 'main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	branch 'one' of ../
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8	not-for-merge	branch 'two' of ../
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5	not-for-merge	tag 'tag-master' of ../
+ecf3b3627b498bdcb735cc4343bf165f76964e9a	not-for-merge	tag 'tag-main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	tag 'tag-one' of ../
 22feea448b023a2d864ef94b013735af34d238ba	not-for-merge	tag 'tag-one-tree' of ../
 c61a82b60967180544e3c19f819ddbd0c9f89899	not-for-merge	tag 'tag-three' of ../

--- a/t/t5515/fetch.br-remote-glob-octopus
+++ b/t/t5515/fetch.br-remote-glob-octopus
@@ -1,9 +1,9 @@
 # br-remote-glob-octopus
 8e32a6d901327a23ef831511badce7bf3bf46689		branch 'one' of ../
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8		branch 'two' of ../
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f	not-for-merge	branch 'master' of ../
+b4ab76b1a01ea602209932134a44f1e6bd610832	not-for-merge	branch 'main' of ../
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b	not-for-merge	branch 'three' of ../
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5	not-for-merge	tag 'tag-master' of ../
+ecf3b3627b498bdcb735cc4343bf165f76964e9a	not-for-merge	tag 'tag-main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	tag 'tag-one' of ../
 22feea448b023a2d864ef94b013735af34d238ba	not-for-merge	tag 'tag-one-tree' of ../
 c61a82b60967180544e3c19f819ddbd0c9f89899	not-for-merge	tag 'tag-three' of ../

--- a/t/t5515/fetch.br-remote-glob-octopus_remote-glob
+++ b/t/t5515/fetch.br-remote-glob-octopus_remote-glob
@@ -1,9 +1,9 @@
 # br-remote-glob-octopus remote-glob
 8e32a6d901327a23ef831511badce7bf3bf46689		branch 'one' of ../
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8		branch 'two' of ../
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f	not-for-merge	branch 'master' of ../
+b4ab76b1a01ea602209932134a44f1e6bd610832	not-for-merge	branch 'main' of ../
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b	not-for-merge	branch 'three' of ../
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5	not-for-merge	tag 'tag-master' of ../
+ecf3b3627b498bdcb735cc4343bf165f76964e9a	not-for-merge	tag 'tag-main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	tag 'tag-one' of ../
 22feea448b023a2d864ef94b013735af34d238ba	not-for-merge	tag 'tag-one-tree' of ../
 c61a82b60967180544e3c19f819ddbd0c9f89899	not-for-merge	tag 'tag-three' of ../

--- a/t/t5515/fetch.br-remote-glob_remote-glob
+++ b/t/t5515/fetch.br-remote-glob_remote-glob
@@ -1,9 +1,9 @@
 # br-remote-glob remote-glob
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f	not-for-merge	branch 'master' of ../
+b4ab76b1a01ea602209932134a44f1e6bd610832	not-for-merge	branch 'main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	branch 'one' of ../
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b	not-for-merge	branch 'three' of ../
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8	not-for-merge	branch 'two' of ../
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5	not-for-merge	tag 'tag-master' of ../
+ecf3b3627b498bdcb735cc4343bf165f76964e9a	not-for-merge	tag 'tag-main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	tag 'tag-one' of ../
 22feea448b023a2d864ef94b013735af34d238ba	not-for-merge	tag 'tag-one-tree' of ../
 c61a82b60967180544e3c19f819ddbd0c9f89899	not-for-merge	tag 'tag-three' of ../

--- a/t/t5515/fetch.br-unconfig
+++ b/t/t5515/fetch.br-unconfig
@@ -1,9 +1,9 @@
 # br-unconfig
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f	not-for-merge	branch 'master' of ../
+b4ab76b1a01ea602209932134a44f1e6bd610832	not-for-merge	branch 'main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	branch 'one' of ../
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b	not-for-merge	branch 'three' of ../
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8	not-for-merge	branch 'two' of ../
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5	not-for-merge	tag 'tag-master' of ../
+ecf3b3627b498bdcb735cc4343bf165f76964e9a	not-for-merge	tag 'tag-main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	tag 'tag-one' of ../
 22feea448b023a2d864ef94b013735af34d238ba	not-for-merge	tag 'tag-one-tree' of ../
 c61a82b60967180544e3c19f819ddbd0c9f89899	not-for-merge	tag 'tag-three' of ../

--- a/t/t5515/fetch.br-unconfig_--tags_.._.git
+++ b/t/t5515/fetch.br-unconfig_--tags_.._.git
@@ -1,6 +1,6 @@
 # br-unconfig --tags ../.git
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b		../
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5	not-for-merge	tag 'tag-master' of ../
+ecf3b3627b498bdcb735cc4343bf165f76964e9a	not-for-merge	tag 'tag-main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	tag 'tag-one' of ../
 22feea448b023a2d864ef94b013735af34d238ba	not-for-merge	tag 'tag-one-tree' of ../
 c61a82b60967180544e3c19f819ddbd0c9f89899	not-for-merge	tag 'tag-three' of ../

--- a/t/t5515/fetch.br-unconfig_.._.git_one_tag_tag-one_tag_tag-three-file
+++ b/t/t5515/fetch.br-unconfig_.._.git_one_tag_tag-one_tag_tag-three-file
@@ -2,7 +2,7 @@
 8e32a6d901327a23ef831511badce7bf3bf46689		branch 'one' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689		tag 'tag-one' of ../
 0e3b14047d3ee365f4f2a1b673db059c3972589c	not-for-merge	tag 'tag-three-file' of ../
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5	not-for-merge	tag 'tag-master' of ../
+ecf3b3627b498bdcb735cc4343bf165f76964e9a	not-for-merge	tag 'tag-main' of ../
 22feea448b023a2d864ef94b013735af34d238ba	not-for-merge	tag 'tag-one-tree' of ../
 c61a82b60967180544e3c19f819ddbd0c9f89899	not-for-merge	tag 'tag-three' of ../
 525b7fb068d59950d185a8779dc957c77eed73ba	not-for-merge	tag 'tag-two' of ../

--- a/t/t5515/fetch.br-unconfig_.._.git_tag_tag-one-tree_tag_tag-three-file
+++ b/t/t5515/fetch.br-unconfig_.._.git_tag_tag-one-tree_tag_tag-three-file
@@ -1,7 +1,7 @@
 # br-unconfig ../.git tag tag-one-tree tag tag-three-file
 22feea448b023a2d864ef94b013735af34d238ba	not-for-merge	tag 'tag-one-tree' of ../
 0e3b14047d3ee365f4f2a1b673db059c3972589c	not-for-merge	tag 'tag-three-file' of ../
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5	not-for-merge	tag 'tag-master' of ../
+ecf3b3627b498bdcb735cc4343bf165f76964e9a	not-for-merge	tag 'tag-main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	tag 'tag-one' of ../
 c61a82b60967180544e3c19f819ddbd0c9f89899	not-for-merge	tag 'tag-three' of ../
 525b7fb068d59950d185a8779dc957c77eed73ba	not-for-merge	tag 'tag-two' of ../

--- a/t/t5515/fetch.br-unconfig_.._.git_tag_tag-one_tag_tag-three
+++ b/t/t5515/fetch.br-unconfig_.._.git_tag_tag-one_tag_tag-three
@@ -1,7 +1,7 @@
 # br-unconfig ../.git tag tag-one tag tag-three
 8e32a6d901327a23ef831511badce7bf3bf46689		tag 'tag-one' of ../
 c61a82b60967180544e3c19f819ddbd0c9f89899		tag 'tag-three' of ../
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5	not-for-merge	tag 'tag-master' of ../
+ecf3b3627b498bdcb735cc4343bf165f76964e9a	not-for-merge	tag 'tag-main' of ../
 22feea448b023a2d864ef94b013735af34d238ba	not-for-merge	tag 'tag-one-tree' of ../
 0e3b14047d3ee365f4f2a1b673db059c3972589c	not-for-merge	tag 'tag-three-file' of ../
 525b7fb068d59950d185a8779dc957c77eed73ba	not-for-merge	tag 'tag-two' of ../

--- a/t/t5515/fetch.br-unconfig_branches-default
+++ b/t/t5515/fetch.br-unconfig_branches-default
@@ -1,6 +1,6 @@
 # br-unconfig branches-default
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f		branch 'master' of ../
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5	not-for-merge	tag 'tag-master' of ../
+b4ab76b1a01ea602209932134a44f1e6bd610832		branch 'main' of ../
+ecf3b3627b498bdcb735cc4343bf165f76964e9a	not-for-merge	tag 'tag-main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	tag 'tag-one' of ../
 22feea448b023a2d864ef94b013735af34d238ba	not-for-merge	tag 'tag-one-tree' of ../
 c61a82b60967180544e3c19f819ddbd0c9f89899	not-for-merge	tag 'tag-three' of ../

--- a/t/t5515/fetch.br-unconfig_branches-one
+++ b/t/t5515/fetch.br-unconfig_branches-one
@@ -1,6 +1,6 @@
 # br-unconfig branches-one
 8e32a6d901327a23ef831511badce7bf3bf46689		branch 'one' of ../
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5	not-for-merge	tag 'tag-master' of ../
+ecf3b3627b498bdcb735cc4343bf165f76964e9a	not-for-merge	tag 'tag-main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	tag 'tag-one' of ../
 22feea448b023a2d864ef94b013735af34d238ba	not-for-merge	tag 'tag-one-tree' of ../
 c61a82b60967180544e3c19f819ddbd0c9f89899	not-for-merge	tag 'tag-three' of ../

--- a/t/t5515/fetch.br-unconfig_config-explicit
+++ b/t/t5515/fetch.br-unconfig_config-explicit
@@ -1,9 +1,9 @@
 # br-unconfig config-explicit
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f		branch 'master' of ../
+b4ab76b1a01ea602209932134a44f1e6bd610832		branch 'main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	branch 'one' of ../
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8	not-for-merge	branch 'two' of ../
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b	not-for-merge	branch 'three' of ../
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5	not-for-merge	tag 'tag-master' of ../
+ecf3b3627b498bdcb735cc4343bf165f76964e9a	not-for-merge	tag 'tag-main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	tag 'tag-one' of ../
 22feea448b023a2d864ef94b013735af34d238ba	not-for-merge	tag 'tag-one-tree' of ../
 c61a82b60967180544e3c19f819ddbd0c9f89899	not-for-merge	tag 'tag-three' of ../

--- a/t/t5515/fetch.br-unconfig_config-glob
+++ b/t/t5515/fetch.br-unconfig_config-glob
@@ -1,9 +1,9 @@
 # br-unconfig config-glob
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f	not-for-merge	branch 'master' of ../
+b4ab76b1a01ea602209932134a44f1e6bd610832	not-for-merge	branch 'main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	branch 'one' of ../
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b	not-for-merge	branch 'three' of ../
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8	not-for-merge	branch 'two' of ../
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5	not-for-merge	tag 'tag-master' of ../
+ecf3b3627b498bdcb735cc4343bf165f76964e9a	not-for-merge	tag 'tag-main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	tag 'tag-one' of ../
 22feea448b023a2d864ef94b013735af34d238ba	not-for-merge	tag 'tag-one-tree' of ../
 c61a82b60967180544e3c19f819ddbd0c9f89899	not-for-merge	tag 'tag-three' of ../

--- a/t/t5515/fetch.br-unconfig_remote-explicit
+++ b/t/t5515/fetch.br-unconfig_remote-explicit
@@ -1,9 +1,9 @@
 # br-unconfig remote-explicit
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f		branch 'master' of ../
+b4ab76b1a01ea602209932134a44f1e6bd610832		branch 'main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	branch 'one' of ../
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8	not-for-merge	branch 'two' of ../
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b	not-for-merge	branch 'three' of ../
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5	not-for-merge	tag 'tag-master' of ../
+ecf3b3627b498bdcb735cc4343bf165f76964e9a	not-for-merge	tag 'tag-main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	tag 'tag-one' of ../
 22feea448b023a2d864ef94b013735af34d238ba	not-for-merge	tag 'tag-one-tree' of ../
 c61a82b60967180544e3c19f819ddbd0c9f89899	not-for-merge	tag 'tag-three' of ../

--- a/t/t5515/fetch.br-unconfig_remote-glob
+++ b/t/t5515/fetch.br-unconfig_remote-glob
@@ -1,9 +1,9 @@
 # br-unconfig remote-glob
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f	not-for-merge	branch 'master' of ../
+b4ab76b1a01ea602209932134a44f1e6bd610832	not-for-merge	branch 'main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	branch 'one' of ../
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b	not-for-merge	branch 'three' of ../
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8	not-for-merge	branch 'two' of ../
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5	not-for-merge	tag 'tag-master' of ../
+ecf3b3627b498bdcb735cc4343bf165f76964e9a	not-for-merge	tag 'tag-main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	tag 'tag-one' of ../
 22feea448b023a2d864ef94b013735af34d238ba	not-for-merge	tag 'tag-one-tree' of ../
 c61a82b60967180544e3c19f819ddbd0c9f89899	not-for-merge	tag 'tag-three' of ../

--- a/t/t5515/fetch.main
+++ b/t/t5515/fetch.main
@@ -1,9 +1,9 @@
-# master config-explicit
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f		branch 'master' of ../
+# main
+b4ab76b1a01ea602209932134a44f1e6bd610832	not-for-merge	branch 'main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	branch 'one' of ../
-6134ee8f857693b96ff1cc98d3e2fd62b199e5a8	not-for-merge	branch 'two' of ../
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b	not-for-merge	branch 'three' of ../
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5	not-for-merge	tag 'tag-master' of ../
+6134ee8f857693b96ff1cc98d3e2fd62b199e5a8	not-for-merge	branch 'two' of ../
+ecf3b3627b498bdcb735cc4343bf165f76964e9a	not-for-merge	tag 'tag-main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	tag 'tag-one' of ../
 22feea448b023a2d864ef94b013735af34d238ba	not-for-merge	tag 'tag-one-tree' of ../
 c61a82b60967180544e3c19f819ddbd0c9f89899	not-for-merge	tag 'tag-three' of ../

--- a/t/t5515/fetch.main_--tags_.._.git
+++ b/t/t5515/fetch.main_--tags_.._.git
@@ -1,9 +1,6 @@
-# master
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f	not-for-merge	branch 'master' of ../
-8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	branch 'one' of ../
-0567da4d5edd2ff4bb292a465ba9e64dcad9536b	not-for-merge	branch 'three' of ../
-6134ee8f857693b96ff1cc98d3e2fd62b199e5a8	not-for-merge	branch 'two' of ../
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5	not-for-merge	tag 'tag-master' of ../
+# main --tags ../.git
+0567da4d5edd2ff4bb292a465ba9e64dcad9536b		../
+ecf3b3627b498bdcb735cc4343bf165f76964e9a	not-for-merge	tag 'tag-main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	tag 'tag-one' of ../
 22feea448b023a2d864ef94b013735af34d238ba	not-for-merge	tag 'tag-one-tree' of ../
 c61a82b60967180544e3c19f819ddbd0c9f89899	not-for-merge	tag 'tag-three' of ../

--- a/t/t5515/fetch.main_.._.git
+++ b/t/t5515/fetch.main_.._.git
@@ -1,2 +1,2 @@
-# master ../.git
+# main ../.git
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b		../

--- a/t/t5515/fetch.main_.._.git_one
+++ b/t/t5515/fetch.main_.._.git_one
@@ -1,2 +1,2 @@
-# master ../.git one
+# main ../.git one
 8e32a6d901327a23ef831511badce7bf3bf46689		branch 'one' of ../

--- a/t/t5515/fetch.main_.._.git_one_tag_tag-one_tag_tag-three-file
+++ b/t/t5515/fetch.main_.._.git_one_tag_tag-one_tag_tag-three-file
@@ -1,8 +1,8 @@
-# master ../.git one tag tag-one tag tag-three-file
+# main ../.git one tag tag-one tag tag-three-file
 8e32a6d901327a23ef831511badce7bf3bf46689		branch 'one' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689		tag 'tag-one' of ../
 0e3b14047d3ee365f4f2a1b673db059c3972589c	not-for-merge	tag 'tag-three-file' of ../
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5	not-for-merge	tag 'tag-master' of ../
+ecf3b3627b498bdcb735cc4343bf165f76964e9a	not-for-merge	tag 'tag-main' of ../
 22feea448b023a2d864ef94b013735af34d238ba	not-for-merge	tag 'tag-one-tree' of ../
 c61a82b60967180544e3c19f819ddbd0c9f89899	not-for-merge	tag 'tag-three' of ../
 525b7fb068d59950d185a8779dc957c77eed73ba	not-for-merge	tag 'tag-two' of ../

--- a/t/t5515/fetch.main_.._.git_one_two
+++ b/t/t5515/fetch.main_.._.git_one_two
@@ -1,3 +1,3 @@
-# master ../.git one two
+# main ../.git one two
 8e32a6d901327a23ef831511badce7bf3bf46689		branch 'one' of ../
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8		branch 'two' of ../

--- a/t/t5515/fetch.main_.._.git_tag_tag-one-tree_tag_tag-three-file
+++ b/t/t5515/fetch.main_.._.git_tag_tag-one-tree_tag_tag-three-file
@@ -1,7 +1,7 @@
-# master ../.git tag tag-one-tree tag tag-three-file
+# main ../.git tag tag-one-tree tag tag-three-file
 22feea448b023a2d864ef94b013735af34d238ba	not-for-merge	tag 'tag-one-tree' of ../
 0e3b14047d3ee365f4f2a1b673db059c3972589c	not-for-merge	tag 'tag-three-file' of ../
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5	not-for-merge	tag 'tag-master' of ../
+ecf3b3627b498bdcb735cc4343bf165f76964e9a	not-for-merge	tag 'tag-main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	tag 'tag-one' of ../
 c61a82b60967180544e3c19f819ddbd0c9f89899	not-for-merge	tag 'tag-three' of ../
 525b7fb068d59950d185a8779dc957c77eed73ba	not-for-merge	tag 'tag-two' of ../

--- a/t/t5515/fetch.main_.._.git_tag_tag-one_tag_tag-three
+++ b/t/t5515/fetch.main_.._.git_tag_tag-one_tag_tag-three
@@ -1,7 +1,7 @@
-# master ../.git tag tag-one tag tag-three
+# main ../.git tag tag-one tag tag-three
 8e32a6d901327a23ef831511badce7bf3bf46689		tag 'tag-one' of ../
 c61a82b60967180544e3c19f819ddbd0c9f89899		tag 'tag-three' of ../
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5	not-for-merge	tag 'tag-master' of ../
+ecf3b3627b498bdcb735cc4343bf165f76964e9a	not-for-merge	tag 'tag-main' of ../
 22feea448b023a2d864ef94b013735af34d238ba	not-for-merge	tag 'tag-one-tree' of ../
 0e3b14047d3ee365f4f2a1b673db059c3972589c	not-for-merge	tag 'tag-three-file' of ../
 525b7fb068d59950d185a8779dc957c77eed73ba	not-for-merge	tag 'tag-two' of ../

--- a/t/t5515/fetch.main_branches-default
+++ b/t/t5515/fetch.main_branches-default
@@ -1,6 +1,6 @@
-# master --tags ../.git
-0567da4d5edd2ff4bb292a465ba9e64dcad9536b		../
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5	not-for-merge	tag 'tag-master' of ../
+# main branches-default
+b4ab76b1a01ea602209932134a44f1e6bd610832		branch 'main' of ../
+ecf3b3627b498bdcb735cc4343bf165f76964e9a	not-for-merge	tag 'tag-main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	tag 'tag-one' of ../
 22feea448b023a2d864ef94b013735af34d238ba	not-for-merge	tag 'tag-one-tree' of ../
 c61a82b60967180544e3c19f819ddbd0c9f89899	not-for-merge	tag 'tag-three' of ../

--- a/t/t5515/fetch.main_branches-one
+++ b/t/t5515/fetch.main_branches-one
@@ -1,6 +1,6 @@
-# master branches-default
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f		branch 'master' of ../
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5	not-for-merge	tag 'tag-master' of ../
+# main branches-one
+8e32a6d901327a23ef831511badce7bf3bf46689		branch 'one' of ../
+ecf3b3627b498bdcb735cc4343bf165f76964e9a	not-for-merge	tag 'tag-main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	tag 'tag-one' of ../
 22feea448b023a2d864ef94b013735af34d238ba	not-for-merge	tag 'tag-one-tree' of ../
 c61a82b60967180544e3c19f819ddbd0c9f89899	not-for-merge	tag 'tag-three' of ../

--- a/t/t5515/fetch.main_config-explicit
+++ b/t/t5515/fetch.main_config-explicit
@@ -1,9 +1,9 @@
-# master remote-glob
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f	not-for-merge	branch 'master' of ../
+# main config-explicit
+b4ab76b1a01ea602209932134a44f1e6bd610832		branch 'main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	branch 'one' of ../
-0567da4d5edd2ff4bb292a465ba9e64dcad9536b	not-for-merge	branch 'three' of ../
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8	not-for-merge	branch 'two' of ../
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5	not-for-merge	tag 'tag-master' of ../
+0567da4d5edd2ff4bb292a465ba9e64dcad9536b	not-for-merge	branch 'three' of ../
+ecf3b3627b498bdcb735cc4343bf165f76964e9a	not-for-merge	tag 'tag-main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	tag 'tag-one' of ../
 22feea448b023a2d864ef94b013735af34d238ba	not-for-merge	tag 'tag-one-tree' of ../
 c61a82b60967180544e3c19f819ddbd0c9f89899	not-for-merge	tag 'tag-three' of ../

--- a/t/t5515/fetch.main_config-glob
+++ b/t/t5515/fetch.main_config-glob
@@ -1,9 +1,9 @@
-# master remote-explicit
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f		branch 'master' of ../
+# main config-glob
+b4ab76b1a01ea602209932134a44f1e6bd610832	not-for-merge	branch 'main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	branch 'one' of ../
-6134ee8f857693b96ff1cc98d3e2fd62b199e5a8	not-for-merge	branch 'two' of ../
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b	not-for-merge	branch 'three' of ../
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5	not-for-merge	tag 'tag-master' of ../
+6134ee8f857693b96ff1cc98d3e2fd62b199e5a8	not-for-merge	branch 'two' of ../
+ecf3b3627b498bdcb735cc4343bf165f76964e9a	not-for-merge	tag 'tag-main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	tag 'tag-one' of ../
 22feea448b023a2d864ef94b013735af34d238ba	not-for-merge	tag 'tag-one-tree' of ../
 c61a82b60967180544e3c19f819ddbd0c9f89899	not-for-merge	tag 'tag-three' of ../

--- a/t/t5515/fetch.main_remote-explicit
+++ b/t/t5515/fetch.main_remote-explicit
@@ -1,6 +1,9 @@
-# master branches-one
-8e32a6d901327a23ef831511badce7bf3bf46689		branch 'one' of ../
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5	not-for-merge	tag 'tag-master' of ../
+# main remote-explicit
+b4ab76b1a01ea602209932134a44f1e6bd610832		branch 'main' of ../
+8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	branch 'one' of ../
+6134ee8f857693b96ff1cc98d3e2fd62b199e5a8	not-for-merge	branch 'two' of ../
+0567da4d5edd2ff4bb292a465ba9e64dcad9536b	not-for-merge	branch 'three' of ../
+ecf3b3627b498bdcb735cc4343bf165f76964e9a	not-for-merge	tag 'tag-main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	tag 'tag-one' of ../
 22feea448b023a2d864ef94b013735af34d238ba	not-for-merge	tag 'tag-one-tree' of ../
 c61a82b60967180544e3c19f819ddbd0c9f89899	not-for-merge	tag 'tag-three' of ../

--- a/t/t5515/fetch.main_remote-glob
+++ b/t/t5515/fetch.main_remote-glob
@@ -1,9 +1,9 @@
-# master config-glob
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f	not-for-merge	branch 'master' of ../
+# main remote-glob
+b4ab76b1a01ea602209932134a44f1e6bd610832	not-for-merge	branch 'main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	branch 'one' of ../
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b	not-for-merge	branch 'three' of ../
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8	not-for-merge	branch 'two' of ../
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5	not-for-merge	tag 'tag-master' of ../
+ecf3b3627b498bdcb735cc4343bf165f76964e9a	not-for-merge	tag 'tag-main' of ../
 8e32a6d901327a23ef831511badce7bf3bf46689	not-for-merge	tag 'tag-one' of ../
 22feea448b023a2d864ef94b013735af34d238ba	not-for-merge	tag 'tag-one-tree' of ../
 c61a82b60967180544e3c19f819ddbd0c9f89899	not-for-merge	tag 'tag-three' of ../

--- a/t/t5515/refs.br-branches-default
+++ b/t/t5515/refs.br-branches-default
@@ -1,10 +1,10 @@
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/heads/branches-default
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/heads/branches-default
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5 refs/tags/tag-master
+ecf3b3627b498bdcb735cc4343bf165f76964e9a refs/tags/tag-main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/tags/tag-one
 22feea448b023a2d864ef94b013735af34d238ba refs/tags/tag-one-tree
 c61a82b60967180544e3c19f819ddbd0c9f89899 refs/tags/tag-three

--- a/t/t5515/refs.br-branches-default-merge
+++ b/t/t5515/refs.br-branches-default-merge
@@ -1,10 +1,10 @@
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/heads/branches-default
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/heads/branches-default
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5 refs/tags/tag-master
+ecf3b3627b498bdcb735cc4343bf165f76964e9a refs/tags/tag-main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/tags/tag-one
 22feea448b023a2d864ef94b013735af34d238ba refs/tags/tag-one-tree
 c61a82b60967180544e3c19f819ddbd0c9f89899 refs/tags/tag-three

--- a/t/t5515/refs.br-branches-default-merge_branches-default
+++ b/t/t5515/refs.br-branches-default-merge_branches-default
@@ -1,10 +1,10 @@
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/heads/branches-default
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/heads/branches-default
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5 refs/tags/tag-master
+ecf3b3627b498bdcb735cc4343bf165f76964e9a refs/tags/tag-main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/tags/tag-one
 22feea448b023a2d864ef94b013735af34d238ba refs/tags/tag-one-tree
 c61a82b60967180544e3c19f819ddbd0c9f89899 refs/tags/tag-three

--- a/t/t5515/refs.br-branches-default-octopus
+++ b/t/t5515/refs.br-branches-default-octopus
@@ -1,10 +1,10 @@
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/heads/branches-default
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/heads/branches-default
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5 refs/tags/tag-master
+ecf3b3627b498bdcb735cc4343bf165f76964e9a refs/tags/tag-main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/tags/tag-one
 22feea448b023a2d864ef94b013735af34d238ba refs/tags/tag-one-tree
 c61a82b60967180544e3c19f819ddbd0c9f89899 refs/tags/tag-three

--- a/t/t5515/refs.br-branches-default-octopus_branches-default
+++ b/t/t5515/refs.br-branches-default-octopus_branches-default
@@ -1,10 +1,10 @@
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/heads/branches-default
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/heads/branches-default
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5 refs/tags/tag-master
+ecf3b3627b498bdcb735cc4343bf165f76964e9a refs/tags/tag-main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/tags/tag-one
 22feea448b023a2d864ef94b013735af34d238ba refs/tags/tag-one-tree
 c61a82b60967180544e3c19f819ddbd0c9f89899 refs/tags/tag-three

--- a/t/t5515/refs.br-branches-default_branches-default
+++ b/t/t5515/refs.br-branches-default_branches-default
@@ -1,10 +1,10 @@
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/heads/branches-default
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/heads/branches-default
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5 refs/tags/tag-master
+ecf3b3627b498bdcb735cc4343bf165f76964e9a refs/tags/tag-main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/tags/tag-one
 22feea448b023a2d864ef94b013735af34d238ba refs/tags/tag-one-tree
 c61a82b60967180544e3c19f819ddbd0c9f89899 refs/tags/tag-three

--- a/t/t5515/refs.br-branches-one
+++ b/t/t5515/refs.br-branches-one
@@ -1,10 +1,10 @@
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/heads/branches-one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5 refs/tags/tag-master
+ecf3b3627b498bdcb735cc4343bf165f76964e9a refs/tags/tag-main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/tags/tag-one
 22feea448b023a2d864ef94b013735af34d238ba refs/tags/tag-one-tree
 c61a82b60967180544e3c19f819ddbd0c9f89899 refs/tags/tag-three

--- a/t/t5515/refs.br-branches-one-merge
+++ b/t/t5515/refs.br-branches-one-merge
@@ -1,10 +1,10 @@
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/heads/branches-one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5 refs/tags/tag-master
+ecf3b3627b498bdcb735cc4343bf165f76964e9a refs/tags/tag-main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/tags/tag-one
 22feea448b023a2d864ef94b013735af34d238ba refs/tags/tag-one-tree
 c61a82b60967180544e3c19f819ddbd0c9f89899 refs/tags/tag-three

--- a/t/t5515/refs.br-branches-one-merge_branches-one
+++ b/t/t5515/refs.br-branches-one-merge_branches-one
@@ -1,10 +1,10 @@
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/heads/branches-one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5 refs/tags/tag-master
+ecf3b3627b498bdcb735cc4343bf165f76964e9a refs/tags/tag-main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/tags/tag-one
 22feea448b023a2d864ef94b013735af34d238ba refs/tags/tag-one-tree
 c61a82b60967180544e3c19f819ddbd0c9f89899 refs/tags/tag-three

--- a/t/t5515/refs.br-branches-one-octopus
+++ b/t/t5515/refs.br-branches-one-octopus
@@ -1,10 +1,10 @@
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/heads/branches-one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5 refs/tags/tag-master
+ecf3b3627b498bdcb735cc4343bf165f76964e9a refs/tags/tag-main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/tags/tag-one
 22feea448b023a2d864ef94b013735af34d238ba refs/tags/tag-one-tree
 c61a82b60967180544e3c19f819ddbd0c9f89899 refs/tags/tag-three

--- a/t/t5515/refs.br-branches-one-octopus_branches-one
+++ b/t/t5515/refs.br-branches-one-octopus_branches-one
@@ -1,10 +1,10 @@
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/heads/branches-one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5 refs/tags/tag-master
+ecf3b3627b498bdcb735cc4343bf165f76964e9a refs/tags/tag-main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/tags/tag-one
 22feea448b023a2d864ef94b013735af34d238ba refs/tags/tag-one-tree
 c61a82b60967180544e3c19f819ddbd0c9f89899 refs/tags/tag-three

--- a/t/t5515/refs.br-branches-one_branches-one
+++ b/t/t5515/refs.br-branches-one_branches-one
@@ -1,10 +1,10 @@
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/heads/branches-one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5 refs/tags/tag-master
+ecf3b3627b498bdcb735cc4343bf165f76964e9a refs/tags/tag-main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/tags/tag-one
 22feea448b023a2d864ef94b013735af34d238ba refs/tags/tag-one-tree
 c61a82b60967180544e3c19f819ddbd0c9f89899 refs/tags/tag-three

--- a/t/t5515/refs.br-config-explicit
+++ b/t/t5515/refs.br-config-explicit
@@ -1,13 +1,13 @@
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/rem/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/rem/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/rem/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/rem/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/rem/two
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5 refs/tags/tag-master
+ecf3b3627b498bdcb735cc4343bf165f76964e9a refs/tags/tag-main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/tags/tag-one
 22feea448b023a2d864ef94b013735af34d238ba refs/tags/tag-one-tree
 c61a82b60967180544e3c19f819ddbd0c9f89899 refs/tags/tag-three

--- a/t/t5515/refs.br-config-explicit-merge
+++ b/t/t5515/refs.br-config-explicit-merge
@@ -1,13 +1,13 @@
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/rem/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/rem/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/rem/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/rem/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/rem/two
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5 refs/tags/tag-master
+ecf3b3627b498bdcb735cc4343bf165f76964e9a refs/tags/tag-main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/tags/tag-one
 22feea448b023a2d864ef94b013735af34d238ba refs/tags/tag-one-tree
 c61a82b60967180544e3c19f819ddbd0c9f89899 refs/tags/tag-three

--- a/t/t5515/refs.br-config-explicit-merge_config-explicit
+++ b/t/t5515/refs.br-config-explicit-merge_config-explicit
@@ -1,13 +1,13 @@
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/rem/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/rem/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/rem/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/rem/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/rem/two
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5 refs/tags/tag-master
+ecf3b3627b498bdcb735cc4343bf165f76964e9a refs/tags/tag-main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/tags/tag-one
 22feea448b023a2d864ef94b013735af34d238ba refs/tags/tag-one-tree
 c61a82b60967180544e3c19f819ddbd0c9f89899 refs/tags/tag-three

--- a/t/t5515/refs.br-config-explicit-octopus
+++ b/t/t5515/refs.br-config-explicit-octopus
@@ -1,13 +1,13 @@
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/rem/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/rem/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/rem/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/rem/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/rem/two
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5 refs/tags/tag-master
+ecf3b3627b498bdcb735cc4343bf165f76964e9a refs/tags/tag-main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/tags/tag-one
 22feea448b023a2d864ef94b013735af34d238ba refs/tags/tag-one-tree
 c61a82b60967180544e3c19f819ddbd0c9f89899 refs/tags/tag-three

--- a/t/t5515/refs.br-config-explicit-octopus_config-explicit
+++ b/t/t5515/refs.br-config-explicit-octopus_config-explicit
@@ -1,13 +1,13 @@
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/rem/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/rem/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/rem/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/rem/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/rem/two
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5 refs/tags/tag-master
+ecf3b3627b498bdcb735cc4343bf165f76964e9a refs/tags/tag-main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/tags/tag-one
 22feea448b023a2d864ef94b013735af34d238ba refs/tags/tag-one-tree
 c61a82b60967180544e3c19f819ddbd0c9f89899 refs/tags/tag-three

--- a/t/t5515/refs.br-config-explicit_config-explicit
+++ b/t/t5515/refs.br-config-explicit_config-explicit
@@ -1,13 +1,13 @@
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/rem/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/rem/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/rem/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/rem/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/rem/two
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5 refs/tags/tag-master
+ecf3b3627b498bdcb735cc4343bf165f76964e9a refs/tags/tag-main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/tags/tag-one
 22feea448b023a2d864ef94b013735af34d238ba refs/tags/tag-one-tree
 c61a82b60967180544e3c19f819ddbd0c9f89899 refs/tags/tag-three

--- a/t/t5515/refs.br-config-glob
+++ b/t/t5515/refs.br-config-glob
@@ -1,13 +1,13 @@
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/rem/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/rem/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/rem/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/rem/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/rem/two
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5 refs/tags/tag-master
+ecf3b3627b498bdcb735cc4343bf165f76964e9a refs/tags/tag-main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/tags/tag-one
 22feea448b023a2d864ef94b013735af34d238ba refs/tags/tag-one-tree
 c61a82b60967180544e3c19f819ddbd0c9f89899 refs/tags/tag-three

--- a/t/t5515/refs.br-config-glob-merge
+++ b/t/t5515/refs.br-config-glob-merge
@@ -1,13 +1,13 @@
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/rem/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/rem/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/rem/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/rem/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/rem/two
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5 refs/tags/tag-master
+ecf3b3627b498bdcb735cc4343bf165f76964e9a refs/tags/tag-main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/tags/tag-one
 22feea448b023a2d864ef94b013735af34d238ba refs/tags/tag-one-tree
 c61a82b60967180544e3c19f819ddbd0c9f89899 refs/tags/tag-three

--- a/t/t5515/refs.br-config-glob-merge_config-glob
+++ b/t/t5515/refs.br-config-glob-merge_config-glob
@@ -1,13 +1,13 @@
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/rem/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/rem/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/rem/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/rem/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/rem/two
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5 refs/tags/tag-master
+ecf3b3627b498bdcb735cc4343bf165f76964e9a refs/tags/tag-main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/tags/tag-one
 22feea448b023a2d864ef94b013735af34d238ba refs/tags/tag-one-tree
 c61a82b60967180544e3c19f819ddbd0c9f89899 refs/tags/tag-three

--- a/t/t5515/refs.br-config-glob-octopus
+++ b/t/t5515/refs.br-config-glob-octopus
@@ -1,13 +1,13 @@
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/rem/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/rem/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/rem/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/rem/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/rem/two
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5 refs/tags/tag-master
+ecf3b3627b498bdcb735cc4343bf165f76964e9a refs/tags/tag-main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/tags/tag-one
 22feea448b023a2d864ef94b013735af34d238ba refs/tags/tag-one-tree
 c61a82b60967180544e3c19f819ddbd0c9f89899 refs/tags/tag-three

--- a/t/t5515/refs.br-config-glob-octopus_config-glob
+++ b/t/t5515/refs.br-config-glob-octopus_config-glob
@@ -1,13 +1,13 @@
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/rem/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/rem/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/rem/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/rem/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/rem/two
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5 refs/tags/tag-master
+ecf3b3627b498bdcb735cc4343bf165f76964e9a refs/tags/tag-main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/tags/tag-one
 22feea448b023a2d864ef94b013735af34d238ba refs/tags/tag-one-tree
 c61a82b60967180544e3c19f819ddbd0c9f89899 refs/tags/tag-three

--- a/t/t5515/refs.br-config-glob_config-glob
+++ b/t/t5515/refs.br-config-glob_config-glob
@@ -1,13 +1,13 @@
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/rem/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/rem/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/rem/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/rem/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/rem/two
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5 refs/tags/tag-master
+ecf3b3627b498bdcb735cc4343bf165f76964e9a refs/tags/tag-main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/tags/tag-one
 22feea448b023a2d864ef94b013735af34d238ba refs/tags/tag-one-tree
 c61a82b60967180544e3c19f819ddbd0c9f89899 refs/tags/tag-three

--- a/t/t5515/refs.br-remote-explicit
+++ b/t/t5515/refs.br-remote-explicit
@@ -1,13 +1,13 @@
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/rem/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/rem/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/rem/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/rem/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/rem/two
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5 refs/tags/tag-master
+ecf3b3627b498bdcb735cc4343bf165f76964e9a refs/tags/tag-main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/tags/tag-one
 22feea448b023a2d864ef94b013735af34d238ba refs/tags/tag-one-tree
 c61a82b60967180544e3c19f819ddbd0c9f89899 refs/tags/tag-three

--- a/t/t5515/refs.br-remote-explicit-merge
+++ b/t/t5515/refs.br-remote-explicit-merge
@@ -1,13 +1,13 @@
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/rem/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/rem/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/rem/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/rem/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/rem/two
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5 refs/tags/tag-master
+ecf3b3627b498bdcb735cc4343bf165f76964e9a refs/tags/tag-main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/tags/tag-one
 22feea448b023a2d864ef94b013735af34d238ba refs/tags/tag-one-tree
 c61a82b60967180544e3c19f819ddbd0c9f89899 refs/tags/tag-three

--- a/t/t5515/refs.br-remote-explicit-merge_remote-explicit
+++ b/t/t5515/refs.br-remote-explicit-merge_remote-explicit
@@ -1,13 +1,13 @@
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/rem/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/rem/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/rem/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/rem/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/rem/two
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5 refs/tags/tag-master
+ecf3b3627b498bdcb735cc4343bf165f76964e9a refs/tags/tag-main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/tags/tag-one
 22feea448b023a2d864ef94b013735af34d238ba refs/tags/tag-one-tree
 c61a82b60967180544e3c19f819ddbd0c9f89899 refs/tags/tag-three

--- a/t/t5515/refs.br-remote-explicit-octopus
+++ b/t/t5515/refs.br-remote-explicit-octopus
@@ -1,13 +1,13 @@
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/rem/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/rem/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/rem/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/rem/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/rem/two
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5 refs/tags/tag-master
+ecf3b3627b498bdcb735cc4343bf165f76964e9a refs/tags/tag-main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/tags/tag-one
 22feea448b023a2d864ef94b013735af34d238ba refs/tags/tag-one-tree
 c61a82b60967180544e3c19f819ddbd0c9f89899 refs/tags/tag-three

--- a/t/t5515/refs.br-remote-explicit-octopus_remote-explicit
+++ b/t/t5515/refs.br-remote-explicit-octopus_remote-explicit
@@ -1,13 +1,13 @@
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/rem/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/rem/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/rem/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/rem/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/rem/two
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5 refs/tags/tag-master
+ecf3b3627b498bdcb735cc4343bf165f76964e9a refs/tags/tag-main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/tags/tag-one
 22feea448b023a2d864ef94b013735af34d238ba refs/tags/tag-one-tree
 c61a82b60967180544e3c19f819ddbd0c9f89899 refs/tags/tag-three

--- a/t/t5515/refs.br-remote-explicit_remote-explicit
+++ b/t/t5515/refs.br-remote-explicit_remote-explicit
@@ -1,13 +1,13 @@
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/rem/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/rem/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/rem/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/rem/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/rem/two
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5 refs/tags/tag-master
+ecf3b3627b498bdcb735cc4343bf165f76964e9a refs/tags/tag-main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/tags/tag-one
 22feea448b023a2d864ef94b013735af34d238ba refs/tags/tag-one-tree
 c61a82b60967180544e3c19f819ddbd0c9f89899 refs/tags/tag-three

--- a/t/t5515/refs.br-remote-glob
+++ b/t/t5515/refs.br-remote-glob
@@ -1,13 +1,13 @@
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/rem/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/rem/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/rem/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/rem/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/rem/two
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5 refs/tags/tag-master
+ecf3b3627b498bdcb735cc4343bf165f76964e9a refs/tags/tag-main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/tags/tag-one
 22feea448b023a2d864ef94b013735af34d238ba refs/tags/tag-one-tree
 c61a82b60967180544e3c19f819ddbd0c9f89899 refs/tags/tag-three

--- a/t/t5515/refs.br-remote-glob-merge
+++ b/t/t5515/refs.br-remote-glob-merge
@@ -1,13 +1,13 @@
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/rem/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/rem/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/rem/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/rem/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/rem/two
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5 refs/tags/tag-master
+ecf3b3627b498bdcb735cc4343bf165f76964e9a refs/tags/tag-main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/tags/tag-one
 22feea448b023a2d864ef94b013735af34d238ba refs/tags/tag-one-tree
 c61a82b60967180544e3c19f819ddbd0c9f89899 refs/tags/tag-three

--- a/t/t5515/refs.br-remote-glob-merge_remote-glob
+++ b/t/t5515/refs.br-remote-glob-merge_remote-glob
@@ -1,13 +1,13 @@
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/rem/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/rem/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/rem/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/rem/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/rem/two
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5 refs/tags/tag-master
+ecf3b3627b498bdcb735cc4343bf165f76964e9a refs/tags/tag-main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/tags/tag-one
 22feea448b023a2d864ef94b013735af34d238ba refs/tags/tag-one-tree
 c61a82b60967180544e3c19f819ddbd0c9f89899 refs/tags/tag-three

--- a/t/t5515/refs.br-remote-glob-octopus
+++ b/t/t5515/refs.br-remote-glob-octopus
@@ -1,13 +1,13 @@
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/rem/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/rem/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/rem/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/rem/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/rem/two
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5 refs/tags/tag-master
+ecf3b3627b498bdcb735cc4343bf165f76964e9a refs/tags/tag-main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/tags/tag-one
 22feea448b023a2d864ef94b013735af34d238ba refs/tags/tag-one-tree
 c61a82b60967180544e3c19f819ddbd0c9f89899 refs/tags/tag-three

--- a/t/t5515/refs.br-remote-glob-octopus_remote-glob
+++ b/t/t5515/refs.br-remote-glob-octopus_remote-glob
@@ -1,13 +1,13 @@
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/rem/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/rem/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/rem/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/rem/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/rem/two
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5 refs/tags/tag-master
+ecf3b3627b498bdcb735cc4343bf165f76964e9a refs/tags/tag-main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/tags/tag-one
 22feea448b023a2d864ef94b013735af34d238ba refs/tags/tag-one-tree
 c61a82b60967180544e3c19f819ddbd0c9f89899 refs/tags/tag-three

--- a/t/t5515/refs.br-remote-glob_remote-glob
+++ b/t/t5515/refs.br-remote-glob_remote-glob
@@ -1,13 +1,13 @@
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/rem/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/rem/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/rem/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/rem/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/rem/two
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5 refs/tags/tag-master
+ecf3b3627b498bdcb735cc4343bf165f76964e9a refs/tags/tag-main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/tags/tag-one
 22feea448b023a2d864ef94b013735af34d238ba refs/tags/tag-one-tree
 c61a82b60967180544e3c19f819ddbd0c9f89899 refs/tags/tag-three

--- a/t/t5515/refs.br-unconfig
+++ b/t/t5515/refs.br-unconfig
@@ -1,9 +1,9 @@
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5 refs/tags/tag-master
+ecf3b3627b498bdcb735cc4343bf165f76964e9a refs/tags/tag-main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/tags/tag-one
 22feea448b023a2d864ef94b013735af34d238ba refs/tags/tag-one-tree
 c61a82b60967180544e3c19f819ddbd0c9f89899 refs/tags/tag-three

--- a/t/t5515/refs.br-unconfig_--tags_.._.git
+++ b/t/t5515/refs.br-unconfig_--tags_.._.git
@@ -1,9 +1,9 @@
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5 refs/tags/tag-master
+ecf3b3627b498bdcb735cc4343bf165f76964e9a refs/tags/tag-main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/tags/tag-one
 22feea448b023a2d864ef94b013735af34d238ba refs/tags/tag-one-tree
 c61a82b60967180544e3c19f819ddbd0c9f89899 refs/tags/tag-three

--- a/t/t5515/refs.br-unconfig_.._.git
+++ b/t/t5515/refs.br-unconfig_.._.git
@@ -1,5 +1,5 @@
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two

--- a/t/t5515/refs.br-unconfig_.._.git_one
+++ b/t/t5515/refs.br-unconfig_.._.git_one
@@ -1,5 +1,5 @@
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two

--- a/t/t5515/refs.br-unconfig_.._.git_one_tag_tag-one_tag_tag-three-file
+++ b/t/t5515/refs.br-unconfig_.._.git_one_tag_tag-one_tag_tag-three-file
@@ -1,9 +1,9 @@
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5 refs/tags/tag-master
+ecf3b3627b498bdcb735cc4343bf165f76964e9a refs/tags/tag-main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/tags/tag-one
 22feea448b023a2d864ef94b013735af34d238ba refs/tags/tag-one-tree
 c61a82b60967180544e3c19f819ddbd0c9f89899 refs/tags/tag-three

--- a/t/t5515/refs.br-unconfig_.._.git_one_two
+++ b/t/t5515/refs.br-unconfig_.._.git_one_two
@@ -1,5 +1,5 @@
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two

--- a/t/t5515/refs.br-unconfig_.._.git_tag_tag-one-tree_tag_tag-three-file
+++ b/t/t5515/refs.br-unconfig_.._.git_tag_tag-one-tree_tag_tag-three-file
@@ -1,9 +1,9 @@
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5 refs/tags/tag-master
+ecf3b3627b498bdcb735cc4343bf165f76964e9a refs/tags/tag-main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/tags/tag-one
 22feea448b023a2d864ef94b013735af34d238ba refs/tags/tag-one-tree
 c61a82b60967180544e3c19f819ddbd0c9f89899 refs/tags/tag-three

--- a/t/t5515/refs.br-unconfig_.._.git_tag_tag-one_tag_tag-three
+++ b/t/t5515/refs.br-unconfig_.._.git_tag_tag-one_tag_tag-three
@@ -1,9 +1,9 @@
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5 refs/tags/tag-master
+ecf3b3627b498bdcb735cc4343bf165f76964e9a refs/tags/tag-main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/tags/tag-one
 22feea448b023a2d864ef94b013735af34d238ba refs/tags/tag-one-tree
 c61a82b60967180544e3c19f819ddbd0c9f89899 refs/tags/tag-three

--- a/t/t5515/refs.br-unconfig_branches-default
+++ b/t/t5515/refs.br-unconfig_branches-default
@@ -1,10 +1,10 @@
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/heads/branches-default
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/heads/branches-default
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5 refs/tags/tag-master
+ecf3b3627b498bdcb735cc4343bf165f76964e9a refs/tags/tag-main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/tags/tag-one
 22feea448b023a2d864ef94b013735af34d238ba refs/tags/tag-one-tree
 c61a82b60967180544e3c19f819ddbd0c9f89899 refs/tags/tag-three

--- a/t/t5515/refs.br-unconfig_branches-one
+++ b/t/t5515/refs.br-unconfig_branches-one
@@ -1,10 +1,10 @@
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/heads/branches-one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5 refs/tags/tag-master
+ecf3b3627b498bdcb735cc4343bf165f76964e9a refs/tags/tag-main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/tags/tag-one
 22feea448b023a2d864ef94b013735af34d238ba refs/tags/tag-one-tree
 c61a82b60967180544e3c19f819ddbd0c9f89899 refs/tags/tag-three

--- a/t/t5515/refs.br-unconfig_config-explicit
+++ b/t/t5515/refs.br-unconfig_config-explicit
@@ -1,13 +1,13 @@
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/rem/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/rem/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/rem/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/rem/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/rem/two
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5 refs/tags/tag-master
+ecf3b3627b498bdcb735cc4343bf165f76964e9a refs/tags/tag-main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/tags/tag-one
 22feea448b023a2d864ef94b013735af34d238ba refs/tags/tag-one-tree
 c61a82b60967180544e3c19f819ddbd0c9f89899 refs/tags/tag-three

--- a/t/t5515/refs.br-unconfig_config-glob
+++ b/t/t5515/refs.br-unconfig_config-glob
@@ -1,13 +1,13 @@
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/rem/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/rem/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/rem/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/rem/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/rem/two
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5 refs/tags/tag-master
+ecf3b3627b498bdcb735cc4343bf165f76964e9a refs/tags/tag-main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/tags/tag-one
 22feea448b023a2d864ef94b013735af34d238ba refs/tags/tag-one-tree
 c61a82b60967180544e3c19f819ddbd0c9f89899 refs/tags/tag-three

--- a/t/t5515/refs.br-unconfig_remote-explicit
+++ b/t/t5515/refs.br-unconfig_remote-explicit
@@ -1,13 +1,13 @@
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/rem/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/rem/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/rem/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/rem/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/rem/two
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5 refs/tags/tag-master
+ecf3b3627b498bdcb735cc4343bf165f76964e9a refs/tags/tag-main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/tags/tag-one
 22feea448b023a2d864ef94b013735af34d238ba refs/tags/tag-one-tree
 c61a82b60967180544e3c19f819ddbd0c9f89899 refs/tags/tag-three

--- a/t/t5515/refs.br-unconfig_remote-glob
+++ b/t/t5515/refs.br-unconfig_remote-glob
@@ -1,13 +1,13 @@
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/rem/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/rem/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/rem/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/rem/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/rem/two
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5 refs/tags/tag-master
+ecf3b3627b498bdcb735cc4343bf165f76964e9a refs/tags/tag-main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/tags/tag-one
 22feea448b023a2d864ef94b013735af34d238ba refs/tags/tag-one-tree
 c61a82b60967180544e3c19f819ddbd0c9f89899 refs/tags/tag-three

--- a/t/t5515/refs.main
+++ b/t/t5515/refs.main
@@ -1,10 +1,9 @@
-8e32a6d901327a23ef831511badce7bf3bf46689 refs/heads/branches-one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5 refs/tags/tag-master
+ecf3b3627b498bdcb735cc4343bf165f76964e9a refs/tags/tag-main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/tags/tag-one
 22feea448b023a2d864ef94b013735af34d238ba refs/tags/tag-one-tree
 c61a82b60967180544e3c19f819ddbd0c9f89899 refs/tags/tag-three

--- a/t/t5515/refs.main_--tags_.._.git
+++ b/t/t5515/refs.main_--tags_.._.git
@@ -1,13 +1,9 @@
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/rem/master
-8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/rem/one
-0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/rem/three
-6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/rem/two
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5 refs/tags/tag-master
+ecf3b3627b498bdcb735cc4343bf165f76964e9a refs/tags/tag-main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/tags/tag-one
 22feea448b023a2d864ef94b013735af34d238ba refs/tags/tag-one-tree
 c61a82b60967180544e3c19f819ddbd0c9f89899 refs/tags/tag-three

--- a/t/t5515/refs.main_.._.git
+++ b/t/t5515/refs.main_.._.git
@@ -1,5 +1,5 @@
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two

--- a/t/t5515/refs.main_.._.git_one
+++ b/t/t5515/refs.main_.._.git_one
@@ -1,5 +1,5 @@
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two

--- a/t/t5515/refs.main_.._.git_one_tag_tag-one_tag_tag-three-file
+++ b/t/t5515/refs.main_.._.git_one_tag_tag-one_tag_tag-three-file
@@ -1,13 +1,9 @@
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/rem/master
-8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/rem/one
-0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/rem/three
-6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/rem/two
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5 refs/tags/tag-master
+ecf3b3627b498bdcb735cc4343bf165f76964e9a refs/tags/tag-main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/tags/tag-one
 22feea448b023a2d864ef94b013735af34d238ba refs/tags/tag-one-tree
 c61a82b60967180544e3c19f819ddbd0c9f89899 refs/tags/tag-three

--- a/t/t5515/refs.main_.._.git_one_two
+++ b/t/t5515/refs.main_.._.git_one_two
@@ -1,5 +1,5 @@
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two

--- a/t/t5515/refs.main_.._.git_tag_tag-one-tree_tag_tag-three-file
+++ b/t/t5515/refs.main_.._.git_tag_tag-one-tree_tag_tag-three-file
@@ -1,13 +1,9 @@
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/rem/master
-8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/rem/one
-0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/rem/three
-6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/rem/two
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5 refs/tags/tag-master
+ecf3b3627b498bdcb735cc4343bf165f76964e9a refs/tags/tag-main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/tags/tag-one
 22feea448b023a2d864ef94b013735af34d238ba refs/tags/tag-one-tree
 c61a82b60967180544e3c19f819ddbd0c9f89899 refs/tags/tag-three

--- a/t/t5515/refs.main_.._.git_tag_tag-one_tag_tag-three
+++ b/t/t5515/refs.main_.._.git_tag_tag-one_tag_tag-three
@@ -1,13 +1,9 @@
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/rem/master
-8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/rem/one
-0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/rem/three
-6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/rem/two
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5 refs/tags/tag-master
+ecf3b3627b498bdcb735cc4343bf165f76964e9a refs/tags/tag-main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/tags/tag-one
 22feea448b023a2d864ef94b013735af34d238ba refs/tags/tag-one-tree
 c61a82b60967180544e3c19f819ddbd0c9f89899 refs/tags/tag-three

--- a/t/t5515/refs.main_branches-default
+++ b/t/t5515/refs.main_branches-default
@@ -1,9 +1,10 @@
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/heads/branches-default
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5 refs/tags/tag-master
+ecf3b3627b498bdcb735cc4343bf165f76964e9a refs/tags/tag-main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/tags/tag-one
 22feea448b023a2d864ef94b013735af34d238ba refs/tags/tag-one-tree
 c61a82b60967180544e3c19f819ddbd0c9f89899 refs/tags/tag-three

--- a/t/t5515/refs.main_branches-one
+++ b/t/t5515/refs.main_branches-one
@@ -1,10 +1,10 @@
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/heads/branches-default
+8e32a6d901327a23ef831511badce7bf3bf46689 refs/heads/branches-one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5 refs/tags/tag-master
+ecf3b3627b498bdcb735cc4343bf165f76964e9a refs/tags/tag-main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/tags/tag-one
 22feea448b023a2d864ef94b013735af34d238ba refs/tags/tag-one-tree
 c61a82b60967180544e3c19f819ddbd0c9f89899 refs/tags/tag-three

--- a/t/t5515/refs.main_config-explicit
+++ b/t/t5515/refs.main_config-explicit
@@ -1,9 +1,13 @@
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5 refs/tags/tag-master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/rem/main
+8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/rem/one
+0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/rem/three
+6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/rem/two
+ecf3b3627b498bdcb735cc4343bf165f76964e9a refs/tags/tag-main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/tags/tag-one
 22feea448b023a2d864ef94b013735af34d238ba refs/tags/tag-one-tree
 c61a82b60967180544e3c19f819ddbd0c9f89899 refs/tags/tag-three

--- a/t/t5515/refs.main_config-glob
+++ b/t/t5515/refs.main_config-glob
@@ -1,9 +1,13 @@
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5 refs/tags/tag-master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/rem/main
+8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/rem/one
+0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/rem/three
+6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/rem/two
+ecf3b3627b498bdcb735cc4343bf165f76964e9a refs/tags/tag-main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/tags/tag-one
 22feea448b023a2d864ef94b013735af34d238ba refs/tags/tag-one-tree
 c61a82b60967180544e3c19f819ddbd0c9f89899 refs/tags/tag-three

--- a/t/t5515/refs.main_remote-explicit
+++ b/t/t5515/refs.main_remote-explicit
@@ -1,9 +1,13 @@
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5 refs/tags/tag-master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/rem/main
+8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/rem/one
+0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/rem/three
+6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/rem/two
+ecf3b3627b498bdcb735cc4343bf165f76964e9a refs/tags/tag-main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/tags/tag-one
 22feea448b023a2d864ef94b013735af34d238ba refs/tags/tag-one-tree
 c61a82b60967180544e3c19f819ddbd0c9f89899 refs/tags/tag-three

--- a/t/t5515/refs.main_remote-glob
+++ b/t/t5515/refs.main_remote-glob
@@ -1,9 +1,13 @@
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/HEAD
-754b754407bf032e9a2f9d5a9ad05ca79a6b228f refs/remotes/origin/master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/origin/main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/origin/one
 0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/origin/three
 6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/origin/two
-6c9dec2b923228c9ff994c6cfe4ae16c12408dc5 refs/tags/tag-master
+b4ab76b1a01ea602209932134a44f1e6bd610832 refs/remotes/rem/main
+8e32a6d901327a23ef831511badce7bf3bf46689 refs/remotes/rem/one
+0567da4d5edd2ff4bb292a465ba9e64dcad9536b refs/remotes/rem/three
+6134ee8f857693b96ff1cc98d3e2fd62b199e5a8 refs/remotes/rem/two
+ecf3b3627b498bdcb735cc4343bf165f76964e9a refs/tags/tag-main
 8e32a6d901327a23ef831511badce7bf3bf46689 refs/tags/tag-one
 22feea448b023a2d864ef94b013735af34d238ba refs/tags/tag-one-tree
 c61a82b60967180544e3c19f819ddbd0c9f89899 refs/tags/tag-three


### PR DESCRIPTION
To allow for switching the default of `init.defaultBranch` to `main`, we adjust the test script `t5515` and its friends in `t/t5515/`. This is a large chunk of modifications, but happily, most of them are a totally trivial search-and-replace.

This patch series is part of the over-all effort tracked in https://github.com/gitgitgadget/git/pull/655.