### PR TITLE
git-p4: handle non-unicode characters in p4 changelist description 

### DIFF
--- a/Documentation/git-p4.txt
+++ b/Documentation/git-p4.txt
@@ -638,6 +638,19 @@ git-p4.pathEncoding::
 	to transcode the paths to UTF-8. As an example, Perforce on Windows
 	often uses "cp1252" to encode path names.
 
+git-p4.clDescEncoding::
+	Perforce allows non-unicode characters in changelist description. 
+	Use this config to tell git-p4 what encoding Perforce had used for 
+	description text. This encoding is used to transcode the text to
+	UTF-8. Defaults to "utf_8".
+
+git-p4.clDescNonUnicodeHandling::
+	Perforce allows non-unicode characters in changelist description. 
+	Use this config to tell git-p4 what to do when it does not recognize 
+	the character encoding in description body. Defaults to "strict" for 
+	stopping upon encounter. "ignore" for skipping unrecognized
+	characters; "replace" for attempting to convert into UTF-8. 
+
 git-p4.largeFileSystem::
 	Specify the system that is used for large (binary) files. Please note
 	that large file systems do not support the 'git p4 submit' command.


### PR DESCRIPTION
P4 allows non-unicode characters in changelist description body,
so git-p4 needs to be character encoding aware when reading p4 cl.

This change adds 2 config options: one specifies encoding,
the other specifies erro handling upon unrecognized character.
Those configs apply when it reads p4 description text, mostly
from commands "p4 describe" and "p4 changes".

--------

I have an open question in mind: what might be the best default config to use? 

Currently the python's `bytes.decode()` is called with default utf-8 and strict error handling, so git-p4 pukes on non-unicode characters. I encountered it when `git p4 sync` attempts to ingest a certain CL. 

It seems to make sense to default to `replace` so that it gets rid of non-unicode chars while trying to retain information. However, i am uncertain on if we have use cases where it relies on the stop-on-non-unicode behavior. (Hypothetically say an automation that's expected to return error on non-unicode char in order to stop them from propagating further?)

-------

I tested it with `git p4 sync` to a P4 CL that somehow has non-unicode control character in description. With `git-p4.cldescencodingerrhandling=ignore`, it proceeded without error. 

cc: Luke Diamand <luke@diamand.org>
cc: Andrew Oakley <andrew@adoakley.name>