### PR TITLE
status: learn --color for piping colored output

### DIFF
--- a/Documentation/git-status.txt
+++ b/Documentation/git-status.txt
@@ -32,6 +32,15 @@ OPTIONS
 --branch::
 	Show the branch and tracking info even in short-format.
 
+--color[=<when>]::
+	Color status output, overriding configuration file setting.
+	The value must be always (the default), never, or auto.
+
+--no-color::
+	Turn off color ouput, even when the configuration file gives
+	the default to color output.
+	Same as `--color=never`.
+
 --show-stash::
 	Show the number of entries currently stashed away.
 

--- a/builtin/commit.c
+++ b/builtin/commit.c
@@ -1355,6 +1355,7 @@ static int git_status_config(const char *k, const char *v, void *cb)
 int cmd_status(int argc, const char **argv, const char *prefix)
 {
 	static int no_renames = -1;
+	static int use_color = GIT_COLOR_AUTO;
 	static const char *rename_score_arg = (const char *)-1;
 	static struct wt_status s;
 	unsigned int progress_flag = 0;
@@ -1378,6 +1379,7 @@ int cmd_status(int argc, const char **argv, const char *prefix)
 			    STATUS_FORMAT_LONG),
 		OPT_BOOL('z', "null", &s.null_termination,
 			 N_("terminate entries with NUL")),
+		OPT__COLOR(&use_color, N_("use colored output")),
 		{ OPTION_STRING, 'u', "untracked-files", &untracked_files_arg,
 		  N_("mode"),
 		  N_("show untracked files, optional modes: all, normal, no. (Default: all)"),
@@ -1409,6 +1411,10 @@ int cmd_status(int argc, const char **argv, const char *prefix)
 
 	handle_untracked_files_arg(&s);
 	handle_ignored_arg(&s);
+
+	if (use_color != GIT_COLOR_AUTO) {
+		s.use_color=use_color;
+	}
 
 	if (s.show_ignored_mode == SHOW_MATCHING_IGNORED &&
 	    s.show_untracked_files == SHOW_NO_UNTRACKED_FILES)

--- a/t/t7527-status-color-pipe.sh
+++ b/t/t7527-status-color-pipe.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+
+test_description='git status color option'
+
+. ./test-lib.sh
+
+test_expect_success setup '
+	echo 1 >original &&
+	git add .
+'
+
+# Normal git status does not pipe colors
+test_expect_success 'git status' '
+	git status >raw &&
+	test_decode_color <raw >out &&
+	grep "original$" out
+'
+
+# Test new color option with never (expect same as above)
+test_expect_success 'git status --color=never' '
+	git status --color=never >raw &&
+	test_decode_color <raw >out &&
+	grep "original$" out
+'
+
+# Test new color (default is always)
+test_expect_success 'git status --color' '
+	git status --color >raw &&
+	test_decode_color <raw >out &&
+	grep "original<RESET>$" out
+'
+
+# Test new color option with always
+test_expect_success 'git status --color=always' '
+	git status --color=always >raw &&
+	test_decode_color <raw >out &&
+	grep "original<RESET>$" out
+'
+
+# Test verbose (default)
+test_expect_success 'git status -v' '
+	git status -v >raw &&
+	test_decode_color <raw >out &&
+	grep "+1" out
+'
+
+# Test verbose --color=never
+test_expect_success 'git status -v --color=never' '
+	git status -v --color=never >raw &&
+	test_decode_color <raw >out &&
+	grep "+1" out
+'
+
+# Test verbose --color (default always)
+test_expect_success 'git status -v --color' '
+	git status -v --color >raw &&
+	test_decode_color <raw >out &&
+	grep "<CYAN>@@ -0,0 +1 @@<RESET>" out &&
+	grep "<GREEN>+<RESET><GREEN>1<RESET>" out
+'
+
+# Test verbose --color=always
+test_expect_success 'git status -v --color=always' '
+	git status -v --color=always >raw &&
+	test_decode_color <raw >out &&
+	grep "<CYAN>@@ -0,0 +1 @@<RESET>" out &&
+	grep "GREEN>+<RESET><GREEN>1<RESET>" out
+'
+
+test_done

--- a/wt-status.c
+++ b/wt-status.c
@@ -1042,6 +1042,7 @@ static void wt_longstatus_print_verbose(struct wt_status *s)
 	repo_init_revisions(s->repo, &rev, NULL);
 	rev.diffopt.flags.allow_textconv = 1;
 	rev.diffopt.ita_invisible_in_index = 1;
+	rev.diffopt.use_color = s->use_color;
 
 	memset(&opt, 0, sizeof(opt));
 	opt.def = s->is_initial ? empty_tree_oid_hex() : s->reference;


### PR DESCRIPTION
Many users like to pipe colored results of git status to other commands
such as more or less, but by default colors are lost when piping without
changing the user's git configuration.  Many other commands such as diff,
show, log and grep have a --color option to easily override this behavior.
This allows the status command to have a similar --color option providing
a simpler mechanism for temporarily forcing piped colored output.
 

Signed-off-by: Lance Ward <ljward10@gmail.com>

Thanks for taking the time to contribute to Git! Please be advised that the
Git community does not use github.com for their contributions. Instead, we use
a mailing list (git@vger.kernel.org) for code submissions, code reviews, and
bug reports. Nevertheless, you can use GitGitGadget (https://gitgitgadget.github.io/)
to conveniently send your Pull Requests commits to our mailing list.

Please read the "guidelines for contributing" linked above!


cc: Eric Sunshine <sunshine@sunshineco.com>

cc: Lance Ward <ljward10@gmail.com>
cc: Eric Sunshine <sunshine@sunshineco.com>