### PR TITLE
[GSOC] cherry-pick: fix bug when used with GIT_CHERRY_PICK_HELP

### DIFF
--- a/builtin/revert.c
+++ b/builtin/revert.c
@@ -245,6 +245,7 @@ int cmd_cherry_pick(int argc, const char **argv, const char *prefix)
 
 	opts.action = REPLAY_PICK;
 	sequencer_init_config(&opts);
+	unsetenv("GIT_CHERRY_PICK_HELP");
 	res = run_sequencer(argc, argv, &opts);
 	if (res < 0)
 		die(_("cherry-pick failed"));

--- a/t/t3507-cherry-pick-conflict.sh
+++ b/t/t3507-cherry-pick-conflict.sh
@@ -76,6 +76,23 @@ test_expect_success 'advice from failed cherry-pick --no-commit' "
 	test_cmp expected actual
 "
 
+test_expect_success 'advice from failed cherry-pick with GIT_CHERRY_PICK_HELP' "
+	pristine_detach initial &&
+	(
+		picked=\$(git rev-parse --short picked) &&
+		cat <<-EOF >expected &&
+		error: could not apply \$picked... picked
+		hint: after resolving the conflicts, mark the corrected paths
+		hint: with 'git add <paths>' or 'git rm <paths>'
+		hint: and commit the result with 'git commit'
+		EOF
+		GIT_CHERRY_PICK_HELP='and then do something else' &&
+		export GIT_CHERRY_PICK_HELP &&
+		test_must_fail git cherry-pick picked 2>actual &&
+		test_cmp expected actual
+	)
+"
+
 test_expect_success 'failed cherry-pick sets CHERRY_PICK_HEAD' '
 	pristine_detach initial &&
 	test_must_fail git cherry-pick picked &&
@@ -106,16 +123,6 @@ test_expect_success \
 	pristine_detach initial &&
 	echo foo >foo &&
 	test_must_fail git cherry-pick --strategy=resolve base &&
-	test_must_fail git rev-parse --verify CHERRY_PICK_HEAD
-'
-
-test_expect_success 'GIT_CHERRY_PICK_HELP suppresses CHERRY_PICK_HEAD' '
-	pristine_detach initial &&
-	(
-		GIT_CHERRY_PICK_HELP="and then do something else" &&
-		export GIT_CHERRY_PICK_HELP &&
-		test_must_fail git cherry-pick picked
-	) &&
 	test_must_fail git rev-parse --verify CHERRY_PICK_HEAD
 '
 


### PR DESCRIPTION
This patch fixes the bug when git cherry-pick is used with environment
variable GIT_CHERRY_PICK_HELP.

Change from last version:
1. Only unsetenv(GIT_CHERRY_PICK_HELP) without touching anything in
sequencer.c. Now git cherry-pick will ignore GIT_CHERRY_PICK_HELP,

$ GIT_CHERRY_PICK_HELP="213" git cherry-pick dev~3..dev

will only output default advice:

hint: after resolving the conflicts, mark the corrected paths
hint: with 'git add <paths>' or 'git rm <paths>'
hint: and commit the result with 'git commit'

This may still not be good enough, hope that cherry-pick will not advice
anything related to "git commit". Maybe we should make --no-commit as 
cherry-pick default behavior?

cc: Junio C Hamano gitster@pobox.com
cc: Christian Couder christian.couder@gmail.com
cc: Hariom Verma hariom18599@gmail.com
cc: Ævar Arnfjörð Bjarmason avarab@gmail.com
cc: Han-Wen Nienhuys hanwen@google.com
cc: Ramkumar Ramachandra artagnon@gmail.com
cc: Felipe Contreras <felipe.contreras@gmail.com>
cc: Phillip Wood <phillip.wood123@gmail.com>