### PR TITLE
New config for help.autocorrect to prompt user before action

### DIFF
--- a/Documentation/config/help.txt
+++ b/Documentation/config/help.txt
@@ -9,13 +9,15 @@ help.format::
 
 help.autoCorrect::
 	If git detects typos and can identify exactly one valid command similar
-	to the error, git will automatically run the intended command after
-	waiting a duration of time defined by this configuration value in
-	deciseconds (0.1 sec).  If this value is 0, the suggested corrections
-	will be shown, but not executed. If it is a negative integer, or
-	"immediate", the suggested command
-	is run immediately. If "never", suggestions are not shown at all. The
-	default value is zero.
+	to the error, git will try to suggest the correct command or even
+	run the suggestion automatically. Possible config values are:
+	 - 0 (default): show the suggested command.
+	 - positive number: run the suggested command after specified
+deciseconds (0.1 sec).
+	 - "immediate": run the suggested command immediately.
+	 - "prompt": show the suggestion and prompt for confirmation to run
+the command.
+	 - "never": don't run or show any suggested command.
 
 help.htmlPath::
 	Specify the path where the HTML documentation resides. File system paths


### PR DESCRIPTION
Only minor style changes have been made since v2:

- Moved `*` to variable name instead of the type name
- Keep code in the same line for readability

cc: David Barr b@rr-dav.id.au
cc: Bagas Sanjaya <bagasdotme@gmail.com>
cc: Azeem Bande-Ali <me@azeemba.com>
cc: Johannes Schindelin <Johannes.Schindelin@gmx.de>