### PR TITLE
commit-graph: warn about incompatibilities only when trying to write

### DIFF
--- a/t/t5318-commit-graph.sh
+++ b/t/t5318-commit-graph.sh
@@ -741,4 +741,17 @@ test_expect_success 'corrupt commit-graph write (missing tree)' '
 	)
 '
 
+test_expect_success 'warn about incompatibilities (only) when writing' '
+	git init warn &&
+	test_commit -C warn initial &&
+	test_commit -C warn second &&
+	git -C warn replace --graft second &&
+	test_config -C warn gc.writecommitgraph true &&
+
+	git -C warn gc 2>err &&
+	test_i18ngrep "skipping commit-graph" err &&
+	git -C warn rev-list -1 second 2>err &&
+	test_i18ngrep ! "skipping commit-graph" err
+'
+
 test_done


### PR DESCRIPTION
As pointed out by Ævar in https://lore.kernel.org/git/87pn0o6y1e.fsf@evledraar.gmail.com, my recent patch to trigger warnings in repositories that are incompatible with the commit-graph was a bit too overzealous. Here is a fix for that.

cc: Ævar Arnfjörð Bjarmason <avarab@gmail.com>