### PR TITLE
Remove warning that repack only works on non-promisor packfiles

### DIFF
--- a/Documentation/technical/partial-clone.txt
+++ b/Documentation/technical/partial-clone.txt
@@ -242,8 +242,7 @@ remote in a specific order.
   repository and can satisfy all such requests.
 
 - Repack essentially treats promisor and non-promisor packfiles as 2
-  distinct partitions and does not mix them.  Repack currently only works
-  on non-promisor packfiles and loose objects.
+  distinct partitions and does not mix them.
 
 - Dynamic object fetching invokes fetch-pack once *for each item*
   because most algorithms stumble upon a missing object and need to have
@@ -272,9 +271,6 @@ to use those promisor remotes in that order."
 +
 The user might want to work in a triangular work flow with multiple
 promisor remotes that each have an incomplete view of the repository.
-
-- Allow repack to work on promisor packfiles (while keeping them distinct
-  from non-promisor packfiles).
 
 - Allow non-pathname-based filters to make use of packfile bitmaps (when
   present).  This was just an omission during the initial implementation.


### PR DESCRIPTION
The git-repack doc clearly states that it *does* operate on promisor packfiles (in a separate partition), with "-a" specified. Presumably the statements here are outdated, as they feature from the first doc in 2017 (and the repack support was added in 2018)

cc: Taylor Blau <me@ttaylorr.com>
cc: Jonathan Tan <jonathantanmy@google.com>