### PR TITLE
ci: make the whitespace checker more robust

### DIFF
--- a/.github/workflows/check-whitespace.yml
+++ b/.github/workflows/check-whitespace.yml
@@ -58,12 +58,14 @@ jobs:
     - name: Add Check Output as Comment
       uses: actions/github-script@v3
       id: add-comment
+      env:
+        log: ${{ steps.check_out.outputs.checkout }}
       with:
         script: |
-            github.issues.createComment({
+            await github.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: "Whitespace errors found in workflow ${{ github.workflow }}:\n\n${{ steps.check_out.outputs.checkout }}"
+              body: `Whitespace errors found in workflow ${{ github.workflow }}:\n\n\`\`\`\n${process.env.log.replace(/\\n/g, "\n")}\n\`\`\``
             })
       if: ${{ failure() }}


### PR DESCRIPTION
I noticed that the checker [failed to add a comment](https://github.com/gitgitgadget/git/runs/1344883313?check_suite_focus=true) in one of my PRs. Turns out that the double-quote characters in the log output made it fail.

One thing we discussed earlier whether the log should be pasted as pre-formatted text or not, and we fell on the side of not pre-formatting it. However, in my tests, this [does not look right](https://github.com/dscho/git/pull/18#issuecomment-721160985), and it [looks much better pre-formatted](https://github.com/dscho/git/pull/18#issuecomment-721167209) (even if we unfortunately lose the [direct link to the commit](https://github.com/dscho/git/commit/68317764849af81b17c4b31906da20bdf2c52082)).

Cc: Chris. Webster <chris@webstech.net>