### PR TITLE
Remove implicit dependency of `the_repository`

### DIFF
--- a/cache-tree.c
+++ b/cache-tree.c
@@ -446,10 +446,10 @@ int cache_tree_update(struct index_state *istate, int flags)
 		istate->cache_tree = cache_tree();
 
 	trace_performance_enter();
-	trace2_region_enter("cache_tree", "update", the_repository);
+	trace2_region_enter("cache_tree", "update", istate->repo);
 	i = update_one(istate->cache_tree, istate->cache, istate->cache_nr,
 		       "", 0, &skip, flags);
-	trace2_region_leave("cache_tree", "update", the_repository);
+	trace2_region_leave("cache_tree", "update", istate->repo);
 	trace_performance_leave("cache_tree_update");
 	if (i < 0)
 		return i;
@@ -746,13 +746,13 @@ void prime_cache_tree(struct repository *r,
 		      struct index_state *istate,
 		      struct tree *tree)
 {
-	trace2_region_enter("cache-tree", "prime_cache_tree", the_repository);
+	trace2_region_enter("cache-tree", "prime_cache_tree", r);
 	cache_tree_free(&istate->cache_tree);
 	istate->cache_tree = cache_tree();
 
 	prime_cache_tree_rec(r, istate->cache_tree, tree);
 	istate->cache_changed |= CACHE_TREE_CHANGED;
-	trace2_region_leave("cache-tree", "prime_cache_tree", the_repository);
+	trace2_region_leave("cache-tree", "prime_cache_tree", r);
 }
 
 /*


### PR DESCRIPTION
There are multiple files that try to reference `the repository` and `the_index` directly. To follow a more object-oriented
convention these references should be replaced with `r` and
`index`, or with `istate->repo` and passed through functions.

Signed-off-by: Chinmoy Chakraborty <chinmoy12c@gmail.com>

## Related issue

#379 


cc: Derrick Stolee <stolee@gmail.com>

## Changes since v3

- Used istate->repo instead of the_repository to prevent making changes in callers of the function.

cc: Derrick Stolee <stolee@gmail.com>