### PR TITLE
Speed up remove_redundant()

### DIFF
--- a/commit-reach.c
+++ b/commit-reach.c
@@ -160,9 +160,10 @@ static int remove_redundant(struct repository *r, struct commit **array, int cnt
 {
 	/*
 	 * Some commit in the array may be an ancestor of
-	 * another commit.  Move such commit to the end of
-	 * the array, and return the number of commits that
-	 * are independent from each other.
+	 * another commit.  Move the independent commits to the
+	 * beginning of 'array' and return their number. Callers
+	 * should not rely upon the contents of 'array' after
+	 * that number.
 	 */
 	struct commit **work;
 	unsigned char *redundant;
@@ -209,9 +210,6 @@ static int remove_redundant(struct repository *r, struct commit **array, int cnt
 	for (i = filled = 0; i < cnt; i++)
 		if (!redundant[i])
 			array[filled++] = work[i];
-	for (j = filled, i = 0; i < cnt; i++)
-		if (redundant[i])
-			array[j++] = work[i];
 	free(work);
 	free(redundant);
 	free(filled_index);

--- a/commit-reach.c
+++ b/commit-reach.c
@@ -17,6 +17,21 @@
 
 static const unsigned all_flags = (PARENT1 | PARENT2 | STALE | RESULT);
 
+static int compare_commits_by_gen(const void *_a, const void *_b)
+{
+	const struct commit *a = *(const struct commit * const *)_a;
+	const struct commit *b = *(const struct commit * const *)_b;
+
+	timestamp_t generation_a = commit_graph_generation(a);
+	timestamp_t generation_b = commit_graph_generation(b);
+
+	if (generation_a < generation_b)
+		return -1;
+	if (generation_a > generation_b)
+		return 1;
+	return 0;
+}
+
 static int queue_has_nonstale(struct prio_queue *queue)
 {
 	int i;
@@ -645,21 +660,6 @@ int commit_contains(struct ref_filter *filter, struct commit *commit,
 	if (filter->with_commit_tag_algo)
 		return contains_tag_algo(commit, list, cache) == CONTAINS_YES;
 	return repo_is_descendant_of(the_repository, commit, list);
-}
-
-static int compare_commits_by_gen(const void *_a, const void *_b)
-{
-	const struct commit *a = *(const struct commit * const *)_a;
-	const struct commit *b = *(const struct commit * const *)_b;
-
-	timestamp_t generation_a = commit_graph_generation(a);
-	timestamp_t generation_b = commit_graph_generation(b);
-
-	if (generation_a < generation_b)
-		return -1;
-	if (generation_a > generation_b)
-		return 1;
-	return 0;
 }
 
 int can_all_from_reach_with_flag(struct object_array *from,


### PR DESCRIPTION
Michael Haggerty pointed out that `git merge-base --independent` is quite slow when many commits are provided in the input. This boils down to some quadratic behavior in `remove_redundant()` because it calls `paint_down_to_common()` in a loop.

This series avoids that by using a single commit walk, pushing a flag that means "this commit is reachable from a parent of a commit in the list." At the end of the walk, the input commits without that flag are independent.

There is an extra performance enhancement using the first-parent history as a heuristic. This helps only when there is a single independent result, as we can short circuit the walk when all other inputs are found to be reachable from the top one. It also gets faster when we discover the commit with lowest generation and can restrict our walk further to the next-lowest generation number.

My tests were on the Linux kernel repository, testing this command:

```
  git merge-base --independent $(git for-each-ref refs/tags --format="%(refname)")

       Before: 16.4s
After Patch 1:  1.1s
After Patch 2:  0.1s
```

This does not change the correctness of the function. It is tested carefully in t6600-test-reach.c, among existing merge-base tests. There are also more tests in scripts like t6012-rev-list-simplify.sh that trigger the new logic under GIT_TEST_COMMIT_GRAPH=1.

Updates in V3
---------------

* Patch 2 is updated to René's comments. Sorry I dropped the ball on this. I had the changes locally, but never pushed them until now.

Updates in V2
----------------

* The old algorithm is not entirely removed. It is still faster than the new algorithm if all input commits are not in the commit-graph file (unless the commit-graph file is _really close_ to the input commits, but that is an unreasonable expectation). Now, the new logic only happens if there is an input commit with finite generation number.

* There was a copy of 'array' being used for the final reorder which is now removed. We still need to be careful about the RESULT bit.

* The final patch is new, adding yet another speedup in the form of increasing the min_generation cutoff when we find the input commit of smallest generation. This can reduce the time significantly when given many inputs. This does require copying the 'array' again, so we can sort by generation number while preserving the original order of 'array' which is required by some callers.

Thanks,
-Stolee

Cc: Michael Haggerty <mhagger@alum.mit.edu>
Cc: me@ttaylorr.com
Cc: peff@peff.net
Cc: gitster@pobox.com
cc: René Scharfe <l.s.r@web.de>
cc: Derrick Stolee <stolee@gmail.com>