### PR TITLE
added new BANNED_EXPL macro for better error messages

### DIFF
--- a/banned.h
+++ b/banned.h
@@ -9,9 +9,10 @@
  */
 
 #define BANNED(func) sorry_##func##_is_a_banned_function
+#define BANNED_EXPL(func, expl) sorry_##func##_is_a_banned_funcion_because_##expl##.
 
 #undef strcpy
-#define strcpy(x,y) BANNED(strcpy)
+#define strcpy(x,y) BANNED_EXPL(strcpy, buffer_overflow_risk)
 #undef strcat
 #define strcat(x,y) BANNED(strcat)
 #undef strncpy


### PR DESCRIPTION
# Extend Banned Function Error Messages
##### As a newer user, I want to be able to understand why certain functions are banned as well as know what functions to use instead. 

## Changes
- Added new macro named `BANNED_EXPL(func, expl)` which added the expl onto the error message
- Used `strcpy` as an example