### PR TITLE
t2402: fix typo

### DIFF
--- a/t/t2402-worktree-list.sh
+++ b/t/t2402-worktree-list.sh
@@ -61,7 +61,7 @@ test_expect_success '"list" all worktrees --porcelain' '
 	test_cmp expect actual
 '
 
-test_expect_success '"list" all worktress with locked annotation' '
+test_expect_success '"list" all worktrees with locked annotation' '
 	test_when_finished "rm -rf locked unlocked out && git worktree prune" &&
 	git worktree add --detach locked master &&
 	git worktree add --detach unlocked master &&


### PR DESCRIPTION
Just a fix for a typo introduced in c57b3367bed (worktree: teach `list` to annotate locked worktree, 2020-10-11).

Cc: Rafael Silva <rafaeloliveira.cs@gmail.com>
cc: Johannes Schindelin <Johannes.Schindelin@gmx.de>