### PR TITLE
branch: return error when --list finds no matches

### DIFF
--- a/builtin/branch.c
+++ b/builtin/branch.c
@@ -426,6 +426,8 @@ static void print_ref_list(struct ref_filter *filter, struct ref_sorting *sortin
 	memset(&array, 0, sizeof(array));
 
 	filter_refs(&array, filter, filter->kind | FILTER_REFS_INCLUDE_BROKEN);
+	if (!array.nr)
+		die(_("no branches found"));
 
 	if (filter->verbose)
 		maxwidth = calc_maxwidth(&array, strlen(remote_prefix));


### PR DESCRIPTION
Currently git branch --list foo always returns an exit status of 0 even
when the branch being searched for does not exist. Now an error is printed
and returns a non-zero exit status.

Signed-off-by: Josh Hunt <johunt@akamai.com>

Thanks for taking the time to contribute to Git! Please be advised that the
Git community does not use github.com for their contributions. Instead, we use
a mailing list (git@vger.kernel.org) for code submissions, code reviews, and
bug reports. Nevertheless, you can use GitGitGadget (https://gitgitgadget.github.io/)
to conveniently send your Pull Requests commits to our mailing list.

Please read the "guidelines for contributing" linked above!
