### PR TITLE
Fix: wrongly put comment for __git_complete_worktree_paths completion helper function

### DIFF
--- a/contrib/completion/git-completion.bash
+++ b/contrib/completion/git-completion.bash
@@ -3268,9 +3268,10 @@ _git_whatchanged ()
 __git_complete_worktree_paths ()
 {
 	local IFS=$'\n'
+	# Generate completion reply from worktree list skipping the first
+	# entry: it's the path of the main worktree, which can't be moved,
+	# removed, locked, etc.
 	__gitcomp_nl "$(git worktree list --porcelain |
-		# Skip the first entry: it's the path of the main worktree,
-		# which can't be moved, removed, locked, etc.
 		sed -n -e '2,$ s/^worktree //p')"
 }
 


### PR DESCRIPTION
git completion script fails for zsh

```console
$ git worktree remove [TAB]
$ git worktree remove __git_complete_worktree_paths:7: command not found: #
```