### PR TITLE
fsmonitor: only enable it in non-bare repositories

### DIFF
--- a/config.c
+++ b/config.c
@@ -2515,6 +2515,12 @@ int git_config_get_max_percent_split_change(void)
 
 int repo_config_get_fsmonitor(struct repository *r)
 {
+	if (!r->worktree) {
+		/* FSMonitor makes no sense in bare repositories */
+		core_fsmonitor = NULL;
+		return 1;
+	}
+
 	if (r->settings.use_builtin_fsmonitor > 0) {
 		core_fsmonitor = "(built-in daemon)";
 		return 1;


### PR DESCRIPTION
For quite a while now, I run with the built-in FSMonitor via my user config. Happily, the only issue I ran into was that FSMonitor tried to run in a bare repository the other day. But an FSMonitor makes only sense if we have a worktree. So let's disable it automatically in bare repositories.

This patch applies near the top of `jh/rfc-builtin-fsmonitor`. I would like to keep it as a separate topic because the built-in FSMonitor did _not_ introduce this bug. This bug has been in Git's FSMonitor feature for a long, long time.

Changes since v1:
- Using `NULL` instead of `0` (d'oh!)

cc: Ævar Arnfjörð Bjarmason <avarab@gmail.com>
cc: Jeff Hostetler <git@jeffhostetler.com>