### PR TITLE
(Mostly whitespace) cleanups in preparation for renaming the default main branch

### DIFF
--- a/t/t1004-read-tree-m-u-wf.sh
+++ b/t/t1004-read-tree-m-u-wf.sh
@@ -20,7 +20,7 @@ test_expect_success 'two-way setup' '
 	git branch side &&
 	git tag -f branch-point &&
 
-	echo file2 is not tracked on the master anymore &&
+	echo file2 is not tracked on the master branch anymore &&
 	rm -f file2 subdir/file2 &&
 	git update-index --remove file2 subdir/file2 &&
 	git commit -a -m "master removes file2 and subdir/file2"

--- a/t/t3406-rebase-message.sh
+++ b/t/t3406-rebase-message.sh
@@ -46,22 +46,22 @@ test_expect_success 'rebase fast-forward to master' '
 
 test_expect_success 'rebase --stat' '
 	git reset --hard start &&
-        git rebase --stat master >diffstat.txt &&
-        grep "^ fileX |  *1 +$" diffstat.txt
+	git rebase --stat master >diffstat.txt &&
+	grep "^ fileX |  *1 +$" diffstat.txt
 '
 
 test_expect_success 'rebase w/config rebase.stat' '
 	git reset --hard start &&
-        git config rebase.stat true &&
-        git rebase master >diffstat.txt &&
-        grep "^ fileX |  *1 +$" diffstat.txt
+	git config rebase.stat true &&
+	git rebase master >diffstat.txt &&
+	grep "^ fileX |  *1 +$" diffstat.txt
 '
 
 test_expect_success 'rebase -n overrides config rebase.stat config' '
 	git reset --hard start &&
-        git config rebase.stat true &&
-        git rebase -n master >diffstat.txt &&
-        ! grep "^ fileX |  *1 +$" diffstat.txt
+	git config rebase.stat true &&
+	git rebase -n master >diffstat.txt &&
+	! grep "^ fileX |  *1 +$" diffstat.txt
 '
 
 # Output to stderr:

