### PR TITLE
Sparse checkout: fix mixed-mode pattern issues

### DIFF
--- a/builtin/sparse-checkout.c
+++ b/builtin/sparse-checkout.c
@@ -513,6 +513,9 @@ static void add_patterns_cone_mode(int argc, const char **argv,
 		die(_("unable to load existing sparse-checkout patterns"));
 	free(sparse_filename);
 
+	if (!existing.use_cone_patterns)
+		die(_("existing sparse-checkout patterns do not use cone mode"));
+
 	hashmap_for_each_entry(&existing.recursive_hashmap, &iter, pe, ent) {
 		if (!hashmap_contains_parent(&pl->recursive_hashmap,
 					pe->pattern, &buffer) ||

--- a/builtin/sparse-checkout.c
+++ b/builtin/sparse-checkout.c
@@ -348,8 +348,17 @@ static int sparse_checkout_init(int argc, const char **argv)
 
 	/* If we already have a sparse-checkout file, use it. */
 	if (res >= 0) {
-		free(sparse_filename);
-		return update_working_directory(NULL);
+		if (pl.use_cone_patterns || !init_opts.cone_mode) {
+			free(sparse_filename);
+			return update_working_directory(NULL);
+		}
+
+		/*
+		 * At this point, note that if res >= 0 but pl.use_cone_patterns
+		 * is false, then we want to override the patterns with the
+		 * initial set of cone mode patterns.
+		 */
+		clear_pattern_list(&pl);
 	}
 
 	if (get_oid("HEAD", &oid)) {

--- a/builtin/sparse-checkout.c
+++ b/builtin/sparse-checkout.c
@@ -389,7 +389,7 @@ static void insert_recursive_pattern(struct pattern_list *pl, struct strbuf *pat
 		char *oldpattern = e->pattern;
 		size_t newlen;
 
-		if (slash == e->pattern)
+		if (!slash || slash == e->pattern)
 			break;
 
 		newlen = slash - e->pattern;

--- a/dir.c
+++ b/dir.c
@@ -727,7 +727,7 @@ static void add_pattern_to_hashsets(struct pattern_list *pl, struct path_pattern
 	}
 
 	if (given->patternlen < 2 ||
-	    *given->pattern == '*' ||
+	    *given->pattern != '/' ||
 	    strstr(given->pattern, "**")) {
 		/* Not a cone pattern. */
 		warning(_("unrecognized pattern: '%s'"), given->pattern);

--- a/t/t1091-sparse-checkout-builtin.sh
+++ b/t/t1091-sparse-checkout-builtin.sh
@@ -108,7 +108,14 @@ test_expect_success 'switching to cone mode with non-cone mode patterns' '
 	git -C bad-patterns sparse-checkout init &&
 	git -C bad-patterns sparse-checkout add dir &&
 	git -C bad-patterns config core.sparseCheckoutCone true &&
-	git -C bad-patterns sparse-checkout add dir
+	git -C bad-patterns sparse-checkout add dir &&
+
+	git -C bad-patterns sparse-checkout init --cone &&
+	cat >expect <<-\EOF &&
+	/*
+	!/*/
+	EOF
+	test_cmp expect bad-patterns/.git/info/sparse-checkout
 '
 
 test_expect_success 'interaction with clone --no-checkout (unborn index)' '

--- a/t/t1091-sparse-checkout-builtin.sh
+++ b/t/t1091-sparse-checkout-builtin.sh
@@ -108,14 +108,17 @@ test_expect_success 'switching to cone mode with non-cone mode patterns' '
 	git -C bad-patterns sparse-checkout init &&
 	git -C bad-patterns sparse-checkout add dir &&
 	git -C bad-patterns config core.sparseCheckoutCone true &&
-	git -C bad-patterns sparse-checkout add dir &&
+
+	test_must_fail git -C bad-patterns sparse-checkout add dir 2>err &&
+	grep "existing sparse-checkout patterns do not use cone mode" err &&
 
 	git -C bad-patterns sparse-checkout init --cone &&
 	cat >expect <<-\EOF &&
 	/*
 	!/*/
 	EOF
-	test_cmp expect bad-patterns/.git/info/sparse-checkout
+	test_cmp expect bad-patterns/.git/info/sparse-checkout &&
+	git -C bad-patterns sparse-checkout add dir
 '
 
 test_expect_success 'interaction with clone --no-checkout (unborn index)' '
@@ -182,9 +185,9 @@ test_expect_success 'set sparse-checkout using --stdin' '
 test_expect_success 'add to sparse-checkout' '
 	cat repo/.git/info/sparse-checkout >expect &&
 	cat >add <<-\EOF &&
-	pattern1
+	/pattern1
 	/folder1/
-	pattern2
+	/pattern2
 	EOF
 	cat add >>expect &&
 	git -C repo sparse-checkout add --stdin <add &&

--- a/t/t1091-sparse-checkout-builtin.sh
+++ b/t/t1091-sparse-checkout-builtin.sh
@@ -103,6 +103,14 @@ test_expect_success 'clone --sparse' '
 	check_files clone a
 '
 
+test_expect_success 'switching to cone mode with non-cone mode patterns' '
+	git init bad-patterns &&
+	git -C bad-patterns sparse-checkout init &&
+	git -C bad-patterns sparse-checkout add dir &&
+	git -C bad-patterns config core.sparseCheckoutCone true &&
+	git -C bad-patterns sparse-checkout add dir
+'
+
 test_expect_success 'interaction with clone --no-checkout (unborn index)' '
 	git clone --no-checkout "file://$(pwd)/repo" clone_no_checkout &&
 	git -C clone_no_checkout sparse-checkout init --cone &&


### PR DESCRIPTION
This fixes a memory leak reported in [1], but also fixes some behavior concerns around the sparse-checkout command when the sparse-checkout file does not use cone mode patterns, but cone mode is enabled.

[1] https://lore.kernel.org/git/CAKRwm5a9PyqffEC5N__urSpNcZ-d5vz9GBM2Ei16eGS25B=-FQ@mail.gmail.com/

1. The first patch fixes the OOM as recommended by Taylor.
2. The second patch changes the behavior of 'git sparse-checkout init --cone' to overwrite the sparse-checkout file if the patterns are not in cone mode.
3. The third patch causes 'git sparse-checkout add' to fail if cone mode is enabled but the existing patterns are not in cone mode. This also requires strengthening our pattern filtering to require the first character be a slash ('/'), which should have been there from the start.

Thanks,
-Stolee

cc: gitster@pobox.com
cc: me@ttaylorr.com
cc: calbabreaker@gmail.com
cc: Derrick Stolee <stolee@gmail.com>