### PR TITLE
git-prompt.sh: make `option` a local variable

### DIFF
--- a/contrib/completion/git-prompt.sh
+++ b/contrib/completion/git-prompt.sh
@@ -137,6 +137,7 @@ __git_ps1_show_upstream ()
 	done <<< "$output"
 
 	# parse configuration values
+	local option
 	for option in ${GIT_PS1_SHOWUPSTREAM}; do
 		case "$option" in
 		git|svn) upstream="$option" ;;


### PR DESCRIPTION
This is very trivial, but variables like `key` and `value` are local to `git-prompt.sh`, so I think the same should be done with `option`. I have `GIT_PS1_SHOW_UPSTREAM` set to `verbose` in my `~/.bashrc`, so `option` gets set to `verbose` in my Bash session whenever I change directories to a local repository with a remote.

cc: Sibo Dong <sibo.dong@mail.utoronto.ca>