### PR TITLE
read-cache: make the index write buffer size 128K

### DIFF
--- a/read-cache.c
+++ b/read-cache.c
@@ -2447,7 +2447,7 @@ int repo_index_has_changes(struct repository *repo,
 	}
 }
 
-#define WRITE_BUFFER_SIZE 8192
+#define WRITE_BUFFER_SIZE (128 * 1024)
 static unsigned char write_buffer[WRITE_BUFFER_SIZE];
 static unsigned long write_buffer_len;
 


### PR DESCRIPTION
Writing an index 8K at a time invokes the OS filesystem and caching code
very frequently, introducing noticeable overhead while writing large
indexes. When experimenting with different write buffer sizes on Windows
writing the Windows OS repo index (260MB), most of the benefit came by
bumping the index write buffer size to 64K. I picked 128K to ensure that
we're past the knee of the curve.

With this change, the time under do_write_index for an index with 3M
files goes from ~1.02s to ~0.72s.

Signed-off-by: Neeraj Singh <neerajsi@ntdev.microsoft.com>

Note: This was previously discussed on the mailing list in 2016 at:
https://lore.kernel.org/git/1458350341-12276-1-git-send-email-dturner@twopensource.com/.

Since then, I believe we have a couple changes:
* 'small' development platforms like raspberry pi have gotten larger (4GB RAM).
* spectre and meltdown make individual system calls more expensive when mitigations are enabled
* there have been many investments to make very large repos scale well in git, so huge repos are more common now.

cc: Jeff Hostetler <git@jeffhostetler.com>
cc: Neeraj Singh <nksingh85@gmail.com>
cc: Chris Torek <chris.torek@gmail.com>