### PR TITLE
negative-refspec: fix segfault on : refspec

### DIFF
--- a/remote.c
+++ b/remote.c
@@ -751,9 +751,13 @@ static int query_matches_negative_refspec(struct refspec *rs, struct refspec_ite
 
 			if (match_name_with_pattern(key, needle, value, &expn_name))
 				string_list_append_nodup(&reversed, expn_name);
-		} else {
-			if (!strcmp(needle, refspec->src))
-				string_list_append(&reversed, refspec->src);
+		} else if (refspec->matching) {
+			/* For the special matching refspec, any query should match */
+			string_list_append(&reversed, needle);
+		} else if (!refspec->src) {
+			BUG("refspec->src should not be null here");
+		} else if (!strcmp(needle, refspec->src)) {
+			string_list_append(&reversed, refspec->src);
 		}
 	}
 

--- a/remote.c
+++ b/remote.c
@@ -736,6 +736,12 @@ static int query_matches_negative_refspec(struct refspec *rs, struct refspec_ite
 	 * item uses the destination. To handle this, we apply pattern
 	 * refspecs in reverse to figure out if the query source matches any
 	 * of the negative refspecs.
+	 *
+	 * The first loop finds and expands all positive refspecs
+	 * matched by the queried ref.
+	 *
+	 * The second loop checks if any of the results of the first loop
+	 * match any negative refspec.
 	 */
 	for (i = 0; i < rs->nr; i++) {
 		struct refspec_item *refspec = &rs->items[i];


### PR DESCRIPTION
If remote.origin.push was set to ":",
git segfaults during a push operation, due to bad
parsing logic in query_matches_negative_refspec. Per
bisect, the bug was introduced in:
c0192df630 (refspec: add support for negative refspecs, 2020-09-30)

We found this issue when rolling out git 2.29 at Dropbox - as several folks had "push = :" in their configuration.
I based my diff off the master branch, but also confirmed that it patches cleanly onto maint - if the maintainers
would like to also fix the segfault on 2.29

Update since Patch series V1:
- Handled matching refspec explicitly
- Added testing for "+:" case
- Added comment explaining how the two loops work together

Update since Patch series V2
- style suggestion in remote.c
- Use test_config
- Add test for a case with a matching refspec + negative refspec
- Fix test_config to work with --add
- Updated commit message to describe what git is told to do instead of segfaulting

Update since Patch series V3
- Removed commit modifying test_config
- Remove segfault-related comments in test
- Consolidate the three tests to two tests (1st and 3rd test overlapped in functionality)
- Base the patch series on the maint branch - since the bug affects 2.29.2

Update since Patch series V4
- Squashed in Junio's patch to handle non-master named branches
- Explicitly use test_unconfig

Appreciate the reviews from Junio and Eric! Happy Holidays!

cc: Eric Sunshine <sunshine@sunshineco.com>