### PR TITLE
userdiff: support Clojure

### DIFF
--- a/Documentation/gitattributes.txt
+++ b/Documentation/gitattributes.txt
@@ -807,6 +807,8 @@ patterns are available:
 
 - `bibtex` suitable for files with BibTeX coded references.
 
+- `clojure` suitable for source code in the Clojure language.
+
 - `cpp` suitable for source code in the C and C++ languages.
 
 - `csharp` suitable for source code in the C# language.

--- a/t/t4018-diff-funcname.sh
+++ b/t/t4018-diff-funcname.sh
@@ -29,6 +29,7 @@ diffpatterns="
 	ada
 	bash
 	bibtex
+	clojure
 	cpp
 	csharp
 	css

--- a/t/t4018/clojure-comment
+++ b/t/t4018/clojure-comment
@@ -1,0 +1,8 @@
+(comment ;; RIGHT rich comment
+
+
+;; ignore comment
+
+
+    (do-something "ChangeMe"))
+

--- a/t/t4018/clojure-function
+++ b/t/t4018/clojure-function
@@ -1,0 +1,6 @@
+(defn RIGHT
+  []
+; ignore comment
+
+  (ChangeMe))
+

--- a/t/t4018/clojure-ns
+++ b/t/t4018/clojure-ns
@@ -1,0 +1,10 @@
+(ns RIGHT
+
+;; ignore comment
+
+  (:require [some.lib :refer [
+
+
+                              ChangeMe
+
+                              ]))

--- a/t/t4018/clojure-reader-comment
+++ b/t/t4018/clojure-reader-comment
@@ -1,0 +1,5 @@
+#_((def commented-RIGHT-definition
+
+; ignore comment
+
+     ChangeMe))

--- a/userdiff.c
+++ b/userdiff.c
@@ -44,6 +44,17 @@ PATTERNS("bash",
 	 /* -- */
 	 /* Characters not in the default $IFS value */
 	 "[^ \t]+"),
+PATTERNS("clojure",
+	 /* Ignore comments */
+	 "!^;.*\n"
+	 /* Top level forms */
+	 "^[^ \t].*$",
+	 /* Atoms, Keywords, Symbols */
+	 "[#@:]?[^0-9][a-zA-Z0-9*+!-_'?<>=/.]+"
+	 /* Numbers */
+	 "|[-]?[0-9a-fA-Frxb/MN]+"
+	 /* Characters */
+	 "|[\\0-9a-fA-F]+"),
 PATTERNS("dts",
 	 "!;\n"
 	 "!=\n"


### PR DESCRIPTION
Add support for Clojure[1]. Include test cases for the xfuncname pattern
(t4018) and update documentation.

The xfuncname pattern matches any top level form except a line comment.

The word_regex has been constructed based on Reader documentation[2].

[1]: https://clojure.org
[2]: https://clojure.org/reference/reader

Signed-off-by: Nazarii Bardiuk <nazarii@bardiuk.com>
