### PR TITLE
fsmonitor: fix overflow read

### DIFF
--- a/fsmonitor.c
+++ b/fsmonitor.c
@@ -185,10 +185,10 @@ static int query_fsmonitor(int version, const char *last_update, struct strbuf *
 int fsmonitor_is_trivial_response(const struct strbuf *query_result)
 {
 	static char trivial_response[3] = { '\0', '/', '\0' };
-	int is_trivial = !memcmp(trivial_response,
-				 &query_result->buf[query_result->len - 3], 3);
 
-	return is_trivial;
+	return query_result->len >= 3 &&
+		!memcmp(trivial_response,
+			&query_result->buf[query_result->len - 3], 3);
 }
 
 static void fsmonitor_refresh_callback(struct index_state *istate, char *name)


### PR DESCRIPTION
This patch fixes a buffer overflow read in fsmonitor_is_trivial_response().

I'm not super familiar with fsmonitor, so I'm not 100% sure what the empty response actually means. Based on my reading of the docs below, this can happen with fsmonitor-watchman v1 when no files have changed. But it could also happen for v2 if the implementation is broken (in which case we also shouldn't overflow)? Either way, I'm guessing the empty response doesn't count as trivial:
https://git-scm.com/docs/githooks#_fsmonitor_watchman

The other question I had is: can watchman V1 return "/\0" as the trivial response (as it has no token header) - and should we be recognising that too?

ATB,

Andrzej

CC: Jeff Hostetler <jeffhost@microsoft.com>
cc: Bagas Sanjaya <bagasdotme@gmail.com>
cc: Jeff Hostetler <git@jeffhostetler.com>