### PR TITLE
Fix regression in 'git {diff,merge}tool --tool-help'

### DIFF
--- a/git-mergetool--lib.sh
+++ b/git-mergetool--lib.sh
@@ -46,9 +46,11 @@ show_tool_names () {
 		while read scriptname
 		do
 			setup_tool "$scriptname" 2>/dev/null
-			variants="$variants$(list_tool_variants)\n"
+			# We need an actual line feed here
+			variants="$variants
+$(list_tool_variants)"
 		done
-		variants="$(echo "$variants" | sort | uniq)"
+		variants="$(echo "$variants" | sort -u)"
 
 		for toolname in $variants
 		do

--- a/t/t7610-mergetool.sh
+++ b/t/t7610-mergetool.sh
@@ -828,4 +828,15 @@ test_expect_success 'mergetool -Oorder-file is honored' '
 	test_cmp expect actual
 '
 
+test_expect_success 'mergetool --tool-help shows recognized tools' '
+	# Check a few known tools are correctly shown
+	git mergetool --tool-help >mergetools &&
+	grep vimdiff mergetools &&
+	grep vimdiff3 mergetools &&
+	grep gvimdiff2 mergetools &&
+	grep araxis mergetools &&
+	grep xxdiff mergetools &&
+	grep meld mergetools
+'
+
 test_done


### PR DESCRIPTION
Changes since v1:
- Changed commit authorship (v1 sent with wrong identity).

v1:
I went with Johannes' suggestion finally because upon further inspection,
René's patch for some reason (I did not debug further) caused to code to never
reach 'any_shown=yes' in show_tool_help, therefore changing the output of the
command.

I guess it's too late for inclusion in 2.30...

CC: Johannes Sixt <j6t@kdbg.org>, Felipe Contreras <felipe.contreras@gmail.com>,  pudinha <rogi@skylittlesystem.org>, René Scharfe <l.s.r@web.de>
cc: SZEDER Gábor <szeder.dev@gmail.com>
cc: Philippe Blain <levraiphilippeblain@gmail.com>