### PR TITLE
sparse-index: copy dir_hash in ensure_full_index()

### DIFF
--- a/sparse-index.c
+++ b/sparse-index.c
@@ -283,6 +283,7 @@ void ensure_full_index(struct index_state *istate)
 
 	/* Copy back into original index. */
 	memcpy(&istate->name_hash, &full->name_hash, sizeof(full->name_hash));
+	memcpy(&istate->dir_hash, &full->dir_hash, sizeof(full->dir_hash));
 	istate->sparse_index = 0;
 	free(istate->cache);
 	istate->cache = full->cache;


### PR DESCRIPTION
This fix is an issue we discovered in our first experimental release of the sparse index in the microsoft/git fork. We fixed it in the latest experimental release [1] and then I almost forgot about it until we started rebasing sparse-index work on top of the 2.33.0 release candidates.

[1] https://github.com/microsoft/git/releases/tag/v2.32.0.vfs.0.102.exp

This is a change that can be taken anywhere since 4300f8 (sparse-index: implement ensure_full_index(), 2021-03-30), but this version is based on v2.33.0-rc2.

While the bug is alarming for users who hit it (seg fault) it requires sufficient scale and use of the optional sparse index feature. We are not recommending wide adoption of the sparse index yet because we don't have a sufficient density of integrated commands. For that reason, I don't think this should halt progress towards the full v2.33.0 release. I did want to send this as soon as possible so that could be at the discretion of the maintainer.

Thanks,
-Stolee

Cc: git@jeffhostetler.com
Cc: gitster@pobox.com
Cc: newren@gmail.com
Cc: stolee@gmail.com
cc: Johannes Schindelin <Johannes.Schindelin@gmx.de>
cc: Ævar Arnfjörð Bjarmason <avarab@gmail.com>