### PR TITLE
clone: set submodule.recurse=true if submodule.stickyRecursiveClone enabled

### DIFF
--- a/builtin/clone.c
+++ b/builtin/clone.c
@@ -986,6 +986,7 @@ int cmd_clone(int argc, const char **argv, const char *prefix)
 	struct remote *remote;
 	int err = 0, complete_refs_before_fetch = 1;
 	int submodule_progress;
+	int sticky_recursive_clone;
 
 	struct transport_ls_refs_options transport_ls_refs_options =
 		TRANSPORT_LS_REFS_OPTIONS_INIT;
@@ -1128,6 +1129,11 @@ int cmd_clone(int argc, const char **argv, const char *prefix)
 				    item->string);
 			string_list_append(&option_config,
 					   strbuf_detach(&sb, NULL));
+		}
+
+		if (!git_config_get_bool("submodule.stickyRecursiveClone", &sticky_recursive_clone)
+		    && sticky_recursive_clone) {
+		    string_list_append(&option_config, "submodule.recurse=true");
 		}
 
 		if (option_required_reference.nr &&

--- a/t/t5606-clone-options.sh
+++ b/t/t5606-clone-options.sh
@@ -16,6 +16,18 @@ test_expect_success 'setup' '
 
 '
 
+test_expect_success 'submodule.stickyRecursiveClone flag manipulates submodule.recurse value' '
+
+	test_config_global submodule.stickyRecursiveClone true &&
+	git clone --recurse-submodules parent clone_recurse_true &&
+	test_cmp_config -C clone_recurse_true true submodule.recurse &&
+
+	test_config_global submodule.stickyRecursiveClone false &&
+	git clone --recurse-submodules parent clone_recurse_false &&
+	test_expect_code 1 git -C clone_recurse_false config --get submodule.recurse
+
+'
+
 test_expect_success 'clone -o' '
 
 	git clone -o foo parent clone-o &&


### PR DESCRIPTION
Based on current experience, when running `git clone --recurse-submodules`, 
developers do not expect other commands such as `pull` or `checkout` to run 
recursively into active submodules. However, setting `submodule.recurse=true` 
at this step could make for a simpler workflow by eliminating the need for 
the `--recurse-submodules` option in subsequent commands. To collect more 
data on developers' behavior and preferences when making `submodule.recurse=true` 
a default, deploy this feature under the opt in `submodule.stickyRecursiveClone` flag.

Signed-off-by: Mahi Kolla <mkolla2@illinois.edu>

Since V1: Made this an opt in feature under a custom `submodule.stickyRecursiveClone` 
flag as opposed to `feature.experimental`. Updated tests to reflect this design change. 
Also updated commit message. Additionally, I will be contributing from my personal email
going forward as opposed to my @google email.

Thanks for taking the time to contribute to Git! Please be advised that the
Git community does not use github.com for their contributions. Instead, we use
a mailing list (git@vger.kernel.org) for code submissions, code reviews, and
bug reports. Nevertheless, you can use GitGitGadget (https://gitgitgadget.github.io/)
to conveniently send your Pull Requests commits to our mailing list.

Please read the "guidelines for contributing" linked above!


cc: Philippe Blain <levraiphilippeblain@gmail.com>

cc: Philippe Blain <levraiphilippeblain@gmail.com>
cc: Mahi Kolla <mahikolla@google.com>
cc: Emily Shaffer <emilyshaffer@google.com>
cc: Felipe Contreras <felipe.contreras@gmail.com>