### PR TITLE
Make `git reflog expire --stale-fix` a lot more useful

### DIFF
--- a/builtin/reflog.c
+++ b/builtin/reflog.c
@@ -602,6 +602,9 @@ static int cmd_reflog_expire(int argc, const char **argv, const char *prefix)
 	 */
 	if (cb.cmd.stalefix) {
 		repo_init_revisions(the_repository, &cb.cmd.revs, prefix);
+		cb.cmd.revs.do_not_die_on_missing_tree = 1;
+		cb.cmd.revs.ignore_missing = 1;
+		cb.cmd.revs.ignore_missing_links = 1;
 		if (flags & EXPIRE_REFLOGS_VERBOSE)
 			printf(_("Marking reachable objects..."));
 		mark_reachable_objects(&cb.cmd.revs, 0, 0, NULL);


### PR DESCRIPTION
Yesterday, I tried to run a quick test to find out whether `master`'s version of `git repack` prevents `.bitmap` files from being  deleted by still having them `mmap()`ed. Since I do not have a build of `master` lying around just like that, I checked it out, built the thing, and then ran

```
./bin-wrappers/git -c alias.c='!(cd /path/to/directory && ./test-whether-bitmaps-are-mmaped-during-repack.sh) c
```

Do NOT try this at home! The problem with this invocation is that the alias will still have `GIT_DIR` set, therefore the `git init` in that script will _not_ create a new Git directory, and the `git repack -ad` in that script will remove all kinds of precious objects from the Git checkout. Even though I interrupted the run as quickly as I realized that things were going wrong, my repository was corrupted in a major way, and it took me many hours to get back to a healthy state.

It made matters worse that `git reflog expire --stale-fix` was less helpful than it could have been, and this patch is the result of my directed emotional energy.

cc: Jeff King <peff@peff.net>