### PR TITLE
doc: point to diff attribute in patch format docs

### DIFF
--- a/Documentation/diff-generate-patch.txt
+++ b/Documentation/diff-generate-patch.txt
@@ -11,7 +11,7 @@ linkgit:git-diff-files[1]
 with the `-p` option produces patch text.
 You can customize the creation of patch text via the
 `GIT_EXTERNAL_DIFF` and the `GIT_DIFF_OPTS` environment variables
-(see linkgit:git[1]).
+(see linkgit:git[1]), and the `diff` attribute (see linkgit:gitattributes[5]).
 
 What the -p option produces is slightly different from the traditional
 diff format:
@@ -73,6 +73,11 @@ separate lines indicate the old and the new mode.
       diff --git a/b b/a
       rename from b
       rename to a
+
+5.  Hunk headers mention the name of the function to which the hunk
+    applies.  See "Defining a custom hunk-header" in
+    linkgit:gitattributes[5] for details of how to tailor to this to
+    specific languages.
 
 
 Combined diff format

--- a/Documentation/diff-generate-patch.txt
+++ b/Documentation/diff-generate-patch.txt
@@ -76,7 +76,7 @@ separate lines indicate the old and the new mode.
 
 5.  Hunk headers mention the name of the function to which the hunk
     applies.  See "Defining a custom hunk-header" in
-    linkgit:gitattributes[5] for details of how to tailor to this to
+    linkgit:gitattributes[5] for details of how to tailor this to
     specific languages.
 
 


### PR DESCRIPTION
From the documentation for generating patch text with diff-related commands, refer to the documentation for the diff attribute.

This attribute influences the way that patches are generated, but this was previously not mentioned in e.g., the git-diff manpage.

v2: Mention the specific relevant section of the gitattributes manual.  Thanks to Junio C Hamano for the suggestion.
cc: Peter Oliver <p.d.oliver@mavit.org.uk>