### PR TITLE
subtree : fix split output containing unrelated history 

### DIFF
--- a/contrib/subtree/git-subtree.sh
+++ b/contrib/subtree/git-subtree.sh
@@ -667,10 +667,6 @@ process_split_commit () {
 	if test -z "$tree"
 	then
 		set_notree "$rev"
-		if test -n "$newparents"
-		then
-			cache_set "$rev" "$rev"
-		fi
 		return
 	fi
 


### PR DESCRIPTION
When a subtree is deleted and re-added at the same location with the
--squash arguement the history created by "git subtree split" will
contain commits that do not affect the files in the given prefix
resulting in an incorrect history for the subtree.

This commit fixes the issue by removing lines that create cache files for
commits that did not contain the given prefix after new parent commits have
been created. The history created by "git subtree split" with this change
no longer contains unrelated commits or commits that occured before the
subtree was removed and re-added.

Signed-off-by: Taylor Jones <tjones629@gmail.com>
