### PR TITLE
Optimization batch 10: avoid detecting even more irrelevant renames

### DIFF
--- a/diffcore-rename.c
+++ b/diffcore-rename.c
@@ -667,7 +667,7 @@ static void cleanup_dir_rename_info(struct dir_rename_info *info,
 		const char *source_dir = entry->key;
 		struct strintmap *counts = entry->value;
 
-		if (!strintmap_contains(dirs_removed, source_dir)) {
+		if (!strintmap_get(dirs_removed, source_dir)) {
 			string_list_append(&to_remove, source_dir);
 			strintmap_clear(counts);
 			continue;

--- a/diffcore-rename.c
+++ b/diffcore-rename.c
@@ -1073,6 +1073,24 @@ static void remove_unneeded_paths_from_src(int detecting_copies,
 	rename_src_nr = new_num_src;
 }
 
+static void handle_early_known_dir_renames(struct dir_rename_info *info,
+					   struct strset *relevant_sources,
+					   struct strset *dirs_removed)
+{
+	/*
+	 * Not yet implemented; directory renames are determined via an
+	 * aggregate of all renames under them and using a "majority wins"
+	 * rule.  The fact that "majority wins", though, means we don't need
+	 * all the renames under the given directory, we only need enough to
+	 * ensure we have a majority.
+	 *
+	 * For now, we don't have enough information to know if we have a
+	 * majority after exact renames and basename-guided rename detection,
+	 * so just return early without doing any extra filtering.
+	 */
+	return;
+}
+
 void diffcore_rename_extended(struct diff_options *options,
 			      struct strset *relevant_sources,
 			      struct strset *dirs_removed,
@@ -1208,9 +1226,16 @@ void diffcore_rename_extended(struct diff_options *options,
 		 * Cull sources, again:
 		 *   - remove ones involved in renames (found via basenames)
 		 *   - remove ones not found in relevant_sources
+		 * and
+		 *   - remove ones in relevant_sources which are needed only
+		 *     for directory renames IF no ancestory directory
+		 *     actually needs to know any more individual path
+		 *     renames under them
 		 */
 		trace2_region_enter("diff", "cull basename", options->repo);
 		remove_unneeded_paths_from_src(want_copies, relevant_sources);
+		handle_early_known_dir_renames(&info, relevant_sources,
+					       dirs_removed);
 		trace2_region_leave("diff", "cull basename", options->repo);
 	}
 

--- a/diffcore.h
+++ b/diffcore.h
@@ -8,8 +8,8 @@
 
 struct diff_options;
 struct repository;
+struct strintmap;
 struct strmap;
-struct strset;
 struct userdiff_driver;
 
 /* This header file is internal between diff.c and its diff transformers
@@ -166,8 +166,8 @@ void partial_clear_dir_rename_count(struct strmap *dir_rename_count);
 void diffcore_break(struct repository *, int);
 void diffcore_rename(struct diff_options *);
 void diffcore_rename_extended(struct diff_options *options,
-			      struct strset *relevant_sources,
-			      struct strset *dirs_removed,
+			      struct strintmap *relevant_sources,
+			      struct strintmap *dirs_removed,
 			      struct strmap *dir_rename_count);
 void diffcore_merge_broken(void);
 void diffcore_pickaxe(struct diff_options *);

--- a/diffcore.h
+++ b/diffcore.h
@@ -167,6 +167,12 @@ enum dir_rename_relevance {
 	RELEVANT_FOR_ANCESTOR = 1,
 	RELEVANT_FOR_SELF = 2
 };
+/* file_rename_relevance: the reason(s) we want rename information for a file */
+enum file_rename_relevance {
+	RELEVANT_NO_MORE = 0,  /* i.e. NOT relevant */
+	RELEVANT_CONTENT = 1,
+	RELEVANT_LOCATION = 2
+};
 
 void partial_clear_dir_rename_count(struct strmap *dir_rename_count);
 

--- a/diffcore.h
+++ b/diffcore.h
@@ -161,6 +161,13 @@ struct diff_filepair *diff_queue(struct diff_queue_struct *,
 				 struct diff_filespec *);
 void diff_q(struct diff_queue_struct *, struct diff_filepair *);
 
+/* dir_rename_relevance: the reason we want rename information for a dir */
+enum dir_rename_relevance {
+	NOT_RELEVANT = 0,
+	RELEVANT_FOR_ANCESTOR = 1,
+	RELEVANT_FOR_SELF = 2
+};
+
 void partial_clear_dir_rename_count(struct strmap *dir_rename_count);
 
 void diffcore_break(struct repository *, int);

--- a/merge-ort.c
+++ b/merge-ort.c
@@ -1546,6 +1546,9 @@ static void get_provisional_directory_renames(struct merge_options *opt,
 			}
 		}
 
+		if (max == 0)
+			continue;
+
 		if (bad_max == max) {
 			path_msg(opt, source_dir, 0,
 			       _("CONFLICT (directory rename split): "


### PR DESCRIPTION
This series depends on ort-perf-batch-9.

=== Basic Optimization idea ===

This series adds additional special cases where detection of renames
is irrelevant, where the irrelevance is due to the fact that the merge
machinery will arrive at the same result regardless of whether a
rename is detected for any of those paths.  That high level wording
makes it sound the same as ort-perf-batch-9, and basically it is, it's
just trying to take the optimization a step further.

As noted in the last series, there are two reasons that the merge
machinery needs renames:

  * in order to do three-way content merging (pairing appropriate files)
  * in order to find where directories have been renamed

ort-perf-batch-9 provided a rough approximation for the second
criteria that was good enough, but which still left us detecting more
renames than necessary.  This series focuses further on that criteria
and finds ways to avoid the need to detect as many renames while still
detecting directory renames identically to before.  Thus, this series
is an improvement on "Optimization #2" from my Git Merge 2020 talk[1].

=== Results ===

For the testcases mentioned in commit 557ac03 ("merge-ort: begin
performance work; instrument with trace2_region_* calls", 2020-10-28),
the changes in just this series improves the performance as follows:

                         Before Series           After Series
    no-renames:        5.680 s ±  0.096 s     5.665 s ±  0.129 s 
    mega-renames:     13.812 s ±  0.162 s    11.435 s ±  0.158 s
    just-one-mega:   506.0  ms ±  3.9  ms   494.2  ms ±  6.1  ms

While those results may look somewhat meager, it is important to note
that the previous optimizations have already reduced rename detection
time to nearly 0 for these particular testcases so there just isn't
much left to improve.  The final patch in the series shows an
alternate testcase where the previous optimizations aren't as
effective (a simple cherry-pick of a commit that simply adds one new
empty file), where there was a speedup factor of approximately 3 due
to this series:

                         Before Series           After Series
    pick-empty:        1.936 s ±  0.024 s     688.1 ms ±  4.2 ms

There was also another testcase at $DAYJOB where I saw a factor 7
improvement from this particular optimization, so it certainly has the
potential to help when the previous optimizations are not quite
enough.

As a reminder, before any merge-ort/diffcore-rename performance work,
the performance results we started with (as noted in the same commit
message) were:

    no-renames-am:      6.940 s ±  0.485 s
    no-renames:        18.912 s ±  0.174 s
    mega-renames:    5964.031 s ± 10.459 s
    just-one-mega:    149.583 s ±  0.751 s

[1] https://github.com/newren/presentations/blob/pdfs/merge-performance/merge-performance-slides.pdf

cc: Derrick Stolee <dstolee@microsoft.com>
cc: Ævar Arnfjörð Bjarmason <avarab@gmail.com>
cc: Jonathan Tan <jonathantanmy@google.com>
cc: Taylor Blau <me@ttaylorr.com>
cc: Derrick Stolee <stolee@gmail.com>
cc: Elijah Newren <newren@gmail.com>