### PR TITLE
git-mv: fix git mv bug with case insensitive fs

### DIFF
--- a/builtin/mv.c
+++ b/builtin/mv.c
@@ -292,8 +292,10 @@ int cmd_mv(int argc, const char **argv, const char *prefix)
 			continue;
 
 		pos = cache_name_pos(src, strlen(src));
-		assert(pos >= 0);
-		rename_cache_entry_at(pos, dst);
+		if (pos >= 0)
+			rename_cache_entry_at(pos, dst);
+		else if (!ignore_errors)
+			die(_("bad source: source=%s, destination=%s"), src, dst);
 	}
 
 	if (gitmodules_modified)

--- a/t/t7001-mv.sh
+++ b/t/t7001-mv.sh
@@ -152,6 +152,14 @@ test_expect_success \
     'move into "."' \
     'git mv path1/path2/ .'
 
+test_expect_success \
+    'fail to move file already in index under different cased name' \
+    'echo 1 > foo &&
+     git add foo &&
+     git commit -m add_file -- foo &&
+     git mv foo FOO &&
+     test_expect_code 128 git mv foo BAR'
+
 test_expect_success "Michael Cassar's test case" '
 	rm -fr .git papers partA &&
 	git init &&


### PR DESCRIPTION
On a case-insensitive fs, where core.caseInsensitive=true, attempting
to git mv a file already in the index under a new casing will assert.

Since 9b906af657 the check that git mv does to ensure
the src is in the cache respects caseInsensitive. As a result git mv
allows a move from a file that has a different case in the index than
it does on disk. After the rename on disk, git mv fails to find the
file in the cache in order to rename it in the index, and asserts.

This is the simplest possible fix, suggested by @tboegi. It does
leave the file renamed on disk, but that is easy to reverse after
the error.

Another option would be to change the aforementioned check
to be case sensitive, but I am not sure why it is case insensitive
currently.

Signed-off-by: Dan Moseley <danmose@microsoft.com>

Thanks for taking the time to contribute to Git! Please be advised that the
Git community does not use github.com for their contributions. Instead, we use
a mailing list (git@vger.kernel.org) for code submissions, code reviews, and
bug reports. Nevertheless, you can use GitGitGadget (https://gitgitgadget.github.io/)
to conveniently send your Pull Requests commits to our mailing list.

Please read the "guidelines for contributing" linked above!
