### PR TITLE
Drop the PREPARE_FOR_MAIN_BRANCH prereq

### DIFF
--- a/t/t1400-update-ref.sh
+++ b/t/t1400-update-ref.sh
@@ -8,7 +8,7 @@ test_description='Test git update-ref and basic ref logging'
 
 Z=$ZERO_OID
 
-m=refs/heads/master
+m=refs/heads/main
 n_dir=refs/heads/gu
 n=$n_dir/fixes
 outside=refs/foo
@@ -27,10 +27,11 @@ create_test_commits ()
 }
 
 test_expect_success setup '
+	git checkout --orphan main &&
 	create_test_commits "" &&
 	mkdir $bare &&
 	cd $bare &&
-	git init --bare &&
+	git init --bare -b main &&
 	create_test_commits "bare" &&
 	cd -
 '
@@ -264,7 +265,7 @@ test_expect_success "(not) changed .git/$m" '
 	! test $B = $(git show-ref -s --verify $m)
 '
 
-rm -f .git/logs/refs/heads/master
+rm -f .git/logs/refs/heads/main
 test_expect_success "create $m (logged by touch)" '
 	test_config core.logAllRefUpdates false &&
 	GIT_COMMITTER_DATE="2005-05-26 23:30" \
@@ -300,7 +301,7 @@ test_expect_success 'symref empty directory removal' '
 	git branch e1/e2/r1 HEAD &&
 	git branch e1/r2 HEAD &&
 	git checkout e1/e2/r1 &&
-	test_when_finished "git checkout master" &&
+	test_when_finished "git checkout main" &&
 	test_path_is_file .git/refs/heads/e1/e2/r1 &&
 	test_path_is_file .git/logs/refs/heads/e1/e2/r1 &&
 	git update-ref -d HEAD &&
@@ -364,68 +365,68 @@ test_expect_success 'set up for querying the reflog' '
 ed="Thu, 26 May 2005 18:32:00 -0500"
 gd="Thu, 26 May 2005 18:33:00 -0500"
 ld="Thu, 26 May 2005 18:43:00 -0500"
-test_expect_success 'Query "master@{May 25 2005}" (before history)' '
+test_expect_success 'Query "main@{May 25 2005}" (before history)' '
 	test_when_finished "rm -f o e" &&
-	git rev-parse --verify "master@{May 25 2005}" >o 2>e &&
+	git rev-parse --verify "main@{May 25 2005}" >o 2>e &&
 	echo "$C" >expect &&
 	test_cmp expect o &&
-	echo "warning: log for '\''master'\'' only goes back to $ed" >expect &&
+	echo "warning: log for '\''main'\'' only goes back to $ed" >expect &&
 	test_i18ncmp expect e
 '
-test_expect_success 'Query master@{2005-05-25} (before history)' '
+test_expect_success 'Query main@{2005-05-25} (before history)' '
 	test_when_finished "rm -f o e" &&
-	git rev-parse --verify master@{2005-05-25} >o 2>e &&
+	git rev-parse --verify main@{2005-05-25} >o 2>e &&
 	echo "$C" >expect &&
 	test_cmp expect o &&
-	echo "warning: log for '\''master'\'' only goes back to $ed" >expect &&
+	echo "warning: log for '\''main'\'' only goes back to $ed" >expect &&
 	test_i18ncmp expect e
 '
-test_expect_success 'Query "master@{May 26 2005 23:31:59}" (1 second before history)' '
+test_expect_success 'Query "main@{May 26 2005 23:31:59}" (1 second before history)' '
 	test_when_finished "rm -f o e" &&
-	git rev-parse --verify "master@{May 26 2005 23:31:59}" >o 2>e &&
+	git rev-parse --verify "main@{May 26 2005 23:31:59}" >o 2>e &&
 	echo "$C" >expect &&
 	test_cmp expect o &&
-	echo "warning: log for '\''master'\'' only goes back to $ed" >expect &&
+	echo "warning: log for '\''main'\'' only goes back to $ed" >expect &&
 	test_i18ncmp expect e
 '
-test_expect_success 'Query "master@{May 26 2005 23:32:00}" (exactly history start)' '
+test_expect_success 'Query "main@{May 26 2005 23:32:00}" (exactly history start)' '
 	test_when_finished "rm -f o e" &&
-	git rev-parse --verify "master@{May 26 2005 23:32:00}" >o 2>e &&
+	git rev-parse --verify "main@{May 26 2005 23:32:00}" >o 2>e &&
 	echo "$C" >expect &&
 	test_cmp expect o &&
 	test_must_be_empty e
 '
-test_expect_success 'Query "master@{May 26 2005 23:32:30}" (first non-creation change)' '
+test_expect_success 'Query "main@{May 26 2005 23:32:30}" (first non-creation change)' '
 	test_when_finished "rm -f o e" &&
-	git rev-parse --verify "master@{May 26 2005 23:32:30}" >o 2>e &&
+	git rev-parse --verify "main@{May 26 2005 23:32:30}" >o 2>e &&
 	echo "$A" >expect &&
 	test_cmp expect o &&
 	test_must_be_empty e
 '
-test_expect_success 'Query "master@{2005-05-26 23:33:01}" (middle of history with gap)' '
+test_expect_success 'Query "main@{2005-05-26 23:33:01}" (middle of history with gap)' '
 	test_when_finished "rm -f o e" &&
-	git rev-parse --verify "master@{2005-05-26 23:33:01}" >o 2>e &&
+	git rev-parse --verify "main@{2005-05-26 23:33:01}" >o 2>e &&
 	echo "$B" >expect &&
 	test_cmp expect o &&
 	test_i18ngrep -F "warning: log for ref $m has gap after $gd" e
 '
-test_expect_success 'Query "master@{2005-05-26 23:38:00}" (middle of history)' '
+test_expect_success 'Query "main@{2005-05-26 23:38:00}" (middle of history)' '
 	test_when_finished "rm -f o e" &&
-	git rev-parse --verify "master@{2005-05-26 23:38:00}" >o 2>e &&
+	git rev-parse --verify "main@{2005-05-26 23:38:00}" >o 2>e &&
 	echo "$Z" >expect &&
 	test_cmp expect o &&
 	test_must_be_empty e
 '
-test_expect_success 'Query "master@{2005-05-26 23:43:00}" (exact end of history)' '
+test_expect_success 'Query "main@{2005-05-26 23:43:00}" (exact end of history)' '
 	test_when_finished "rm -f o e" &&
-	git rev-parse --verify "master@{2005-05-26 23:43:00}" >o 2>e &&
+	git rev-parse --verify "main@{2005-05-26 23:43:00}" >o 2>e &&
 	echo "$E" >expect &&
 	test_cmp expect o &&
 	test_must_be_empty e
 '
-test_expect_success 'Query "master@{2005-05-28}" (past end of history)' '
+test_expect_success 'Query "main@{2005-05-28}" (past end of history)' '
 	test_when_finished "rm -f o e" &&
-	git rev-parse --verify "master@{2005-05-28}" >o 2>e &&
+	git rev-parse --verify "main@{2005-05-28}" >o 2>e &&
 	echo "$D" >expect &&
 	test_cmp expect o &&
 	test_i18ngrep -F "warning: log for ref $m unexpectedly ended on $ld" e
@@ -467,14 +468,14 @@ test_expect_success 'git commit logged updates' '
 '
 unset h_TEST h_OTHER h_FIXED h_MERGED
 
-test_expect_success 'git cat-file blob master:F (expect OTHER)' '
-	test OTHER = $(git cat-file blob master:F)
+test_expect_success 'git cat-file blob main:F (expect OTHER)' '
+	test OTHER = $(git cat-file blob main:F)
 '
-test_expect_success 'git cat-file blob master@{2005-05-26 23:30}:F (expect TEST)' '
-	test TEST = $(git cat-file blob "master@{2005-05-26 23:30}:F")
+test_expect_success 'git cat-file blob main@{2005-05-26 23:30}:F (expect TEST)' '
+	test TEST = $(git cat-file blob "main@{2005-05-26 23:30}:F")
 '
-test_expect_success 'git cat-file blob master@{2005-05-26 23:42}:F (expect OTHER)' '
-	test OTHER = $(git cat-file blob "master@{2005-05-26 23:42}:F")
+test_expect_success 'git cat-file blob main@{2005-05-26 23:42}:F (expect OTHER)' '
+	test OTHER = $(git cat-file blob "main@{2005-05-26 23:42}:F")
 '
 
 # Test adding and deleting pseudorefs
@@ -586,21 +587,21 @@ test_expect_success 'stdin fails on unknown command' '
 '
 
 test_expect_success 'stdin fails on unbalanced quotes' '
-	echo "create $a \"master" >stdin &&
+	echo "create $a \"main" >stdin &&
 	test_must_fail git update-ref --stdin <stdin 2>err &&
-	grep "fatal: badly quoted argument: \\\"master" err
+	grep "fatal: badly quoted argument: \\\"main" err
 '
 
-test_expect_success PREPARE_FOR_MAIN_BRANCH 'stdin fails on invalid escape' '
+test_expect_success 'stdin fails on invalid escape' '
 	echo "create $a \"ma\zn\"" >stdin &&
 	test_must_fail git update-ref --stdin <stdin 2>err &&
 	grep "fatal: badly quoted argument: \\\"ma\\\\zn\\\"" err
 '
 
 test_expect_success 'stdin fails on junk after quoted argument' '
-	echo "create \"$a\"master" >stdin &&
+	echo "create \"$a\"main" >stdin &&
 	test_must_fail git update-ref --stdin <stdin 2>err &&
-	grep "fatal: unexpected character after quoted argument: \\\"$a\\\"master" err
+	grep "fatal: unexpected character after quoted argument: \\\"$a\\\"main" err
 '
 
 test_expect_success 'stdin fails create with no ref' '
@@ -710,7 +711,7 @@ test_expect_success 'stdin succeeds with quoted argument' '
 	test_cmp expect actual
 '
 
-test_expect_success PREPARE_FOR_MAIN_BRANCH 'stdin succeeds with escaped character' '
+test_expect_success 'stdin succeeds with escaped character' '
 	git update-ref -d $a &&
 	echo "create $a \"ma\\151n\"" >stdin &&
 	git update-ref --stdin <stdin &&

--- a/t/t3200-branch.sh
+++ b/t/t3200-branch.sh
@@ -12,6 +12,7 @@ test_expect_success 'prepare a trivial repository' '
 	echo Hello >A &&
 	git update-index --add A &&
 	git commit -m "Initial commit." &&
+	git branch -M main &&
 	echo World >>A &&
 	git update-index --add A &&
 	git commit -m "Second commit." &&
@@ -27,8 +28,8 @@ test_expect_success 'branch -h in broken repository' '
 	mkdir broken &&
 	(
 		cd broken &&
-		git init &&
-		>.git/refs/heads/master &&
+		git init -b main &&
+		>.git/refs/heads/main &&
 		test_expect_code 129 git branch -h >usage 2>&1
 	) &&
 	test_i18ngrep "[Uu]sage" broken/usage
@@ -42,8 +43,8 @@ test_expect_success 'git branch a/b/c should create a branch' '
 	git branch a/b/c && test_path_is_file .git/refs/heads/a/b/c
 '
 
-test_expect_success 'git branch mb master... should create a branch' '
-	git branch mb master... && test_path_is_file .git/refs/heads/mb
+test_expect_success 'git branch mb main... should create a branch' '
+	git branch mb main... && test_path_is_file .git/refs/heads/mb
 '
 
 test_expect_success 'git branch HEAD should fail' '
@@ -51,7 +52,7 @@ test_expect_success 'git branch HEAD should fail' '
 '
 
 cat >expect <<EOF
-$ZERO_OID $HEAD $GIT_COMMITTER_NAME <$GIT_COMMITTER_EMAIL> 1117150200 +0000	branch: Created from master
+$ZERO_OID $HEAD $GIT_COMMITTER_NAME <$GIT_COMMITTER_EMAIL> 1117150200 +0000	branch: Created from main
 EOF
 test_expect_success 'git branch --create-reflog d/e/f should create a branch and a log' '
 	GIT_COMMITTER_DATE="2005-05-26 23:30" \
@@ -110,7 +111,7 @@ test_expect_success 'git branch -m n/n n should work' '
 
 test_expect_success 'git branch -m bbb should rename checked out branch' '
 	test_when_finished git branch -D bbb &&
-	test_when_finished git checkout master &&
+	test_when_finished git checkout main &&
 	git checkout -b aaa &&
 	git commit --allow-empty -m "a new commit" &&
 	git rev-parse aaa@{0} >expect &&
@@ -124,7 +125,7 @@ test_expect_success 'git branch -m bbb should rename checked out branch' '
 
 test_expect_success 'renaming checked out branch works with d/f conflict' '
 	test_when_finished "git branch -D foo/bar || git branch -D foo" &&
-	test_when_finished git checkout master &&
+	test_when_finished git checkout main &&
 	git checkout -b foo &&
 	git branch -m foo/bar &&
 	git symbolic-ref HEAD >actual &&
@@ -178,14 +179,14 @@ test_expect_success 'git branch -M baz bam should add entries to .git/logs/HEAD'
 '
 
 test_expect_success 'git branch -M should leave orphaned HEAD alone' '
-	git init orphan &&
+	git init -b main orphan &&
 	(
 		cd orphan &&
 		test_commit initial &&
 		git checkout --orphan lonely &&
 		grep lonely .git/HEAD &&
 		test_path_is_missing .git/refs/head/lonely &&
-		git branch -M master mistress &&
+		git branch -M main mistress &&
 		grep lonely .git/HEAD
 	)
 '
@@ -201,7 +202,7 @@ test_expect_success 'resulting reflog can be shown by log -g' '
 '
 
 test_expect_success 'git branch -M baz bam should succeed when baz is checked out as linked working tree' '
-	git checkout master &&
+	git checkout main &&
 	git worktree add -b baz bazdir &&
 	git worktree add -f bazdir2 baz &&
 	git branch -M baz bam &&
@@ -224,18 +225,18 @@ test_expect_success 'git branch -M baz bam should succeed within a worktree in w
 	git worktree prune
 '
 
-test_expect_success 'git branch -M master should work when master is checked out' '
-	git checkout master &&
-	git branch -M master
+test_expect_success 'git branch -M main should work when main is checked out' '
+	git checkout main &&
+	git branch -M main
 '
 
-test_expect_success 'git branch -M master master should work when master is checked out' '
-	git checkout master &&
-	git branch -M master master
+test_expect_success 'git branch -M main main should work when main is checked out' '
+	git checkout main &&
+	git branch -M main main
 '
 
-test_expect_success 'git branch -M topic topic should work when master is checked out' '
-	git checkout master &&
+test_expect_success 'git branch -M topic topic should work when main is checked out' '
+	git checkout main &&
 	git branch topic &&
 	git branch -M topic topic
 '
@@ -289,11 +290,11 @@ test_expect_success 'deleting checked-out branch from repo that is a submodule' 
 test_expect_success 'bare main worktree has HEAD at branch deleted by secondary worktree' '
 	test_when_finished "rm -rf nonbare base secondary" &&
 
-	git init nonbare &&
+	git init -b main nonbare &&
 	test_commit -C nonbare x &&
 	git clone --bare nonbare bare &&
-	git -C bare worktree add --detach ../secondary master &&
-	git -C secondary branch -D master
+	git -C bare worktree add --detach ../secondary main &&
+	git -C secondary branch -D main
 '
 
 test_expect_success 'git branch --list -v with --abbrev' '
@@ -321,7 +322,7 @@ test_expect_success 'git branch --list -v with --abbrev' '
 
 '
 
-test_expect_success PREPARE_FOR_MAIN_BRANCH 'git branch --column' '
+test_expect_success 'git branch --column' '
 	COLUMNS=81 git branch --column=column >actual &&
 	cat >expect <<\EOF &&
   a/b/c   bam     foo     l     * main    n       o/p     r
@@ -345,7 +346,7 @@ test_expect_success 'git branch --column with an extremely long branch name' '
   j/k
   l
   m/m
-* master
+* main
   mb
   n
   o/o
@@ -358,7 +359,7 @@ EOF
 	test_cmp expect actual
 '
 
-test_expect_success PREPARE_FOR_MAIN_BRANCH 'git branch with column.*' '
+test_expect_success 'git branch with column.*' '
 	git config column.ui column &&
 	git config column.branch "dense" &&
 	COLUMNS=80 git branch >actual &&
@@ -375,7 +376,7 @@ test_expect_success 'git branch --column -v should fail' '
 	test_must_fail git branch --column -v
 '
 
-test_expect_success PREPARE_FOR_MAIN_BRANCH 'git branch -v with column.ui ignored' '
+test_expect_success 'git branch -v with column.ui ignored' '
 	git config column.ui column &&
 	COLUMNS=80 git branch -v | cut -c -8 | sed "s/ *$//" >actual &&
 	git config --unset column.ui &&
@@ -388,7 +389,7 @@ test_expect_success PREPARE_FOR_MAIN_BRANCH 'git branch -v with column.ui ignore
   j/k
   l
   m/m
-* master
+* main
   mb
   n
   o/o
@@ -427,8 +428,8 @@ test_expect_success 'config information was renamed, too' '
 '
 
 test_expect_success 'git branch -m correctly renames multiple config sections' '
-	test_when_finished "git checkout master" &&
-	git checkout -b source master &&
+	test_when_finished "git checkout main" &&
+	git checkout -b source main &&
 
 	# Assert that a config file with multiple config sections has
 	# those sections preserved...
@@ -587,18 +588,18 @@ test_expect_success 'git branch -C c1 c2 should never touch HEAD' '
 	! grep "$msg$" .git/logs/HEAD
 '
 
-test_expect_success 'git branch -C master should work when master is checked out' '
-	git checkout master &&
-	git branch -C master
+test_expect_success 'git branch -C main should work when main is checked out' '
+	git checkout main &&
+	git branch -C main
 '
 
-test_expect_success 'git branch -C master master should work when master is checked out' '
-	git checkout master &&
-	git branch -C master master
+test_expect_success 'git branch -C main main should work when main is checked out' '
+	git checkout main &&
+	git branch -C main main
 '
 
-test_expect_success 'git branch -C main5 main5 should work when master is checked out' '
-	git checkout master &&
+test_expect_success 'git branch -C main5 main5 should work when main is checked out' '
+	git checkout main &&
 	git branch main5 &&
 	git branch -C main5 main5
 '
@@ -620,8 +621,8 @@ test_expect_success 'git branch -C ab cd should overwrite existing config for cd
 test_expect_success 'git branch -c correctly copies multiple config sections' '
 	FOO=1 &&
 	export FOO &&
-	test_when_finished "git checkout master" &&
-	git checkout -b source2 master &&
+	test_when_finished "git checkout main" &&
+	git checkout -b source2 main &&
 
 	# Assert that a config file with multiple config sections has
 	# those sections preserved...
@@ -711,10 +712,10 @@ test_expect_success 'deleting a self-referential symref' '
 '
 
 test_expect_success 'renaming a symref is not allowed' '
-	git symbolic-ref refs/heads/topic refs/heads/master &&
+	git symbolic-ref refs/heads/topic refs/heads/main &&
 	test_must_fail git branch -m topic new-topic &&
 	git symbolic-ref refs/heads/topic &&
-	test_path_is_file .git/refs/heads/master &&
+	test_path_is_file .git/refs/heads/main &&
 	test_path_is_missing .git/refs/heads/new-topic
 '
 
