### PR TITLE
RFC: teaching git-clone --repack

### DIFF
--- a/Documentation/git-clone.txt
+++ b/Documentation/git-clone.txt
@@ -115,7 +115,12 @@ objects from the source repository into a pack in the cloned repository.
 	repository that already borrows objects from another
 	repository--the new repository will borrow objects from the
 	same repository, and this option can be used to stop the
-	borrowing.
+	borrowing. This implies `--repack`.
+
+--repack::
+	Repack the repository for optimal diskspace usage after
+	cloning.  This option will make cloning the repository slower
+	but ensure the final storage size on-disk is the most optimal.
 
 -q::
 --quiet::


### PR DESCRIPTION
Initial git-clone could leave a repository in an not optimal state:
- loose objects are not packed (depends on 'transfer.unpackLimit')
- packed object were packed with '--thin'
- refs are kept as loose instead of packed-refs

For systems with storage constraints, cloning a big repository would be a waste of resource until the next git-gc run.
One trick to help levitate this would be running git-repack right after cloning to ensure all the objects are tightly packed.

On the server side, this is also a good opportunity to built the early bitmap-index and commit-graph for better serving performance.

This patch is an RFC, there are some missing items but I jut want to collect early feedbacks of possible iterations
- Lack of testing
- Handle interaction with --reference
- To include git-pack-refs (?)
- To include git-commit-graph (?)