### PR TITLE
t7064: avoid relying on a specific default branch name

### DIFF
--- a/t/t7064-wtstatus-pv2.sh
+++ b/t/t7064-wtstatus-pv2.sh
@@ -9,6 +9,7 @@ This test exercises porcelain V2 output for git status.'
 
 
 test_expect_success setup '
+	git checkout -f --orphan initial-branch &&
 	test_tick &&
 	git config core.autocrlf false &&
 	echo x >file_x &&
@@ -22,7 +23,7 @@ test_expect_success setup '
 test_expect_success 'before initial commit, nothing added, only untracked' '
 	cat >expect <<-EOF &&
 	# branch.oid (initial)
-	# branch.head master
+	# branch.head initial-branch
 	? actual
 	? dir1/
 	? expect
@@ -45,7 +46,7 @@ test_expect_success 'before initial commit, things added' '
 
 	cat >expect <<-EOF &&
 	# branch.oid (initial)
-	# branch.head master
+	# branch.head initial-branch
 	1 A. N... 000000 100644 100644 $ZERO_OID $OID_A dir1/file_a
 	1 A. N... 000000 100644 100644 $ZERO_OID $OID_B dir1/file_b
 	1 A. N... 000000 100644 100644 $ZERO_OID $OID_X file_x
@@ -62,7 +63,7 @@ test_expect_success 'before initial commit, things added' '
 test_expect_success 'before initial commit, things added (-z)' '
 	lf_to_nul >expect <<-EOF &&
 	# branch.oid (initial)
-	# branch.head master
+	# branch.head initial-branch
 	1 A. N... 000000 100644 100644 $ZERO_OID $OID_A dir1/file_a
 	1 A. N... 000000 100644 100644 $ZERO_OID $OID_B dir1/file_b
 	1 A. N... 000000 100644 100644 $ZERO_OID $OID_X file_x
@@ -81,7 +82,7 @@ test_expect_success 'make first commit, comfirm HEAD oid and branch' '
 	H0=$(git rev-parse HEAD) &&
 	cat >expect <<-EOF &&
 	# branch.oid $H0
-	# branch.head master
+	# branch.head initial-branch
 	? actual
 	? expect
 	EOF
@@ -98,7 +99,7 @@ test_expect_success 'after first commit, create unstaged changes' '
 
 	cat >expect <<-EOF &&
 	# branch.oid $H0
-	# branch.head master
+	# branch.head initial-branch
 	1 .M N... 100644 100644 100644 $OID_X $OID_X file_x
 	1 .D N... 100644 100644 000000 $OID_Z $OID_Z file_z
 	? actual
@@ -126,7 +127,7 @@ test_expect_success 'after first commit, stage existing changes' '
 
 	cat >expect <<-EOF &&
 	# branch.oid $H0
-	# branch.head master
+	# branch.head initial-branch
 	1 M. N... 100644 100644 100644 $OID_X $OID_X1 file_x
 	1 D. N... 100644 000000 000000 $OID_Z $ZERO_OID file_z
 	? actual
@@ -143,7 +144,7 @@ test_expect_success 'rename causes 2 path lines' '
 
 	q_to_tab >expect <<-EOF &&
 	# branch.oid $H0
-	# branch.head master
+	# branch.head initial-branch
 	1 M. N... 100644 100644 100644 $OID_X $OID_X1 file_x
 	1 D. N... 100644 000000 000000 $OID_Z $ZERO_OID file_z
 	2 R. N... 100644 100644 100644 $OID_Y $OID_Y R100 renamed_yQfile_y
@@ -161,7 +162,7 @@ test_expect_success 'rename causes 2 path lines (-z)' '
 	## Lines use NUL path separator and line terminator, so double transform here.
 	q_to_nul <<-EOF | lf_to_nul >expect &&
 	# branch.oid $H0
-	# branch.head master
+	# branch.head initial-branch
 	1 M. N... 100644 100644 100644 $OID_X $OID_X1 file_x
 	1 D. N... 100644 000000 000000 $OID_Z $ZERO_OID file_z
 	2 R. N... 100644 100644 100644 $OID_Y $OID_Y R100 renamed_yQfile_y
@@ -179,7 +180,7 @@ test_expect_success 'make second commit, confirm clean and new HEAD oid' '
 
 	cat >expect <<-EOF &&
 	# branch.oid $H1
-	# branch.head master
+	# branch.head initial-branch
 	? actual
 	? expect
 	EOF
@@ -231,7 +232,7 @@ test_expect_success 'create and commit permanent ignore file' '
 
 	cat >expect <<-EOF &&
 	# branch.oid $H1
-	# branch.head master
+	# branch.head initial-branch
 	EOF
 
 	git status --porcelain=v2 --branch >actual &&
@@ -257,14 +258,14 @@ test_expect_success 'verify --intent-to-add output' '
 test_expect_success 'verify AA (add-add) conflict' '
 	test_when_finished "git reset --hard" &&
 
-	git branch AA_A master &&
+	git branch AA_A initial-branch &&
 	git checkout AA_A &&
 	echo "Branch AA_A" >conflict.txt &&
 	OID_AA_A=$(git hash-object -t blob -- conflict.txt) &&
 	git add conflict.txt &&
 	git commit -m "branch aa_a" &&
 
