### PR TITLE
doc: fix some typos

### DIFF
--- a/Documentation/config/http.txt
+++ b/Documentation/config/http.txt
@@ -42,12 +42,12 @@ http.proxySSLKey::
 http.proxySSLCertPasswordProtected::
 	Enable Git's password prompt for the proxy SSL certificate.  Otherwise OpenSSL
 	will prompt the user, possibly many times, if the certificate or private key
-	is encrypted. Can be overriden by the `GIT_PROXY_SSL_CERT_PASSWORD_PROTECTED`
+	is encrypted. Can be overridden by the `GIT_PROXY_SSL_CERT_PASSWORD_PROTECTED`
 	environment variable.
 
 http.proxySSLCAInfo::
 	Pathname to the file containing the certificate bundle that should be used to
-	verify the proxy with when using an HTTPS proxy. Can be overriden by the
+	verify the proxy with when using an HTTPS proxy. Can be overridden by the
 	`GIT_PROXY_SSL_CAINFO` environment variable.
 
 http.emptyAuth::

--- a/Documentation/config/trace2.txt
+++ b/Documentation/config/trace2.txt
@@ -54,7 +54,7 @@ trace2.envVars::
 	`GIT_HTTP_USER_AGENT,GIT_CONFIG` would cause the trace2 output to
 	contain events listing the overrides for HTTP user agent and the
 	location of the Git configuration file (assuming any are set).  May be
-	overriden by the `GIT_TRACE2_ENV_VARS` environment variable.  Unset by
+	overridden by the `GIT_TRACE2_ENV_VARS` environment variable.  Unset by
 	default.
 
 trace2.destinationDebug::

--- a/Documentation/git-maintenance.txt
+++ b/Documentation/git-maintenance.txt
@@ -38,7 +38,7 @@ register::
 	for running in the background without disrupting foreground
 	processes.
 +
-The `register` subcomand will also set the `maintenance.strategy` config
+The `register` subcommand will also set the `maintenance.strategy` config
 value to `incremental`, if this value is not previously set. The
 `incremental` strategy uses the following schedule for each maintenance
 task:

--- a/Documentation/git-p4.txt
+++ b/Documentation/git-p4.txt
@@ -397,7 +397,7 @@ changelist text. Exiting with a non-zero status from the script
 will abort the process.
 
 The purpose of the hook is to edit the message file in place,
-and it is not supressed by the `--no-verify` option. This hook
+and it is not suppressed by the `--no-verify` option. This hook
 is called even if `--prepare-p4-only` is set.
 
 p4-changelist

--- a/Documentation/githooks.txt
+++ b/Documentation/githooks.txt
@@ -644,7 +644,7 @@ changelist text. Exiting with a non-zero status from the script
 will abort the process.
 
 The purpose of the hook is to edit the message file in place,
-and it is not supressed by the `--no-verify` option. This hook
+and it is not suppressed by the `--no-verify` option. This hook
 is called even if `--prepare-p4-only` is set.
 
 Run `git-p4 submit --help` for details.

--- a/Documentation/technical/reftable.txt
+++ b/Documentation/technical/reftable.txt
@@ -446,7 +446,7 @@ especially if readers will not use the object name to ref mapping.
 Object blocks use unique, abbreviated 2-32 object name keys, mapping to
 ref blocks containing references pointing to that object directly, or as
 the peeled value of an annotated tag. Like ref blocks, object blocks use
-the file's standard block size. The abbrevation length is available in
+the file's standard block size. The abbreviation length is available in
 the footer as `obj_id_len`.
 
 To save space in small files, object blocks may be omitted if the ref


### PR DESCRIPTION
Changed since v1:
- Removed changes in non-doc file contrib/buildsystems/CMakeLists.txt from the patch. Thanks to Martin and Felipe for pointing this out.

Signed-off-by: Thomas Ackermann <th.acker@arcor.de>

cc: Junio C Hamano <gitster@pobox.com>
cc: Martin Ågren <martin.agren@gmail.com>
cc: Felipe Contreras <felipe.contreras@gmail.com>

cc: Chris Torek <chris.torek@gmail.com>
cc: Martin Ågren <martin.agren@gmail.com>