### PR TITLE
ci: avoid using the deprecated `set-env` construct

### DIFF
--- a/.github/workflows/check-whitespace.yml
+++ b/.github/workflows/check-whitespace.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - name: Set commit count
       shell: bash
-      run: echo "::set-env name=COMMIT_DEPTH::$((1+$COMMITS))"
+      run: echo "COMMIT_DEPTH=$((1+$COMMITS))" >>$GITHUB_ENV
       env:
         COMMITS: ${{ github.event.pull_request.commits }}
 


### PR DESCRIPTION
This avoids an ugly warning (see e.g. [this run](https://github.com/gitgitgadget/git/actions/runs/350443139)).

Cc: Chris. Webster <chris@webstech.net>