### PR TITLE
p4: respect init.defaultBranch

### DIFF
--- a/git-p4.py
+++ b/git-p4.py
@@ -4186,7 +4186,7 @@ class P4Clone(P4Sync):
 
         # create a master branch and check out a work tree
         if gitBranchExists(self.branch):
-            system([ "git", "branch", "master", self.branch ])
+            system([ "git", "branch", currentGitBranch(), self.branch ])
             if not self.cloneBare:
                 system([ "git", "checkout", "-f" ])
         else:


### PR DESCRIPTION
Just something I noticed while working on the big `master` -> `main` rename in the test suite.

Cc: Luke Diamand <luke@diamand.org>