### PR TITLE
ci: run `make sparse` as a GitHub workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -350,6 +350,26 @@ jobs:
     - uses: actions/checkout@v1
     - run: ci/install-dependencies.sh
     - run: ci/run-static-analysis.sh
+  sparse:
+    needs: ci-config
+    if: needs.ci-config.outputs.enabled == 'yes'
+    env:
+      jobname: sparse
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Download a current `sparse` package
+      # Ubuntu's `sparse` version is too old for us
+      uses: git-for-windows/get-azure-pipelines-artifact@v0
+      with:
+        repository: git/git
+        definitionId: 10
+        artifact: sparse-20.04
+    - name: Install the current `sparse` package
+      run: sudo dpkg -i sparse-20.04/sparse_*.deb
+    - uses: actions/checkout@v2
+    - name: Install other dependencies
+      run: ci/install-dependencies.sh
+    - run: make sparse
   documentation:
     needs: ci-config
     if: needs.ci-config.outputs.enabled == 'yes'

--- a/ci/install-dependencies.sh
+++ b/ci/install-dependencies.sh
@@ -65,6 +65,11 @@ StaticAnalysis)
 	sudo apt-get -q -y install coccinelle libcurl4-openssl-dev libssl-dev \
 		libexpat-dev gettext make
 	;;
+sparse)
+	sudo apt-get -q update -q
+	sudo apt-get -q -y install libssl-dev libcurl4-openssl-dev \
+		libexpat-dev gettext zlib1g-dev
+	;;
 Documentation)
 	sudo apt-get -q update
 	sudo apt-get -q -y install asciidoc xmlto docbook-xsl-ns make


### PR DESCRIPTION
One of the earliest open source static analyzers is called "sparse", and occasionally Ramsay Jones sends out mails on the Git mailing list that some function or other should be declared static because sparse found out that it is only used within the same file.

Let's add a GitHub workflow running "make sparse".

Example run: https://github.com/gitgitgadget/git/pull/994/checks?check_run_id=3065255116

Changes since v2:

- We're now reusing the `ci/install-dependencies.sh` script even in the `sparse` job.

Changes since v1:

- The job was folded into `main.yml`
- The commit message and a code comment now explain why we have to download & install a custom `sparse` package instead of using Ubuntu's default one
- The commit message now contains a link to the documentation of the `sparse` tool

Cc: Ramsay Jones <ramsay@ramsayjones.plus.com>
Cc: Đoàn Trần Công Danh <congdanhqx@gmail.com>
cc: Philippe Blain <levraiphilippeblain@gmail.com>
cc: Jeff King <peff@peff.net>