### PR TITLE
difftool: fix user-defined Beyond Compare setups

### DIFF
--- a/git-mergetool--lib.sh
+++ b/git-mergetool--lib.sh
@@ -138,6 +138,10 @@ setup_user_tool () {
 	merge_cmd () {
 		( eval $merge_tool_cmd )
 	}
+
+	list_tool_variants () {
+		echo "$tool"
+	}
 }
 
 setup_tool () {

--- a/mergetools/bc
+++ b/mergetools/bc
@@ -25,4 +25,5 @@ translate_merge_tool_path() {
 list_tool_variants () {
 	echo bc
 	echo bc3
+	echo bc4
 }


### PR DESCRIPTION
Git v2.29.0 includes patches that try to support Beyond Compare better by default. However, as reported in https://github.com/git-for-windows/git/issues/2893, they broke user-defined setups that use `bc4` as the name for the difftool.

This patch series fixes that and is based on `pd/mergetool-nvimdiff`.

Cc: pudinha <rogi@skylittlesystem.org>