### PR TITLE
refactor of git_setup_gettext method

### DIFF
--- a/gettext.c
+++ b/gettext.c
@@ -109,16 +109,13 @@ void git_setup_gettext(void)
 	if (!podir)
 		podir = p = system_path(GIT_LOCALE_PATH);
 
-	if (!is_directory(podir)) {
-		free(p);
-		return;
+	if (is_directory(podir)) {
+		bindtextdomain("git", podir);
+		setlocale(LC_MESSAGES, "");
+		setlocale(LC_TIME, "");
+		init_gettext_charset("git");
+		textdomain("git");
 	}
-
-	bindtextdomain("git", podir);
-	setlocale(LC_MESSAGES, "");
-	setlocale(LC_TIME, "");
-	init_gettext_charset("git");
-	textdomain("git");
 
 	free(p);
 }


### PR DESCRIPTION
Use one "free" call at the end of the function,
instead of being dependent on the execution flow.

Signed-off-by: Dima Kov <dima.kovol@gmail.com>

Hi.
My first PR fot Git repository.
I went over the code and saw that maybe this part can be more clearer.
Thanks.


cc: Eric Sunshine <sunshine@sunshineco.com>

cc: Bagas Sanjaya <bagasdotme@gmail.com>