### PR TITLE
t4015: let the test pass with any default branch name

### DIFF
--- a/t/t4015-diff-whitespace.sh
+++ b/t/t4015-diff-whitespace.sh
@@ -877,13 +877,13 @@ test_expect_success 'rename empty' '
 test_expect_success 'combined diff with autocrlf conversion' '
 
 	git reset --hard &&
-	echo >x hello &&
-	git commit -m "one side" x &&
+	test_commit "one side" x hello one-side &&
 	git checkout HEAD^ &&
 	echo >x goodbye &&
 	git commit -m "the other side" x &&
 	git config core.autocrlf true &&
-	test_must_fail git merge master &&
+	test_must_fail git merge one-side >actual &&
+	test_i18ngrep "Automatic merge failed" actual &&
 
 	git diff >actual.raw &&
 	sed -e "1,/^@@@/d" actual.raw >actual &&


### PR DESCRIPTION
Aaaaand another issue, also found while working on https://github.com/gitgitgadget/git/pull/762.

Changes since v1:

- We now use `test_commit` and the tag it creates, rather than the reflog.
- 
cc: Johannes Schindelin <Johannes.Schindelin@gmx.de>