### PR TITLE
t1092: use GIT_PROGRESS_DELAY for consistent results

### DIFF
--- a/t/t1092-sparse-checkout-compatibility.sh
+++ b/t/t1092-sparse-checkout-compatibility.sh
@@ -106,18 +106,18 @@ init_repos () {
 run_on_sparse () {
 	(
 		cd sparse-checkout &&
-		"$@" >../sparse-checkout-out 2>../sparse-checkout-err
+		GIT_PROGRESS_DELAY=100000 "$@" >../sparse-checkout-out 2>../sparse-checkout-err
 	) &&
 	(
 		cd sparse-index &&
-		"$@" >../sparse-index-out 2>../sparse-index-err
+		GIT_PROGRESS_DELAY=100000 "$@" >../sparse-index-out 2>../sparse-index-err
 	)
 }
 
 run_on_all () {
 	(
 		cd full-checkout &&
-		"$@" >../full-checkout-out 2>../full-checkout-err
+		GIT_PROGRESS_DELAY=100000 "$@" >../full-checkout-out 2>../full-checkout-err
 	) &&
 	run_on_sparse "$@"
 }


### PR DESCRIPTION
We found this while running PR builds in microsoft/git.

Thanks,
-Stolee

cc: gitster@pobox.com
cc: stolee@gmail.com
cc: Jonathan Nieder <jrnieder@gmail.com>
cc: Taylor Blau <me@ttaylorr.com>
cc: Ævar Arnfjörð Bjarmason <avarab@gmail.com>