### PR TITLE
parse-options: don't complete option aliases by default

### DIFF
--- a/parse-options.c
+++ b/parse-options.c
@@ -585,7 +585,7 @@ static int show_gitcomp(const struct option *opts, int show_all)
 		if (!opts->long_name)
 			continue;
 		if (!show_all &&
-			(opts->flags & (PARSE_OPT_HIDDEN | PARSE_OPT_NOCOMPLETE)))
+			(opts->flags & (PARSE_OPT_HIDDEN | PARSE_OPT_NOCOMPLETE | PARSE_OPT_FROM_ALIAS)))
 			continue;
 
 		switch (opts->type) {

--- a/t/t9902-completion.sh
+++ b/t/t9902-completion.sh
@@ -2404,6 +2404,19 @@ test_expect_success 'sourcing the completion script clears cached --options' '
 	verbose test -z "$__gitcomp_builtin_notes_edit"
 '
 
+test_expect_success 'option aliases are not shown by default' '
+	test_completion "git clone --recurs" "--recurse-submodules "
+'
+
+test_expect_success 'option aliases are shown with GIT_COMPLETION_SHOW_ALL' '
+	. "$GIT_BUILD_DIR/contrib/completion/git-completion.bash" &&
+	GIT_COMPLETION_SHOW_ALL=1 && export GIT_COMPLETION_SHOW_ALL &&
+	test_completion "git clone --recurs" <<-\EOF
+	--recurse-submodules Z
+	--recursive Z
+	EOF
+'
+
 test_expect_success '__git_complete' '
 	unset -f __git_wrap__git_main &&
 


### PR DESCRIPTION
Changes since v1:
- Added a paragraph to the commit message to clarify that the goal of this
  patch is to have the completion show only the canonical option and not its
  alias.

CC: Nguyễn Thái Ngọc Duy <pclouds@gmail.com>
CC: Brandon Williams <bwilliamseng@gmail.com>
CC: Felipe Contreras <felipe.contreras@gmail.com>
CC: Ryan Zoeller <rtzoeller@rtzoeller.com>
CC: SZEDER Gábor <szeder.dev@gmail.com>
cc: Ævar Arnfjörð Bjarmason <avarab@gmail.com>
