### PR TITLE
perf/fsmonitor: use test_must_be_empty helper

### DIFF
--- a/t/perf/p7519-fsmonitor.sh
+++ b/t/perf/p7519-fsmonitor.sh
@@ -129,8 +129,7 @@ setup_for_fsmonitor() {
 
 	git config core.fsmonitor "$INTEGRATION_SCRIPT" &&
 	git update-index --fsmonitor 2>error &&
-	cat error &&
-	[ ! -s error ] # ensure no silent error
+	test_must_be_empty error  # ensure no silent error
 }
 
 test_perf_w_drop_caches () {


### PR DESCRIPTION
Simplify perf/fsmonitor test and make error messages more clear.

cc: Derrick Stolee <stolee@gmail.com>