### PR TITLE
checkout -p: handle tree arguments correctly again

### DIFF
--- a/builtin/checkout.c
+++ b/builtin/checkout.c
@@ -482,7 +482,7 @@ static int checkout_paths(const struct checkout_opts *opts,
 		 * properly. However, there is special logic for the HEAD case
 		 * so we mustn't replace that.
 		 */
-		if (rev && strcmp(rev, "HEAD"))
+		if (rev && new_branch_info->commit && strcmp(rev, "HEAD"))
 			rev = oid_to_hex_r(rev_oid, &new_branch_info->commit->object.oid);
 
 		if (opts->checkout_index && opts->checkout_worktree)

--- a/t/t2016-checkout-patch.sh
+++ b/t/t2016-checkout-patch.sh
@@ -123,4 +123,9 @@ test_expect_success PERL 'none of this moved HEAD' '
 	verify_saved_head
 '
 
+test_expect_success PERL 'empty tree can be handled' '
+	test_when_finished "git reset --hard" &&
+	git checkout -p $(test_oid empty_tree) --
+'
+
 test_done


### PR DESCRIPTION
I literally _just_ ran into this segmentation fault after rebasing Git for Windows onto -rc1, and did not really think that the regression was introduced in the v2.30.0 cycle, but was proven wrong by my investigation: it was introduced by v2.30.0-rc0~151^2~3.

Cc: Denton Liu <liu.denton@gmail.com>