### PR TITLE
documentation: handle non-existing html pages and document 'git version'

### DIFF
--- a/Documentation/git-version.txt
+++ b/Documentation/git-version.txt
@@ -1,0 +1,28 @@
+git-version(1)
+==============
+
+NAME
+----
+git-version - Display version information about Git
+
+SYNOPSIS
+--------
+[verse]
+'git version' [--build-options]
+
+DESCRIPTION
+-----------
+With no options given, the version of 'git' is printed on the standard output.
+
+Note that `git --version` is identical to `git version` because the
+former is internally converted into the latter.
+
+OPTIONS
+-------
+--build-options::
+	Include additional information about how git was built for diagnostic
+	purposes.
+
+GIT
+---
+Part of the linkgit:git[1] suite

--- a/Documentation/git.txt
+++ b/Documentation/git.txt
@@ -41,6 +41,10 @@ OPTIONS
 -------
 --version::
 	Prints the Git suite version that the 'git' program came from.
++
+This option is internaly converted to `git version ...` and accepts
+the same options as the linkgit:git-version[1] command. If `--help` is
+also given, it takes precedence over `--version`.
 
 --help::
 	Prints the synopsis and a list of the most commonly used

--- a/builtin/help.c
+++ b/builtin/help.c
@@ -467,11 +467,14 @@ static void get_html_page_path(struct strbuf *page_path, const char *page)
 	if (!html_path)
 		html_path = to_free = system_path(GIT_HTML_PATH);
 
-	/* Check that we have a git documentation directory. */
+	/*
+	 * Check that the page we're looking for exists.
+	 */
 	if (!strstr(html_path, "://")) {
-		if (stat(mkpath("%s/git.html", html_path), &st)
+		if (stat(mkpath("%s/%s.html", html_path, page), &st)
 		    || !S_ISREG(st.st_mode))
-			die("'%s': not a documentation directory.", html_path);
+			die("'%s/%s.html': documentation file not found.",
+				html_path, page);
 	}
 
 	strbuf_init(page_path, 0);

--- a/t/t0012-help.sh
+++ b/t/t0012-help.sh
@@ -73,6 +73,22 @@ test_expect_success 'git help -g' '
 	test_i18ngrep "^   tutorial   " help.output
 '
 
+test_expect_success 'git help fails for non-existing html pages' '
+	configure_help &&
+	mkdir html-empty &&
+	test_must_fail git -c help.htmlpath=html-empty help status &&
+	test_must_be_empty test-browser.log
+'
+
+test_expect_success 'git help succeeds without git.html' '
+	configure_help &&
+	mkdir html-with-docs &&
+	touch html-with-docs/git-status.html &&
+	git -c help.htmlpath=html-with-docs help status &&
+	echo "html-with-docs/git-status.html" >expect &&
+	test_cmp expect test-browser.log
+'
+
 test_expect_success 'generate builtin list' '
 	git --list-cmds=builtins >builtins
 '


### PR DESCRIPTION
These two patches are grouped as one patch series, because they arose from the
same Git for Windows issue [1], but they can be reviewed or applied independent
from one another.

One interesting oddity I found while preparing V2:
`git --version --help` gets converted to `git version --help` which then calls `git help version`,
but `git --help --version` gets converted to `git help --version` and `git help` doesn't know what to do with `--version`.

[1] https://github.com/git-for-windows/git/issues/3308

Changes since V1:
* fixed various typos in the log message of patch 1
* changed patch 1 to just check the requested page instead of both the requested page and `git.html`
* moved the test up before the  "generate builtin list" test
* reworked the test slightly
* added a second test
* removed the redundant description of `--build-options` from the `DESCRIPTION` section
* added a small paragraph to `Documentation/git.txt` that links to the new `git version` page (like we already do for `git help`)

cc: Ævar Arnfjörð Bjarmason <avarab@gmail.com>
cc: Eric Sunshine <sunshine@sunshineco.com>
cc: Matthias Aßhauer <mha1993@live.de>
cc: Junio C Hamano <gitster@pobox.com>