### PR TITLE
config.mak.uname: PCRE1 cleanup

### DIFF
--- a/config.mak.uname
+++ b/config.mak.uname
@@ -668,7 +668,7 @@ else
 		HAVE_LIBCHARSET_H = YesPlease
 		NO_GETTEXT =
 		USE_GETTEXT_SCHEME = fallthrough
-		USE_LIBPCRE= YesPlease
+		USE_LIBPCRE = YesPlease
 		NO_CURL =
 		USE_NED_ALLOCATOR = YesPlease
 	else


### PR DESCRIPTION
Git for Windows carried a patch retiring PCRE1 for a long time that was superseded by `ab/retire-pcre1`. This is the surviving remainder of that patch.