### PR TITLE
Fix `git subtree` on Windows

### DIFF
--- a/contrib/subtree/git-subtree.sh
+++ b/contrib/subtree/git-subtree.sh
@@ -5,7 +5,10 @@
 # Copyright (C) 2009 Avery Pennarun <apenwarr@gmail.com>
 #
 
-if test -z "$GIT_EXEC_PATH" || test "${PATH#"${GIT_EXEC_PATH}:"}" = "$PATH" || ! test -f "$GIT_EXEC_PATH/git-sh-setup"
+if test -z "$GIT_EXEC_PATH" || ! test -f "$GIT_EXEC_PATH/git-sh-setup" || {
+	test "${PATH#"${GIT_EXEC_PATH}:"}" = "$PATH" &&
+	test ! "$GIT_EXEC_PATH" -ef "${PATH%%:*}" 2>/dev/null
+}
 then
 	echo >&2 'It looks like either your git installation or your'
 	echo >&2 'git-subtree installation is broken.'

--- a/contrib/subtree/git-subtree.sh
+++ b/contrib/subtree/git-subtree.sh
@@ -10,6 +10,7 @@ if test -z "$GIT_EXEC_PATH" || ! test -f "$GIT_EXEC_PATH/git-sh-setup" || {
 	test ! "$GIT_EXEC_PATH" -ef "${PATH%%:*}" 2>/dev/null
 }
 then
+	basename=${0##*[/\\]}
 	echo >&2 'It looks like either your git installation or your'
 	echo >&2 'git-subtree installation is broken.'
 	echo >&2
@@ -17,10 +18,10 @@ then
 	echo >&2 " - If \`git --exec-path\` does not print the correct path to"
 	echo >&2 "   your git install directory, then set the GIT_EXEC_PATH"
 	echo >&2 "   environment variable to the correct directory."
-	echo >&2 " - Make sure that your \`${0##*/}\` file is either in your"
+	echo >&2 " - Make sure that your \`$basename\` file is either in your"
 	echo >&2 "   PATH or in your git exec path (\`$(git --exec-path)\`)."
-	echo >&2 " - You should run git-subtree as \`git ${0##*/git-}\`,"
-	echo >&2 "   not as \`${0##*/}\`." >&2
+	echo >&2 " - You should run git-subtree as \`git ${basename#git-}\`,"
+	echo >&2 "   not as \`$basename\`." >&2
 	exit 126
 fi
 


### PR DESCRIPTION
In the topic branch `ls/subtree`, we saw a lot of improvements of the `git subtree` command, and some cleaning up, too. For example, 22d550749361 (subtree: don't fuss with PATH, 2021-04-27) carefully laid out a history of changes intended to work around issues where the `git-subtree` script was not in the intended location, and removed a statement modifying `PATH` in favor of a conditional warning (contingent on the `PATH` being in an unexpected shape).

This particular condition, however, was never tested on Windows, and it broke `git subtree` in Git for Windows v2.32.0, as reported [here](https://github.com/git-for-windows/git/issues/3260). Now, every invocation of `git subtree`, with or without command-line arguments, results in output like this:

```
It looks like either your git installation or your
git-subtree installation is broken.

Tips:
 - If `git --exec-path` does not print the correct path to
   your git install directory, then set the GIT_EXEC_PATH
   environment variable to the correct directory.
 - Make sure that your `git-core\git-subtree` file is either in your
   PATH or in your git exec path (`C:/Users/harry/Downloads/PortableGit/mingw64/libexec/git-core`).
 - You should run git-subtree as `git core\git-subtree`,
   not as `git-core\git-subtree`.
```

This patch series provides a fix for that symptom, and is based on `ls/subtree`.

Changes since v1:

- Instead of using the Windows-specific `cygpath` construct, we now instead fall back to verify that `GIT_EXEC_PATH` and the first component of `PATH` refer to the same entity (via the `-ef` operator, which compares inodes). Since the bug affects only Windows, as far as we know, the non-portability of the `-ef` operator does not matter because Git for Windows' Bash _does_ have support for it.

cc: Luke Shumaker <lukeshu@lukeshu.com>
cc: Jeff King <peff@peff.net>
cc: Bagas Sanjaya <bagasdotme@gmail.com>