### PR TITLE
Update fsmonitor perf suite to support integration comparisons

### DIFF
--- a/t/perf/p7519-fsmonitor.sh
+++ b/t/perf/p7519-fsmonitor.sh
@@ -141,7 +141,11 @@ test_perf_w_drop_caches () {
 }
 
 test_fsmonitor_suite() {
-	DESC="fsmonitor=$INTEGRATION_SCRIPT"
+	if test -n "$INTEGRATION_SCRIPT"; then
+		DESC="fsmonitor=$(basename $INTEGRATION_SCRIPT)"
+	else
+		DESC="fsmonitor=disabled"
+	fi
 
 	test_perf_w_drop_caches "status ($DESC)" '
 		git status

--- a/t/perf/p7519-fsmonitor.sh
+++ b/t/perf/p7519-fsmonitor.sh
@@ -165,6 +165,11 @@ test_fsmonitor_suite() {
 		git status -uall
 	'
 
+	test_perf_w_drop_caches "status (dirty) ($DESC)" '
+		git ls-files | head -100000 | xargs -d "\n" touch -h &&
+		git status
+	'
+
 	test_perf_w_drop_caches "diff ($DESC)" '
 		git diff
 	'

--- a/t/perf/p7519-fsmonitor.sh
+++ b/t/perf/p7519-fsmonitor.sh
@@ -128,8 +128,7 @@ setup_for_fsmonitor() {
 	git config core.fsmonitor "$INTEGRATION_SCRIPT" &&
 	git update-index --fsmonitor 2>error &&
 	cat error &&
-	[ ! -s error ] && # ensure no silent error
-	git status  # Warm caches
+	[ ! -s error ] # ensure no silent error
 }
 
 test_perf_w_drop_caches () {
@@ -146,6 +145,11 @@ test_fsmonitor_suite() {
 	else
 		DESC="fsmonitor=disabled"
 	fi
+
+	test_expect_success "test_initialization" '
+		git reset --hard &&
+		git status  # Warm caches
+	'
 
 	test_perf_w_drop_caches "status ($DESC)" '
 		git status

--- a/t/perf/p7519-fsmonitor.sh
+++ b/t/perf/p7519-fsmonitor.sh
@@ -103,7 +103,7 @@ test_expect_success "one time repo setup" '
 	fi
 '
 
-test_expect_success "setup for fsmonitor" '
+setup_for_fsmonitor() {
 	# set INTEGRATION_SCRIPT depending on the environment
 	if test -n "$GIT_PERF_7519_FSMONITOR"
 	then
@@ -130,7 +130,7 @@ test_expect_success "setup for fsmonitor" '
 	cat error &&
 	[ ! -s error ] && # ensure no silent error
 	git status  # Warm caches
-'
+}
 
 test_perf_w_drop_caches () {
 	if test -n "$GIT_PERF_7519_DROP_CACHE"; then
@@ -187,6 +187,10 @@ test_fsmonitor_suite() {
 		git add  --all
 	'
 }
+
+test_expect_success "setup for fsmonitor" '
+	setup_for_fsmonitor
+'
 
 test_fsmonitor_suite
 

--- a/t/perf/p7519-fsmonitor.sh
+++ b/t/perf/p7519-fsmonitor.sh
@@ -94,7 +94,7 @@ test_expect_success "one time repo setup" '
 	for i in $(test_seq 1 1000); do touch 1000_files/$i; done &&
 	for i in $(test_seq 1 10000); do touch 10000_files/$i; done &&
 	git add 1_file 10_files 100_files 1000_files 10000_files &&
-	git commit -m "Add files" &&
+	git commit -qm "Add files" &&
 
 	# If Watchman exists, watch the work tree and attempt a query.
 	if test_have_prereq WATCHMAN; then

--- a/t/perf/p7519-fsmonitor.sh
+++ b/t/perf/p7519-fsmonitor.sh
@@ -141,43 +141,45 @@ test_perf_w_drop_caches () {
 }
 
 test_fsmonitor_suite() {
-	test_perf_w_drop_caches "status (fsmonitor=$INTEGRATION_SCRIPT)" '
+	DESC="fsmonitor=$INTEGRATION_SCRIPT"
+
+	test_perf_w_drop_caches "status ($DESC)" '
 		git status
 	'
 
-	test_perf_w_drop_caches "status -uno (fsmonitor=$INTEGRATION_SCRIPT)" '
+	test_perf_w_drop_caches "status -uno ($DESC)" '
 		git status -uno
 	'
 
-	test_perf_w_drop_caches "status -uall (fsmonitor=$INTEGRATION_SCRIPT)" '
+	test_perf_w_drop_caches "status -uall ($DESC)" '
 		git status -uall
 	'
 
-	test_perf_w_drop_caches "diff (fsmonitor=$INTEGRATION_SCRIPT)" '
+	test_perf_w_drop_caches "diff ($DESC)" '
 		git diff
 	'
 
-	test_perf_w_drop_caches "diff -- 0_files (fsmonitor=$INTEGRATION_SCRIPT)" '
+	test_perf_w_drop_caches "diff -- 0_files ($DESC)" '
 		git diff -- 1_file
 	'
 
-	test_perf_w_drop_caches "diff -- 10_files (fsmonitor=$INTEGRATION_SCRIPT)" '
+	test_perf_w_drop_caches "diff -- 10_files ($DESC)" '
 		git diff -- 10_files
 	'
 
-	test_perf_w_drop_caches "diff -- 100_files (fsmonitor=$INTEGRATION_SCRIPT)" '
+	test_perf_w_drop_caches "diff -- 100_files ($DESC)" '
 		git diff -- 100_files
 	'
 
-	test_perf_w_drop_caches "diff -- 1000_files (fsmonitor=$INTEGRATION_SCRIPT)" '
+	test_perf_w_drop_caches "diff -- 1000_files ($DESC)" '
 		git diff -- 1000_files
 	'
 
-	test_perf_w_drop_caches "diff -- 10000_files (fsmonitor=$INTEGRATION_SCRIPT)" '
+	test_perf_w_drop_caches "diff -- 10000_files ($DESC)" '
 		git diff -- 10000_files
 	'
 
-	test_perf_w_drop_caches "add (fsmonitor=$INTEGRATION_SCRIPT)" '
+	test_perf_w_drop_caches "add ($DESC)" '
 		git add  --all
 	'
 }

--- a/t/perf/p7519-fsmonitor.sh
+++ b/t/perf/p7519-fsmonitor.sh
@@ -126,7 +126,9 @@ test_expect_success "setup for fsmonitor" '
 	fi &&
 
 	git config core.fsmonitor "$INTEGRATION_SCRIPT" &&
-	git update-index --fsmonitor &&
+	git update-index --fsmonitor 2>error &&
+	cat error &&
+	[ ! -s error ] && # ensure no silent error
 	git status  # Warm caches
 '
 

--- a/t/perf/p7519-fsmonitor.sh
+++ b/t/perf/p7519-fsmonitor.sh
@@ -68,7 +68,7 @@ then
 	fi
 fi
 
-test_expect_success "setup for fsmonitor" '
+test_expect_success "one time repo setup" '
 	# set untrackedCache depending on the environment
 	if test -n "$GIT_PERF_7519_UNTRACKED_CACHE"
 	then
@@ -88,6 +88,16 @@ test_expect_success "setup for fsmonitor" '
 		git config core.splitIndex "$GIT_PERF_7519_SPLIT_INDEX"
 	fi &&
 
+	mkdir 1_file 10_files 100_files 1000_files 10000_files &&
+	for i in $(test_seq 1 10); do touch 10_files/$i; done &&
+	for i in $(test_seq 1 100); do touch 100_files/$i; done &&
+	for i in $(test_seq 1 1000); do touch 1000_files/$i; done &&
+	for i in $(test_seq 1 10000); do touch 10000_files/$i; done &&
+	git add 1_file 10_files 100_files 1000_files 10000_files &&
+	git commit -m "Add files"
+'
+
+test_expect_success "setup for fsmonitor" '
 	# set INTEGRATION_SCRIPT depending on the environment
 	if test -n "$GIT_PERF_7519_FSMONITOR"
 	then
@@ -115,13 +125,6 @@ test_expect_success "setup for fsmonitor" '
 
 	git config core.fsmonitor "$INTEGRATION_SCRIPT" &&
 	git update-index --fsmonitor &&
-	mkdir 1_file 10_files 100_files 1000_files 10000_files &&
-	for i in $(test_seq 1 10); do touch 10_files/$i; done &&
-	for i in $(test_seq 1 100); do touch 100_files/$i; done &&
-	for i in $(test_seq 1 1000); do touch 1000_files/$i; done &&
-	for i in $(test_seq 1 10000); do touch 10000_files/$i; done &&
-	git add 1_file 10_files 100_files 1000_files 10000_files &&
-	git commit -m "Add files" &&
 	git status  # Warm caches
 '
 

--- a/t/perf/p7519-fsmonitor.sh
+++ b/t/perf/p7519-fsmonitor.sh
@@ -22,7 +22,9 @@ test_description="Test core.fsmonitor"
 #
 # GIT_PERF_7519_UNTRACKED_CACHE: used to configure core.untrackedCache
 # GIT_PERF_7519_SPLIT_INDEX: used to configure core.splitIndex
-# GIT_PERF_7519_FSMONITOR: used to configure core.fsMonitor
+# GIT_PERF_7519_FSMONITOR: used to configure core.fsMonitor. May be an
+#   absolute path to an integration. May be a space delimited list of
+#   absolute paths to integrations.
 #
 # The big win for using fsmonitor is the elimination of the need to scan the
 # working directory looking for changed and untracked files. If the file
@@ -105,9 +107,9 @@ test_expect_success "one time repo setup" '
 
 setup_for_fsmonitor() {
 	# set INTEGRATION_SCRIPT depending on the environment
-	if test -n "$GIT_PERF_7519_FSMONITOR"
+	if test -n "$INTEGRATION_PATH"
 	then
-		INTEGRATION_SCRIPT="$GIT_PERF_7519_FSMONITOR"
+		INTEGRATION_SCRIPT="$INTEGRATION_PATH"
 	else
 		#
 		# Choose integration script based on existence of Watchman.
@@ -192,11 +194,15 @@ test_fsmonitor_suite() {
 	'
 }
 
-test_expect_success "setup for fsmonitor" '
-	setup_for_fsmonitor
-'
-
-test_fsmonitor_suite
+if test -n "$GIT_PERF_7519_FSMONITOR"; then
+	for INTEGRATION_PATH in $GIT_PERF_7519_FSMONITOR; do
+		test_expect_success "setup for fsmonitor $INTEGRATION_PATH" 'setup_for_fsmonitor'
+		test_fsmonitor_suite
+	done
+else
+	test_expect_success "setup for fsmonitor" 'setup_for_fsmonitor'
+	test_fsmonitor_suite
+fi
 
 test_expect_success "setup without fsmonitor" '
 	unset INTEGRATION_SCRIPT &&


### PR DESCRIPTION
This patch series builds upon nk/diff-files-vs-fsmonitor

This builds up to a comparison between our perl script and https://github.com/jgavris/rs-git-fsmonitor. Stats on the comparison are in the final commit message. I've found that
rs-git-fsmonitor saves 20-30ms off of every git command compared to the perl script.

It may provide some motivation for supplying a faster implementation of fsmonitor-watchman.

cc: Nipunn Koorapati <nipunn1313@gmail.com>