### PR TITLE
mingw: support the `git-repo` tool better

### DIFF
--- a/t/t3400-rebase.sh
+++ b/t/t3400-rebase.sh
@@ -406,4 +406,14 @@ test_expect_success 'refuse to switch to branch checked out elsewhere' '
 	test_i18ngrep "already checked out" err
 '
 
+test_expect_success MINGW,SYMLINKS_WINDOWS 'rebase when .git/logs is a symlink' '
+	git checkout main &&
+	mv .git/logs actual_logs &&
+	cmd //c "mklink /D .git\logs ..\actual_logs" &&
+	git rebase -f HEAD^ &&
+	test -L .git/logs &&
+	rm .git/logs &&
+	mv actual_logs .git/logs
+'
+
 test_done

--- a/t/test-lib.sh
+++ b/t/test-lib.sh
@@ -1513,6 +1513,12 @@ test_lazy_prereq SYMLINKS '
 	ln -s x y && test -h y
 '
 
+test_lazy_prereq SYMLINKS_WINDOWS '
+	# test whether symbolic links are enabled on Windows
+	test_have_prereq MINGW &&
+	cmd //c "mklink y x" &> /dev/null && test -h y
+'
+
 test_lazy_prereq FILEMODE '
 	test "$(git config --bool core.filemode)" = true
 '


### PR DESCRIPTION
This addresses an issue, originally reported at https://github.com/git-for-windows/git/issues/2967, where [the `git-repo` tool](https://gerrit.googlesource.com/git-repo/) replaces folders in .git/ with symlinks and `mingw_rmdir()` erroneously removes the symlink target directory's contents.

Changes since v1:

- Fixed the authorship
- Augmented the commit message to elaborate on what the issues are, concretely, with the current behavior of `mingw_rmdir()`
- Added an explanation to the commit message as to what happens during a `git rebase` that would trigger the `rmdir()` code path to misbehave
- Adjusted the code comment to talk specifically about the `remove_path()` caller and why we want to align with Linux' `rmdir()` behavior

cc: Eric Sunshine <sunshine@sunshineco.com>