### PR TITLE
Two cleanups around 'prefetch' refs

### DIFF
--- a/builtin/gc.c
+++ b/builtin/gc.c
@@ -897,6 +897,12 @@ static int maintenance_task_prefetch(struct maintenance_run_opts *opts)
 	struct string_list_item *item;
 	struct string_list remotes = STRING_LIST_INIT_DUP;
 
+	git_config_set_multivar_gently("log.excludedecoration",
+					"refs/prefetch/",
+					"refs/prefetch/",
+					CONFIG_FLAGS_FIXED_VALUE |
+					CONFIG_FLAGS_MULTI_REPLACE);
+
 	if (for_each_remote(append_remote, &remotes)) {
 		error(_("failed to fill remotes"));
 		result = 1;

--- a/t/t7900-maintenance.sh
+++ b/t/t7900-maintenance.sh
@@ -256,6 +256,13 @@ test_expect_success 'incremental-repack task' '
 	HEAD
 	^HEAD~1
 	EOF
+
+	# Delete refs that have not been repacked in these packs.
+	git for-each-ref --format="delete %(refname)" \
+		refs/prefetch refs/tags >refs &&
+	git update-ref --stdin <refs &&
+
+	# Replace the object directory with this pack layout.
 	rm -f $packDir/pack-* &&
 	rm -f $packDir/loose-* &&
 	ls $packDir/*.pack >packs-before &&


### PR DESCRIPTION
Here are a couple things that caught my eye during a recent evaluation of the maintenance feature:

1. 'refs/prefetch/' refs show up in 'git log' decorations. Auto-hide these.
2. t7900-maintenance.sh had some scary warnings that end up being unimportant.

This is based on 'master' at 66e871b (The third batch, 2021-01-15).

Update in v2: deleting refs more safely for alternate ref backends. (Thanks, Taylor!)

Thanks,
-Stolee

Cc: gitster@pobox.com
Cc: Eric Sunshine <sunshine@sunshineco.com>
Cc: Emily Shaffer <emilyshaffer@google.com>
cc: Taylor Blau <me@ttaylorr.com>
cc: Derrick Stolee <stolee@gmail.com>