--- a/t/t3427-rebase-subtree.sh
+++ b/t/t3427-rebase-subtree.sh
@@ -19,7 +19,7 @@ commit_message() {
 #                             \
 # README ---------------------- Add subproject master - topic_4 - files_subtree/topic_5
 #
-# Where the merge moves the files master[123].t into the subdirectory
+# Where the merge moves the files topic_[123].t into the subdirectory
 # files_subtree/ and topic_4 as well as files_subtree/topic_5 add files to that
 # directory directly.
 #

--- a/t/t5400-send-pack.sh
+++ b/t/t5400-send-pack.sh
@@ -21,14 +21,15 @@ test_expect_success setup '
 	i=0 &&
 	while test $i -le $cnt
 	do
-	    i=$(($i+1)) &&
-	    test_tick &&
-	    echo "Commit #$i" >mozart/is/pink &&
-	    git update-index --add mozart/is/pink &&
-	    tree=$(git write-tree) &&
-	    commit=$(echo "Commit #$i" | git commit-tree $tree -p $parent) &&
-	    git update-ref refs/tags/commit$i $commit &&
-	    parent=$commit || return 1
+		i=$(($i+1)) &&
+		test_tick &&
+		echo "Commit #$i" >mozart/is/pink &&
+		git update-index --add mozart/is/pink &&
+		tree=$(git write-tree) &&
+		commit=$(echo "Commit #$i" |
+			 git commit-tree $tree -p $parent) &&
+		git update-ref refs/tags/commit$i $commit &&
+		parent=$commit || return 1
 	done &&
 	git update-ref HEAD "$commit" &&
 	git clone ./. victim &&
@@ -38,14 +39,14 @@ test_expect_success setup '
 	i=0 &&
 	while test $i -le $cnt
 	do
-	    i=$(($i+1)) &&
-	    test_tick &&
-	    echo "Rebase #$i" >mozart/is/pink &&
-	    git update-index --add mozart/is/pink &&
-	    tree=$(git write-tree) &&
-	    commit=$(echo "Rebase #$i" | git commit-tree $tree -p $parent) &&
-	    git update-ref refs/tags/rebase$i $commit &&
-	    parent=$commit || return 1
+		i=$(($i+1)) &&
+		test_tick &&
+		echo "Rebase #$i" >mozart/is/pink &&
+		git update-index --add mozart/is/pink &&
+		tree=$(git write-tree) &&
+		commit=$(echo "Rebase #$i" | git commit-tree $tree -p $parent) &&
+		git update-ref refs/tags/rebase$i $commit &&
+		parent=$commit || return 1
 	done &&
 	git update-ref HEAD "$commit" &&
 	echo Rebase &&
@@ -57,11 +58,11 @@ test_expect_success 'pack the source repository' '
 '
 
 test_expect_success 'pack the destination repository' '
-    (
-	cd victim &&
-	git repack -a -d &&
-	git prune
-    )
+	(
+		cd victim &&
+		git repack -a -d &&
+		git prune
+	)
 '
 
 test_expect_success 'refuse pushing rewound head without --force' '
@@ -85,10 +86,10 @@ test_expect_success 'push can be used to delete a ref' '
 
 test_expect_success 'refuse deleting push with denyDeletes' '
 	(
-	    cd victim &&
-	    test_might_fail git branch -D extra &&
-	    git config receive.denyDeletes true &&
-	    git branch extra master
+		cd victim &&
+		test_might_fail git branch -D extra &&
+		git config receive.denyDeletes true &&
+		git branch extra master
 	) &&
 	test_must_fail git send-pack ./victim :extra master
 '
@@ -118,9 +119,9 @@ test_expect_success 'override denyDeletes with git -c receive-pack' '
 
 test_expect_success 'denyNonFastforwards trumps --force' '
 	(
-	    cd victim &&
-	    test_might_fail git branch -D extra &&
-	    git config receive.denyNonFastforwards true
+		cd victim &&
+		test_might_fail git branch -D extra &&
+		git config receive.denyNonFastforwards true
 	) &&
 	victim_orig=$(cd victim && git rev-parse --verify master) &&
 	test_must_fail git send-pack --force ./victim master^:master &&
@@ -143,16 +144,16 @@ test_expect_success 'send-pack --all sends all branches' '
 test_expect_success 'push --all excludes remote-tracking hierarchy' '
 	mkdir parent &&
 	(
-	    cd parent &&
-	    git init && : >file && git add file && git commit -m add
+		cd parent &&
+		git init && : >file && git add file && git commit -m add
 	) &&
 	git clone parent child &&
 	(
-	    cd child && git push --all
+		cd child && git push --all
 	) &&
 	(
-	    cd parent &&
-	    test -z "$(git for-each-ref refs/remotes/origin)"
+		cd parent &&
+		test -z "$(git for-each-ref refs/remotes/origin)"
 	)
 '
 
@@ -160,33 +161,33 @@ test_expect_success 'receive-pack runs auto-gc in remote repo' '
 	rm -rf parent child &&
 	git init parent &&
 	(
-	    # Setup a repo with 2 packs
-	    cd parent &&
-	    echo "Some text" >file.txt &&
-	    git add . &&
-	    git commit -m "Initial commit" &&
-	    git repack -adl &&
-	    echo "Some more text" >>file.txt &&
-	    git commit -a -m "Second commit" &&
-	    git repack
+		# Setup a repo with 2 packs
+		cd parent &&
+		echo "Some text" >file.txt &&
+		git add . &&
+		git commit -m "Initial commit" &&
+		git repack -adl &&
+		echo "Some more text" >>file.txt &&
+		git commit -a -m "Second commit" &&
+		git repack
 	) &&
 	cp -R parent child &&
 	(
-	    # Set the child to auto-pack if more than one pack exists
-	    cd child &&
-	    git config gc.autopacklimit 1 &&
-	    git config gc.autodetach false &&
-	    git branch test_auto_gc &&
-	    # And create a file that follows the temporary object naming
-	    # convention for the auto-gc to remove
-	    : >.git/objects/tmp_test_object &&
-	    test-tool chmtime =-1209601 .git/objects/tmp_test_object
+		# Set the child to auto-pack if more than one pack exists
+		cd child &&
+		git config gc.autopacklimit 1 &&
+		git config gc.autodetach false &&
+		git branch test_auto_gc &&
+		# And create a file that follows the temporary object naming
+		# convention for the auto-gc to remove
+		: >.git/objects/tmp_test_object &&
+		test-tool chmtime =-1209601 .git/objects/tmp_test_object
 	) &&
 	(
-	    cd parent &&
-	    echo "Even more text" >>file.txt &&
-	    git commit -a -m "Third commit" &&
-	    git send-pack ../child HEAD:refs/heads/test_auto_gc
+		cd parent &&
+		echo "Even more text" >>file.txt &&
+		git commit -a -m "Third commit" &&
+		git send-pack ../child HEAD:refs/heads/test_auto_gc
 	) &&
 	test ! -e child/.git/objects/tmp_test_object
 '
@@ -195,15 +196,15 @@ rewound_push_setup() {
 	rm -rf parent child &&
 	mkdir parent &&
 	(
-	    cd parent &&
-	    git init &&
-	    echo one >file && git add file && git commit -m one &&
-	    git config receive.denyCurrentBranch warn &&
-	    echo two >file && git commit -a -m two
+		cd parent &&
+		git init &&
+		echo one >file && git add file && git commit -m one &&
+		git config receive.denyCurrentBranch warn &&
+		echo two >file && git commit -a -m two
 	) &&
 	git clone parent child &&
 	(
-	    cd child && git reset --hard HEAD^
+		cd child && git reset --hard HEAD^
 	)
 }
 
@@ -211,16 +212,16 @@ test_expect_success 'pushing explicit refspecs respects forcing' '
 	rewound_push_setup &&
 	parent_orig=$(cd parent && git rev-parse --verify master) &&
 	(
-	    cd child &&
-	    test_must_fail git send-pack ../parent \
-		refs/heads/master:refs/heads/master
+		cd child &&
+		test_must_fail git send-pack ../parent \
+			refs/heads/master:refs/heads/master
 	) &&
 	parent_head=$(cd parent && git rev-parse --verify master) &&
 	test "$parent_orig" = "$parent_head" &&
 	(
-	    cd child &&
-	    git send-pack ../parent \
-	        +refs/heads/master:refs/heads/master
+		cd child &&
+		git send-pack ../parent \
+			+refs/heads/master:refs/heads/master
 	) &&
 	parent_head=$(cd parent && git rev-parse --verify master) &&
 	child_head=$(cd child && git rev-parse --verify master) &&
@@ -231,16 +232,16 @@ test_expect_success 'pushing wildcard refspecs respects forcing' '
 	rewound_push_setup &&
 	parent_orig=$(cd parent && git rev-parse --verify master) &&
 	(
-	    cd child &&
-	    test_must_fail git send-pack ../parent \
-	        "refs/heads/*:refs/heads/*"
+		cd child &&
+		test_must_fail git send-pack ../parent \
+			"refs/heads/*:refs/heads/*"
 	) &&
 	parent_head=$(cd parent && git rev-parse --verify master) &&
 	test "$parent_orig" = "$parent_head" &&
 	(
-	    cd child &&
-	    git send-pack ../parent \
-	        "+refs/heads/*:refs/heads/*"
+		cd child &&
+		git send-pack ../parent \
+			"+refs/heads/*:refs/heads/*"
 	) &&
 	parent_head=$(cd parent && git rev-parse --verify master) &&
 	child_head=$(cd child && git rev-parse --verify master) &&
@@ -250,8 +251,8 @@ test_expect_success 'pushing wildcard refspecs respects forcing' '
 test_expect_success 'deny pushing to delete current branch' '
 	rewound_push_setup &&
 	(
-	    cd child &&
-	    test_must_fail git send-pack ../parent :refs/heads/master 2>errs
+		cd child &&
+		test_must_fail git send-pack ../parent :refs/heads/master 2>errs
 	)
 '
 
@@ -289,7 +290,7 @@ test_expect_success 'receive-pack de-dupes .have lines' '
 	EOF
 
 	GIT_TRACE_PACKET=$(pwd)/trace GIT_TEST_PROTOCOL_VERSION=0 \
-	    git push \
+	git push \
 		--receive-pack="unset GIT_TRACE_PACKET; git-receive-pack" \
 		fork HEAD:foo &&
 	extract_ref_advertisement <trace >refs &&

--- a/t/t5402-post-merge-hook.sh
+++ b/t/t5402-post-merge-hook.sh
@@ -15,7 +15,7 @@ test_expect_success setup '
 	git update-index a &&
 	tree1=$(git write-tree) &&
 	commit1=$(echo modify | git commit-tree $tree1 -p $commit0) &&
-        git update-ref refs/heads/master $commit0 &&
+	git update-ref refs/heads/master $commit0 &&
 	git clone ./. clone1 &&
 	GIT_DIR=clone1/.git git update-index --add a &&
 	git clone ./. clone2 &&
@@ -23,34 +23,34 @@ test_expect_success setup '
 '
 
 for clone in 1 2; do
-    cat >clone${clone}/.git/hooks/post-merge <<'EOF'
+	cat >clone${clone}/.git/hooks/post-merge <<'EOF'
 #!/bin/sh
 echo $@ >> $GIT_DIR/post-merge.args
 EOF
-    chmod u+x clone${clone}/.git/hooks/post-merge
+	chmod u+x clone${clone}/.git/hooks/post-merge
 done
 
 test_expect_success 'post-merge does not run for up-to-date ' '
-        GIT_DIR=clone1/.git git merge $commit0 &&
+	GIT_DIR=clone1/.git git merge $commit0 &&
 	! test -f clone1/.git/post-merge.args
 '
 
 test_expect_success 'post-merge runs as expected ' '
-        GIT_DIR=clone1/.git git merge $commit1 &&
+	GIT_DIR=clone1/.git git merge $commit1 &&
 	test -e clone1/.git/post-merge.args
 '
 
 test_expect_success 'post-merge from normal merge receives the right argument ' '
-        grep 0 clone1/.git/post-merge.args
+	grep 0 clone1/.git/post-merge.args
 '
 
 test_expect_success 'post-merge from squash merge runs as expected ' '
-        GIT_DIR=clone2/.git git merge --squash $commit1 &&
+	GIT_DIR=clone2/.git git merge --squash $commit1 &&
 	test -e clone2/.git/post-merge.args
 '
 
 test_expect_success 'post-merge from squash merge receives the right argument ' '
-        grep 1 clone2/.git/post-merge.args
+	grep 1 clone2/.git/post-merge.args
 '
 
 test_done

--- a/t/t5570-git-daemon.sh
+++ b/t/t5570-git-daemon.sh
@@ -147,18 +147,18 @@ test_remote_error()
 }
 
 msg="access denied or repository not exported"
