### PR TITLE
[RFC] gitk: tag add right click options

### DIFF
--- a/gitk-git/gitk
+++ b/gitk-git/gitk
@@ -1874,6 +1874,28 @@ proc removehead {id name} {
     unset headids($name)
 }
 
+proc movetag {id name} {
+    global tagids idtags
+
+    removetag $tagids($name) $name
+    set tagids($name) $id
+    lappend idtags($id) $name
+}
+
+proc removetag {id name} {
+    global tagids idtags
+
+    if {$idtags($id) eq $name} {
+        unset idtags($id)
+    } else {
+        set i [lsearch -exact $idtags($id) $name]
+        if {$i >= 0} {
+            set idtags($id) [lreplace $idtags($id) $i $i]
+        }
+    }
+    unset tagids($name)
+}
+
 proc ttk_toplevel {w args} {
     global use_ttk
     eval [linsert $args 0 ::toplevel $w]
@@ -2077,6 +2099,7 @@ proc makewindow {} {
     global filesepbgcolor filesepfgcolor
     global mergecolors foundbgcolor currentsearchhitbgcolor
     global headctxmenu progresscanv progressitem progresscoords statusw
+    global tagctxmenu
     global fprogitem fprogcoord lastprogupdate progupdatepending
     global rprogitem rprogcoord rownumsel numcommits
     global have_tk85 use_ttk NS
@@ -2684,6 +2707,14 @@ proc makewindow {} {
         {mc "Copy branch name" command {clipboard clear; clipboard append $headmenuhead}}
     }
     $headctxmenu configure -tearoff 0
+
+    set tagctxmenu .tagctxmenu
+    makemenu $tagctxmenu {
+        {mc "Rename this tag" command mvtag}
+        {mc "Remove this tag" command rmtag}
+        {mc "Copy tag name" command {clipboard clear; clipboard append $tagmenutag}}
+    }
+    $tagctxmenu configure -tearoff 0
 
     global flist_menu
     set flist_menu .flistctxmenu
@@ -6581,6 +6612,7 @@ proc drawtags {id x xt y1} {
 
     set marks {}
     set ntags 0
+    set ntags_copy 0
     set nheads 0
     set singletag 0
     set maxtags 3
@@ -6592,6 +6624,7 @@ proc drawtags {id x xt y1} {
     if {[info exists idtags($id)]} {
         set marks $idtags($id)
         set ntags [llength $marks]
+        set ntags_copy $ntags
         if {$ntags > $maxtags ||
             [totalwidth $marks mainfont $extra] > $maxwidth} {
             # show just a single "n tags..." tag
@@ -6678,6 +6711,9 @@ proc drawtags {id x xt y1} {
                    -font $font -tags [list tag.$id text]]
         if {$ntags >= 0} {
             $canv bind $t <1> $tagclick
+            if {$ntags_copy < $maxtags} {
+              $canv bind $t $ctxbut [list tagmenu %X %Y $id $tag_quoted]
+            }
         } elseif {$nheads >= 0} {
             $canv bind $t $ctxbut [list headmenu %X %Y $id $tag_quoted]
         }
@@ -9531,6 +9567,57 @@ proc mkbranch {} {
     branchdia $top val ui
 }
 
+proc mvtag {} {
+    global NS
+    global tagmenuid tagmenutag
+
+    set top .tagdialog
+
+    set val(name) $tagmenutag
+    set val(id) $tagmenuid
+    set val(command) [list mvtago $top $tagmenutag]
+
+    set ui(title) [mc "Rename tag %s" $tagmenutag]
+    set ui(accept) [mc "Rename"]
+
+    tagdia $top val ui
+}
+
+proc tagdia {top valvar uivar} {
+    global NS commitinfo
+    upvar $valvar val $uivar ui
+
+    catch {destroy $top}
+    ttk_toplevel $top
+    make_transient $top .
+    ${NS}::label $top.title -text $ui(title)
+    grid $top.title - -pady 10
+    ${NS}::label $top.id -text [mc "ID:"]
+    ${NS}::entry $top.sha1 -width 40
+    $top.sha1 insert 0 $val(id)
+    $top.sha1 conf -state readonly
+    grid $top.id $top.sha1 -sticky w
+    ${NS}::entry $top.head -width 60
+    $top.head insert 0 [lindex $commitinfo($val(id)) 0]
+    $top.head conf -state readonly
+    grid x $top.head -sticky ew
+    grid columnconfigure $top 1 -weight 1
+    ${NS}::label $top.nlab -text [mc "Name:"]
+    ${NS}::entry $top.name -width 40
+    $top.name insert 0 $val(name)
+    grid $top.nlab $top.name -sticky w
+    ${NS}::frame $top.buts
+    ${NS}::button $top.buts.go -text $ui(accept) -command $val(command)
+    ${NS}::button $top.buts.can -text [mc "Cancel"] -command "catch {destroy $top}"
+    bind $top <Key-Return> $val(command)
+    bind $top <Key-Escape> "catch {destroy $top}"
+    grid $top.buts.go $top.buts.can
+    grid columnconfigure $top.buts 0 -weight 1 -uniform a
+    grid columnconfigure $top.buts 1 -weight 1 -uniform a
+    grid $top.buts - -pady 10 -sticky ew
+    focus $top.name
+}
+
 proc mvbranch {} {
     global NS
     global headmenuid headmenuhead
@@ -9580,6 +9667,38 @@ proc branchdia {top valvar uivar} {
     grid columnconfigure $top.buts 1 -weight 1 -uniform a
     grid $top.buts - -pady 10 -sticky ew
     focus $top.name
+}
+
+proc mvtago {top prevname} {
+    global tagids idheads mainhead mainheadid
+
+    set name [$top.name get]
+    set id [$top.sha1 get]
+    if {$name eq $prevname} {
+          catch {destroy $top}
+          return
+    }
+    if {$name eq {}} {
+      error_popup [mc "Please specify a new name for the tag"] $top
+      return
+    }
+    catch {destroy $top}
+    nowbusy renametag
+    update
+    if {[catch {
+        eval exec "git tag $name $prevname"
+        eval exec "git tag -d $prevname"
+    } err]} {
+        notbusy renametag
+        error_popup $err
+    } else {
+        notbusy renametag
+        removetag $id $prevname
+        set tagids($name) $id
+        lappend idtags($id) $name
+        run refill_reflist
+    }
+
 }
 
 proc mkbrgo {top} {
@@ -9915,6 +10034,17 @@ proc headmenu {x y id head} {
     tk_popup $headctxmenu $x $y
 }
 
+# context menu for a tag
+proc tagmenu {x y id tag} {
+    global tagmenuid tagmenutag tagctxmenu mainhead
+
+    stopfinding
+    set tagmenuid $id
+    set tagmenutag $tag
+
+    tk_popup $tagctxmenu $x $y
+}
+
 proc cobranch {} {
     global headmenuid headmenuhead headids
     global showlocalchanges
@@ -10016,6 +10146,25 @@ proc rmbranch {} {
     redrawtags $id
     notbusy rmbranch
     dispneartags 0
+    run refill_reflist
+}
+
+proc rmtag {} {
+    global tagmenuid tagmenutag
+    global idtags
+
+    set tag $tagmenutag
+    set id $tagmenuid
+
+    nowbusy rmtag
+    update
+    if {[catch {exec git tag -d $tag} err]} {
+        notbusy rmtag
+        error_popup $err
+        return
+    }
+    removetag $id $tag
+    notbusy rmtag
     run refill_reflist
 }
 


### PR DESCRIPTION
This patch want to fix:
https://github.com/gitgitgadget/git/issues/855

We can provide for right-clicking the tag icon in gitk
Rename this tag", "Remove this tag", "Copy tag name" function.

For convenience, only the tags on the branch with the number of 
tags <=3 are processed temporarily.

Now I may need a little help:
after we successfully deleted or modified the tag name,the content show on
gitk has not changed, and I am stuck here.

In addition,I just learned part of the syntax of the tcl/tk language, and there
may be some bad uses in my patch.

Thanks!
