### PR TITLE
git-p4.py rebase fails when default branch name not master

### DIFF
--- a/git-p4.py
+++ b/git-p4.py
@@ -4091,6 +4091,7 @@ class P4Rebase(Command):
     def __init__(self):
         Command.__init__(self)
         self.options = [
+		optparse.make_option("--branch", dest="branch"),
                 optparse.make_option("--import-labels", dest="importLabels", action="store_true"),
         ]
         self.importLabels = False
@@ -4100,6 +4101,7 @@ class P4Rebase(Command):
     def run(self, args):
         sync = P4Sync()
         sync.importLabels = self.importLabels
+	sync.branch = self.branch
         sync.run([])
 
         return self.rebase()


### PR DESCRIPTION
git-p4.py rebase fail if default branch name not 'master'

In git-p4.py the P4Rebase class calls through to P4Sync() but will now pass along an optional branch argument. This has been needed lately as I haven't been able to rebase since my remote origins stopped using 'master' as their default branch names (in favour of 'main'). This small change resolves that. I've verified this change to git-p4.py in my DevOps systems where I'm continually syncing Perforce Helix code in to Git repos.

I didn't have to add documentation since ArgParse already generates that.

All I had to do to correct this behavior is:
1. Add a line to the P4Rebase class to accept "branch" as an argument. 
2. When the rebase function preps to call the Sync function, pass long the branch name. If none is given, sync already handled that case and continues on the way it always did (which assumes the default branch name remains 'master').

Signed-off-by: James T Snell <contact@jamessnell.com>
