### PR TITLE
clone: --filter=tree:0 implies fetch.recurseSubmodules=no

### DIFF
--- a/list-objects-filter-options.c
+++ b/list-objects-filter-options.c
@@ -376,6 +376,10 @@ void partial_clone_register(
 		       expand_list_objects_filter_spec(filter_options));
 	free(filter_name);
 
+	if (filter_options->choice == LOFC_TREE_DEPTH &&
+	    !filter_options->tree_exclude_depth)
+		git_config_set("fetch.recursesubmodules", "no");
+
 	/* Make sure the config info are reset */
 	promisor_remote_reinit();
 }

--- a/t/t5616-partial-clone.sh
+++ b/t/t5616-partial-clone.sh
@@ -341,6 +341,12 @@ test_expect_success 'partial clone with sparse filter succeeds' '
 	)
 '
 
+test_expect_success '--filter=tree:0 sets fetch.recurseSubmodules=no' '
+	rm -rf dst &&
+	git clone --filter=tree:0 "file://$(pwd)/src" dst &&
+	test_config -C dst fetch.recursesubmodules no
+'
+
 test_expect_success 'partial clone with unresolvable sparse filter fails cleanly' '
 	rm -rf dst.git &&
 	test_must_fail git clone --no-local --bare \


### PR DESCRIPTION
While testing different partial clone options, I stumbled across this one. My initial thought was that we were parsing commits and loading their root trees unnecessarily, but I see that doesn't happen after this change.

Here are some recent discussions about using --filter=tree:0:

[1] https://lore.kernel.org/git/aa7b89ee-08aa-7943-6a00-28dcf344426e@syntevo.com/
[2] https://lore.kernel.org/git/cover.1588633810.git.me@ttaylorr.com/
[3] https://lore.kernel.org/git/58274817-7ac6-b6ae-0d10-22485dfe5e0e@syntevo.com/

Thanks,
-Stolee

cc: Jonathan Tan <jonathantanmy@google.com>
cc: Taylor Blau <me@ttaylorr.com>
cc: Jeff King <peff@peff.net>
cc: Philippe Blain <levraiphilippeblain@gmail.com>
cc: Derrick Stolee <stolee@gmail.com>