-	git branch AA_B master &&
+	git branch AA_B initial-branch &&
 	git checkout AA_B &&
 	echo "Branch AA_B" >conflict.txt &&
 	OID_AA_B=$(git hash-object -t blob -- conflict.txt) &&
@@ -290,7 +291,7 @@ test_expect_success 'verify AA (add-add) conflict' '
 test_expect_success 'verify UU (edit-edit) conflict' '
 	test_when_finished "git reset --hard" &&
 
-	git branch UU_ANC master &&
+	git branch UU_ANC initial-branch &&
 	git checkout UU_ANC &&
 	echo "Ancestor" >conflict.txt &&
 	OID_UU_ANC=$(git hash-object -t blob -- conflict.txt) &&
@@ -328,18 +329,18 @@ test_expect_success 'verify UU (edit-edit) conflict' '
 '
 
 test_expect_success 'verify upstream fields in branch header' '
-	git checkout master &&
+	git checkout initial-branch &&
 	test_when_finished "rm -rf sub_repo" &&
 	git clone . sub_repo &&
 	(
-		## Confirm local master tracks remote master.
+		## Confirm local initial-branch tracks remote initial-branch.
 		cd sub_repo &&
 		HUF=$(git rev-parse HEAD) &&
 
 		cat >expect <<-EOF &&
 		# branch.oid $HUF
-		# branch.head master
-		# branch.upstream origin/master
+		# branch.head initial-branch
+		# branch.upstream origin/initial-branch
 		# branch.ab +0 -0
 		EOF
 
@@ -355,8 +356,8 @@ test_expect_success 'verify upstream fields in branch header' '
 
 		cat >expect <<-EOF &&
 		# branch.oid $HUF
-		# branch.head master
-		# branch.upstream origin/master
+		# branch.head initial-branch
+		# branch.upstream origin/initial-branch
 		# branch.ab +1 -0
 		EOF
 
@@ -367,9 +368,9 @@ test_expect_success 'verify upstream fields in branch header' '
 		git status --porcelain=v2 --untracked-files=all >actual &&
 		test_must_be_empty actual &&
 
-		## Test upstream-gone case. Fake this by pointing origin/master at
-		## a non-existing commit.
-		OLD=$(git rev-parse origin/master) &&
+		## Test upstream-gone case. Fake this by pointing
+		## origin/initial-branch at a non-existing commit.
+		OLD=$(git rev-parse origin/initial-branch) &&
 		NEW=$ZERO_OID &&
 		mv .git/packed-refs .git/old-packed-refs &&
 		sed "s/$OLD/$NEW/g" <.git/old-packed-refs >.git/packed-refs &&
@@ -378,8 +379,8 @@ test_expect_success 'verify upstream fields in branch header' '
 
 		cat >expect <<-EOF &&
 		# branch.oid $HUF
-		# branch.head master
-		# branch.upstream origin/master
+		# branch.head initial-branch
+		# branch.upstream origin/initial-branch
 		EOF
 
 		git status --porcelain=v2 --branch --untracked-files=all >actual &&
@@ -388,19 +389,19 @@ test_expect_success 'verify upstream fields in branch header' '
 '
 
 test_expect_success 'verify --[no-]ahead-behind with V2 format' '
-	git checkout master &&
+	git checkout initial-branch &&
 	test_when_finished "rm -rf sub_repo" &&
 	git clone . sub_repo &&
 	(
-		## Confirm local master tracks remote master.
+		## Confirm local initial-branch tracks remote initial-branch.
 		cd sub_repo &&
 		HUF=$(git rev-parse HEAD) &&
 
 		# Confirm --no-ahead-behind reports traditional branch.ab with 0/0 for equal branches.
 		cat >expect <<-EOF &&
 		# branch.oid $HUF
-		# branch.head master
-		# branch.upstream origin/master
+		# branch.head initial-branch
+		# branch.upstream origin/initial-branch
 		# branch.ab +0 -0
 		EOF
 
@@ -410,8 +411,8 @@ test_expect_success 'verify --[no-]ahead-behind with V2 format' '
 		# Confirm --ahead-behind reports traditional branch.ab with 0/0.
 		cat >expect <<-EOF &&
 		# branch.oid $HUF
-		# branch.head master
-		# branch.upstream origin/master
+		# branch.head initial-branch
+		# branch.upstream origin/initial-branch
 		# branch.ab +0 -0
 		EOF
 
@@ -428,8 +429,8 @@ test_expect_success 'verify --[no-]ahead-behind with V2 format' '
 		# Confirm --no-ahead-behind reports branch.ab with ?/? for non-equal branches.
 		cat >expect <<-EOF &&
 		# branch.oid $HUF
-		# branch.head master
-		# branch.upstream origin/master
+		# branch.head initial-branch
+		# branch.upstream origin/initial-branch
 		# branch.ab +? -?
 		EOF
 
@@ -439,8 +440,8 @@ test_expect_success 'verify --[no-]ahead-behind with V2 format' '
 		# Confirm --ahead-behind reports traditional branch.ab with 1/0.
 		cat >expect <<-EOF &&
 		# branch.oid $HUF
-		# branch.head master
-		# branch.upstream origin/master
+		# branch.head initial-branch
+		# branch.upstream origin/initial-branch
 		# branch.ab +1 -0
 		EOF
 
@@ -458,7 +459,7 @@ test_expect_success 'verify --[no-]ahead-behind with V2 format' '
 '
 
 test_expect_success 'create and add submodule, submodule appears clean (A. S...)' '
-	git checkout master &&
+	git checkout initial-branch &&
 	git clone . sub_repo &&
 	git clone . super_repo &&
 	(	cd super_repo &&
@@ -471,8 +472,8 @@ test_expect_success 'create and add submodule, submodule appears clean (A. S...)
 
 		cat >expect <<-EOF &&
 		# branch.oid $HSUP
-		# branch.head master
-		# branch.upstream origin/master
+		# branch.head initial-branch
+		# branch.upstream origin/initial-branch
 		# branch.ab +0 -0
 		1 A. N... 000000 100644 100644 $ZERO_OID $HMOD .gitmodules
 		1 A. S... 000000 160000 160000 $ZERO_OID $HSUB sub1
@@ -496,8 +497,8 @@ test_expect_success 'untracked changes in added submodule (AM S..U)' '
 
 		cat >expect <<-EOF &&
 		# branch.oid $HSUP
-		# branch.head master
-		# branch.upstream origin/master
+		# branch.head initial-branch
+		# branch.upstream origin/initial-branch
 		# branch.ab +0 -0
 		1 A. N... 000000 100644 100644 $ZERO_OID $HMOD .gitmodules
 		1 AM S..U 000000 160000 160000 $ZERO_OID $HSUB sub1
@@ -521,8 +522,8 @@ test_expect_success 'staged changes in added submodule (AM S.M.)' '
 
 		cat >expect <<-EOF &&
 		# branch.oid $HSUP
-		# branch.head master
-		# branch.upstream origin/master
+		# branch.head initial-branch
+		# branch.upstream origin/initial-branch
 		# branch.ab +0 -0
 		1 A. N... 000000 100644 100644 $ZERO_OID $HMOD .gitmodules
 		1 AM S.M. 000000 160000 160000 $ZERO_OID $HSUB sub1
@@ -548,8 +549,8 @@ test_expect_success 'staged and unstaged changes in added (AM S.M.)' '
 
 		cat >expect <<-EOF &&
 		# branch.oid $HSUP
-		# branch.head master
-		# branch.upstream origin/master
+		# branch.head initial-branch
+		# branch.upstream origin/initial-branch
 		# branch.ab +0 -0
 		1 A. N... 000000 100644 100644 $ZERO_OID $HMOD .gitmodules
 		1 AM S.M. 000000 160000 160000 $ZERO_OID $HSUB sub1
@@ -575,8 +576,8 @@ test_expect_success 'staged and untracked changes in added submodule (AM S.MU)' 
 
 		cat >expect <<-EOF &&
 		# branch.oid $HSUP
-		# branch.head master
-		# branch.upstream origin/master
+		# branch.head initial-branch
+		# branch.upstream origin/initial-branch
 		# branch.ab +0 -0
 		1 A. N... 000000 100644 100644 $ZERO_OID $HMOD .gitmodules
 		1 AM S.MU 000000 160000 160000 $ZERO_OID $HSUB sub1
@@ -602,8 +603,8 @@ test_expect_success 'commit within the submodule appears as new commit in super 
 
 		cat >expect <<-EOF &&
 		# branch.oid $HSUP
-		# branch.head master
-		# branch.upstream origin/master
+		# branch.head initial-branch
+		# branch.upstream origin/initial-branch
 		# branch.ab +0 -0
 		1 A. N... 000000 100644 100644 $ZERO_OID $HMOD .gitmodules
 		1 AM SC.. 000000 160000 160000 $ZERO_OID $HSUB sub1
@@ -625,8 +626,8 @@ test_expect_success 'stage submodule in super and commit' '
 
 		cat >expect <<-EOF &&
 		# branch.oid $HSUP
-		# branch.head master
-		# branch.upstream origin/master
+		# branch.head initial-branch
+		# branch.upstream origin/initial-branch
 		# branch.ab +1 -0
 		EOF
 
@@ -646,8 +647,8 @@ test_expect_success 'make unstaged changes in existing submodule (.M S.M.)' '
 
 		cat >expect <<-EOF &&
 		# branch.oid $HSUP
-		# branch.head master
-		# branch.upstream origin/master
+		# branch.head initial-branch
+		# branch.upstream origin/initial-branch
 		# branch.ab +1 -0
 		1 .M S.M. 160000 160000 160000 $HSUB $HSUB sub1
 		EOF


### PR DESCRIPTION
This one goes on top of `sj/untracked-files-in-submodule-directory-is-not-dirty`.

Changes since v1:

- Fixed a typo and a grammatical construct that was not quite English in the commit message.

Cc: David Aguilar <davvid@gmail.com>