### PR TITLE
merge-ort: some groundwork for further implementation

### DIFF
--- a/merge-ort.c
+++ b/merge-ort.c
@@ -210,6 +210,8 @@ struct conflict_info {
 	unsigned match_mask:3;
 };
 
+/*** Function Grouping: various utility functions ***/
+
 /*
  * For the next three macros, see warning for conflict_info.merged.
  *
@@ -289,6 +291,8 @@ static int err(struct merge_options *opt, const char *err, ...)
 
 	return -1;
 }
+
+/*** Function Grouping: functions related to collect_merge_info() ***/
 
 static void setup_path_info(struct merge_options *opt,
 			    struct string_list_item *result,
@@ -544,6 +548,15 @@ static int collect_merge_info(struct merge_options *opt,
 	return ret;
 }
 
+/*** Function Grouping: functions related to threeway content merges ***/
+
+/*** Function Grouping: functions related to detect_and_process_renames(), ***
+ *** which are split into directory and regular rename detection sections. ***/
+
+/*** Function Grouping: functions related to directory rename detection ***/
+
+/*** Function Grouping: functions related to regular rename detection ***/
+
 static int detect_and_process_renames(struct merge_options *opt,
 				      struct tree *merge_base,
 				      struct tree *side1,
@@ -560,6 +573,8 @@ static int detect_and_process_renames(struct merge_options *opt,
 	 */
 	return clean;
 }
+
+/*** Function Grouping: functions related to process_entries() ***/
 
 static int string_list_df_name_compare(const char *one, const char *two)
 {
@@ -1039,6 +1054,8 @@ static void process_entries(struct merge_options *opt,
 	string_list_clear(&dir_metadata.offsets, 0);
 }
 
+/*** Function Grouping: functions related to merge_switch_to_result() ***/
+
 static int checkout(struct merge_options *opt,
 		    struct tree *prev,
 		    struct tree *next)
@@ -1226,6 +1243,8 @@ void merge_finalize(struct merge_options *opt,
 	FREE_AND_NULL(opti);
 }
 
+/*** Function Grouping: helper functions for merge_incore_*() ***/
+
 static void merge_start(struct merge_options *opt, struct merge_result *result)
 {
 	/* Sanity checks on opt */
@@ -1275,6 +1294,8 @@ static void merge_start(struct merge_options *opt, struct merge_result *result)
 	strmap_init_with_options(&opt->priv->conflicted, NULL, 0);
 	string_list_init(&opt->priv->paths_to_free, 0);
 }
+
+/*** Function Grouping: merge_incore_*() and their internal variants ***/
 
 /*
  * Originally from merge_trees_internal(); heavily adapted, though.

--- a/merge-ort.c
+++ b/merge-ort.c
@@ -17,7 +17,9 @@
 #include "cache.h"
 #include "merge-ort.h"
 
+#include "blob.h"
 #include "cache-tree.h"
+#include "commit-reach.h"
 #include "diff.h"
 #include "diffcore.h"
 #include "dir.h"

--- a/merge-ort.c
+++ b/merge-ort.c
@@ -166,6 +166,13 @@ struct conflict_info {
 	unsigned df_conflict:1;
 
 	/*
+	 * Whether this path is/was involved in a non-content conflict other
+	 * than a directory/file conflict (e.g. rename/rename, rename/delete,
+	 * file location based on possible directory rename).
+	 */
+	unsigned path_conflict:1;
+
+	/*
 	 * For filemask and dirmask, the ith bit corresponds to whether the
 	 * ith entry is a file (filemask) or a directory (dirmask).  Thus,
 	 * filemask & dirmask is always zero, and filemask | dirmask is at

--- a/merge-ort.c
+++ b/merge-ort.c
@@ -550,6 +550,18 @@ static int collect_merge_info(struct merge_options *opt,
 
 /*** Function Grouping: functions related to threeway content merges ***/
 
+static int handle_content_merge(struct merge_options *opt,
+				const char *path,
+				const struct version_info *o,
+				const struct version_info *a,
+				const struct version_info *b,
+				const char *pathnames[3],
+				const int extra_marker_size,
+				struct version_info *result)
+{
+	die("Not yet implemented");
+}
+
 /*** Function Grouping: functions related to detect_and_process_renames(), ***
  *** which are split into directory and regular rename detection sections. ***/
 
@@ -957,6 +969,8 @@ static void process_entry(struct merge_options *opt,
 		ci->merged.clean = 0;
 		ci->merged.result.mode = ci->stages[1].mode;
 		oidcpy(&ci->merged.result.oid, &ci->stages[1].oid);
+		/* When we fix above, we'll call handle_content_merge() */
+		(void)handle_content_merge;
 	} else if (ci->filemask == 3 || ci->filemask == 5) {
 		/* Modify/delete */
 		die("Not yet implemented.");


### PR DESCRIPTION
This series is based on en/merge-ort-impl.  This series sets up three future patch series (to add recursive merges, three-way content merging, and rename detection) for the merge-ort implementation, and allows the future series to be submitted, reviewed, and merged in any order.  Since those three things actually do have some minor dependencies between them, this preparatory series is needed to make a few small changes to set things up to allow them to be submitted independently. 

The first six patches are trivial.  They should be easy to review, and as a bonus you get to find how I mess up even the trivial stuff. ;-)  The final patch is more substantive and represents one of the big changes between merge-recursive and merge-ort -- namely, how notice/warning/conflict messages are reported to the user (I possibly should have included it in merge-ort-impl, but that series seemed so long already...).

cc: Derrick Stolee <stolee@gmail.com>
cc: Elijah Newren <newren@gmail.com>