### PR TITLE
for-each-repo: do nothing on empty config

### DIFF
--- a/builtin/for-each-repo.c
+++ b/builtin/for-each-repo.c
@@ -51,6 +51,13 @@ int cmd_for_each_repo(int argc, const char **argv, const char *prefix)
 	values = repo_config_get_value_multi(the_repository,
 					     config_key);
 
+	/*
+	 * Do nothing on an empty list, which is equivalent to the case
+	 * where the config variable does not exist at all.
+	 */
+	if (!values)
+		return 0;
+
 	for (i = 0; !result && i < values->nr; i++)
 		result = run_command_on_repo(values->items[i].string, &args);
 

--- a/t/t0068-for-each-repo.sh
+++ b/t/t0068-for-each-repo.sh
@@ -27,4 +27,10 @@ test_expect_success 'run based on configured value' '
 	grep again message
 '
 
+test_expect_success 'do nothing on empty config' '
+	# the whole thing would fail if for-each-ref iterated even
+	# once, because "git help --no-such-option" would fail
+	git for-each-repo --config=bogus.config -- help --no-such-option
+'
+
 test_done


### PR DESCRIPTION
Thanks, Andreas, for drawing my attention to this bug.

V3: update comment in test and use `git help --no-such-option` as the subcommand to fail.

[1] https://github.com/gitgitgadget/git/issues/833

cc: gitster@pobox.com
cc: Eric Sunshine <sunshine@sunshineco.com>
cc: Derrick Stolee <stolee@gmail.com>