### PR TITLE
strbuf.c|h: Add the constant version initialization method of strbuf

### DIFF
--- a/strbuf.h
+++ b/strbuf.h
@@ -72,6 +72,13 @@ struct strbuf {
 extern char strbuf_slopbuf[];
 #define STRBUF_INIT  { .alloc = 0, .len = 0, .buf = strbuf_slopbuf }
 
+#define STRBUF_INIT_CONST(str)  { .alloc = 0, .len = strlen(str), .buf = str }
+
+/*
+ *  Through this function, we can turn a constant buffer into a non-constant buffer
+ */
+void strbuf_const_to_no_const(struct strbuf *sb);
+
 /*
  * Predeclare this here, since cache.h includes this file before it defines the
  * struct.
@@ -159,6 +166,7 @@ void strbuf_grow(struct strbuf *sb, size_t amount);
  */
 static inline void strbuf_setlen(struct strbuf *sb, size_t len)
 {
+	strbuf_const_to_no_const(sb);
 	if (len > (sb->alloc ? sb->alloc - 1 : 0))
 		die("BUG: strbuf_setlen() beyond buffer");
 	sb->len = len;


### PR DESCRIPTION
According to
https://public-inbox.org/git/nycvar.QRO.7.76.6.1806210857520.11870@tvgsbejvaqbjf.bet/,
we can create a new way to initialize strbuf with string constant
to save the overhead of dynamically allocated memory.
the marco function STRBUF_INIT_CONST(str).For Example,STRBUF_ININ_DEFAULT("default")
will create a strbuf which buf eqoal to "default",len eqoal to 7 and alloc eqoal to 0.
this constant strbuf will be changed to dynamic allocation when we want to modify the contents of the constant buffer,
the function strbuf_const_to_no_const do this by change buf with xstrdup,
some function like strbuf_grow and strbuf_setlen will use it,
to change the strbuf to a dynamically expand buffer.

Signed-off-by: ZheNing Hu <adlternative@gmail.com>