-test_expect_success 'clone non-existent' "test_remote_error    '$msg' clone nowhere.git    "
+test_expect_success 'clone non-existent' "test_remote_error    '$msg' clone nowhere.git"
 test_expect_success 'push disabled'      "test_remote_error    '$msg' push  repo.git master"
-test_expect_success 'read access denied' "test_remote_error -x '$msg' fetch repo.git       "
-test_expect_success 'not exported'       "test_remote_error -n '$msg' fetch repo.git       "
+test_expect_success 'read access denied' "test_remote_error -x '$msg' fetch repo.git"
+test_expect_success 'not exported'       "test_remote_error -n '$msg' fetch repo.git"
 
 stop_git_daemon
 start_git_daemon --informative-errors
 
-test_expect_success 'clone non-existent' "test_remote_error    'no such repository'      clone nowhere.git    "
+test_expect_success 'clone non-existent' "test_remote_error    'no such repository'      clone nowhere.git"
 test_expect_success 'push disabled'      "test_remote_error    'service not enabled'     push  repo.git master"
-test_expect_success 'read access denied' "test_remote_error -x 'no such repository'      fetch repo.git       "
-test_expect_success 'not exported'       "test_remote_error -n 'repository not exported' fetch repo.git       "
+test_expect_success 'read access denied' "test_remote_error -x 'no such repository'      fetch repo.git"
+test_expect_success 'not exported'       "test_remote_error -n 'repository not exported' fetch repo.git"
 
 stop_git_daemon
 start_git_daemon --interpolated-path="$GIT_DAEMON_DOCUMENT_ROOT_PATH/%H%D"

