### PR TITLE
[GSOC] cherry-pick: fix bug when used with GIT_CHERRY_PICK_HELP

### DIFF
--- a/builtin/revert.c
+++ b/builtin/revert.c
@@ -127,6 +127,8 @@ static int run_sequencer(int argc, const char **argv, struct replay_opts *opts)
 			OPT_BOOL(0, "allow-empty", &opts->allow_empty, N_("preserve initially empty commits")),
 			OPT_BOOL(0, "allow-empty-message", &opts->allow_empty_message, N_("allow commits with empty messages")),
 			OPT_BOOL(0, "keep-redundant-commits", &opts->keep_redundant_commits, N_("keep redundant, empty commits")),
+			OPT_BOOL_F(0, "rebase-preserve-merges-mode", &opts->rebase_preserve_merges_mode,
+				   N_("use for git-rebase--preserve-merges backend"), PARSE_OPT_HIDDEN),
 			OPT_END(),
 		};
 		options = parse_options_concat(options, cp_extra);

--- a/git-rebase--preserve-merges.sh
+++ b/git-rebase--preserve-merges.sh
@@ -444,7 +444,7 @@ pick_one_preserving_merges () {
 			output eval git cherry-pick $allow_rerere_autoupdate \
 				$allow_empty_message \
 				${gpg_sign_opt:+$(git rev-parse --sq-quote "$gpg_sign_opt")} \
-				"$strategy_args" "$@" ||
+				"$strategy_args" --rebase-preserve-merges-mode "$@" ||
 				die_with_patch $sha1 "$(eval_gettext "Could not pick \$sha1")"
 			;;
 		esac

--- a/sequencer.c
+++ b/sequencer.c
@@ -39,6 +39,16 @@
 
 static const char sign_off_header[] = "Signed-off-by: ";
 static const char cherry_picked_prefix[] = "(cherry picked from commit ";
+static const char *no_commit_advice = N_("after resolving the conflicts, mark the corrected paths\n"
+				"with 'git add <paths>' or 'git rm <paths>'");
+static const char *commit_advice = N_("after resolving the conflicts, mark the corrected paths\n"
+			    "with 'git add <paths>' or 'git rm <paths>'\n"
+			    "and commit the result with 'git commit'");
+static const char *cherry_pick_advice = N_("Resolve all conflicts manually, mark them as resolved with\n"
+					"\"git add/rm <conflicted_files>\", then run \"git cherry-pick --continue\".\n"
+					"You can instead skip this commit: run \"git cherry-pick --skip\".\n"
+					"To abort and get back to the state before \"git cherry-pick\",\n"
+					"run \"git cherry-pick --abort\".");
 
 GIT_PATH_FUNC(git_path_commit_editmsg, "COMMIT_EDITMSG")
 
@@ -419,12 +429,9 @@ static void print_advice(struct replay_opts *opts, const char *help_msgs)
 	if (help_msgs)
 		advise("%s\n", help_msgs);
 	else if (opts->no_commit)
-		advise(_("after resolving the conflicts, mark the corrected paths\n"
-			 "with 'git add <paths>' or 'git rm <paths>'"));
+		advise("%s\n", _(no_commit_advice));
 	else
-		advise(_("after resolving the conflicts, mark the corrected paths\n"
-			 "with 'git add <paths>' or 'git rm <paths>'\n"
-			 "and commit the result with 'git commit'"));
+		advise("%s\n", _(commit_advice));
 }
 
 static int write_message(const void *buf, size_t len, const char *filename,
@@ -2269,6 +2276,8 @@ static int do_pick_commit(struct repository *r,
 		      ? _("could not revert %s... %s")
 		      : _("could not apply %s... %s"),
 		      short_commit_name(commit), msg.subject);
+		if (opts->action == REPLAY_PICK)
+			help_msgs = _(cherry_pick_advice);
 		if (((opts->action == REPLAY_PICK &&
 		      !opts->rebase_preserve_merges_mode) ||
 		      (help_msgs = check_need_delete_cherry_pick_head(r))) &&

--- a/sequencer.h
+++ b/sequencer.h
@@ -49,6 +49,7 @@ struct replay_opts {
 	int reschedule_failed_exec;
 	int committer_date_is_author_date;
 	int ignore_date;
+	int rebase_preserve_merges_mode;
 
 	int mainline;
 

--- a/t/t3507-cherry-pick-conflict.sh
+++ b/t/t3507-cherry-pick-conflict.sh
@@ -76,6 +76,23 @@ test_expect_success 'advice from failed cherry-pick --no-commit' "
 	test_cmp expected actual
 "
 
+test_expect_success 'advice from failed cherry-pick with GIT_CHERRY_PICK_HELP' "
+	pristine_detach initial &&
+	(
+		picked=\$(git rev-parse --short picked) &&
+		cat <<-EOF >expected &&
+		error: could not apply \$picked... picked
+		hint: after resolving the conflicts, mark the corrected paths
+		hint: with 'git add <paths>' or 'git rm <paths>'
+		hint: and commit the result with 'git commit'
+		EOF
+		GIT_CHERRY_PICK_HELP='and then do something else' &&
+		export GIT_CHERRY_PICK_HELP &&
+		test_must_fail git cherry-pick picked 2>actual &&
+		test_cmp expected actual
+	)
+"
+
 test_expect_success 'failed cherry-pick sets CHERRY_PICK_HEAD' '
 	pristine_detach initial &&
 	test_must_fail git cherry-pick picked &&
@@ -106,16 +123,6 @@ test_expect_success \
 	pristine_detach initial &&
 	echo foo >foo &&
 	test_must_fail git cherry-pick --strategy=resolve base &&
-	test_must_fail git rev-parse --verify CHERRY_PICK_HEAD
-'
-
-test_expect_success 'GIT_CHERRY_PICK_HELP suppresses CHERRY_PICK_HEAD' '
-	pristine_detach initial &&
-	(
-		GIT_CHERRY_PICK_HELP="and then do something else" &&
-		export GIT_CHERRY_PICK_HELP &&
-		test_must_fail git cherry-pick picked
-	) &&
 	test_must_fail git rev-parse --verify CHERRY_PICK_HEAD
 '
 

--- a/t/t3507-cherry-pick-conflict.sh
+++ b/t/t3507-cherry-pick-conflict.sh
@@ -53,9 +53,11 @@ test_expect_success 'advice from failed cherry-pick' "
 	picked=\$(git rev-parse --short picked) &&
 	cat <<-EOF >expected &&
 	error: could not apply \$picked... picked
-	hint: after resolving the conflicts, mark the corrected paths
-	hint: with 'git add <paths>' or 'git rm <paths>'
-	hint: and commit the result with 'git commit'
+	hint: Resolve all conflicts manually, mark them as resolved with
+	hint: \"git add/rm <conflicted_files>\", then run \"git cherry-pick --continue\".
+	hint: You can instead skip this commit: run \"git cherry-pick --skip\".
+	hint: To abort and get back to the state before \"git cherry-pick\",
+	hint: run \"git cherry-pick --abort\".
 	EOF
 	test_must_fail git cherry-pick picked 2>actual &&
 
@@ -68,8 +70,11 @@ test_expect_success 'advice from failed cherry-pick --no-commit' "
 	picked=\$(git rev-parse --short picked) &&
 	cat <<-EOF >expected &&
 	error: could not apply \$picked... picked
-	hint: after resolving the conflicts, mark the corrected paths
-	hint: with 'git add <paths>' or 'git rm <paths>'
+	hint: Resolve all conflicts manually, mark them as resolved with
+	hint: \"git add/rm <conflicted_files>\", then run \"git cherry-pick --continue\".
+	hint: You can instead skip this commit: run \"git cherry-pick --skip\".
+	hint: To abort and get back to the state before \"git cherry-pick\",
+	hint: run \"git cherry-pick --abort\".
 	EOF
 	test_must_fail git cherry-pick --no-commit picked 2>actual &&
 
@@ -82,9 +87,11 @@ test_expect_success 'advice from failed cherry-pick with GIT_CHERRY_PICK_HELP' "
 		picked=\$(git rev-parse --short picked) &&
 		cat <<-EOF >expected &&
 		error: could not apply \$picked... picked
-		hint: after resolving the conflicts, mark the corrected paths
-		hint: with 'git add <paths>' or 'git rm <paths>'
-		hint: and commit the result with 'git commit'
+		hint: Resolve all conflicts manually, mark them as resolved with
+		hint: \"git add/rm <conflicted_files>\", then run \"git cherry-pick --continue\".
+		hint: You can instead skip this commit: run \"git cherry-pick --skip\".
+		hint: To abort and get back to the state before \"git cherry-pick\",
+		hint: run \"git cherry-pick --abort\".
 		EOF
 		GIT_CHERRY_PICK_HELP='and then do something else' &&
 		export GIT_CHERRY_PICK_HELP &&


### PR DESCRIPTION
This patch fixes the bug when git cherry-pick is used with environment
variable GIT_CHERRY_PICK_HELP, and makes git chery-pick advice 
message better.

v2: https://lore.kernel.org/git/pull.1001.v2.git.1627135281887.gitgitgadget@gmail.com/

v2-->v3:
1. Add hidden option --rebase-preserve-merges-mode to git cherry-pick.
2. Split print_advice() into itself and check_need_delete_cherry_pick_head(). 
3. Only allow git cherry-pick skip check_need_delete_cherry_pick_head().
4. Use better git cherry-pick advice message.

cc: Junio C Hamano gitster@pobox.com
cc: Christian Couder christian.couder@gmail.com
cc: Hariom Verma hariom18599@gmail.com
cc: Ævar Arnfjörð Bjarmason avarab@gmail.com
cc: Han-Wen Nienhuys hanwen@google.com
cc: Ramkumar Ramachandra artagnon@gmail.com
cc: Felipe Contreras <felipe.contreras@gmail.com>
cc: Phillip Wood <phillip.wood123@gmail.com>