@@ -728,27 +729,27 @@ test_expect_success SYMLINKS 'git branch -m u v should fail when the reflog for 
 test_expect_success 'test tracking setup via --track' '
 	git config remote.local.url . &&
 	git config remote.local.fetch refs/heads/*:refs/remotes/local/* &&
-	(git show-ref -q refs/remotes/local/master || git fetch local) &&
-	git branch --track my1 local/master &&
+	(git show-ref -q refs/remotes/local/main || git fetch local) &&
+	git branch --track my1 local/main &&
 	test $(git config branch.my1.remote) = local &&
-	test $(git config branch.my1.merge) = refs/heads/master
+	test $(git config branch.my1.merge) = refs/heads/main
 '
 
 test_expect_success 'test tracking setup (non-wildcard, matching)' '
 	git config remote.local.url . &&
-	git config remote.local.fetch refs/heads/master:refs/remotes/local/master &&
-	(git show-ref -q refs/remotes/local/master || git fetch local) &&
-	git branch --track my4 local/master &&
+	git config remote.local.fetch refs/heads/main:refs/remotes/local/main &&
+	(git show-ref -q refs/remotes/local/main || git fetch local) &&
+	git branch --track my4 local/main &&
 	test $(git config branch.my4.remote) = local &&
-	test $(git config branch.my4.merge) = refs/heads/master
+	test $(git config branch.my4.merge) = refs/heads/main
 '
 
 test_expect_success 'tracking setup fails on non-matching refspec' '
 	git config remote.local.url . &&
 	git config remote.local.fetch refs/heads/*:refs/remotes/local/* &&
-	(git show-ref -q refs/remotes/local/master || git fetch local) &&
+	(git show-ref -q refs/remotes/local/main || git fetch local) &&
 	git config remote.local.fetch refs/heads/s:refs/remotes/local/s &&
-	test_must_fail git branch --track my5 local/master &&
+	test_must_fail git branch --track my5 local/main &&
 	test_must_fail git config branch.my5.remote &&
 	test_must_fail git config branch.my5.merge
 '
@@ -757,21 +758,21 @@ test_expect_success 'test tracking setup via config' '
 	git config branch.autosetupmerge true &&
 	git config remote.local.url . &&
 	git config remote.local.fetch refs/heads/*:refs/remotes/local/* &&
-	(git show-ref -q refs/remotes/local/master || git fetch local) &&
-	git branch my3 local/master &&
+	(git show-ref -q refs/remotes/local/main || git fetch local) &&
+	git branch my3 local/main &&
 	test $(git config branch.my3.remote) = local &&
-	test $(git config branch.my3.merge) = refs/heads/master
+	test $(git config branch.my3.merge) = refs/heads/main
 '
 
 test_expect_success 'test overriding tracking setup via --no-track' '
 	git config branch.autosetupmerge true &&
 	git config remote.local.url . &&
 	git config remote.local.fetch refs/heads/*:refs/remotes/local/* &&
-	(git show-ref -q refs/remotes/local/master || git fetch local) &&
-	git branch --no-track my2 local/master &&
+	(git show-ref -q refs/remotes/local/main || git fetch local) &&
+	git branch --no-track my2 local/main &&
 	git config branch.autosetupmerge false &&
 	! test "$(git config branch.my2.remote)" = local &&
-	! test "$(git config branch.my2.merge)" = refs/heads/master
+	! test "$(git config branch.my2.merge)" = refs/heads/main
 '
 
 test_expect_success 'no tracking without .fetch entries' '
@@ -836,26 +837,26 @@ test_expect_success 'branch from tag w/--track causes failure' '
 
 test_expect_success '--set-upstream-to fails on multiple branches' '
 	echo "fatal: too many arguments to set new upstream" >expect &&
-	test_must_fail git branch --set-upstream-to master a b c 2>err &&
+	test_must_fail git branch --set-upstream-to main a b c 2>err &&
 	test_i18ncmp expect err
 '
 
 test_expect_success '--set-upstream-to fails on detached HEAD' '
 	git checkout HEAD^{} &&
 	test_when_finished git checkout - &&
-	echo "fatal: could not set upstream of HEAD to master when it does not point to any branch." >expect &&
-	test_must_fail git branch --set-upstream-to master 2>err &&
+	echo "fatal: could not set upstream of HEAD to main when it does not point to any branch." >expect &&
+	test_must_fail git branch --set-upstream-to main 2>err &&
 	test_i18ncmp expect err
 '
 
 test_expect_success '--set-upstream-to fails on a missing dst branch' '
 	echo "fatal: branch '"'"'does-not-exist'"'"' does not exist" >expect &&
-	test_must_fail git branch --set-upstream-to master does-not-exist 2>err &&
+	test_must_fail git branch --set-upstream-to main does-not-exist 2>err &&
 	test_i18ncmp expect err
 '
 
 test_expect_success '--set-upstream-to fails on a missing src branch' '
-	test_must_fail git branch --set-upstream-to does-not-exist master 2>err &&
+	test_must_fail git branch --set-upstream-to does-not-exist main 2>err &&
 	test_i18ngrep "the requested upstream branch '"'"'does-not-exist'"'"' does not exist" err
 '
 
@@ -874,20 +875,20 @@ test_expect_success '--set-upstream-to fails on locked config' '
 '
 
 test_expect_success 'use --set-upstream-to modify HEAD' '
-	test_config branch.master.remote foo &&
-	test_config branch.master.merge foo &&
+	test_config branch.main.remote foo &&
+	test_config branch.main.merge foo &&
 	git branch my12 &&
 	git branch --set-upstream-to my12 &&
-	test "$(git config branch.master.remote)" = "." &&
-	test "$(git config branch.master.merge)" = "refs/heads/my12"
+	test "$(git config branch.main.remote)" = "." &&
+	test "$(git config branch.main.merge)" = "refs/heads/my12"
 '
 
 test_expect_success 'use --set-upstream-to modify a particular branch' '
 	git branch my13 &&
-	git branch --set-upstream-to master my13 &&
+	git branch --set-upstream-to main my13 &&
 	test_when_finished "git branch --unset-upstream my13" &&
 	test "$(git config branch.my13.remote)" = "." &&
-	test "$(git config branch.my13.merge)" = "refs/heads/master"
+	test "$(git config branch.my13.merge)" = "refs/heads/main"
 '
 
 test_expect_success '--unset-upstream should fail if given a non-existent branch' '
@@ -906,14 +907,14 @@ test_expect_success '--unset-upstream should fail if config is locked' '
 
 test_expect_success 'test --unset-upstream on HEAD' '
 	git branch my14 &&
-	test_config branch.master.remote foo &&
-	test_config branch.master.merge foo &&
+	test_config branch.main.remote foo &&
+	test_config branch.main.merge foo &&
 	git branch --set-upstream-to my14 &&
 	git branch --unset-upstream &&
-	test_must_fail git config branch.master.remote &&
-	test_must_fail git config branch.master.merge &&
+	test_must_fail git config branch.main.remote &&
+	test_must_fail git config branch.main.merge &&
 	# fail for a branch without upstream set
-	echo "fatal: Branch '"'"'master'"'"' has no upstream information" >expect &&
+	echo "fatal: Branch '"'"'main'"'"' has no upstream information" >expect &&
 	test_must_fail git branch --unset-upstream 2>err &&
 	test_i18ncmp expect err
 '
@@ -934,14 +935,14 @@ test_expect_success '--unset-upstream should fail on detached HEAD' '
 
 test_expect_success 'test --unset-upstream on a particular branch' '
 	git branch my15 &&
-	git branch --set-upstream-to master my14 &&
+	git branch --set-upstream-to main my14 &&
 	git branch --unset-upstream my14 &&
 	test_must_fail git config branch.my14.remote &&
 	test_must_fail git config branch.my14.merge
 '
 
 test_expect_success 'disabled option --set-upstream fails' '
-	test_must_fail git branch --set-upstream origin/master
+	test_must_fail git branch --set-upstream origin/main
 '
 
 test_expect_success '--set-upstream-to notices an error to set branch as own upstream' '
@@ -956,32 +957,32 @@ test_expect_success '--set-upstream-to notices an error to set branch as own ups
 
 # Keep this test last, as it changes the current branch
 cat >expect <<EOF
-$ZERO_OID $HEAD $GIT_COMMITTER_NAME <$GIT_COMMITTER_EMAIL> 1117150200 +0000	branch: Created from master
+$ZERO_OID $HEAD $GIT_COMMITTER_NAME <$GIT_COMMITTER_EMAIL> 1117150200 +0000	branch: Created from main
 EOF
 test_expect_success 'git checkout -b g/h/i -l should create a branch and a log' '
 	GIT_COMMITTER_DATE="2005-05-26 23:30" \
-	git checkout -b g/h/i -l master &&
+	git checkout -b g/h/i -l main &&
 	test_path_is_file .git/refs/heads/g/h/i &&
 	test_path_is_file .git/logs/refs/heads/g/h/i &&
 	test_cmp expect .git/logs/refs/heads/g/h/i
 '
 
 test_expect_success 'checkout -b makes reflog by default' '
-	git checkout master &&
+	git checkout main &&
 	git config --unset core.logAllRefUpdates &&
 	git checkout -b alpha &&
 	git rev-parse --verify alpha@{0}
 '
 
 test_expect_success 'checkout -b does not make reflog when core.logAllRefUpdates = false' '
-	git checkout master &&
+	git checkout main &&
 	git config core.logAllRefUpdates false &&
 	git checkout -b beta &&
 	test_must_fail git rev-parse --verify beta@{0}
 '
 
 test_expect_success 'checkout -b with -l makes reflog when core.logAllRefUpdates = false' '
-	git checkout master &&
+	git checkout main &&
 	git checkout -lb gamma &&
 	git config --unset core.logAllRefUpdates &&
 	git rev-parse --verify gamma@{0}
@@ -990,10 +991,10 @@ test_expect_success 'checkout -b with -l makes reflog when core.logAllRefUpdates
 test_expect_success 'avoid ambiguous track' '
 	git config branch.autosetupmerge true &&
 	git config remote.ambi1.url lalala &&
-	git config remote.ambi1.fetch refs/heads/lalala:refs/heads/master &&
+	git config remote.ambi1.fetch refs/heads/lalala:refs/heads/main &&
 	git config remote.ambi2.url lilili &&
-	git config remote.ambi2.fetch refs/heads/lilili:refs/heads/master &&
-	test_must_fail git branch all1 master &&
+	git config remote.ambi2.fetch refs/heads/lilili:refs/heads/main &&
+	test_must_fail git branch all1 main &&
 	test -z "$(git config branch.all1.merge)"
 '
 
@@ -1049,10 +1050,10 @@ test_expect_success 'autosetuprebase local on a tracked remote branch' '
 	git config remote.local.url . &&
 	git config remote.local.fetch refs/heads/*:refs/remotes/local/* &&
 	git config branch.autosetuprebase local &&
-	(git show-ref -q refs/remotes/local/master || git fetch local) &&
-	git branch --track myr5 local/master &&
+	(git show-ref -q refs/remotes/local/main || git fetch local) &&
+	git branch --track myr5 local/main &&
 	test "$(git config branch.myr5.remote)" = local &&
-	test "$(git config branch.myr5.merge)" = refs/heads/master &&
+	test "$(git config branch.myr5.merge)" = refs/heads/main &&
 	! test "$(git config branch.myr5.rebase)" = true
 '
 
@@ -1060,10 +1061,10 @@ test_expect_success 'autosetuprebase never on a tracked remote branch' '
 	git config remote.local.url . &&
 	git config remote.local.fetch refs/heads/*:refs/remotes/local/* &&
 	git config branch.autosetuprebase never &&
-	(git show-ref -q refs/remotes/local/master || git fetch local) &&
-	git branch --track myr6 local/master &&
+	(git show-ref -q refs/remotes/local/main || git fetch local) &&
+	git branch --track myr6 local/main &&
 	test "$(git config branch.myr6.remote)" = local &&
-	test "$(git config branch.myr6.merge)" = refs/heads/master &&
+	test "$(git config branch.myr6.merge)" = refs/heads/main &&
 	! test "$(git config branch.myr6.rebase)" = true
 '
 
@@ -1071,10 +1072,10 @@ test_expect_success 'autosetuprebase remote on a tracked remote branch' '
 	git config remote.local.url . &&
 	git config remote.local.fetch refs/heads/*:refs/remotes/local/* &&
 	git config branch.autosetuprebase remote &&
-	(git show-ref -q refs/remotes/local/master || git fetch local) &&
-	git branch --track myr7 local/master &&
+	(git show-ref -q refs/remotes/local/main || git fetch local) &&
+	git branch --track myr7 local/main &&
 	test "$(git config branch.myr7.remote)" = local &&
-	test "$(git config branch.myr7.merge)" = refs/heads/master &&
+	test "$(git config branch.myr7.merge)" = refs/heads/main &&
 	test "$(git config branch.myr7.rebase)" = true
 '
 
@@ -1082,10 +1083,10 @@ test_expect_success 'autosetuprebase always on a tracked remote branch' '
 	git config remote.local.url . &&
 	git config remote.local.fetch refs/heads/*:refs/remotes/local/* &&
 	git config branch.autosetuprebase remote &&
-	(git show-ref -q refs/remotes/local/master || git fetch local) &&
-	git branch --track myr8 local/master &&
+	(git show-ref -q refs/remotes/local/main || git fetch local) &&
+	git branch --track myr8 local/main &&
 	test "$(git config branch.myr8.remote)" = local &&
-	test "$(git config branch.myr8.merge)" = refs/heads/master &&
+	test "$(git config branch.myr8.merge)" = refs/heads/main &&
 	test "$(git config branch.myr8.rebase)" = true
 '
 
@@ -1093,10 +1094,10 @@ test_expect_success 'autosetuprebase unconfigured on a tracked remote branch' '
 	git config --unset branch.autosetuprebase &&
 	git config remote.local.url . &&
 	git config remote.local.fetch refs/heads/*:refs/remotes/local/* &&
-	(git show-ref -q refs/remotes/local/master || git fetch local) &&
-	git branch --track myr9 local/master &&
+	(git show-ref -q refs/remotes/local/main || git fetch local) &&
+	git branch --track myr9 local/main &&
 	test "$(git config branch.myr9.remote)" = local &&
-	test "$(git config branch.myr9.merge)" = refs/heads/master &&
+	test "$(git config branch.myr9.merge)" = refs/heads/main &&
 	test "z$(git config branch.myr9.rebase)" = z
 '
 
@@ -1114,7 +1115,7 @@ test_expect_success 'autosetuprebase unconfigured on a tracked local branch' '
 test_expect_success 'autosetuprebase unconfigured on untracked local branch' '
 	git config remote.local.url . &&
 	git config remote.local.fetch refs/heads/*:refs/remotes/local/* &&
-	(git show-ref -q refs/remotes/local/master || git fetch local) &&
+	(git show-ref -q refs/remotes/local/main || git fetch local) &&
 	git branch --no-track myr11 mybase2 &&
 	test "z$(git config branch.myr11.remote)" = z &&
 	test "z$(git config branch.myr11.merge)" = z &&
@@ -1124,8 +1125,8 @@ test_expect_success 'autosetuprebase unconfigured on untracked local branch' '
 test_expect_success 'autosetuprebase unconfigured on untracked remote branch' '
 	git config remote.local.url . &&
 	git config remote.local.fetch refs/heads/*:refs/remotes/local/* &&
-	(git show-ref -q refs/remotes/local/master || git fetch local) &&
-	git branch --no-track myr12 local/master &&
+	(git show-ref -q refs/remotes/local/main || git fetch local) &&
+	git branch --no-track myr12 local/main &&
 	test "z$(git config branch.myr12.remote)" = z &&
 	test "z$(git config branch.myr12.merge)" = z &&
 	test "z$(git config branch.myr12.rebase)" = z
@@ -1135,7 +1136,7 @@ test_expect_success 'autosetuprebase never on an untracked local branch' '
 	git config branch.autosetuprebase never &&
 	git config remote.local.url . &&
 	git config remote.local.fetch refs/heads/*:refs/remotes/local/* &&
-	(git show-ref -q refs/remotes/local/master || git fetch local) &&
+	(git show-ref -q refs/remotes/local/main || git fetch local) &&
 	git branch --no-track myr13 mybase2 &&
 	test "z$(git config branch.myr13.remote)" = z &&
 	test "z$(git config branch.myr13.merge)" = z &&
@@ -1146,7 +1147,7 @@ test_expect_success 'autosetuprebase local on an untracked local branch' '
 	git config branch.autosetuprebase local &&
 	git config remote.local.url . &&
 	git config remote.local.fetch refs/heads/*:refs/remotes/local/* &&
-	(git show-ref -q refs/remotes/local/master || git fetch local) &&
+	(git show-ref -q refs/remotes/local/main || git fetch local) &&
 	git branch --no-track myr14 mybase2 &&
 	test "z$(git config branch.myr14.remote)" = z &&
 	test "z$(git config branch.myr14.merge)" = z &&
@@ -1157,7 +1158,7 @@ test_expect_success 'autosetuprebase remote on an untracked local branch' '
 	git config branch.autosetuprebase remote &&
 	git config remote.local.url . &&
 	git config remote.local.fetch refs/heads/*:refs/remotes/local/* &&
-	(git show-ref -q refs/remotes/local/master || git fetch local) &&
+	(git show-ref -q refs/remotes/local/main || git fetch local) &&
 	git branch --no-track myr15 mybase2 &&
 	test "z$(git config branch.myr15.remote)" = z &&
 	test "z$(git config branch.myr15.merge)" = z &&
@@ -1168,7 +1169,7 @@ test_expect_success 'autosetuprebase always on an untracked local branch' '
 	git config branch.autosetuprebase always &&
 	git config remote.local.url . &&
 	git config remote.local.fetch refs/heads/*:refs/remotes/local/* &&
-	(git show-ref -q refs/remotes/local/master || git fetch local) &&
+	(git show-ref -q refs/remotes/local/main || git fetch local) &&
 	git branch --no-track myr16 mybase2 &&
 	test "z$(git config branch.myr16.remote)" = z &&
 	test "z$(git config branch.myr16.merge)" = z &&
@@ -1179,8 +1180,8 @@ test_expect_success 'autosetuprebase never on an untracked remote branch' '
 	git config branch.autosetuprebase never &&
 	git config remote.local.url . &&
 	git config remote.local.fetch refs/heads/*:refs/remotes/local/* &&
-	(git show-ref -q refs/remotes/local/master || git fetch local) &&
-	git branch --no-track myr17 local/master &&
+	(git show-ref -q refs/remotes/local/main || git fetch local) &&
+	git branch --no-track myr17 local/main &&
 	test "z$(git config branch.myr17.remote)" = z &&
 	test "z$(git config branch.myr17.merge)" = z &&
 	test "z$(git config branch.myr17.rebase)" = z
@@ -1190,8 +1191,8 @@ test_expect_success 'autosetuprebase local on an untracked remote branch' '
 	git config branch.autosetuprebase local &&
 	git config remote.local.url . &&
 	git config remote.local.fetch refs/heads/*:refs/remotes/local/* &&
-	(git show-ref -q refs/remotes/local/master || git fetch local) &&
-	git branch --no-track myr18 local/master &&
+	(git show-ref -q refs/remotes/local/main || git fetch local) &&
+	git branch --no-track myr18 local/main &&
 	test "z$(git config branch.myr18.remote)" = z &&
 	test "z$(git config branch.myr18.merge)" = z &&
 	test "z$(git config branch.myr18.rebase)" = z
@@ -1201,8 +1202,8 @@ test_expect_success 'autosetuprebase remote on an untracked remote branch' '
 	git config branch.autosetuprebase remote &&
 	git config remote.local.url . &&
 	git config remote.local.fetch refs/heads/*:refs/remotes/local/* &&
-	(git show-ref -q refs/remotes/local/master || git fetch local) &&
-	git branch --no-track myr19 local/master &&
+	(git show-ref -q refs/remotes/local/main || git fetch local) &&
+	git branch --no-track myr19 local/main &&
 	test "z$(git config branch.myr19.remote)" = z &&
 	test "z$(git config branch.myr19.merge)" = z &&
 	test "z$(git config branch.myr19.rebase)" = z
@@ -1212,8 +1213,8 @@ test_expect_success 'autosetuprebase always on an untracked remote branch' '
 	git config branch.autosetuprebase always &&
 	git config remote.local.url . &&
 	git config remote.local.fetch refs/heads/*:refs/remotes/local/* &&
-	(git show-ref -q refs/remotes/local/master || git fetch local) &&
-	git branch --no-track myr20 local/master &&
+	(git show-ref -q refs/remotes/local/main || git fetch local) &&
+	git branch --no-track myr20 local/main &&
 	test "z$(git config branch.myr20.remote)" = z &&
 	test "z$(git config branch.myr20.merge)" = z &&
 	test "z$(git config branch.myr20.rebase)" = z
@@ -1221,7 +1222,7 @@ test_expect_success 'autosetuprebase always on an untracked remote branch' '
 
 test_expect_success 'autosetuprebase always on detached HEAD' '
 	git config branch.autosetupmerge always &&
-	test_when_finished git checkout master &&
+	test_when_finished git checkout main &&
 	git checkout HEAD^0 &&
 	git branch my11 &&
 	test -z "$(git config branch.my11.remote)" &&
@@ -1249,18 +1250,18 @@ test_expect_success 'attempt to delete a branch without base and unmerged to HEA
 test_expect_success 'attempt to delete a branch merged to its base' '
 	# we are on my9 which is the initial commit; traditionally
 	# we would not have allowed deleting my8 that is not merged
-	# to my9, but it is set to track master that already has my8
-	git config branch.my8.merge refs/heads/master &&
+	# to my9, but it is set to track main that already has my8
+	git config branch.my8.merge refs/heads/main &&
 	git branch -d my8
 '
 
 test_expect_success 'attempt to delete a branch merged to its base' '
-	git checkout master &&
+	git checkout main &&
 	echo Third >>A &&
 	git commit -m "Third commit" A &&
 	git branch -t my10 my9 &&
 	git branch -f my10 HEAD^ &&
-	# we are on master which is at the third commit, and my10
+	# we are on main which is at the third commit, and my10
 	# is behind us, so traditionally we would have allowed deleting
 	# it; but my10 is set to track my9 that is further behind.
 	test_must_fail git branch -d my10
@@ -1287,7 +1288,7 @@ test_expect_success 'detect typo in branch name when using --edit-description' '
 '
 
 test_expect_success 'refuse --edit-description on unborn branch for now' '
-	test_when_finished "git checkout master" &&
+	test_when_finished "git checkout main" &&
 	write_script editor <<-\EOF &&
 		echo "New contents" >"$1"
 	EOF
@@ -1301,18 +1302,18 @@ test_expect_success '--merged catches invalid object names' '
 
 test_expect_success '--list during rebase' '
 	test_when_finished "reset_rebase" &&
-	git checkout master &&
+	git checkout main &&
 	FAKE_LINES="1 edit 2" &&
 	export FAKE_LINES &&
 	set_fake_editor &&
 	git rebase -i HEAD~2 &&
 	git branch --list >actual &&
-	test_i18ngrep "rebasing master" actual
+	test_i18ngrep "rebasing main" actual
 '
 
 test_expect_success '--list during rebase from detached HEAD' '
-	test_when_finished "reset_rebase && git checkout master" &&
-	git checkout master^0 &&
+	test_when_finished "reset_rebase && git checkout main" &&
+	git checkout main^0 &&
 	oid=$(git rev-parse --short HEAD) &&
 	FAKE_LINES="1 edit 2" &&
 	export FAKE_LINES &&
@@ -1324,17 +1325,17 @@ test_expect_success '--list during rebase from detached HEAD' '
 
 test_expect_success 'tracking with unexpected .fetch refspec' '
 	rm -rf a b c d &&
-	git init a &&
+	git init -b main a &&
 	(
 		cd a &&
 		test_commit a
 	) &&
-	git init b &&
+	git init -b main b &&
 	(
 		cd b &&
 		test_commit b
 	) &&
-	git init c &&
+	git init -b main c &&
 	(
 		cd c &&
 		test_commit c &&
@@ -1342,23 +1343,23 @@ test_expect_success 'tracking with unexpected .fetch refspec' '
 		git remote add b ../b &&
 		git fetch --all
 	) &&
-	git init d &&
+	git init -b main d &&
 	(
 		cd d &&
 		git remote add c ../c &&
 		git config remote.c.fetch "+refs/remotes/*:refs/remotes/*" &&
 		git fetch c &&
-		git branch --track local/a/master remotes/a/master &&
-		test "$(git config branch.local/a/master.remote)" = "c" &&
-		test "$(git config branch.local/a/master.merge)" = "refs/remotes/a/master" &&
+		git branch --track local/a/main remotes/a/main &&
+		test "$(git config branch.local/a/main.remote)" = "c" &&
+		test "$(git config branch.local/a/main.merge)" = "refs/remotes/a/main" &&
 		git rev-parse --verify a >expect &&
-		git rev-parse --verify local/a/master >actual &&
+		git rev-parse --verify local/a/main >actual &&
 		test_cmp expect actual
 	)
 '
 
 test_expect_success 'configured committerdate sort' '
-	git init sort &&
+	git init -b main sort &&
 	(
 		cd sort &&
 		git config branch.sort committerdate &&
@@ -1371,7 +1372,7 @@ test_expect_success 'configured committerdate sort' '
 		test_commit b &&
 		git branch >actual &&
 		cat >expect <<-\EOF &&
-		  master
+		  main
 		  a
 		  c
 		* b
@@ -1389,7 +1390,7 @@ test_expect_success 'option override configured sort' '
 		  a
 		* b
 		  c
-		  master
+		  main
 		EOF
 		test_cmp expect actual
 	)

--- a/t/t3201-branch-contains.sh
+++ b/t/t3201-branch-contains.sh
@@ -10,51 +10,52 @@ test_expect_success setup '
 	git add file &&
 	test_tick &&
 	git commit -m initial &&
+	git branch -M main &&
 	git branch side &&
 
 	echo 1 >file &&
 	test_tick &&
-	git commit -a -m "second on master" &&
+	git commit -a -m "second on main" &&
 
 	git checkout side &&
 	echo 1 >file &&
 	test_tick &&
 	git commit -a -m "second on side" &&
 
-	git merge master
+	git merge main
 
 '
 
-test_expect_success 'branch --contains=master' '
+test_expect_success 'branch --contains=main' '
 
-	git branch --contains=master >actual &&
+	git branch --contains=main >actual &&
 	{
-		echo "  master" && echo "* side"
+		echo "  main" && echo "* side"
 	} >expect &&
 	test_cmp expect actual
 
 '
 
-test_expect_success 'branch --contains master' '
+test_expect_success 'branch --contains main' '
 
-	git branch --contains master >actual &&
+	git branch --contains main >actual &&
 	{
-		echo "  master" && echo "* side"
+		echo "  main" && echo "* side"
 	} >expect &&
 	test_cmp expect actual
 
 '
 
-test_expect_success 'branch --no-contains=master' '
+test_expect_success 'branch --no-contains=main' '
 
-	git branch --no-contains=master >actual &&
+	git branch --no-contains=main >actual &&
 	test_must_be_empty actual
 
 '
 
-test_expect_success 'branch --no-contains master' '
+test_expect_success 'branch --no-contains main' '
 
-	git branch --no-contains master >actual &&
+	git branch --no-contains main >actual &&
 	test_must_be_empty actual
 
 '
@@ -73,7 +74,7 @@ test_expect_success 'branch --no-contains=side' '
 
 	git branch --no-contains=side >actual &&
 	{
-		echo "  master"
+		echo "  main"
 	} >expect &&
 	test_cmp expect actual
 
@@ -81,9 +82,9 @@ test_expect_success 'branch --no-contains=side' '
 
 test_expect_success 'branch --contains with pattern implies --list' '
 
-	git branch --contains=master master >actual &&
+	git branch --contains=main main >actual &&
 	{
-		echo "  master"
+		echo "  main"
 	} >expect &&
 	test_cmp expect actual
 
@@ -91,7 +92,7 @@ test_expect_success 'branch --contains with pattern implies --list' '
 
 test_expect_success 'branch --no-contains with pattern implies --list' '
 
-	git branch --no-contains=master master >actual &&
+	git branch --no-contains=main main >actual &&
 	test_must_be_empty actual
 
 '
@@ -100,7 +101,7 @@ test_expect_success 'side: branch --merged' '
 
 	git branch --merged >actual &&
 	{
-		echo "  master" &&
+		echo "  main" &&
 		echo "* side"
 	} >expect &&
 	test_cmp expect actual
@@ -109,9 +110,9 @@ test_expect_success 'side: branch --merged' '
 
 test_expect_success 'branch --merged with pattern implies --list' '
 
-	git branch --merged=side master >actual &&
+	git branch --merged=side main >actual &&
 	{
-		echo "  master"
+		echo "  main"
 	} >expect &&
 	test_cmp expect actual
 
@@ -124,18 +125,18 @@ test_expect_success 'side: branch --no-merged' '
 
 '
 
-test_expect_success 'master: branch --merged' '
+test_expect_success 'main: branch --merged' '
 
-	git checkout master &&
+	git checkout main &&
 	git branch --merged >actual &&
 	{
-		echo "* master"
+		echo "* main"
 	} >expect &&
 	test_cmp expect actual
 
 '
 
-test_expect_success 'master: branch --no-merged' '
+test_expect_success 'main: branch --no-merged' '
 
 	git branch --no-merged >actual &&
 	{
@@ -147,22 +148,22 @@ test_expect_success 'master: branch --no-merged' '
 
 test_expect_success 'branch --no-merged with pattern implies --list' '
 
-	git branch --no-merged=master master >actual &&
+	git branch --no-merged=main main >actual &&
 	test_must_be_empty actual
 
 '
 
 test_expect_success 'implicit --list conflicts with modification options' '
 
-	test_must_fail git branch --contains=master -d &&
-	test_must_fail git branch --contains=master -m foo &&
-	test_must_fail git branch --no-contains=master -d &&
-	test_must_fail git branch --no-contains=master -m foo
+	test_must_fail git branch --contains=main -d &&
+	test_must_fail git branch --contains=main -m foo &&
+	test_must_fail git branch --no-contains=main -d &&
+	test_must_fail git branch --no-contains=main -m foo
 
 '
 
 test_expect_success 'Assert that --contains only works on commits, not trees & blobs' '
-	test_must_fail git branch --contains master^{tree} &&
+	test_must_fail git branch --contains main^{tree} &&
 	blob=$(git hash-object -w --stdin <<-\EOF
 	Some blob
 	EOF
@@ -172,11 +173,11 @@ test_expect_success 'Assert that --contains only works on commits, not trees & b
 '
 
 test_expect_success 'multiple branch --contains' '
-	git checkout -b side2 master &&
+	git checkout -b side2 main &&
 	>feature &&
 	git add feature &&
 	git commit -m "add feature" &&
-	git checkout -b next master &&
+	git checkout -b next main &&
 	git merge side &&
 	git branch --contains side --contains side2 >actual &&
 	cat >expect <<-\EOF &&
@@ -188,9 +189,9 @@ test_expect_success 'multiple branch --contains' '
 '
 
 test_expect_success 'multiple branch --merged' '
-	git branch --merged next --merged master >actual &&
+	git branch --merged next --merged main >actual &&
 	cat >expect <<-\EOF &&
-	  master
+	  main
 	* next
 	  side
 	EOF
@@ -200,13 +201,13 @@ test_expect_success 'multiple branch --merged' '
 test_expect_success 'multiple branch --no-contains' '
 	git branch --no-contains side --no-contains side2 >actual &&
 	cat >expect <<-\EOF &&
-	  master
+	  main
 	EOF
 	test_cmp expect actual
 '
 
 test_expect_success 'multiple branch --no-merged' '
-	git branch --no-merged next --no-merged master >actual &&
+	git branch --no-merged next --no-merged main >actual &&
 	cat >expect <<-\EOF &&
 	  side2
 	EOF
@@ -214,7 +215,7 @@ test_expect_success 'multiple branch --no-merged' '
 '
 
 test_expect_success 'branch --contains combined with --no-contains' '
-	git checkout -b seen master &&
+	git checkout -b seen main &&
 	git merge side &&
 	git merge side2 &&
 	git branch --contains side --no-contains side2 >actual &&
@@ -239,17 +240,17 @@ test_expect_success 'branch --merged combined with --no-merged' '
 # that the latter walk does not mess up our flag to see if it was
 # merged).
 #
-# Here "topic" tracks "master" with one extra commit, and "zzz" points to the
-# same tip as master The name "zzz" must come alphabetically after "topic"
+# Here "topic" tracks "main" with one extra commit, and "zzz" points to the
+# same tip as main The name "zzz" must come alphabetically after "topic"
 # as we process them in that order.
-test_expect_success PREPARE_FOR_MAIN_BRANCH 'branch --merged with --verbose' '
-	git branch --track topic master &&
+test_expect_success 'branch --merged with --verbose' '
+	git branch --track topic main &&
 	git branch zzz topic &&
 	git checkout topic &&
 	test_commit foo &&
 	git branch --merged topic >actual &&
 	cat >expect <<-\EOF &&
-	  master
+	  main
 	* topic
 	  zzz
 	EOF

--- a/t/t3203-branch-output.sh
+++ b/t/t3203-branch-output.sh
@@ -8,6 +8,7 @@ test_expect_success 'make commits' '
 	echo content >file &&
 	git add file &&
 	git commit -m one &&
+	git branch -M main &&
 	echo content >>file &&
 	git commit -a -m two
 '
@@ -26,7 +27,7 @@ test_expect_success 'make remote branches' '
 cat >expect <<'EOF'
   branch-one
   branch-two
-* master
+* main
 EOF
 test_expect_success 'git branch shows local branches' '
 	git branch >actual &&
@@ -60,7 +61,7 @@ test_expect_success 'git branch -r shows remote branches' '
 cat >expect <<'EOF'
   branch-one
   branch-two
-* master
+* main
   remotes/origin/HEAD -> origin/branch-one
   remotes/origin/branch-one
   remotes/origin/branch-two
@@ -152,7 +153,7 @@ test_expect_success 'git branch shows detached HEAD properly' '
 * (HEAD detached at $(git rev-parse --short HEAD^0))
   branch-one
   branch-two
-  master
+  main
 EOF
 	git checkout HEAD^0 &&
 	git branch >actual &&
@@ -160,12 +161,12 @@ EOF
 '
 
 test_expect_success 'git branch shows detached HEAD properly after checkout --detach' '
-	git checkout master &&
+	git checkout main &&
 	cat >expect <<EOF &&
 * (HEAD detached at $(git rev-parse --short HEAD^0))
   branch-one
   branch-two
-  master
+  main
 EOF
 	git checkout --detach &&
 	git branch >actual &&
@@ -177,7 +178,7 @@ test_expect_success 'git branch shows detached HEAD properly after moving' '
 * (HEAD detached from $(git rev-parse --short HEAD))
   branch-one
   branch-two
-  master
+  main
 EOF
 	git reset --hard HEAD^1 &&
 	git branch >actual &&
@@ -189,9 +190,9 @@ test_expect_success 'git branch shows detached HEAD properly from tag' '
 * (HEAD detached at fromtag)
   branch-one
   branch-two
-  master
+  main
 EOF
-	git tag fromtag master &&
+	git tag fromtag main &&
 	git checkout fromtag &&
 	git branch >actual &&
 	test_i18ncmp expect actual
@@ -202,7 +203,7 @@ test_expect_success 'git branch shows detached HEAD properly after moving from t
 * (HEAD detached from fromtag)
   branch-one
   branch-two
-  master
+  main
 EOF
 	git reset --hard HEAD^1 &&
 	git branch >actual &&
@@ -214,7 +215,7 @@ test_expect_success 'git branch `--sort` option' '
 	* (HEAD detached from fromtag)
 	  branch-two
 	  branch-one
-	  master
+	  main
 	EOF
 	git branch --sort=objectsize >actual &&
 	test_i18ncmp expect actual
@@ -223,7 +224,7 @@ test_expect_success 'git branch `--sort` option' '
 test_expect_success 'git branch --points-at option' '
 	cat >expect <<-\EOF &&
 	  branch-one
-	  master
+	  main
 	EOF
 	git branch --points-at=branch-one >actual &&
 	test_cmp expect actual
@@ -251,7 +252,7 @@ test_expect_success 'local-branch symrefs shortened properly' '
 
 test_expect_success 'sort branches, ignore case' '
 	(
-		git init sort-icase &&
+		git init -b main sort-icase &&
 		cd sort-icase &&
 		test_commit initial &&
 		git branch branch-one &&
@@ -260,14 +261,14 @@ test_expect_success 'sort branches, ignore case' '
 		cat >expected <<-\EOF &&
 		BRANCH-two
 		branch-one
-		master
+		main
 		EOF
 		test_cmp expected actual &&
 		git branch --list -i | awk "{print \$NF}" >actual &&
 		cat >expected <<-\EOF &&
 		branch-one
 		BRANCH-two
-		master
+		main
 		EOF
 		test_cmp expected actual
 	)
@@ -279,7 +280,7 @@ test_expect_success 'git branch --format option' '
 	Refname is refs/heads/ambiguous
 	Refname is refs/heads/branch-one
 	Refname is refs/heads/branch-two
-	Refname is refs/heads/master
+	Refname is refs/heads/main
 	Refname is refs/heads/ref-to-branch
 	Refname is refs/heads/ref-to-remote
 	EOF
@@ -293,7 +294,7 @@ test_expect_success 'worktree colors correct' '
 	  ambiguous<RESET>
 	  branch-one<RESET>
 	+ <CYAN>branch-two<RESET>
-	  master<RESET>
+	  main<RESET>
 	  ref-to-branch<RESET> -> branch-one
 	  ref-to-remote<RESET> -> origin/branch-one
 	EOF
@@ -306,9 +307,9 @@ test_expect_success 'worktree colors correct' '
 '
 
 test_expect_success "set up color tests" '
-	echo "<RED>master<RESET>" >expect.color &&
-	echo "master" >expect.bare &&
-	color_args="--format=%(color:red)%(refname:short) --list master"
+	echo "<RED>main<RESET>" >expect.color &&
+	echo "main" >expect.bare &&
+	color_args="--format=%(color:red)%(refname:short) --list main"
 '
 
 test_expect_success '%(color) omitted without tty' '
@@ -329,9 +330,9 @@ test_expect_success '--color overrides auto-color' '
 	test_cmp expect.color actual
 '
 
-test_expect_success PREPARE_FOR_MAIN_BRANCH 'verbose output lists worktree path' '
+test_expect_success 'verbose output lists worktree path' '
 	one=$(git rev-parse --short HEAD) &&
-	two=$(git rev-parse --short master) &&
+	two=$(git rev-parse --short main) &&
 	cat >expect <<-EOF &&
 	* (HEAD detached from fromtag) $one one
 	  ambiguous                    $one one

--- a/t/t3205-branch-color.sh
+++ b/t/t3205-branch-color.sh
@@ -5,7 +5,8 @@ test_description='basic branch output coloring'
 
 test_expect_success 'set up some sample branches' '
 	test_commit foo &&
-	git update-ref refs/remotes/origin/master HEAD &&
+	git branch -M main &&
+	git update-ref refs/remotes/origin/main HEAD &&
 	git update-ref refs/heads/other HEAD
 '
 
@@ -19,16 +20,16 @@ test_expect_success 'set up some color config' '
 
 test_expect_success 'regular output shows colors' '
 	cat >expect <<-\EOF &&
-	* <CYAN>master<RESET>
+	* <CYAN>main<RESET>
 	  <BLUE>other<RESET>
-	  <YELLOW>remotes/origin/master<RESET>
+	  <YELLOW>remotes/origin/main<RESET>
 	EOF
 	git branch --color -a >actual.raw &&
 	test_decode_color <actual.raw >actual &&
 	test_cmp expect actual
 '
 
-test_expect_success PREPARE_FOR_MAIN_BRANCH 'verbose output shows colors' '
+test_expect_success 'verbose output shows colors' '
 	oid=$(git rev-parse --short HEAD) &&
 	cat >expect <<-EOF &&
 	* <CYAN>main               <RESET> $oid foo

--- a/t/t5505-remote.sh
+++ b/t/t5505-remote.sh
@@ -7,7 +7,7 @@ test_description='git remote porcelain-ish'
 setup_repository () {
 	mkdir "$1" && (
 	cd "$1" &&
-	git init &&
+	git init -b main &&
 	>file &&
 	git add file &&
 	test_tick &&
@@ -17,7 +17,7 @@ setup_repository () {
 	git add elif &&
 	test_tick &&
 	git commit -m "Second" &&
-	git checkout master
+	git checkout main
 	)
 }
 
@@ -60,8 +60,8 @@ test_expect_success C_LOCALE_OUTPUT 'remote information for the origin' '
 	(
 		cd test &&
 		tokens_match origin "$(git remote)" &&
-		check_remote_track origin master side &&
-		check_tracking_branch origin HEAD master side
+		check_remote_track origin main side &&
+		check_tracking_branch origin HEAD main side
 	)
 '
 
@@ -70,7 +70,7 @@ test_expect_success 'add another remote' '
 		cd test &&
 		git remote add -f second ../two &&
 		tokens_match "origin second" "$(git remote)" &&
-		check_tracking_branch second master side another &&
+		check_tracking_branch second main side another &&
 		git for-each-ref "--format=%(refname)" refs/remotes |
 		sed -e "/^refs\/remotes\/origin\//d" \
 		    -e "/^refs\/remotes\/second\//d" >actual &&
@@ -81,8 +81,8 @@ test_expect_success 'add another remote' '
 test_expect_success C_LOCALE_OUTPUT 'check remote-tracking' '
 	(
 		cd test &&
-		check_remote_track origin master side &&
-		check_remote_track second master side another
+		check_remote_track origin main side &&
+		check_remote_track second main side another
 	)
 '
 
@@ -99,7 +99,7 @@ test_expect_success 'remote forces tracking branches' '
 test_expect_success 'remove remote' '
 	(
 		cd test &&
-		git symbolic-ref refs/remotes/second/HEAD refs/remotes/second/master &&
+		git symbolic-ref refs/remotes/second/HEAD refs/remotes/second/main &&
 		git remote rm second
 	)
 '
@@ -108,7 +108,7 @@ test_expect_success C_LOCALE_OUTPUT 'remove remote' '
 	(
 		cd test &&
 		tokens_match origin "$(git remote)" &&
-		check_remote_track origin master side &&
+		check_remote_track origin main side &&
 		git for-each-ref "--format=%(refname)" refs/remotes |
 		sed -e "/^refs\/remotes\/origin\//d" >actual &&
 		test_must_be_empty actual
@@ -121,13 +121,13 @@ test_expect_success 'remove remote protects local branches' '
 		cat >expect1 <<-\EOF &&
 		Note: A branch outside the refs/remotes/ hierarchy was not removed;
 		to delete it, use:
-		  git branch -d master
+		  git branch -d main
 		EOF
 		cat >expect2 <<-\EOF &&
 		Note: Some branches outside the refs/remotes/ hierarchy were not removed;
 		to delete them, use:
 		  git branch -d foobranch
-		  git branch -d master
+		  git branch -d main
 		EOF
 		git tag footag &&
 		git config --add remote.oops.fetch "+refs/*:refs/*" &&
@@ -153,7 +153,7 @@ test_expect_success 'remove errors out early when deleting non-existent branch' 
 
 test_expect_success 'remove remote with a branch without configured merge' '
 	test_when_finished "(
-		git -C test checkout master;
+		git -C test checkout main;
 		git -C test branch -D two;
 		git -C test config --remove-section remote.two;
 		git -C test config --remove-section branch.second;
@@ -163,9 +163,9 @@ test_expect_success 'remove remote with a branch without configured merge' '
 		cd test &&
 		git remote add two ../two &&
 		git fetch two &&
-		git checkout -b second two/master^0 &&
+		git checkout -b second two/main^0 &&
 		git config branch.second.remote two &&
-		git checkout master &&
+		git checkout main &&
 		git remote rm two
 	)
 '
@@ -211,7 +211,7 @@ cat >test/expect <<EOF
 * remote origin
   Fetch URL: $(pwd)/one
   Push  URL: $(pwd)/one
-  HEAD branch: master
+  HEAD branch: main
   Remote branches:
     main new (next fetch will store in remotes/origin)
     side tracked
@@ -221,32 +221,32 @@ cat >test/expect <<EOF
     octopus  merges with remote topic-a
                 and with remote topic-b
                 and with remote topic-c
-    rebase  rebases onto remote master
+    rebase  rebases onto remote main
   Local refs configured for 'git push':
     main pushes to main     (local out of date)
     main pushes to upstream (create)
 * remote two
   Fetch URL: ../two
   Push  URL: ../three
-  HEAD branch: master
+  HEAD branch: main
   Local refs configured for 'git push':
     ahead forces to main    (fast-forwardable)
     main  pushes to another (up to date)
 EOF
 
-test_expect_success PREPARE_FOR_MAIN_BRANCH 'show' '
+test_expect_success 'show' '
 	(
 		cd test &&
-		git config --add remote.origin.fetch refs/heads/master:refs/heads/upstream &&
+		git config --add remote.origin.fetch refs/heads/main:refs/heads/upstream &&
 		git fetch &&
-		git checkout -b ahead origin/master &&
+		git checkout -b ahead origin/main &&
 		echo 1 >>file &&
 		test_tick &&
 		git commit -m update file &&
-		git checkout master &&
-		git branch --track octopus origin/master &&
-		git branch --track rebase origin/master &&
-		git branch -d -r origin/master &&
+		git checkout main &&
+		git branch --track octopus origin/main &&
+		git branch --track rebase origin/main &&
+		git branch -d -r origin/main &&
 		git config --add remote.two.url ../two &&
 		git config --add remote.two.pushurl ../three &&
 		git config branch.rebase.rebase true &&
@@ -258,10 +258,10 @@ test_expect_success PREPARE_FOR_MAIN_BRANCH 'show' '
 			git commit -m update file
 		) &&
 		git config --add remote.origin.push : &&
-		git config --add remote.origin.push refs/heads/master:refs/heads/upstream &&
+		git config --add remote.origin.push refs/heads/main:refs/heads/upstream &&
 		git config --add remote.origin.push +refs/tags/lastbackup &&
-		git config --add remote.two.push +refs/heads/ahead:refs/heads/master &&
-		git config --add remote.two.push refs/heads/master:refs/heads/another &&
+		git config --add remote.two.push +refs/heads/ahead:refs/heads/main &&
+		git config --add remote.two.push refs/heads/main:refs/heads/another &&
 		git remote show origin two >output &&
 		git branch -d rebase octopus &&
 		test_i18ncmp expect output
@@ -274,7 +274,7 @@ cat >test/expect <<EOF
   Push  URL: $(pwd)/one
   HEAD branch: (not queried)
   Remote branches: (status not queried)
-    master
+    main
     side
   Local branches configured for 'git pull':
     ahead merges with remote main
@@ -285,7 +285,7 @@ cat >test/expect <<EOF
     refs/tags/lastbackup forces to refs/tags/lastbackup
 EOF
 
-test_expect_success PREPARE_FOR_MAIN_BRANCH 'show -n' '
+test_expect_success 'show -n' '
 	mv one one.unreachable &&
 	(
 		cd test &&
@@ -322,18 +322,18 @@ test_expect_success 'set-head --auto' '
 	(
 		cd test &&
 		git remote set-head --auto origin &&
-		echo refs/remotes/origin/master >expect &&
+		echo refs/remotes/origin/main >expect &&
 		git symbolic-ref refs/remotes/origin/HEAD >output &&
 		test_cmp expect output
 	)
 '
 
-test_expect_success PREPARE_FOR_MAIN_BRANCH 'set-head --auto has no problem w/multiple HEADs' '
+test_expect_success 'set-head --auto has no problem w/multiple HEADs' '
 	(
 		cd test &&
 		git fetch two "refs/heads/*:refs/remotes/two/*" &&
 		git remote set-head --auto two >output 2>&1 &&
-		echo "two/HEAD set to master" >expect &&
+		echo "two/HEAD set to main" >expect &&
 		test_i18ncmp expect output
 	)
 '
@@ -347,7 +347,7 @@ test_expect_success 'set-head explicit' '
 		cd test &&
 		git remote set-head origin side2 &&
 		git symbolic-ref refs/remotes/origin/HEAD >output &&
-		git remote set-head origin master &&
+		git remote set-head origin main &&
 		test_cmp expect output
 	)
 '
@@ -394,7 +394,7 @@ test_expect_success 'add --mirror && prune' '
 
 test_expect_success 'add --mirror=fetch' '
 	mkdir mirror-fetch &&
-	git init mirror-fetch/parent &&
+	git init -b main mirror-fetch/parent &&
 	(
 		cd mirror-fetch/parent &&
 		test_commit one
@@ -410,7 +410,7 @@ test_expect_success 'fetch mirrors act as mirrors during fetch' '
 	(
 		cd mirror-fetch/parent &&
 		git branch new &&
-		git branch -m master renamed
+		git branch -m main renamed
 	) &&
 	(
 		cd mirror-fetch/child &&
@@ -424,7 +424,7 @@ test_expect_success 'fetch mirrors can prune' '
 	(
 		cd mirror-fetch/child &&
 		git remote prune parent &&
-		test_must_fail git rev-parse --verify refs/heads/master
+		test_must_fail git rev-parse --verify refs/heads/main
 	)
 '
 
@@ -465,7 +465,7 @@ test_expect_success 'fetch mirror respects specific branches' '
 test_expect_success 'add --mirror=push' '
 	mkdir mirror-push &&
 	git init --bare mirror-push/public &&
-	git init mirror-push/private &&
+	git init -b main mirror-push/private &&
 	(
 		cd mirror-push/private &&
 		test_commit one &&
@@ -477,14 +477,14 @@ test_expect_success 'push mirrors act as mirrors during push' '
 	(
 		cd mirror-push/private &&
 		git branch new &&
-		git branch -m master renamed &&
+		git branch -m main renamed &&
 		git push public
 	) &&
 	(
 		cd mirror-push/private &&
 		git rev-parse --verify refs/heads/new &&
 		git rev-parse --verify refs/heads/renamed &&
-		test_must_fail git rev-parse --verify refs/heads/master
+		test_must_fail git rev-parse --verify refs/heads/main
 	)
 '
 
@@ -610,10 +610,10 @@ test_expect_success 'reject --no-no-tags' '
 '
 
 cat >one/expect <<\EOF
-  apis/master
+  apis/main
   apis/side
   drosophila/another
-  drosophila/master
+  drosophila/main
   drosophila/side
 EOF
 
@@ -630,11 +630,11 @@ test_expect_success 'update' '
 
 cat >one/expect <<\EOF
   drosophila/another
-  drosophila/master
+  drosophila/main
   drosophila/side
-  manduca/master
+  manduca/main
   manduca/side
-  megaloprepus/master
+  megaloprepus/main
   megaloprepus/side
 EOF
 
@@ -673,11 +673,11 @@ test_expect_success 'update --prune' '
 '
 
 cat >one/expect <<-\EOF
-  apis/master
+  apis/main
   apis/side
-  manduca/master
+  manduca/main
   manduca/side
-  megaloprepus/master
+  megaloprepus/main
   megaloprepus/side
 EOF
 
@@ -697,7 +697,7 @@ test_expect_success 'update default' '
 
 cat >one/expect <<\EOF
   drosophila/another
-  drosophila/master
+  drosophila/main
   drosophila/side
 EOF
 
@@ -751,14 +751,14 @@ test_expect_success 'rename a remote' '
 	git clone one four &&
 	(
 		cd four &&
-		git config branch.master.pushRemote origin &&
+		git config branch.main.pushRemote origin &&
 		git remote rename origin upstream &&
 		test -z "$(git for-each-ref refs/remotes/origin)" &&
-		test "$(git symbolic-ref refs/remotes/upstream/HEAD)" = "refs/remotes/upstream/master" &&
-		test "$(git rev-parse upstream/master)" = "$(git rev-parse master)" &&
+		test "$(git symbolic-ref refs/remotes/upstream/HEAD)" = "refs/remotes/upstream/main" &&
+		test "$(git rev-parse upstream/main)" = "$(git rev-parse main)" &&
 		test "$(git config remote.upstream.fetch)" = "+refs/heads/*:refs/remotes/upstream/*" &&
-		test "$(git config branch.master.remote)" = "upstream" &&
-		test "$(git config branch.master.pushRemote)" = "upstream" &&
+		test "$(git config branch.main.remote)" = "upstream" &&
+		test "$(git config branch.main.pushRemote)" = "upstream" &&
 		test "$(git config --global remote.pushDefault)" = "origin"
 	)
 '
@@ -804,7 +804,7 @@ test_expect_success 'rename does not update a non-default fetch refspec' '
 		git config remote.origin.fetch +refs/heads/*:refs/heads/origin/* &&
 		git remote rename origin upstream &&
 		test "$(git config remote.upstream.fetch)" = "+refs/heads/*:refs/heads/origin/*" &&
-		git rev-parse -q origin/master
+		git rev-parse -q origin/main
 	)
 '
 
@@ -824,7 +824,7 @@ test_expect_success 'rename a remote with name prefix of other remote' '
 		cd four.three &&
 		git remote add o git://example.com/repo.git &&
 		git remote rename o upstream &&
-		test "$(git rev-parse origin/master)" = "$(git rev-parse master)"
+		test "$(git rev-parse origin/main)" = "$(git rev-parse main)"
 	)
 '
 
@@ -840,11 +840,11 @@ test_expect_success 'remove a remote' '
 	git clone one four.five &&
 	(
 		cd four.five &&
-		git config branch.master.pushRemote origin &&
+		git config branch.main.pushRemote origin &&
 		git remote remove origin &&
 		test -z "$(git for-each-ref refs/remotes/origin)" &&
-		test_must_fail git config branch.master.remote &&
-		test_must_fail git config branch.master.pushRemote &&
+		test_must_fail git config branch.main.remote &&
+		test_must_fail git config branch.main.pushRemote &&
 		test "$(git config --global remote.pushDefault)" = "origin"
 	)
 '
@@ -885,9 +885,9 @@ test_expect_success 'remove a remote removes repo remote.pushDefault but keeps g
 
 cat >remotes_origin <<EOF
 URL: $(pwd)/one
-Push: refs/heads/master:refs/heads/upstream
+Push: refs/heads/main:refs/heads/upstream
 Push: refs/heads/next:refs/heads/upstream2
-Pull: refs/heads/master:refs/heads/origin
+Pull: refs/heads/main:refs/heads/origin
 Pull: refs/heads/next:refs/heads/origin2
 EOF
 
@@ -903,11 +903,11 @@ test_expect_success 'migrate a remote from named file in $GIT_DIR/remotes' '
 		test_path_is_missing .git/remotes/origin &&
 		test "$(git config remote.origin.url)" = "$origin_url" &&
 		cat >push_expected <<-\EOF &&
-		refs/heads/master:refs/heads/upstream
+		refs/heads/main:refs/heads/upstream
 		refs/heads/next:refs/heads/upstream2
 		EOF
 		cat >fetch_expected <<-\EOF &&
-		refs/heads/master:refs/heads/origin
+		refs/heads/main:refs/heads/origin
 		refs/heads/next:refs/heads/origin2
 		EOF
 		git config --get-all remote.origin.push >push_actual &&
@@ -923,12 +923,12 @@ test_expect_success 'migrate a remote from named file in $GIT_DIR/branches' '
 	(
 		cd six &&
 		git remote rm origin &&
-		echo "$origin_url" >.git/branches/origin &&
+		echo "$origin_url#main" >.git/branches/origin &&
 		git remote rename origin origin &&
 		test_path_is_missing .git/branches/origin &&
 		test "$(git config remote.origin.url)" = "$origin_url" &&
-		test "$(git config remote.origin.fetch)" = "refs/heads/master:refs/heads/origin" &&
-		test "$(git config remote.origin.push)" = "HEAD:refs/heads/master"
+		test "$(git config remote.origin.fetch)" = "refs/heads/main:refs/heads/origin" &&
+		test "$(git config remote.origin.push)" = "HEAD:refs/heads/main"
 	)
 '
 
@@ -951,7 +951,7 @@ test_expect_success 'remote prune to cause a dangling symref' '
 	(
 		cd one &&
 		git checkout side2 &&
-		git branch -D master
+		git branch -D main
 	) &&
 	(
 		cd eight &&
@@ -994,22 +994,22 @@ test_expect_success 'remote set-branches' '
 	EOF
 	sort <<-\EOF >expect.replace &&
 	+refs/heads/maint:refs/remotes/scratch/maint
-	+refs/heads/master:refs/remotes/scratch/master
+	+refs/heads/main:refs/remotes/scratch/main
 	+refs/heads/next:refs/remotes/scratch/next
 	EOF
 	sort <<-\EOF >expect.add-two &&
 	+refs/heads/maint:refs/remotes/scratch/maint
-	+refs/heads/master:refs/remotes/scratch/master
+	+refs/heads/main:refs/remotes/scratch/main
 	+refs/heads/next:refs/remotes/scratch/next
 	+refs/heads/seen:refs/remotes/scratch/seen
 	+refs/heads/t/topic:refs/remotes/scratch/t/topic
 	EOF
 	sort <<-\EOF >expect.setup-ffonly &&
-	refs/heads/master:refs/remotes/scratch/master
+	refs/heads/main:refs/remotes/scratch/main
 	+refs/heads/next:refs/remotes/scratch/next
 	EOF
 	sort <<-\EOF >expect.respect-ffonly &&
-	refs/heads/master:refs/remotes/scratch/master
+	refs/heads/main:refs/remotes/scratch/main
 	+refs/heads/next:refs/remotes/scratch/next
 	+refs/heads/seen:refs/remotes/scratch/seen
 	EOF
@@ -1025,7 +1025,7 @@ test_expect_success 'remote set-branches' '
 		git config --get-all remote.scratch.fetch >config-result &&
 		sort <config-result >../actual.add &&
 
-		git remote set-branches scratch maint master next &&
+		git remote set-branches scratch maint main next &&
 		git config --get-all remote.scratch.fetch >config-result &&
 		sort <config-result >../actual.replace &&
 
@@ -1035,7 +1035,7 @@ test_expect_success 'remote set-branches' '
 
 		git config --unset-all remote.scratch.fetch &&
 		git config remote.scratch.fetch \
-			refs/heads/master:refs/remotes/scratch/master &&
+			refs/heads/main:refs/remotes/scratch/main &&
 		git config --add remote.scratch.fetch \
 			+refs/heads/next:refs/remotes/scratch/next &&
 		git config --get-all remote.scratch.fetch >config-result &&
@@ -1055,14 +1055,14 @@ test_expect_success 'remote set-branches' '
 
 test_expect_success 'remote set-branches with --mirror' '
 	echo "+refs/*:refs/*" >expect.initial &&
-	echo "+refs/heads/master:refs/heads/master" >expect.replace &&
+	echo "+refs/heads/main:refs/heads/main" >expect.replace &&
 	git clone --mirror .git/ setbranches-mirror &&
 	(
 		cd setbranches-mirror &&
 		git remote rename origin scratch &&
 		git config --get-all remote.scratch.fetch >../actual.initial &&
 
-		git remote set-branches scratch heads/master &&
+		git remote set-branches scratch heads/main &&
 		git config --get-all remote.scratch.fetch >../actual.replace
 	) &&
 	test_cmp expect.initial actual.initial &&
@@ -1308,7 +1308,7 @@ test_extra_arg () {
 test_extra_arg add nick url
 test_extra_arg rename origin newname
 test_extra_arg remove origin
-test_extra_arg set-head origin master
+test_extra_arg set-head origin main
 # set-branches takes any number of args
 test_extra_arg get-url origin newurl
 test_extra_arg set-url origin newurl oldurl
@@ -1325,7 +1325,7 @@ test_expect_success 'unqualified <dst> refspec DWIM and advice' '
 	test_when_finished "(cd test && git tag -d some-tag)" &&
 	(
 		cd test &&
-		git tag -a -m "Some tag" some-tag master &&
+		git tag -a -m "Some tag" some-tag main &&
 		exit_with=true &&
 		for type in commit tag tree blob
 		do
@@ -1348,10 +1348,10 @@ test_expect_success 'unqualified <dst> refspec DWIM and advice' '
 	)
 '
 
-test_expect_success PREPARE_FOR_MAIN_BRANCH 'refs/remotes/* <src> refspec and unqualified <dst> DWIM and advice' '
+test_expect_success 'refs/remotes/* <src> refspec and unqualified <dst> DWIM and advice' '
 	(
 		cd two &&
-		git tag -a -m "Some tag" my-tag master &&
+		git tag -a -m "Some tag" my-tag main &&
 		git update-ref refs/trees/my-head-tree HEAD^{tree} &&
 		git update-ref refs/blobs/my-file-blob HEAD:file
 	) &&

--- a/t/t5510-fetch.sh
+++ b/t/t5510-fetch.sh
@@ -25,7 +25,9 @@ convert_bundle_to_pack () {
 test_expect_success setup '
 	echo >file original &&
 	git add file &&
-	git commit -a -m original'
+	git commit -a -m original &&
+	git branch -M main
+'
 
 test_expect_success "clone and setup child repos" '
 	git clone . one &&
@@ -37,19 +39,19 @@ test_expect_success "clone and setup child repos" '
 	git clone . two &&
 	(
 		cd two &&
-		git config branch.master.remote one &&
+		git config branch.main.remote one &&
 		git config remote.one.url ../one/.git/ &&
-		git config remote.one.fetch refs/heads/master:refs/heads/one
+		git config remote.one.fetch refs/heads/main:refs/heads/one
 	) &&
 	git clone . three &&
 	(
 		cd three &&
-		git config branch.master.remote two &&
-		git config branch.master.merge refs/heads/one &&
+		git config branch.main.remote two &&
+		git config branch.main.merge refs/heads/one &&
 		mkdir -p .git/remotes &&
 		{
 			echo "URL: ../two/.git/"
-			echo "Pull: refs/heads/master:refs/heads/two"
+			echo "Pull: refs/heads/main:refs/heads/two"
 			echo "Pull: refs/heads/one:refs/heads/one"
 		} >.git/remotes/two
 	) &&
@@ -65,7 +67,7 @@ test_expect_success "fetch test" '
 	git fetch &&
 	git rev-parse --verify refs/heads/one &&
 	mine=$(git rev-parse refs/heads/one) &&
-	his=$(cd ../one && git rev-parse refs/heads/master) &&
+	his=$(cd ../one && git rev-parse refs/heads/main) &&
 	test "z$mine" = "z$his"
 '
 
@@ -75,11 +77,11 @@ test_expect_success "fetch test for-merge" '
 	git fetch &&
 	git rev-parse --verify refs/heads/two &&
 	git rev-parse --verify refs/heads/one &&
-	master_in_two=$(cd ../two && git rev-parse master) &&
+	main_in_two=$(cd ../two && git rev-parse main) &&
 	one_in_two=$(cd ../two && git rev-parse one) &&
 	{
 		echo "$one_in_two	"
-		echo "$master_in_two	not-for-merge"
+		echo "$main_in_two	not-for-merge"
 	} >expected &&
 	cut -f -2 .git/FETCH_HEAD >actual &&
 	test_cmp expected actual'
@@ -88,7 +90,7 @@ test_expect_success 'fetch --prune on its own works as expected' '
 	cd "$D" &&
 	git clone . prune &&
 	cd prune &&
-	git update-ref refs/remotes/origin/extrabranch master &&
+	git update-ref refs/remotes/origin/extrabranch main &&
 
 	git fetch --prune origin &&
 	test_must_fail git rev-parse origin/extrabranch
@@ -98,9 +100,9 @@ test_expect_success 'fetch --prune with a branch name keeps branches' '
 	cd "$D" &&
 	git clone . prune-branch &&
 	cd prune-branch &&
-	git update-ref refs/remotes/origin/extrabranch master &&
+	git update-ref refs/remotes/origin/extrabranch main &&
 
-	git fetch --prune origin master &&
+	git fetch --prune origin main &&
 	git rev-parse origin/extrabranch
 '
 
@@ -110,18 +112,18 @@ test_expect_success 'fetch --prune with a namespace keeps other namespaces' '
 	cd prune-namespace &&
 
 	git fetch --prune origin refs/heads/a/*:refs/remotes/origin/a/* &&
-	git rev-parse origin/master
+	git rev-parse origin/main
 '
 
 test_expect_success 'fetch --prune handles overlapping refspecs' '
 	cd "$D" &&
-	git update-ref refs/pull/42/head master &&
+	git update-ref refs/pull/42/head main &&
 	git clone . prune-overlapping &&
 	cd prune-overlapping &&
 	git config --add remote.origin.fetch refs/pull/*/head:refs/remotes/origin/pr/* &&
 
 	git fetch --prune origin &&
-	git rev-parse origin/master &&
+	git rev-parse origin/main &&
 	git rev-parse origin/pr/42 &&
 
 	git config --unset-all remote.origin.fetch &&
@@ -129,7 +131,7 @@ test_expect_success 'fetch --prune handles overlapping refspecs' '
 	git config --add remote.origin.fetch refs/heads/*:refs/remotes/origin/* &&
 
 	git fetch --prune origin &&
-	git rev-parse origin/master &&
+	git rev-parse origin/main &&
 	git rev-parse origin/pr/42
 '
 
@@ -137,13 +139,13 @@ test_expect_success 'fetch --prune --tags prunes branches but not tags' '
 	cd "$D" &&
 	git clone . prune-tags &&
 	cd prune-tags &&
-	git tag sometag master &&
+	git tag sometag main &&
 	# Create what looks like a remote-tracking branch from an earlier
 	# fetch that has since been deleted from the remote:
-	git update-ref refs/remotes/origin/fake-remote master &&
+	git update-ref refs/remotes/origin/fake-remote main &&
 
 	git fetch --prune --tags origin &&
-	git rev-parse origin/master &&
+	git rev-parse origin/main &&
 	test_must_fail git rev-parse origin/fake-remote &&
 	git rev-parse sometag
 '
@@ -152,10 +154,10 @@ test_expect_success 'fetch --prune --tags with branch does not prune other thing
 	cd "$D" &&
 	git clone . prune-tags-branch &&
 	cd prune-tags-branch &&
-	git tag sometag master &&
-	git update-ref refs/remotes/origin/extrabranch master &&
+	git tag sometag main &&
+	git update-ref refs/remotes/origin/extrabranch main &&
 
-	git fetch --prune --tags origin master &&
+	git fetch --prune --tags origin main &&
 	git rev-parse origin/extrabranch &&
 	git rev-parse sometag
 '
@@ -164,9 +166,9 @@ test_expect_success 'fetch --prune --tags with refspec prunes based on refspec' 
 	cd "$D" &&
 	git clone . prune-tags-refspec &&
 	cd prune-tags-refspec &&
-	git tag sometag master &&
-	git update-ref refs/remotes/origin/foo/otherbranch master &&
-	git update-ref refs/remotes/origin/extrabranch master &&
+	git tag sometag main &&
+	git update-ref refs/remotes/origin/foo/otherbranch main &&
+	git update-ref refs/remotes/origin/extrabranch main &&
 
 	git fetch --prune --tags origin refs/heads/foo/*:refs/remotes/origin/foo/* &&
 	test_must_fail git rev-parse refs/remotes/origin/foo/otherbranch &&
@@ -177,20 +179,20 @@ test_expect_success 'fetch --prune --tags with refspec prunes based on refspec' 
 test_expect_success '--refmap="" ignores configured refspec' '
 	cd "$TRASH_DIRECTORY" &&
 	git clone "$D" remote-refs &&
-	git -C remote-refs rev-parse remotes/origin/master >old &&
-	git -C remote-refs update-ref refs/remotes/origin/master master~1 &&
-	git -C remote-refs rev-parse remotes/origin/master >new &&
+	git -C remote-refs rev-parse remotes/origin/main >old &&
+	git -C remote-refs update-ref refs/remotes/origin/main main~1 &&
+	git -C remote-refs rev-parse remotes/origin/main >new &&
 	git -C remote-refs fetch --refmap= origin "+refs/heads/*:refs/hidden/origin/*" &&
-	git -C remote-refs rev-parse remotes/origin/master >actual &&
+	git -C remote-refs rev-parse remotes/origin/main >actual &&
 	test_cmp new actual &&
 	git -C remote-refs fetch origin &&
-	git -C remote-refs rev-parse remotes/origin/master >actual &&
+	git -C remote-refs rev-parse remotes/origin/main >actual &&
 	test_cmp old actual
 '
 
 test_expect_success '--refmap="" and --prune' '
-	git -C remote-refs update-ref refs/remotes/origin/foo/otherbranch master &&
-	git -C remote-refs update-ref refs/hidden/foo/otherbranch master &&
+	git -C remote-refs update-ref refs/remotes/origin/foo/otherbranch main &&
+	git -C remote-refs update-ref refs/hidden/foo/otherbranch main &&
 	git -C remote-refs fetch --prune --refmap="" origin +refs/heads/*:refs/hidden/* &&
 	git -C remote-refs rev-parse remotes/origin/foo/otherbranch &&
 	test_must_fail git -C remote-refs rev-parse refs/hidden/foo/otherbranch &&
@@ -250,7 +252,7 @@ test_expect_success 'fetch uses remote ref names to describe new refs' '
 		test_i18ngrep "new tag.* -> descriptive-tag$" actual &&
 		test_i18ngrep "new ref.* -> crazy$" actual
 	) &&
-	git checkout master
+	git checkout main
 '
 
 test_expect_success 'fetch must not resolve short tag name' '
@@ -281,7 +283,7 @@ test_expect_success 'create bundle 1' '
 	cd "$D" &&
 	echo >file updated again by origin &&
 	git commit -a -m "tip" &&
-	git bundle create --version=3 bundle1 master^..master
+	git bundle create --version=3 bundle1 main^..main
 '
 
 test_expect_success 'header of bundle looks right' '
@@ -289,7 +291,7 @@ test_expect_success 'header of bundle looks right' '
 	# v3 git bundle
 	@object-format=$(test_oid algo)
 	-OID updated by origin
-	OID refs/heads/master
+	OID refs/heads/main
 
 	EOF
 	sed -e "s/$OID_REGEX/OID/g" -e "5q" "$D"/bundle1 >actual &&
@@ -298,13 +300,13 @@ test_expect_success 'header of bundle looks right' '
 
 test_expect_success 'create bundle 2' '
 	cd "$D" &&
-	git bundle create bundle2 master~2..master
+	git bundle create bundle2 main~2..main
 '
 
 test_expect_success 'unbundle 1' '
 	cd "$D/bundle" &&
 	git checkout -b some-branch &&
-	test_must_fail git fetch "$D/bundle1" master:master
+	test_must_fail git fetch "$D/bundle1" main:main
 '
 
 
@@ -317,8 +319,8 @@ test_expect_success 'bundle 1 has only 3 files ' '
 
 test_expect_success 'unbundle 2' '
 	cd "$D/bundle" &&
-	git fetch ../bundle2 master:master &&
-	test "tip" = "$(git log -1 --pretty=oneline master | cut -d" " -f2)"
+	git fetch ../bundle2 main:main &&
+	test "tip" = "$(git log -1 --pretty=oneline main | cut -d" " -f2)"
 '
 
 test_expect_success 'bundle does not prerequisite objects' '
@@ -335,14 +337,14 @@ test_expect_success 'bundle does not prerequisite objects' '
 test_expect_success 'bundle should be able to create a full history' '
 
 	cd "$D" &&
-	git tag -a -m "1.0" v1.0 master &&
+	git tag -a -m "1.0" v1.0 main &&
 	git bundle create bundle4 v1.0
 
 '
 
 test_expect_success 'fetch with a non-applying branch.<name>.merge' '
-	git config branch.master.remote yeti &&
-	git config branch.master.merge refs/heads/bigfoot &&
+	git config branch.main.remote yeti &&
+	git config branch.main.merge refs/heads/bigfoot &&
 	git config remote.blub.url one &&
 	git config remote.blub.fetch "refs/heads/*:refs/remotes/one/*" &&
 	git fetch blub
@@ -362,8 +364,8 @@ test_expect_success 'fetch from GIT URL with a non-applying branch.<name>.merge 
 # the merge spec matches the branch the remote HEAD points to
 test_expect_success 'fetch from GIT URL with a non-applying branch.<name>.merge [2]' '
 	one_ref=$(cd one && git symbolic-ref HEAD) &&
-	git config branch.master.remote blub &&
-	git config branch.master.merge "$one_ref" &&
+	git config branch.main.remote blub &&
+	git config branch.main.merge "$one_ref" &&
 	git update-ref -d FETCH_HEAD &&
 	git fetch one &&
 	test $one_head = "$(git rev-parse --verify FETCH_HEAD)" &&
@@ -373,7 +375,7 @@ test_expect_success 'fetch from GIT URL with a non-applying branch.<name>.merge 
 # URL supplied to fetch matches the url of the configured branch's remote, but
 # the merge spec does not match the branch the remote HEAD points to
 test_expect_success 'fetch from GIT URL with a non-applying branch.<name>.merge [3]' '
-	git config branch.master.merge "${one_ref}_not" &&
+	git config branch.main.merge "${one_ref}_not" &&
 	git update-ref -d FETCH_HEAD &&
 	git fetch one &&
 	test $one_head = "$(git rev-parse --verify FETCH_HEAD)" &&
@@ -389,9 +391,9 @@ test_expect_success 'quoting of a strangely named repo' '
 test_expect_success 'bundle should record HEAD correctly' '
 
 	cd "$D" &&
-	git bundle create bundle5 HEAD master &&
+	git bundle create bundle5 HEAD main &&
 	git bundle list-heads bundle5 >actual &&
-	for h in HEAD refs/heads/master
+	for h in HEAD refs/heads/main
 	do
 		echo "$(git rev-parse --verify $h) $h"
 	done >expect &&
@@ -399,10 +401,10 @@ test_expect_success 'bundle should record HEAD correctly' '
 
 '
 
-test_expect_success 'mark initial state of origin/master' '
+test_expect_success 'mark initial state of origin/main' '
 	(
 		cd three &&
-		git tag base-origin-master refs/remotes/origin/master
+		git tag base-origin-main refs/remotes/origin/main
 	)
 '
 
@@ -412,10 +414,10 @@ test_expect_success 'explicit fetch should update tracking' '
 	git branch -f side &&
 	(
 		cd three &&
-		git update-ref refs/remotes/origin/master base-origin-master &&
-		o=$(git rev-parse --verify refs/remotes/origin/master) &&
-		git fetch origin master &&
-		n=$(git rev-parse --verify refs/remotes/origin/master) &&
+		git update-ref refs/remotes/origin/main base-origin-main &&
+		o=$(git rev-parse --verify refs/remotes/origin/main) &&
+		git fetch origin main &&
+		n=$(git rev-parse --verify refs/remotes/origin/main) &&
 		test "$o" != "$n" &&
 		test_must_fail git rev-parse --verify refs/remotes/origin/side
 	)
@@ -427,10 +429,10 @@ test_expect_success 'explicit pull should update tracking' '
 	git branch -f side &&
 	(
 		cd three &&
-		git update-ref refs/remotes/origin/master base-origin-master &&
-		o=$(git rev-parse --verify refs/remotes/origin/master) &&
-		git pull origin master &&
-		n=$(git rev-parse --verify refs/remotes/origin/master) &&
+		git update-ref refs/remotes/origin/main base-origin-main &&
+		o=$(git rev-parse --verify refs/remotes/origin/main) &&
+		git pull origin main &&
+		n=$(git rev-parse --verify refs/remotes/origin/main) &&
 		test "$o" != "$n" &&
 		test_must_fail git rev-parse --verify refs/remotes/origin/side
 	)
@@ -449,13 +451,13 @@ test_expect_success 'explicit --refmap option overrides remote.*.fetch' '
 	git branch -f side &&
 	(
 		cd three &&
-		git update-ref refs/remotes/origin/master base-origin-master &&
-		o=$(git rev-parse --verify refs/remotes/origin/master) &&
-		git fetch --refmap="refs/heads/*:refs/remotes/other/*" origin master &&
-		n=$(git rev-parse --verify refs/remotes/origin/master) &&
+		git update-ref refs/remotes/origin/main base-origin-main &&
+		o=$(git rev-parse --verify refs/remotes/origin/main) &&
+		git fetch --refmap="refs/heads/*:refs/remotes/other/*" origin main &&
+		n=$(git rev-parse --verify refs/remotes/origin/main) &&
 		test "$o" = "$n" &&
 		test_must_fail git rev-parse --verify refs/remotes/origin/side &&
-		git rev-parse --verify refs/remotes/other/master
+		git rev-parse --verify refs/remotes/other/main
 	)
 '
 
@@ -464,10 +466,10 @@ test_expect_success 'explicitly empty --refmap option disables remote.*.fetch' '
 	git branch -f side &&
 	(
 		cd three &&
-		git update-ref refs/remotes/origin/master base-origin-master &&
-		o=$(git rev-parse --verify refs/remotes/origin/master) &&
-		git fetch --refmap="" origin master &&
-		n=$(git rev-parse --verify refs/remotes/origin/master) &&
+		git update-ref refs/remotes/origin/main base-origin-main &&
+		o=$(git rev-parse --verify refs/remotes/origin/main) &&
+		git fetch --refmap="" origin main &&
+		n=$(git rev-parse --verify refs/remotes/origin/main) &&
 		test "$o" = "$n" &&
 		test_must_fail git rev-parse --verify refs/remotes/origin/side
 	)
@@ -479,10 +481,10 @@ test_expect_success 'configured fetch updates tracking' '
 	git branch -f side &&
 	(
 		cd three &&
-		git update-ref refs/remotes/origin/master base-origin-master &&
-		o=$(git rev-parse --verify refs/remotes/origin/master) &&
+		git update-ref refs/remotes/origin/main base-origin-main &&
+		o=$(git rev-parse --verify refs/remotes/origin/main) &&
 		git fetch origin &&
-		n=$(git rev-parse --verify refs/remotes/origin/master) &&
+		n=$(git rev-parse --verify refs/remotes/origin/main) &&
 		test "$o" != "$n" &&
 		git rev-parse --verify refs/remotes/origin/side
 	)
@@ -493,12 +495,12 @@ test_expect_success 'non-matching refspecs do not confuse tracking update' '
 	git update-ref refs/odd/location HEAD &&
 	(
 		cd three &&
-		git update-ref refs/remotes/origin/master base-origin-master &&
+		git update-ref refs/remotes/origin/main base-origin-main &&
 		git config --add remote.origin.fetch \
 			refs/odd/location:refs/remotes/origin/odd &&
-		o=$(git rev-parse --verify refs/remotes/origin/master) &&
-		git fetch origin master &&
-		n=$(git rev-parse --verify refs/remotes/origin/master) &&
+		o=$(git rev-parse --verify refs/remotes/origin/main) &&
+		git fetch origin main &&
+		n=$(git rev-parse --verify refs/remotes/origin/main) &&
 		test "$o" != "$n" &&
 		test_must_fail git rev-parse --verify refs/remotes/origin/odd
 	)
@@ -524,7 +526,7 @@ test_expect_success 'auto tag following fetches minimum' '
 			git tag -a -m $i excess-$i || exit 1
 		done
 	) &&
-	git checkout master &&
+	git checkout main &&
 	(
 		cd follow &&
 		git fetch
@@ -533,13 +535,13 @@ test_expect_success 'auto tag following fetches minimum' '
 
 test_expect_success 'refuse to fetch into the current branch' '
 
-	test_must_fail git fetch . side:master
+	test_must_fail git fetch . side:main
 
 '
 
 test_expect_success 'fetch into the current branch with --update-head-ok' '
 
-	git fetch --update-head-ok . side:master
+	git fetch --update-head-ok . side:main
 
 '
 
@@ -568,7 +570,7 @@ test_expect_success "should be able to fetch with duplicate refspecs" '
 	(
 		cd dups &&
 		git init &&
-		git config branch.master.remote three &&
+		git config branch.main.remote three &&
 		git config remote.three.url ../three/.git &&
 		git config remote.three.fetch +refs/heads/*:refs/remotes/origin/* &&
 		git config --add remote.three.fetch +refs/heads/*:refs/remotes/origin/* &&
@@ -877,11 +879,11 @@ test_expect_success 'all boundary commits are excluded' '
 	test_commit oneside &&
 	git checkout HEAD^ &&
 	test_commit otherside &&
-	git checkout master &&
+	git checkout main &&
 	test_tick &&
 	git merge otherside &&
 	ad=$(git log --no-walk --format=%ad HEAD) &&
-	git bundle create twoside-boundary.bdl master --since="$ad" &&
+	git bundle create twoside-boundary.bdl main --since="$ad" &&
 	convert_bundle_to_pack <twoside-boundary.bdl >twoside-boundary.pack &&
 	pack=$(git index-pack --fix-thin --stdin <twoside-boundary.pack) &&
 	test_bundle_object_count .git/objects/pack/pack-${pack##pack	}.pack 3
@@ -942,7 +944,7 @@ test_expect_success 'fetching with auto-gc does not lock up' '
 	)
 '
 
-test_expect_success PREPARE_FOR_MAIN_BRANCH,C_LOCALE_OUTPUT 'fetch aligned output' '
+test_expect_success C_LOCALE_OUTPUT 'fetch aligned output' '
 	git clone . full-output &&
 	test_commit looooooooooooong-tag &&
 	(
@@ -957,7 +959,7 @@ test_expect_success PREPARE_FOR_MAIN_BRANCH,C_LOCALE_OUTPUT 'fetch aligned outpu
 	test_cmp expect actual
 '
 
-test_expect_success PREPARE_FOR_MAIN_BRANCH,C_LOCALE_OUTPUT 'fetch compact output' '
+test_expect_success C_LOCALE_OUTPUT 'fetch compact output' '
 	git clone . compact &&
 	test_commit extraaa &&
 	(
@@ -1001,7 +1003,7 @@ setup_negotiation_tip () {
 	USE_PROTOCOL_V2="$3"
 
 	rm -rf "$SERVER" client trace &&
-	git init "$SERVER" &&
+	git init -b main "$SERVER" &&
 	test_commit -C "$SERVER" alpha_1 &&
 	test_commit -C "$SERVER" alpha_2 &&
 	git -C "$SERVER" checkout --orphan beta &&
@@ -1017,7 +1019,7 @@ setup_negotiation_tip () {
 	fi &&
 
 	test_commit -C "$SERVER" beta_s &&
-	git -C "$SERVER" checkout master &&
+	git -C "$SERVER" checkout main &&
 	test_commit -C "$SERVER" alpha_s &&
 	git -C "$SERVER" tag -d alpha_1 alpha_2 beta_1 beta_2
 }

--- a/t/t5703-upload-pack-ref-in-want.sh
+++ b/t/t5703-upload-pack-ref-in-want.sh
@@ -38,12 +38,13 @@ write_command () {
 
 # c(o/foo) d(o/bar)
 #        \ /
-#         b   e(baz)  f(master)
+#         b   e(baz)  f(main)
 #          \__  |  __/
 #             \ | /
 #               a
 test_expect_success 'setup repository' '
 	test_commit a &&
+	git branch -M main &&
 	git checkout -b o/foo &&
 	test_commit b &&
 	test_commit c &&
@@ -51,7 +52,7 @@ test_expect_success 'setup repository' '
 	test_commit d &&
 	git checkout -b baz a &&
 	test_commit e &&
-	git checkout master &&
+	git checkout main &&
 	test_commit f
 '
 
@@ -88,7 +89,7 @@ test_expect_success 'invalid want-ref line' '
 test_expect_success 'basic want-ref' '
 	oid=$(git rev-parse f) &&
 	cat >expected_refs <<-EOF &&
-	$oid refs/heads/master
+	$oid refs/heads/main
 	EOF
 	git rev-parse f >expected_commits &&
 
@@ -97,7 +98,7 @@ test_expect_success 'basic want-ref' '
 	$(write_command fetch)
 	0001
 	no-progress
-	want-ref refs/heads/master
+	want-ref refs/heads/main
 	have $oid
 	done
 	0000
@@ -135,7 +136,7 @@ test_expect_success 'multiple want-ref lines' '
 test_expect_success 'mix want and want-ref' '
 	oid=$(git rev-parse f) &&
 	cat >expected_refs <<-EOF &&
-	$oid refs/heads/master
+	$oid refs/heads/main
 	EOF
 	git rev-parse e f >expected_commits &&
 
@@ -143,7 +144,7 @@ test_expect_success 'mix want and want-ref' '
 	$(write_command fetch)
 	0001
 	no-progress
-	want-ref refs/heads/master
+	want-ref refs/heads/main
 	want $(git rev-parse e)
 	have $(git rev-parse a)
 	done
@@ -182,7 +183,7 @@ LOCAL_PRISTINE="$(pwd)/local_pristine"
 # $REPO
 # c(o/foo) d(o/bar)
 #        \ /
-#         b   e(baz)  f(master)
+#         b   e(baz)  f(main)
 #          \__  |  __/
 #             \ | /
 #               a
@@ -193,10 +194,10 @@ LOCAL_PRISTINE="$(pwd)/local_pristine"
 #		.
 #		.
 #		|
-#		a(master)
+#		a(main)
 test_expect_success 'setup repos for fetching with ref-in-want tests' '
 	(
-		git init "$REPO" &&
+		git init -b main "$REPO" &&
 		cd "$REPO" &&
 		test_commit a &&
 
@@ -209,7 +210,7 @@ test_expect_success 'setup repos for fetching with ref-in-want tests' '
 		test_commit_bulk --id=s 33 &&
 
 		# Add novel commits to upstream
-		git checkout master &&
+		git checkout main &&
 		cd "$REPO" &&
 		git checkout -b o/foo &&
 		test_commit b &&
@@ -218,7 +219,7 @@ test_expect_success 'setup repos for fetching with ref-in-want tests' '
 		test_commit d &&
 		git checkout -b baz a &&
 		test_commit e &&
-		git checkout master &&
+		git checkout main &&
 		test_commit f
 	) &&
 	git -C "$REPO" config uploadpack.allowRefInWant true &&
@@ -245,12 +246,12 @@ test_expect_success 'fetching multiple refs' '
 
 	rm -rf local &&
 	cp -r "$LOCAL_PRISTINE" local &&
-	GIT_TRACE_PACKET="$(pwd)/log" git -C local fetch origin master baz &&
+	GIT_TRACE_PACKET="$(pwd)/log" git -C local fetch origin main baz &&
 
-	git -C "$REPO" rev-parse "master" "baz" >expected &&
-	git -C local rev-parse refs/remotes/origin/master refs/remotes/origin/baz >actual &&
+	git -C "$REPO" rev-parse "main" "baz" >expected &&
+	git -C local rev-parse refs/remotes/origin/main refs/remotes/origin/baz >actual &&
 	test_cmp expected actual &&
-	grep "want-ref refs/heads/master" log &&
+	grep "want-ref refs/heads/main" log &&
 	grep "want-ref refs/heads/baz" log
 '
 
@@ -261,13 +262,13 @@ test_expect_success 'fetching ref and exact OID' '
 	cp -r "$LOCAL_PRISTINE" local &&
 	oid=$(git -C "$REPO" rev-parse b) &&
 	GIT_TRACE_PACKET="$(pwd)/log" git -C local fetch origin \
-		master "$oid":refs/heads/actual &&
+		main "$oid":refs/heads/actual &&
 
-	git -C "$REPO" rev-parse "master" "b" >expected &&
-	git -C local rev-parse refs/remotes/origin/master refs/heads/actual >actual &&
+	git -C "$REPO" rev-parse "main" "b" >expected &&
+	git -C local rev-parse refs/remotes/origin/main refs/heads/actual >actual &&
 	test_cmp expected actual &&
 	grep "want $oid" log &&
-	grep "want-ref refs/heads/master" log
+	grep "want-ref refs/heads/main" log
 '
 
 test_expect_success 'fetching with wildcard that does not match any refs' '
@@ -301,7 +302,7 @@ LOCAL_PRISTINE="$(pwd)/local_pristine"
 
 test_expect_success 'setup repos for change-while-negotiating test' '
 	(
-		git init "$REPO" &&
+		git init -b main "$REPO" &&
 		cd "$REPO" &&
 		>.git/git-daemon-export-ok &&
 		test_commit m1 &&
@@ -316,7 +317,7 @@ test_expect_success 'setup repos for change-while-negotiating test' '
 		test_commit_bulk --id=s 33 &&
 
 		# Add novel commits to upstream
-		git checkout master &&
+		git checkout main &&
 		cd "$REPO" &&
 		test_commit m2 &&
 		test_commit m3 &&
@@ -342,7 +343,7 @@ test_expect_success 'server is initially ahead - no ref in want' '
 	git -C "$REPO" config uploadpack.allowRefInWant false &&
 	rm -rf local &&
 	cp -r "$LOCAL_PRISTINE" local &&
-	inconsistency master $(test_oid numeric) &&
+	inconsistency main $(test_oid numeric) &&
 	test_must_fail git -C local fetch 2>err &&
 	test_i18ngrep "fatal: remote error: upload-pack: not our ref" err
 '
@@ -351,11 +352,11 @@ test_expect_success 'server is initially ahead - ref in want' '
 	git -C "$REPO" config uploadpack.allowRefInWant true &&
 	rm -rf local &&
 	cp -r "$LOCAL_PRISTINE" local &&
-	inconsistency master $(test_oid numeric) &&
+	inconsistency main $(test_oid numeric) &&
 	git -C local fetch &&
 
-	git -C "$REPO" rev-parse --verify master >expected &&
-	git -C local rev-parse --verify refs/remotes/origin/master >actual &&
+	git -C "$REPO" rev-parse --verify main >expected &&
+	git -C local rev-parse --verify refs/remotes/origin/main >actual &&
 	test_cmp expected actual
 '
 
@@ -363,11 +364,11 @@ test_expect_success 'server is initially behind - no ref in want' '
 	git -C "$REPO" config uploadpack.allowRefInWant false &&
 	rm -rf local &&
 	cp -r "$LOCAL_PRISTINE" local &&
-	inconsistency master "master^" &&
+	inconsistency main "main^" &&
 	git -C local fetch &&
 
-	git -C "$REPO" rev-parse --verify "master^" >expected &&
-	git -C local rev-parse --verify refs/remotes/origin/master >actual &&
+	git -C "$REPO" rev-parse --verify "main^" >expected &&
+	git -C local rev-parse --verify refs/remotes/origin/main >actual &&
 	test_cmp expected actual
 '
 
@@ -375,15 +376,15 @@ test_expect_success 'server is initially behind - ref in want' '
 	git -C "$REPO" config uploadpack.allowRefInWant true &&
 	rm -rf local &&
 	cp -r "$LOCAL_PRISTINE" local &&
-	inconsistency master "master^" &&
+	inconsistency main "main^" &&
 	git -C local fetch &&
 
-	git -C "$REPO" rev-parse --verify "master" >expected &&
-	git -C local rev-parse --verify refs/remotes/origin/master >actual &&
+	git -C "$REPO" rev-parse --verify "main" >expected &&
+	git -C local rev-parse --verify refs/remotes/origin/main >actual &&
 	test_cmp expected actual
 '
 
-test_expect_success PREPARE_FOR_MAIN_BRANCH 'server loses a ref - ref in want' '
+test_expect_success 'server loses a ref - ref in want' '
 	git -C "$REPO" config uploadpack.allowRefInWant true &&
 	rm -rf local &&
 	cp -r "$LOCAL_PRISTINE" local &&

--- a/t/t6302-for-each-ref-filter.sh
+++ b/t/t6302-for-each-ref-filter.sh
@@ -7,6 +7,7 @@ test_description='test for-each-refs usage of ref-filter APIs'
 
 test_expect_success 'setup some history and refs' '
 	test_commit one &&
+	git branch -M main &&
 	test_commit two &&
 	test_commit three &&
 	git checkout -b side &&
@@ -26,17 +27,17 @@ test_expect_success 'setup some history and refs' '
 	git tag $sign -m "A signed tag" signed-tag &&
 	git tag $sign -m "Signed doubly" doubly-signed-tag signed-tag &&
 
-	git checkout master &&
-	git update-ref refs/odd/spot master
+	git checkout main &&
+	git update-ref refs/odd/spot main
 '
 
 test_expect_success 'filtering with --points-at' '
 	cat >expect <<-\EOF &&
-	refs/heads/master
+	refs/heads/main
 	refs/odd/spot
 	refs/tags/three
 	EOF
-	git for-each-ref --format="%(refname)" --points-at=master >actual &&
+	git for-each-ref --format="%(refname)" --points-at=main >actual &&
 	test_cmp expect actual
 '
 
@@ -53,13 +54,13 @@ test_expect_success 'check signed tags with --points-at' '
 
 test_expect_success 'filtering with --merged' '
 	cat >expect <<-\EOF &&
-	refs/heads/master
+	refs/heads/main
 	refs/odd/spot
 	refs/tags/one
 	refs/tags/three
 	refs/tags/two
 	EOF
-	git for-each-ref --format="%(refname)" --merged=master >actual &&
+	git for-each-ref --format="%(refname)" --merged=main >actual &&
 	test_cmp expect actual
 '
 
@@ -72,13 +73,13 @@ test_expect_success 'filtering with --no-merged' '
 	refs/tags/four
 	refs/tags/signed-tag
 	EOF
-	git for-each-ref --format="%(refname)" --no-merged=master >actual &&
+	git for-each-ref --format="%(refname)" --no-merged=main >actual &&
 	test_cmp expect actual
 '
 
 test_expect_success 'filtering with --contains' '
 	cat >expect <<-\EOF &&
-	refs/heads/master
+	refs/heads/main
 	refs/heads/side
 	refs/odd/spot
 	refs/tags/annotated-tag
@@ -113,7 +114,7 @@ test_expect_success '%(color) must fail' '
 	test_must_fail git for-each-ref --format="%(color)%(refname)"
 '
 
-test_expect_success PREPARE_FOR_MAIN_BRANCH 'left alignment is default' '
+test_expect_success 'left alignment is default' '
 	cat >expect <<-\EOF &&
 	refname is refs/heads/main    |refs/heads/main
 	refname is refs/heads/side    |refs/heads/side
@@ -131,7 +132,7 @@ test_expect_success PREPARE_FOR_MAIN_BRANCH 'left alignment is default' '
 	test_cmp expect actual
 '
 
-test_expect_success PREPARE_FOR_MAIN_BRANCH 'middle alignment' '
+test_expect_success 'middle alignment' '
 	cat >expect <<-\EOF &&
 	|  refname is refs/heads/main  |refs/heads/main
 	|  refname is refs/heads/side  |refs/heads/side
@@ -149,7 +150,7 @@ test_expect_success PREPARE_FOR_MAIN_BRANCH 'middle alignment' '
 	test_cmp expect actual
 '
 
-test_expect_success PREPARE_FOR_MAIN_BRANCH 'right alignment' '
+test_expect_success 'right alignment' '
 	cat >expect <<-\EOF &&
 	|    refname is refs/heads/main|refs/heads/main
 	|    refname is refs/heads/side|refs/heads/side
@@ -184,7 +185,7 @@ EOF
 test_align_permutations() {
 	while read -r option
 	do
-		test_expect_success PREPARE_FOR_MAIN_BRANCH "align:$option" '
+		test_expect_success "align:$option" '
 			git for-each-ref --format="|%(align:$option)refname is %(refname)%(end)|%(refname)" >actual &&
 			test_cmp expect actual
 		'
@@ -213,7 +214,7 @@ EOF
 
 # Individual atoms inside %(align:...) and %(end) must not be quoted.
 
-test_expect_success PREPARE_FOR_MAIN_BRANCH 'alignment with format quote' "
+test_expect_success 'alignment with format quote' "
 	cat >expect <<-\EOF &&
 	|'       '\''main| A U Thor'\''       '|
 	|'       '\''side| A U Thor'\''       '|
@@ -231,7 +232,7 @@ test_expect_success PREPARE_FOR_MAIN_BRANCH 'alignment with format quote' "
 	test_cmp expect actual
 "
 
-test_expect_success PREPARE_FOR_MAIN_BRANCH 'nested alignment with quote formatting' "
+test_expect_success 'nested alignment with quote formatting' "
 	cat >expect <<-\EOF &&
 	|'           main               '|
 	|'           side               '|
@@ -251,7 +252,7 @@ test_expect_success PREPARE_FOR_MAIN_BRANCH 'nested alignment with quote formatt
 
 test_expect_success 'check `%(contents:lines=1)`' '
 	cat >expect <<-\EOF &&
-	master |three
+	main |three
 	side |four
 	odd/spot |three
 	annotated-tag |An annotated tag
@@ -269,7 +270,7 @@ test_expect_success 'check `%(contents:lines=1)`' '
 
 test_expect_success 'check `%(contents:lines=0)`' '
 	cat >expect <<-\EOF &&
-	master |
+	main |
 	side |
 	odd/spot |
 	annotated-tag |
@@ -287,7 +288,7 @@ test_expect_success 'check `%(contents:lines=0)`' '
 
 test_expect_success 'check `%(contents:lines=99999)`' '
 	cat >expect <<-\EOF &&
-	master |three
+	main |three
 	side |four
 	odd/spot |three
 	annotated-tag |An annotated tag
@@ -360,7 +361,7 @@ test_expect_success 'improper usage of %(if), %(then), %(else) and %(end) atoms'
 test_expect_success 'check %(if)...%(then)...%(end) atoms' '
 	git for-each-ref --format="%(refname)%(if)%(authorname)%(then) Author: %(authorname)%(end)" >actual &&
 	cat >expect <<-\EOF &&
-	refs/heads/master Author: A U Thor
+	refs/heads/main Author: A U Thor
 	refs/heads/side Author: A U Thor
 	refs/odd/spot Author: A U Thor
 	refs/tags/annotated-tag
@@ -381,7 +382,7 @@ test_expect_success 'check %(if)...%(then)...%(end) atoms' '
 test_expect_success 'check %(if)...%(then)...%(else)...%(end) atoms' '
 	git for-each-ref --format="%(if)%(authorname)%(then)%(authorname)%(else)No author%(end): %(refname)" >actual &&
 	cat >expect <<-\EOF &&
-	A U Thor: refs/heads/master
+	A U Thor: refs/heads/main
 	A U Thor: refs/heads/side
 	A U Thor: refs/odd/spot
 	No author: refs/tags/annotated-tag
@@ -401,7 +402,7 @@ test_expect_success 'check %(if)...%(then)...%(else)...%(end) atoms' '
 test_expect_success 'ignore spaces in %(if) atom usage' '
 	git for-each-ref --format="%(refname:short): %(if)%(HEAD)%(then)Head ref%(else)Not Head ref%(end)" >actual &&
 	cat >expect <<-\EOF &&
-	master: Head ref
+	main: Head ref
 	side: Not Head ref
 	odd/spot: Not Head ref
 	annotated-tag: Not Head ref
@@ -420,19 +421,19 @@ test_expect_success 'ignore spaces in %(if) atom usage' '
 '
 
 test_expect_success 'check %(if:equals=<string>)' '
-	git for-each-ref --format="%(if:equals=master)%(refname:short)%(then)Found master%(else)Not master%(end)" refs/heads/ >actual &&
+	git for-each-ref --format="%(if:equals=main)%(refname:short)%(then)Found main%(else)Not main%(end)" refs/heads/ >actual &&
 	cat >expect <<-\EOF &&
-	Found master
-	Not master
+	Found main
+	Not main
 	EOF
 	test_cmp expect actual
 '
 
 test_expect_success 'check %(if:notequals=<string>)' '
-	git for-each-ref --format="%(if:notequals=master)%(refname:short)%(then)Not master%(else)Found master%(end)" refs/heads/ >actual &&
+	git for-each-ref --format="%(if:notequals=main)%(refname:short)%(then)Not main%(else)Found main%(end)" refs/heads/ >actual &&
 	cat >expect <<-\EOF &&
-	Found master
-	Not master
+	Found main
+	Not main
 	EOF
 	test_cmp expect actual
 '
@@ -443,11 +444,11 @@ test_expect_success '--merged is compatible with --no-merged' '
 
 test_expect_success 'validate worktree atom' '
 	cat >expect <<-EOF &&
-	master: $(pwd)
-	master_worktree: $(pwd)/worktree_dir
+	main: $(pwd)
+	main_worktree: $(pwd)/worktree_dir
 	side: not checked out
 	EOF
-	git worktree add -b master_worktree worktree_dir master &&
+	git worktree add -b main_worktree worktree_dir main &&
 	git for-each-ref --format="%(refname:short): %(if)%(worktreepath)%(then)%(worktreepath)%(else)not checked out%(end)" refs/heads/ >actual &&
 	rm -r worktree_dir &&
 	git worktree prune &&

--- a/t/t9902-completion.sh
+++ b/t/t9902-completion.sh
@@ -136,7 +136,7 @@ fi
 test_expect_success 'setup for __git_find_repo_path/__gitdir tests' '
 	mkdir -p subdir/subsubdir &&
 	mkdir -p non-repo &&
-	git init otherrepo
+	git init -b main otherrepo
 '
 
 test_expect_success '__git_find_repo_path - from command line (through $__git_dir)' '
@@ -614,12 +614,13 @@ test_expect_success '__git_is_configured_remote' '
 
 test_expect_success 'setup for ref completion' '
 	git commit --allow-empty -m initial &&
+	git branch -M main &&
 	git branch matching-branch &&
 	git tag matching-tag &&
 	(
 		cd otherrepo &&
 		git commit --allow-empty -m initial &&
-		git branch -m master master-in-other &&
+		git branch -m main main-in-other &&
 		git branch branch-in-other &&
 		git tag tag-in-other
 	) &&
@@ -632,10 +633,10 @@ test_expect_success 'setup for ref completion' '
 test_expect_success '__git_refs - simple' '
 	cat >expected <<-EOF &&
 	HEAD
-	master
+	main
 	matching-branch
 	other/branch-in-other
-	other/master-in-other
+	other/main-in-other
 	matching-tag
 	EOF
 	(
@@ -647,10 +648,10 @@ test_expect_success '__git_refs - simple' '
 
 test_expect_success '__git_refs - full refs' '
 	cat >expected <<-EOF &&
-	refs/heads/master
+	refs/heads/main
 	refs/heads/matching-branch
 	refs/remotes/other/branch-in-other
-	refs/remotes/other/master-in-other
+	refs/remotes/other/main-in-other
 	refs/tags/matching-tag
 	EOF
 	(
@@ -664,7 +665,7 @@ test_expect_success '__git_refs - repo given on the command line' '
 	cat >expected <<-EOF &&
 	HEAD
 	branch-in-other
-	master-in-other
+	main-in-other
 	tag-in-other
 	EOF
 	(
@@ -679,7 +680,7 @@ test_expect_success '__git_refs - remote on local file system' '
 	cat >expected <<-EOF &&
 	HEAD
 	branch-in-other
-	master-in-other
+	main-in-other
 	tag-in-other
 	EOF
 	(
@@ -692,7 +693,7 @@ test_expect_success '__git_refs - remote on local file system' '
 test_expect_success '__git_refs - remote on local file system - full refs' '
 	cat >expected <<-EOF &&
 	refs/heads/branch-in-other
-	refs/heads/master-in-other
+	refs/heads/main-in-other
 	refs/tags/tag-in-other
 	EOF
 	(
@@ -706,7 +707,7 @@ test_expect_success '__git_refs - configured remote' '
 	cat >expected <<-EOF &&
 	HEAD
 	branch-in-other
-	master-in-other
+	main-in-other
 	EOF
 	(
 		cur= &&
@@ -719,7 +720,7 @@ test_expect_success '__git_refs - configured remote - full refs' '
 	cat >expected <<-EOF &&
 	HEAD
 	refs/heads/branch-in-other
-	refs/heads/master-in-other
+	refs/heads/main-in-other
 	refs/tags/tag-in-other
 	EOF
 	(
@@ -733,7 +734,7 @@ test_expect_success '__git_refs - configured remote - repo given on the command 
 	cat >expected <<-EOF &&
 	HEAD
 	branch-in-other
-	master-in-other
+	main-in-other
 	EOF
 	(
 		cd thirdrepo &&
@@ -748,7 +749,7 @@ test_expect_success '__git_refs - configured remote - full refs - repo given on 
 	cat >expected <<-EOF &&
 	HEAD
 	refs/heads/branch-in-other
-	refs/heads/master-in-other
+	refs/heads/main-in-other
 	refs/tags/tag-in-other
 	EOF
 	(
@@ -764,7 +765,7 @@ test_expect_success '__git_refs - configured remote - remote name matches a dire
 	cat >expected <<-EOF &&
 	HEAD
 	branch-in-other
-	master-in-other
+	main-in-other
 	EOF
 	mkdir other &&
 	test_when_finished "rm -rf other" &&
@@ -779,7 +780,7 @@ test_expect_success '__git_refs - URL remote' '
 	cat >expected <<-EOF &&
 	HEAD
 	branch-in-other
-	master-in-other
+	main-in-other
 	tag-in-other
 	EOF
 	(
@@ -793,7 +794,7 @@ test_expect_success '__git_refs - URL remote - full refs' '
 	cat >expected <<-EOF &&
 	HEAD
 	refs/heads/branch-in-other
-	refs/heads/master-in-other
+	refs/heads/main-in-other
 	refs/tags/tag-in-other
 	EOF
 	(
@@ -849,23 +850,23 @@ test_expect_success '__git_refs - not in a git repository' '
 test_expect_success '__git_refs - unique remote branches for git checkout DWIMery' '
 	cat >expected <<-EOF &&
 	HEAD
-	master
+	main
 	matching-branch
 	other/ambiguous
 	other/branch-in-other
-	other/master-in-other
+	other/main-in-other
 	remote/ambiguous
 	remote/branch-in-remote
 	matching-tag
 	branch-in-other
 	branch-in-remote
-	master-in-other
+	main-in-other
 	EOF
 	for remote_ref in refs/remotes/other/ambiguous \
 		refs/remotes/remote/ambiguous \
 		refs/remotes/remote/branch-in-remote
 	do
-		git update-ref $remote_ref master &&
+		git update-ref $remote_ref main &&
 		test_when_finished "git update-ref -d $remote_ref"
 	done &&
 	(
@@ -878,10 +879,10 @@ test_expect_success '__git_refs - unique remote branches for git checkout DWIMer
 test_expect_success '__git_refs - after --opt=' '
 	cat >expected <<-EOF &&
 	HEAD
-	master
+	main
 	matching-branch
 	other/branch-in-other
-	other/master-in-other
+	other/main-in-other
 	matching-tag
 	EOF
 	(
@@ -893,10 +894,10 @@ test_expect_success '__git_refs - after --opt=' '
 
 test_expect_success '__git_refs - after --opt= - full refs' '
 	cat >expected <<-EOF &&
-	refs/heads/master
+	refs/heads/main
 	refs/heads/matching-branch
 	refs/remotes/other/branch-in-other
-	refs/remotes/other/master-in-other
+	refs/remotes/other/main-in-other
 	refs/tags/matching-tag
 	EOF
 	(
@@ -909,10 +910,10 @@ test_expect_success '__git_refs - after --opt= - full refs' '
 test_expect_success '__git refs - excluding refs' '
 	cat >expected <<-EOF &&
 	^HEAD
-	^master
+	^main
 	^matching-branch
 	^other/branch-in-other
-	^other/master-in-other
+	^other/main-in-other
 	^matching-tag
 	EOF
 	(
@@ -924,10 +925,10 @@ test_expect_success '__git refs - excluding refs' '
 
 test_expect_success '__git refs - excluding full refs' '
 	cat >expected <<-EOF &&
-	^refs/heads/master
+	^refs/heads/main
 	^refs/heads/matching-branch
 	^refs/remotes/other/branch-in-other
-	^refs/remotes/other/master-in-other
+	^refs/remotes/other/main-in-other
 	^refs/tags/matching-tag
 	EOF
 	(
@@ -948,17 +949,17 @@ test_expect_success 'setup for filtering matching refs' '
 test_expect_success '__git_refs - do not filter refs unless told so' '
 	cat >expected <<-EOF &&
 	HEAD
-	master
+	main
 	matching-branch
 	matching/branch
 	other/branch-in-other
-	other/master-in-other
+	other/main-in-other
 	other/matching/branch-in-other
 	matching-tag
 	matching/tag
 	EOF
 	(
-		cur=master &&
+		cur=main &&
 		__git_refs >"$actual"
 	) &&
 	test_cmp expected "$actual"
@@ -992,7 +993,7 @@ test_expect_success '__git_refs - only matching refs - full refs' '
 
 test_expect_success '__git_refs - only matching refs - remote on local file system' '
 	cat >expected <<-EOF &&
-	master-in-other
+	main-in-other
 	matching/branch-in-other
 	EOF
 	(
@@ -1004,7 +1005,7 @@ test_expect_success '__git_refs - only matching refs - remote on local file syst
 
 test_expect_success '__git_refs - only matching refs - configured remote' '
 	cat >expected <<-EOF &&
-	master-in-other
+	main-in-other
 	matching/branch-in-other
 	EOF
 	(
@@ -1016,7 +1017,7 @@ test_expect_success '__git_refs - only matching refs - configured remote' '
 
 test_expect_success '__git_refs - only matching refs - remote - full refs' '
 	cat >expected <<-EOF &&
-	refs/heads/master-in-other
+	refs/heads/main-in-other
 	refs/heads/matching/branch-in-other
 	EOF
 	(
@@ -1038,7 +1039,7 @@ test_expect_success '__git_refs - only matching refs - checkout DWIMery' '
 		refs/remotes/remote/ambiguous \
 		refs/remotes/remote/branch-in-remote
 	do
-		git update-ref $remote_ref master &&
+		git update-ref $remote_ref main &&
 		test_when_finished "git update-ref -d $remote_ref"
 	done &&
 	(
@@ -1055,9 +1056,9 @@ test_expect_success 'teardown after filtering matching refs' '
 	git -C otherrepo branch -D matching/branch-in-other
 '
 
-test_expect_success PREPARE_FOR_MAIN_BRANCH '__git_refs - for-each-ref format specifiers in prefix' '
+test_expect_success '__git_refs - for-each-ref format specifiers in prefix' '
 	cat >expected <<-EOF &&
-	evil-%%-%42-%(refname)..master
+	evil-%%-%42-%(refname)..main
 	EOF
 	(
 		cur="evil-%%-%42-%(refname)..mai" &&
@@ -1069,10 +1070,10 @@ test_expect_success PREPARE_FOR_MAIN_BRANCH '__git_refs - for-each-ref format sp
 test_expect_success '__git_complete_refs - simple' '
 	sed -e "s/Z$//" >expected <<-EOF &&
 	HEAD Z
-	master Z
+	main Z
 	matching-branch Z
 	other/branch-in-other Z
-	other/master-in-other Z
+	other/main-in-other Z
 	matching-tag Z
 	EOF
 	(
@@ -1100,7 +1101,7 @@ test_expect_success '__git_complete_refs - remote' '
 	sed -e "s/Z$//" >expected <<-EOF &&
 	HEAD Z
 	branch-in-other Z
-	master-in-other Z
+	main-in-other Z
 	EOF
 	(
 		cur= &&
@@ -1113,13 +1114,13 @@ test_expect_success '__git_complete_refs - remote' '
 test_expect_success '__git_complete_refs - track' '
 	sed -e "s/Z$//" >expected <<-EOF &&
 	HEAD Z
-	master Z
+	main Z
 	matching-branch Z
 	other/branch-in-other Z
-	other/master-in-other Z
+	other/main-in-other Z
 	matching-tag Z
 	branch-in-other Z
-	master-in-other Z
+	main-in-other Z
 	EOF
 	(
 		cur= &&
@@ -1158,10 +1159,10 @@ test_expect_success '__git_complete_refs - prefix' '
 test_expect_success '__git_complete_refs - suffix' '
 	cat >expected <<-EOF &&
 	HEAD.
-	master.
+	main.
 	matching-branch.
 	other/branch-in-other.
-	other/master-in-other.
+	other/main-in-other.
 	matching-tag.
 	EOF
 	(
@@ -1176,7 +1177,7 @@ test_expect_success '__git_complete_fetch_refspecs - simple' '
 	sed -e "s/Z$//" >expected <<-EOF &&
 	HEAD:HEAD Z
 	branch-in-other:branch-in-other Z
-	master-in-other:master-in-other Z
+	main-in-other:main-in-other Z
 	EOF
 	(
 		cur= &&
@@ -1202,7 +1203,7 @@ test_expect_success '__git_complete_fetch_refspecs - prefix' '
 	sed -e "s/Z$//" >expected <<-EOF &&
 	+HEAD:HEAD Z
 	+branch-in-other:branch-in-other Z
-	+master-in-other:master-in-other Z
+	+main-in-other:main-in-other Z
 	EOF
 	(
 		cur="+" &&
@@ -1215,7 +1216,7 @@ test_expect_success '__git_complete_fetch_refspecs - prefix' '
 test_expect_success '__git_complete_fetch_refspecs - fully qualified' '
 	sed -e "s/Z$//" >expected <<-EOF &&
 	refs/heads/branch-in-other:refs/heads/branch-in-other Z
-	refs/heads/master-in-other:refs/heads/master-in-other Z
+	refs/heads/main-in-other:refs/heads/main-in-other Z
 	refs/tags/tag-in-other:refs/tags/tag-in-other Z
 	EOF
 	(
@@ -1229,7 +1230,7 @@ test_expect_success '__git_complete_fetch_refspecs - fully qualified' '
 test_expect_success '__git_complete_fetch_refspecs - fully qualified & prefix' '
 	sed -e "s/Z$//" >expected <<-EOF &&
 	+refs/heads/branch-in-other:refs/heads/branch-in-other Z
-	+refs/heads/master-in-other:refs/heads/master-in-other Z
+	+refs/heads/main-in-other:refs/heads/main-in-other Z
 	+refs/tags/tag-in-other:refs/tags/tag-in-other Z
 	EOF
 	(
@@ -1243,8 +1244,8 @@ test_expect_success '__git_complete_fetch_refspecs - fully qualified & prefix' '
 test_expect_success 'git switch - with no options, complete local branches and unique remote branch names for DWIM logic' '
 	test_completion "git switch " <<-\EOF
 	branch-in-other Z
-	master Z
-	master-in-other Z
+	main Z
+	main-in-other Z
 	matching-branch Z
 	EOF
 '
@@ -1253,25 +1254,25 @@ test_expect_success 'git checkout - completes refs and unique remote branches fo
 	test_completion "git checkout " <<-\EOF
 	HEAD Z
 	branch-in-other Z
-	master Z
-	master-in-other Z
+	main Z
+	main-in-other Z
 	matching-branch Z
 	matching-tag Z
 	other/branch-in-other Z
-	other/master-in-other Z
+	other/main-in-other Z
 	EOF
 '
 
 test_expect_success 'git switch - with --no-guess, complete only local branches' '
 	test_completion "git switch --no-guess " <<-\EOF
-	master Z
+	main Z
 	matching-branch Z
 	EOF
 '
 
 test_expect_success 'git switch - with GIT_COMPLETION_CHECKOUT_NO_GUESS=1, complete only local branches' '
 	GIT_COMPLETION_CHECKOUT_NO_GUESS=1 test_completion "git switch " <<-\EOF
-	master Z
+	main Z
 	matching-branch Z
 	EOF
 '
@@ -1279,8 +1280,8 @@ test_expect_success 'git switch - with GIT_COMPLETION_CHECKOUT_NO_GUESS=1, compl
 test_expect_success 'git switch - --guess overrides GIT_COMPLETION_CHECKOUT_NO_GUESS=1, complete local branches and unique remote names for DWIM logic' '
 	GIT_COMPLETION_CHECKOUT_NO_GUESS=1 test_completion "git switch --guess " <<-\EOF
 	branch-in-other Z
-	master Z
-	master-in-other Z
+	main Z
+	main-in-other Z
 	matching-branch Z
 	EOF
 '
@@ -1288,15 +1289,15 @@ test_expect_success 'git switch - --guess overrides GIT_COMPLETION_CHECKOUT_NO_G
 test_expect_success 'git switch - a later --guess overrides previous --no-guess, complete local and remote unique branches for DWIM' '
 	test_completion "git switch --no-guess --guess " <<-\EOF
 	branch-in-other Z
-	master Z
-	master-in-other Z
+	main Z
+	main-in-other Z
 	matching-branch Z
 	EOF
 '
 
 test_expect_success 'git switch - a later --no-guess overrides previous --guess, complete only local branches' '
 	test_completion "git switch --guess --no-guess " <<-\EOF
-	master Z
+	main Z
 	matching-branch Z
 	EOF
 '
@@ -1304,11 +1305,11 @@ test_expect_success 'git switch - a later --no-guess overrides previous --guess,
 test_expect_success 'git checkout - with GIT_COMPLETION_NO_GUESS=1 only completes refs' '
 	GIT_COMPLETION_CHECKOUT_NO_GUESS=1 test_completion "git checkout " <<-\EOF
 	HEAD Z
-	master Z
+	main Z
 	matching-branch Z
 	matching-tag Z
 	other/branch-in-other Z
-	other/master-in-other Z
+	other/main-in-other Z
 	EOF
 '
 
@@ -1316,23 +1317,23 @@ test_expect_success 'git checkout - --guess overrides GIT_COMPLETION_NO_GUESS=1,
 	GIT_COMPLETION_CHECKOUT_NO_GUESS=1 test_completion "git checkout --guess " <<-\EOF
 	HEAD Z
 	branch-in-other Z
-	master Z
-	master-in-other Z
+	main Z
+	main-in-other Z
 	matching-branch Z
 	matching-tag Z
 	other/branch-in-other Z
-	other/master-in-other Z
+	other/main-in-other Z
 	EOF
 '
 
 test_expect_success 'git checkout - with --no-guess, only completes refs' '
 	test_completion "git checkout --no-guess " <<-\EOF
 	HEAD Z
-	master Z
+	main Z
 	matching-branch Z
 	matching-tag Z
 	other/branch-in-other Z
-	other/master-in-other Z
+	other/main-in-other Z
 	EOF
 '
 
@@ -1340,23 +1341,23 @@ test_expect_success 'git checkout - a later --guess overrides previous --no-gues
 	test_completion "git checkout --no-guess --guess " <<-\EOF
 	HEAD Z
 	branch-in-other Z
-	master Z
-	master-in-other Z
+	main Z
+	main-in-other Z
 	matching-branch Z
 	matching-tag Z
 	other/branch-in-other Z
-	other/master-in-other Z
+	other/main-in-other Z
 	EOF
 '
 
 test_expect_success 'git checkout - a later --no-guess overrides previous --guess, complete only refs' '
 	test_completion "git checkout --guess --no-guess " <<-\EOF
 	HEAD Z
-	master Z
+	main Z
 	matching-branch Z
 	matching-tag Z
 	other/branch-in-other Z
-	other/master-in-other Z
+	other/main-in-other Z
 	EOF
 '
 
@@ -1364,11 +1365,11 @@ test_expect_success 'git checkout - with checkout.guess = false, only completes 
 	test_config checkout.guess false &&
 	test_completion "git checkout " <<-\EOF
 	HEAD Z
-	master Z
+	main Z
 	matching-branch Z
 	matching-tag Z
 	other/branch-in-other Z
-	other/master-in-other Z
+	other/main-in-other Z
 	EOF
 '
 
@@ -1377,12 +1378,12 @@ test_expect_success 'git checkout - with checkout.guess = true, completes refs a
 	test_completion "git checkout " <<-\EOF
 	HEAD Z
 	branch-in-other Z
-	master Z
-	master-in-other Z
+	main Z
+	main-in-other Z
 	matching-branch Z
 	matching-tag Z
 	other/branch-in-other Z
-	other/master-in-other Z
+	other/main-in-other Z
 	EOF
 '
 
@@ -1391,12 +1392,12 @@ test_expect_success 'git checkout - a later --guess overrides previous checkout.
 	test_completion "git checkout --guess " <<-\EOF
 	HEAD Z
 	branch-in-other Z
-	master Z
-	master-in-other Z
+	main Z
+	main-in-other Z
 	matching-branch Z
 	matching-tag Z
 	other/branch-in-other Z
-	other/master-in-other Z
+	other/main-in-other Z
 	EOF
 '
 
@@ -1404,75 +1405,75 @@ test_expect_success 'git checkout - a later --no-guess overrides previous checko
 	test_config checkout.guess true &&
 	test_completion "git checkout --no-guess " <<-\EOF
 	HEAD Z
-	master Z
+	main Z
 	matching-branch Z
 	matching-tag Z
 	other/branch-in-other Z
-	other/master-in-other Z
+	other/main-in-other Z
 	EOF
 '
 
 test_expect_success 'git switch - with --detach, complete all references' '
 	test_completion "git switch --detach " <<-\EOF
 	HEAD Z
-	master Z
+	main Z
 	matching-branch Z
 	matching-tag Z
 	other/branch-in-other Z
-	other/master-in-other Z
+	other/main-in-other Z
 	EOF
 '
 
 test_expect_success 'git checkout - with --detach, complete only references' '
 	test_completion "git checkout --detach " <<-\EOF
 	HEAD Z
-	master Z
+	main Z
 	matching-branch Z
 	matching-tag Z
 	other/branch-in-other Z
-	other/master-in-other Z
+	other/main-in-other Z
 	EOF
 '
 
 test_expect_success 'git switch - with -d, complete all references' '
 	test_completion "git switch -d " <<-\EOF
 	HEAD Z
-	master Z
+	main Z
 	matching-branch Z
 	matching-tag Z
 	other/branch-in-other Z
-	other/master-in-other Z
+	other/main-in-other Z
 	EOF
 '
 
 test_expect_success 'git checkout - with -d, complete only references' '
 	test_completion "git checkout -d " <<-\EOF
 	HEAD Z
-	master Z
+	main Z
 	matching-branch Z
 	matching-tag Z
 	other/branch-in-other Z
-	other/master-in-other Z
+	other/main-in-other Z
 	EOF
 '
 
 test_expect_success 'git switch - with --track, complete only remote branches' '
 	test_completion "git switch --track " <<-\EOF
 	other/branch-in-other Z
-	other/master-in-other Z
+	other/main-in-other Z
 	EOF
 '
 
 test_expect_success 'git checkout - with --track, complete only remote branches' '
 	test_completion "git checkout --track " <<-\EOF
 	other/branch-in-other Z
-	other/master-in-other Z
+	other/main-in-other Z
 	EOF
 '
 
 test_expect_success 'git switch - with --no-track, complete only local branch names' '
 	test_completion "git switch --no-track " <<-\EOF
-	master Z
+	main Z
 	matching-branch Z
 	EOF
 '
@@ -1480,151 +1481,151 @@ test_expect_success 'git switch - with --no-track, complete only local branch na
 test_expect_success 'git checkout - with --no-track, complete only local references' '
 	test_completion "git checkout --no-track " <<-\EOF
 	HEAD Z
-	master Z
+	main Z
 	matching-branch Z
 	matching-tag Z
 	other/branch-in-other Z
-	other/master-in-other Z
+	other/main-in-other Z
 	EOF
 '
 
 test_expect_success 'git switch - with -c, complete all references' '
 	test_completion "git switch -c new-branch " <<-\EOF
 	HEAD Z
-	master Z
+	main Z
 	matching-branch Z
 	matching-tag Z
 	other/branch-in-other Z
-	other/master-in-other Z
+	other/main-in-other Z
 	EOF
 '
 
 test_expect_success 'git switch - with -C, complete all references' '
 	test_completion "git switch -C new-branch " <<-\EOF
 	HEAD Z
-	master Z
+	main Z
 	matching-branch Z
 	matching-tag Z
 	other/branch-in-other Z
-	other/master-in-other Z
+	other/main-in-other Z
 	EOF
 '
 
 test_expect_success 'git switch - with -c and --track, complete all references' '
 	test_completion "git switch -c new-branch --track " <<-EOF
 	HEAD Z
-	master Z
+	main Z
 	matching-branch Z
 	matching-tag Z
 	other/branch-in-other Z
-	other/master-in-other Z
+	other/main-in-other Z
 	EOF
 '
 
 test_expect_success 'git switch - with -C and --track, complete all references' '
 	test_completion "git switch -C new-branch --track " <<-EOF
 	HEAD Z
-	master Z
+	main Z
 	matching-branch Z
 	matching-tag Z
 	other/branch-in-other Z
-	other/master-in-other Z
+	other/main-in-other Z
 	EOF
 '
 
 test_expect_success 'git switch - with -c and --no-track, complete all references' '
 	test_completion "git switch -c new-branch --no-track " <<-\EOF
 	HEAD Z
-	master Z
+	main Z
 	matching-branch Z
 	matching-tag Z
 	other/branch-in-other Z
-	other/master-in-other Z
+	other/main-in-other Z
 	EOF
 '
 
 test_expect_success 'git switch - with -C and --no-track, complete all references' '
 	test_completion "git switch -C new-branch --no-track " <<-\EOF
 	HEAD Z
-	master Z
+	main Z
 	matching-branch Z
 	matching-tag Z
 	other/branch-in-other Z
-	other/master-in-other Z
+	other/main-in-other Z
 	EOF
 '
 
 test_expect_success 'git checkout - with -b, complete all references' '
 	test_completion "git checkout -b new-branch " <<-\EOF
 	HEAD Z
-	master Z
+	main Z
 	matching-branch Z
 	matching-tag Z
 	other/branch-in-other Z
-	other/master-in-other Z
+	other/main-in-other Z
 	EOF
 '
 
 test_expect_success 'git checkout - with -B, complete all references' '
 	test_completion "git checkout -B new-branch " <<-\EOF
 	HEAD Z
-	master Z
+	main Z
 	matching-branch Z
 	matching-tag Z
 	other/branch-in-other Z
-	other/master-in-other Z
+	other/main-in-other Z
 	EOF
 '
 
 test_expect_success 'git checkout - with -b and --track, complete all references' '
 	test_completion "git checkout -b new-branch --track " <<-EOF
 	HEAD Z
-	master Z
+	main Z
 	matching-branch Z
 	matching-tag Z
 	other/branch-in-other Z
-	other/master-in-other Z
+	other/main-in-other Z
 	EOF
 '
 
 test_expect_success 'git checkout - with -B and --track, complete all references' '
 	test_completion "git checkout -B new-branch --track " <<-EOF
 	HEAD Z
-	master Z
+	main Z
 	matching-branch Z
 	matching-tag Z
 	other/branch-in-other Z
-	other/master-in-other Z
+	other/main-in-other Z
 	EOF
 '
 
 test_expect_success 'git checkout - with -b and --no-track, complete all references' '
 	test_completion "git checkout -b new-branch --no-track " <<-\EOF
 	HEAD Z
-	master Z
+	main Z
 	matching-branch Z
 	matching-tag Z
 	other/branch-in-other Z
-	other/master-in-other Z
+	other/main-in-other Z
 	EOF
 '
 
 test_expect_success 'git checkout - with -B and --no-track, complete all references' '
 	test_completion "git checkout -B new-branch --no-track " <<-\EOF
 	HEAD Z
-	master Z
+	main Z
 	matching-branch Z
 	matching-tag Z
 	other/branch-in-other Z
-	other/master-in-other Z
+	other/main-in-other Z
 	EOF
 '
 
 test_expect_success 'git switch - for -c, complete local branches and unique remote branches' '
 	test_completion "git switch -c " <<-\EOF
 	branch-in-other Z
-	master Z
-	master-in-other Z
+	main Z
+	main-in-other Z
 	matching-branch Z
 	EOF
 '
@@ -1632,36 +1633,36 @@ test_expect_success 'git switch - for -c, complete local branches and unique rem
 test_expect_success 'git switch - for -C, complete local branches and unique remote branches' '
 	test_completion "git switch -C " <<-\EOF
 	branch-in-other Z
-	master Z
-	master-in-other Z
+	main Z
+	main-in-other Z
 	matching-branch Z
 	EOF
 '
 
 test_expect_success 'git switch - for -c with --no-guess, complete local branches only' '
 	test_completion "git switch --no-guess -c " <<-\EOF
-	master Z
+	main Z
 	matching-branch Z
 	EOF
 '
 
 test_expect_success 'git switch - for -C with --no-guess, complete local branches only' '
 	test_completion "git switch --no-guess -C " <<-\EOF
-	master Z
+	main Z
 	matching-branch Z
 	EOF
 '
 
 test_expect_success 'git switch - for -c with --no-track, complete local branches only' '
 	test_completion "git switch --no-track -c " <<-\EOF
-	master Z
+	main Z
 	matching-branch Z
 	EOF
 '
 
 test_expect_success 'git switch - for -C with --no-track, complete local branches only' '
 	test_completion "git switch --no-track -C " <<-\EOF
-	master Z
+	main Z
 	matching-branch Z
 	EOF
 '
@@ -1669,8 +1670,8 @@ test_expect_success 'git switch - for -C with --no-track, complete local branche
 test_expect_success 'git checkout - for -b, complete local branches and unique remote branches' '
 	test_completion "git checkout -b " <<-\EOF
 	branch-in-other Z
-	master Z
-	master-in-other Z
+	main Z
+	main-in-other Z
 	matching-branch Z
 	EOF
 '
@@ -1678,36 +1679,36 @@ test_expect_success 'git checkout - for -b, complete local branches and unique r
 test_expect_success 'git checkout - for -B, complete local branches and unique remote branches' '
 	test_completion "git checkout -B " <<-\EOF
 	branch-in-other Z
-	master Z
-	master-in-other Z
+	main Z
+	main-in-other Z
 	matching-branch Z
 	EOF
 '
 
 test_expect_success 'git checkout - for -b with --no-guess, complete local branches only' '
 	test_completion "git checkout --no-guess -b " <<-\EOF
-	master Z
+	main Z
 	matching-branch Z
 	EOF
 '
 
 test_expect_success 'git checkout - for -B with --no-guess, complete local branches only' '
 	test_completion "git checkout --no-guess -B " <<-\EOF
-	master Z
+	main Z
 	matching-branch Z
 	EOF
 '
 
 test_expect_success 'git checkout - for -b with --no-track, complete local branches only' '
 	test_completion "git checkout --no-track -b " <<-\EOF
-	master Z
+	main Z
 	matching-branch Z
 	EOF
 '
 
 test_expect_success 'git checkout - for -B with --no-track, complete local branches only' '
 	test_completion "git checkout --no-track -B " <<-\EOF
-	master Z
+	main Z
 	matching-branch Z
 	EOF
 '
@@ -1715,14 +1716,14 @@ test_expect_success 'git checkout - for -B with --no-track, complete local branc
 test_expect_success 'git switch - with --orphan completes local branch names and unique remote branch names' '
 	test_completion "git switch --orphan " <<-\EOF
 	branch-in-other Z
-	master Z
-	master-in-other Z
+	main Z
+	main-in-other Z
 	matching-branch Z
 	EOF
 '
 
 test_expect_success 'git switch - --orphan with branch already provided completes nothing else' '
-	test_completion "git switch --orphan master " <<-\EOF
+	test_completion "git switch --orphan main " <<-\EOF
 
 	EOF
 '
@@ -1730,20 +1731,20 @@ test_expect_success 'git switch - --orphan with branch already provided complete
 test_expect_success 'git checkout - with --orphan completes local branch names and unique remote branch names' '
 	test_completion "git checkout --orphan " <<-\EOF
 	branch-in-other Z
-	master Z
-	master-in-other Z
+	main Z
+	main-in-other Z
 	matching-branch Z
 	EOF
 '
 
 test_expect_success 'git checkout - --orphan with branch already provided completes local refs for a start-point' '
-	test_completion "git checkout --orphan master " <<-\EOF
+	test_completion "git checkout --orphan main " <<-\EOF
 	HEAD Z
-	master Z
+	main Z
 	matching-branch Z
 	matching-tag Z
 	other/branch-in-other Z
-	other/master-in-other Z
+	other/main-in-other Z
 	EOF
 '
 
@@ -2067,7 +2068,7 @@ test_expect_success 'setup for integration tests' '
 
 test_expect_success 'checkout completes ref names' '
 	test_completion "git checkout m" <<-\EOF
-	master Z
+	main Z
 	mybranch Z
 	mytag Z
 	EOF
@@ -2081,7 +2082,7 @@ test_expect_success 'git -C <path> checkout uses the right repo' '
 
 test_expect_success 'show completes all refs' '
 	test_completion "git show m" <<-\EOF
-	master Z
+	main Z
 	mybranch Z
 	mytag Z
 	EOF
@@ -2118,7 +2119,7 @@ test_expect_success PERL 'send-email' '
 	--cover-from-description=Z
 	--cover-letter Z
 	EOF
-	test_completion "git send-email ma" "master "
+	test_completion "git send-email ma" "main "
 '
 
 test_expect_success 'complete files' '
@@ -2198,7 +2199,7 @@ test_expect_success 'complete files' '
 test_expect_success "simple alias" '
 	test_config alias.co checkout &&
 	test_completion "git co m" <<-\EOF
-	master Z
+	main Z
 	mybranch Z
 	mytag Z
 	EOF
@@ -2208,7 +2209,7 @@ test_expect_success "recursive alias" '
 	test_config alias.co checkout &&
 	test_config alias.cod "co --detached" &&
 	test_completion "git cod m" <<-\EOF
-	master Z
+	main Z
 	mybranch Z
 	mytag Z
 	EOF
@@ -2217,7 +2218,7 @@ test_expect_success "recursive alias" '
 test_expect_success "completion uses <cmd> completion for alias: !sh -c 'git <cmd> ...'" '
 	test_config alias.co "!sh -c '"'"'git checkout ...'"'"'" &&
 	test_completion "git co m" <<-\EOF
-	master Z
+	main Z
 	mybranch Z
 	mytag Z
 	EOF
@@ -2226,7 +2227,7 @@ test_expect_success "completion uses <cmd> completion for alias: !sh -c 'git <cm
 test_expect_success 'completion uses <cmd> completion for alias: !f () { VAR=val git <cmd> ... }' '
 	test_config alias.co "!f () { VAR=val git checkout ... ; } f" &&
 	test_completion "git co m" <<-\EOF
-	master Z
+	main Z
 	mybranch Z
 	mytag Z
 	EOF
@@ -2235,7 +2236,7 @@ test_expect_success 'completion uses <cmd> completion for alias: !f () { VAR=val
 test_expect_success 'completion used <cmd> completion for alias: !f() { : git <cmd> ; ... }' '
 	test_config alias.co "!f() { : git checkout ; if ... } f" &&
 	test_completion "git co m" <<-\EOF
-	master Z
+	main Z
 	mybranch Z
 	mytag Z
 	EOF
@@ -2266,7 +2267,7 @@ for flag in -d --delete
 do
 	test_expect_success "__git_complete_remote_or_refspec - push $flag other" '
 		sed -e "s/Z$//" >expected <<-EOF &&
-		master-in-other Z
+		main-in-other Z
 		EOF
 		(
 			words=(git push '$flag' other ma) &&
@@ -2279,7 +2280,7 @@ do
 
 	test_expect_failure "__git_complete_remote_or_refspec - push other $flag" '
 		sed -e "s/Z$//" >expected <<-EOF &&
-		master-in-other Z
+		main-in-other Z
 		EOF
 		(
 			words=(git push other '$flag' ma) &&

--- a/t/test-lib.sh
+++ b/t/test-lib.sh
@@ -1712,14 +1712,6 @@ test_lazy_prereq REBASE_P '
 	test -z "$GIT_TEST_SKIP_REBASE_P"
 '
 
-# Special-purpose prereq for transitioning to a new default branch name:
-# Some tests need more than just a mindless (case-preserving) s/master/main/g
-# replacement. The non-trivial adjustments are guarded behind this
-# prerequisite, acting kind of as a feature flag
-test_lazy_prereq PREPARE_FOR_MAIN_BRANCH '
-	test "$GIT_TEST_DEFAULT_INITIAL_BRANCH_NAME" = main
-'
-
 # Ensure that no test accidentally triggers a Git command
 # that runs 'crontab', affecting a user's cron schedule.
 # Tests that verify the cron integration must set this locally


### PR DESCRIPTION
When I started contributing all those patch series to start preparing for the default branch name `main`, I had the idea that we could change the default branch name in time for v2.30.0, and therefore felt free to introduce the PREPARE_FOR_MAIN_BRANCH prereq whose sole purpose was to adjust a few tests preemptively that would then have to be skipped until the test suite was converted to using `main` as default branch name.

However, this was too ambitious a plan.

The current state is therefore an undesirable one: we skip a few test cases, in preparation for a time when `git init` will default to using a different name than `master` for the initial branch name, and nobody realistically knows when this will happen.

To address that, I spent some time to convert _just_ the affected scripts to using `main`, adjusting them in a way where they do _not_ depend on the name `git init` gave the initial branch at all, which allowed me to drop that prereq altogether.

None of these changes should be controversial, intentionally so, to allow this patch series to go in before v2.30.0 is tagged, so that we can enjoy the full coverage of the test suite again.