### PR TITLE
Fixes for updated Windows CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -169,7 +169,7 @@ jobs:
         VCPKG_ROOT: ${{github.workspace}}\compat\vcbuild\vcpkg
       run: |
         mkdir -p artifacts &&
-        eval "$(make -n artifacts-tar INCLUDE_DLLS_IN_ARTIFACTS=YesPlease ARTIFACTS_DIRECTORY=artifacts 2>&1 | grep ^tar)"
+        eval "$(make -n artifacts-tar INCLUDE_DLLS_IN_ARTIFACTS=YesPlease NO_GETTEXT=YesPlease ARTIFACTS_DIRECTORY=artifacts 2>&1 | grep ^tar)"
     - name: zip up tracked files
       run: git archive -o artifacts/tracked.tar.gz HEAD
     - name: upload tracked files and build artifacts

--- a/Makefile
+++ b/Makefile
@@ -3146,9 +3146,12 @@ ifneq ($(INCLUDE_DLLS_IN_ARTIFACTS),)
 OTHER_PROGRAMS += $(shell echo *.dll t/helper/*.dll)
 endif
 
-artifacts-tar:: $(ALL_COMMANDS_TO_INSTALL) $(SCRIPT_LIB) $(OTHER_PROGRAMS) \
-		GIT-BUILD-OPTIONS $(TEST_PROGRAMS) $(test_bindir_programs) \
-		$(MOFILES)
+ARTIFACTS_TO_TAR = $(ALL_COMMANDS_TO_INSTALL) $(SCRIPT_LIB) $(OTHER_PROGRAMS) \
+		GIT-BUILD-OPTIONS $(TEST_PROGRAMS) $(test_bindir_programs)
+ifndef NO_GETTEXT
+ARTIFACTS_TO_TAR += $(MOFILES)
+endif
+artifacts-tar:: $(ARTIFACTS_TO_TAR)
 	$(QUIET_SUBDIR0)templates $(QUIET_SUBDIR1) \
 		SHELL_PATH='$(SHELL_PATH_SQ)' PERL_PATH='$(PERL_PATH_SQ)'
 	test -n "$(ARTIFACTS_DIRECTORY)"


### PR DESCRIPTION
js/ci-windows-update introduced a couple of performance improvements for our Windows based CI builds,
but in [1] Junio  mentioned build failures on `seen` due to this topic. 

The `make artifacts-tar` part of the `vs-build` job seems to fail, because it can't find `.mo` files anymore,
because we now build with `NO_GETTEXT` since 15008c18eb (ci(vs-build): build with NO_GETTEXT,
2021-06-23). These fixes should address those build failures.

They are based on js/ci-windows-update and can probably either both be squashed into 15008c18eb
(ci(vs-build): build with NO_GETTEXT, 2021-06-23) or alternatively 1/2  be applied on top of 
611b5396a2 (ci(windows): transfer also the Git-tracked files to the test jobs, 2021-06-23) and then only
2/2 squashed into 15008c18eb (ci(vs-build): build with NO_GETTEXT, 2021-06-23) and applied on top.

[1] https://lore.kernel.org/git/xmqqk0m9r8sr.fsf@gitster.g/

CC: Johannes Schindelin <johannes.schindelin@gmx.de>
CC: Junio C Hamano <gitster@pobox.com>
CC: Dennis Ameling <dennis@dennisameling.com>