### PR TITLE
fast-export: fix anonymized tag using original length

### DIFF
--- a/builtin/fast-export.c
+++ b/builtin/fast-export.c
@@ -821,6 +821,7 @@ static void handle_tag(const char *name, struct tag *tag)
 			static struct hashmap tags;
 			message = anonymize_str(&tags, anonymize_tag,
 						message, message_size, NULL);
+			message_size = strlen(message);
 		}
 	}
 

--- a/t/t9351-fast-export-anonymize.sh
+++ b/t/t9351-fast-export-anonymize.sh
@@ -18,7 +18,8 @@ test_expect_success 'setup simple repo' '
 	git update-index --add --cacheinfo 160000,$fake_commit,link1 &&
 	git update-index --add --cacheinfo 160000,$fake_commit,link2 &&
 	git commit -m "add gitlink" &&
-	git tag -m "annotated tag" mytag
+	git tag -m "annotated tag" mytag &&
+	git tag -m "annotated tag with long message" longtag
 '
 
 test_expect_success 'export anonymized stream' '
@@ -55,7 +56,8 @@ test_expect_success 'stream retains other as refname' '
 
 test_expect_success 'stream omits other refnames' '
 	! grep main stream &&
-	! grep mytag stream
+	! grep mytag stream &&
+	! grep longtag stream
 '
 
 test_expect_success 'stream omits identities' '
@@ -118,9 +120,9 @@ test_expect_success 'identical gitlinks got identical oid' '
 	test_line_count = 1 commits
 '
 
-test_expect_success 'tag points to branch tip' '
+test_expect_success 'all tags point to branch tip' '
 	git rev-parse $other_branch >expect &&
-	git for-each-ref --format="%(*objectname)" | grep . >actual &&
+	git for-each-ref --format="%(*objectname)" | grep . | uniq >actual &&
 	test_cmp expect actual
 '
 


### PR DESCRIPTION
Fixes an issue with fast-export anonymization, where any original annotated tag message longer
than 13 characters would make the output unimportable by fast-import (as the data length indicated the original length).

This also resolves a more minor issue, where if the original message was short, the anonymized tag message would be truncated.

CC: Jeff King <peff@peff.net>
CC: Johannes Schindelin <Johannes.Schindelin@gmx.de>
