### PR TITLE
git-merge: rewrite already up to date message

### DIFF
--- a/builtin/merge.c
+++ b/builtin/merge.c
@@ -380,10 +380,14 @@ static void restore_state(const struct object_id *head,
 }
 
 /* This is called when no merge was necessary. */
-static void finish_up_to_date(const char *msg)
+static void finish_up_to_date(void)
 {
-	if (verbosity >= 0)
-		printf("%s%s\n", squash ? _(" (nothing to squash)") : "", msg);
+	if (verbosity >= 0) {
+		if (squash)
+			puts(_("Already up to date (nothing to squash)."));
+		else
+			puts(_("Already up to date."));
+	}
 	remove_merge_branch_state(the_repository);
 }
 
@@ -1482,7 +1486,7 @@ int cmd_merge(int argc, const char **argv, const char *prefix)
 		 * If head can reach all the merge then we are up to date.
 		 * but first the most common case of merging one remote.
 		 */
-		finish_up_to_date(_("Already up to date."));
+		finish_up_to_date();
 		goto done;
 	} else if (fast_forward != FF_NO && !remoteheads->next &&
 			!common->next &&
@@ -1566,7 +1570,7 @@ int cmd_merge(int argc, const char **argv, const char *prefix)
 			}
 		}
 		if (up_to_date) {
-			finish_up_to_date(_("Already up to date. Yeeah!"));
+			finish_up_to_date();
 			goto done;
 		}
 	}


### PR DESCRIPTION
GitHub Actions show things like:

```
 * branch                  master     -> FETCH_HEAD
 (nothing to squash)Already up to date.
```

There was a code path where it would say:
```
Already up to date. Yeeah!
```
It is believed that other than being troublesome for localizers, this message added no value, so it's being removed.

Usually, it is easier to read a message if it makes its primary
point first, before giving a parenthetical note.

The expected results are:
```
 * branch                  master     -> FETCH_HEAD
Already up to date (nothing to squash).
```

As well as an easier chance for localizers to actually translate the now two messages. (As they don't have to fight string pasting. Which is a localization sin.):
`Already up to date.`
`Already up to date (nothing to squash).`

This commit should change that. Other than breaking anyone who actively parses the output and all the localizations (and giving localizers a real chance at localizing these messages), this shouldn't have much impact.

Changes since v2:
- `finish_up_to_date` now figures out the answer on its own to address feedback from Eric Sunshine

-- Yes, I'm well aware of localization rules. But as Eric Sunshine noted, the code was already making a mess of things. I didn't want to make invasive changes. I actually wrote roughly what Eric proposed as an earlier implementation, but the various complexities, including trying to figure out what the `yeah` was for and who cared about it, made me really wary of proposing such a significant change.

cc: Eric Sunshine <sunshine@sunshineco.com>


cc: Josh Soref <jsoref@gmail.com>

cc: Eric Sunshine <sunshine@sunshineco.com>