### PR TITLE
pull: release handles to pack files before potentially gc'ing

### DIFF
--- a/builtin/pull.c
+++ b/builtin/pull.c
@@ -26,6 +26,7 @@
 #include "wt-status.h"
 #include "commit-reach.h"
 #include "sequencer.h"
+#include "packfile.h"
 
 /**
  * Parses the value of --rebase. If value is a false value, returns
@@ -998,6 +999,7 @@ int cmd_pull(int argc, const char **argv, const char *prefix)
 			oidclr(&rebase_fork_point);
 	}
 
+	close_object_store(the_repository->objects);
 	if (run_fetch(repo, refspecs))
 		return 1;
 

--- a/commit-graph.c
+++ b/commit-graph.c
@@ -713,6 +713,7 @@ static void close_commit_graph_one(struct commit_graph *g)
 	if (!g)
 		return;
 
+	clear_commit_graph_data_slab(&commit_graph_data_slab);
 	close_commit_graph_one(g->base_graph);
 	free_commit_graph(g);
 }


### PR DESCRIPTION
It was [reported in Git for Windows](https://github.com/git-for-windows/git/issues/3336) that there are _still_ some code paths where `.pack` files are still open when a garbage collection is triggered. This time, the affected command is `git pull`.

The fix is relatively trivial but uncovers a bug in the `commit-graph` code, which we have to fix first.

Cc: Derrick Stolee <dstolee@microsoft.com>