### PR TITLE
t1309: use a non-loaded branch name in the `onbranch` test cases

### DIFF
--- a/t/t1309-early-config.sh
+++ b/t/t1309-early-config.sh
@@ -91,11 +91,11 @@ test_expect_failure 'ignore .git/ with invalid config' '
 
 test_expect_success 'early config and onbranch' '
 	echo "[broken" >broken &&
-	test_with_config "[includeif \"onbranch:master\"]path=../broken"
+	test_with_config "[includeif \"onbranch:topic\"]path=../broken"
 '
 
 test_expect_success 'onbranch config outside of git repo' '
-	test_config_global includeIf.onbranch:master.path non-existent &&
+	test_config_global includeIf.onbranch:topic.path non-existent &&
 	nongit git help
 '
 


### PR DESCRIPTION
Just something I stumbled over while working on https://github.com/gitgitgadget/git/pull/762.

Changes since v1:

- The commit message was obviously not clear at all, which has been addressed.

cc: Ævar Arnfjörð Bjarmason <avarab@gmail.com>
cc: Johannes Schindelin <Johannes.Schindelin@gmx.de>