### PR TITLE
check-whitespace: two fixes

### DIFF
--- a/.github/workflows/check-whitespace.yml
+++ b/.github/workflows/check-whitespace.yml
@@ -12,15 +12,9 @@ jobs:
   check-whitespace:
     runs-on: ubuntu-latest
     steps:
-    - name: Set commit count
-      shell: bash
-      run: echo "COMMIT_DEPTH=$((1+$COMMITS))" >>$GITHUB_ENV
-      env:
-        COMMITS: ${{ github.event.pull_request.commits }}
-
     - uses: actions/checkout@v2
       with:
-        fetch-depth: ${{ env.COMMIT_DEPTH }}
+        fetch-depth: 0
 
     - name: git log --check
       id: check_out
@@ -47,7 +41,7 @@ jobs:
             echo "${dash} ${etc}"
             ;;
           esac
-        done <<< $(git log --check --pretty=format:"---% h% s" -${{github.event.pull_request.commits}})
+        done <<< $(git log --check --pretty=format:"---% h% s" ${{github.event.pull_request.base.sha}}..)
 
         if test -n "${log}"
         then

--- a/.github/workflows/check-whitespace.yml
+++ b/.github/workflows/check-whitespace.yml
@@ -51,21 +51,5 @@ jobs:
 
         if test -n "${log}"
         then
-          echo "::set-output name=checkout::"${log}""
           exit 2
         fi
-
-    - name: Add Check Output as Comment
-      uses: actions/github-script@v3
-      id: add-comment
-      env:
-        log: ${{ steps.check_out.outputs.checkout }}
-      with:
-        script: |
-            await github.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `Whitespace errors found in workflow ${{ github.workflow }}:\n\n\`\`\`\n${process.env.log.replace(/\\n/g, "\n")}\n\`\`\``
-            })
-      if: ${{ failure() }}


### PR DESCRIPTION
I recently ran into a situation where a merge commit (which admittedly are undesirable in git/git and gitgitgadget/git Pull Requests, but are sometimes totally appropriate in the context of other forks such as git-for-windows/git) misled the logic in the `check-whitespace` workflow to look at upstream commits (and missing some patches that it should have looked at).

At the same time, I also realized that the feature where this workflow adds a PR comment in an attempt to be more helpful requires a read/write token (which weakens the overall security, I'd much rather stay with the read-only token configured e.g. in gitgitgadget/git and in git-for-windows/git).

This patch series addresses both issues.

Cc: Chris. Webster <chris@webstech.net>
cc: Taylor Blau <me@ttaylorr.com>