### PR TITLE
[GSOC] pretty: provide human date format

### DIFF
--- a/Documentation/pretty-formats.txt
+++ b/Documentation/pretty-formats.txt
@@ -190,6 +190,8 @@ The placeholders are:
 '%ai':: author date, ISO 8601-like format
 '%aI':: author date, strict ISO 8601 format
 '%as':: author date, short format (`YYYY-MM-DD`)
+'%ah':: author date, human style (like the `--date=human` option of
+	linkgit:git-rev-list[1])
 '%cn':: committer name
 '%cN':: committer name (respecting .mailmap, see
 	linkgit:git-shortlog[1] or linkgit:git-blame[1])
@@ -206,6 +208,8 @@ The placeholders are:
 '%ci':: committer date, ISO 8601-like format
 '%cI':: committer date, strict ISO 8601 format
 '%cs':: committer date, short format (`YYYY-MM-DD`)
+'%ch':: committer date, human style (like the `--date=human` option of
+	linkgit:git-rev-list[1])
 '%d':: ref names, like the --decorate option of linkgit:git-log[1]
 '%D':: ref names without the " (", ")" wrapping.
 '%(describe[:options])':: human-readable name, like

--- a/pretty.c
+++ b/pretty.c
@@ -745,6 +745,9 @@ static size_t format_person_part(struct strbuf *sb, char part,
 	case 'I':	/* date, ISO 8601 strict */
 		strbuf_addstr(sb, show_ident_date(&s, DATE_MODE(ISO8601_STRICT)));
 		return placeholder_len;
+	case 'h':	/* date, human */
+		strbuf_addstr(sb, show_ident_date(&s, DATE_MODE(HUMAN)));
+		return placeholder_len;
 	case 's':
 		strbuf_addstr(sb, show_ident_date(&s, DATE_MODE(SHORT)));
 		return placeholder_len;

--- a/t/t4205-log-pretty-formats.sh
+++ b/t/t4205-log-pretty-formats.sh
@@ -539,6 +539,12 @@ test_expect_success 'short date' '
 	test_cmp expected actual
 '
 
+test_expect_success '--date=human %ad%cd is the same as %ah%ch' '
+	git log --format=%ad%n%cd --date=human >expected &&
+	git log --format=%ah%n%ch >actual &&
+	test_cmp expected actual
+'
+
 # get new digests (with no abbreviations)
 test_expect_success 'set up log decoration tests' '
 	head1=$(git rev-parse --verify HEAD~0) &&


### PR DESCRIPTION
Reasons for making this patch:
`--date=human` has no corresponding --pretty option.

Although  `--date=human` with `--pretty="%(a|c)d"` can achieve
the same effect with `--pretty="%(a|c)h"`, but it can be noticed that
most time formats implement the corresponding option of `--pretty`,
such as `--date=iso8601 ` can be replaced by `--pretty=%(a|c)i`,
so add `--pretty=%(a|c)h` seems to be a very reasonable thing.

Change from v3: Fix format errors.

cc: René Scharfe <l.s.r@web.de>
cc: Junio C Hamano <gitster@pobox.com>
cc: Linus Torvalds <torvalds@linux-foundation.org>
cc: Taylor Blau <me@ttaylorr.com>
cc: Philip Oakley <philipoakley@iee.email>
cc: Ævar Arnfjörð Bjarmason         <avarab@gmail.com>
cc: Beat Bolli <dev+git@drbeat.li>