### PR TITLE
doc: mention bigFileThreshold for packing

### DIFF
--- a/Documentation/git-pack-objects.txt
+++ b/Documentation/git-pack-objects.txt
@@ -400,6 +400,17 @@ Note that we pick a single island for each regex to go into, using "last
 one wins" ordering (which allows repo-specific config to take precedence
 over user-wide config, and so forth).
 
+
+CONFIGURATION
+-------------
+
+Various configuration variables affect packing, see
+linkgit:git-config[1] (search for "pack" and "delta").
+
+Notably, delta compression is not used on objects larger than the
+`core.bigFileThreshold` configuration variable and on files with the
+attribute `delta` set to false.
+
 SEE ALSO
 --------
 linkgit:git-rev-list[1]

--- a/Documentation/git-repack.txt
+++ b/Documentation/git-repack.txt
@@ -165,8 +165,11 @@ depth is 4095.
 	Pass the `--delta-islands` option to `git-pack-objects`, see
 	linkgit:git-pack-objects[1].
 
-Configuration
+CONFIGURATION
 -------------
+
+Various configuration variables affect packing, see
+linkgit:git-config[1] (search for "pack" and "delta").
 
 By default, the command passes `--delta-base-offset` option to
 'git pack-objects'; this typically results in slightly smaller packs,
@@ -177,6 +180,10 @@ need to set the configuration variable `repack.UseDeltaBaseOffset` to
 "false" and repack. Access from old Git versions over the native protocol
 is unaffected by this option as the conversion is performed on the fly
 as needed in that case.
+
+Delta compression is not used on objects larger than the
+`core.bigFileThreshold` configuration variable and on files with the
+attribute `delta` set to false.
 
 SEE ALSO
 --------


### PR DESCRIPTION
I recently spent a lot of time trying to figure out why `git repack` would create huge packs on some clones of my repository and small ones on others, until I found out about the existence of the core.bigFileThreshold configuration variable, which happened to be set on some and not on others. It would have saved me a lot of time if that variable had been mentioned in the relevant manpages that I was reading, git-repack and git-pack-objects. So this patch adds that.

Changes in v2:
- Move additions to the CONFIGURATION section at the bottom.
- Reword a little after realizing that there are more configuration variables affecting packing.
- Capitalize CONFIGURATION for consistency with other pages having such a section.