### PR TITLE
t/perf/run: fix bin-wrappers computation

### DIFF
--- a/t/perf/run
+++ b/t/perf/run
@@ -74,7 +74,7 @@ set_git_test_installed () {
 	mydir=$1
 
 	mydir_abs=$(cd $mydir && pwd)
-	mydir_abs_wrappers="$mydir_abs_wrappers/bin-wrappers"
+	mydir_abs_wrappers="$mydir_abs/bin-wrappers"
 	if test -d "$mydir_abs_wrappers"
 	then
 		GIT_TEST_INSTALLED=$mydir_abs_wrappers


### PR DESCRIPTION
Found this while we were testing sparse index improvements to 'git stash', which uses a lot of subcommands.

Thanks,
-Stolee

cc: gitster@pobox.com
cc: avarab@gmail.com
cc: vdye@github.com
cc: stolee@gmail.com
cc: Taylor Blau <me@ttaylorr.com>