--- a/t/t9603-cvsimport-patchsets.sh
+++ b/t/t9603-cvsimport-patchsets.sh
@@ -17,23 +17,23 @@ test_description='git cvsimport testing for correct patchset estimation'
 setup_cvs_test_repository t9603
 
 test_expect_failure PERL 'import with criss cross times on revisions' '
-
-    git cvsimport -p"-x" -C module-git module &&
-    (cd module-git &&
-        git log --pretty=format:%s > ../actual-master &&
-        git log A~2..A --pretty="format:%s %ad" -- > ../actual-A &&
-        echo "" >> ../actual-master &&
-	echo "" >> ../actual-A
-    ) &&
-    echo "Rev 4
+	git cvsimport -p"-x" -C module-git module &&
+	(
+		cd module-git &&
+		git log --pretty=format:%s > ../actual-master &&
+		git log A~2..A --pretty="format:%s %ad" -- > ../actual-A &&
+		echo "" >> ../actual-master &&
+		echo "" >> ../actual-A
+	) &&
+	echo "Rev 4
 Rev 3
 Rev 2
 Rev 1" > expect-master &&
-    test_cmp expect-master actual-master &&
+	test_cmp expect-master actual-master &&
 
-    echo "Rev 5 Branch A Wed Mar 11 19:09:10 2009 +0000
+	echo "Rev 5 Branch A Wed Mar 11 19:09:10 2009 +0000
 Rev 4 Branch A Wed Mar 11 19:03:52 2009 +0000" > expect-A &&
-    test_cmp expect-A actual-A
+	test_cmp expect-A actual-A
 '
 
 test_done


### PR DESCRIPTION
This topic branch mostly brings whitespace fixes, so that the `use-main-as-default-branch-name` patch series will avoid being flagged by Git's new `check-whitespace` GitHub workflow.