### PR TITLE
dir: force untracked cache with core.untrackedCache

### DIFF
--- a/dir.c
+++ b/dir.c
@@ -2936,7 +2936,9 @@ int read_directory(struct dir_struct *dir, struct index_state *istate,
 
 		if (force_untracked_cache < 0)
 			force_untracked_cache =
-				git_env_bool("GIT_FORCE_UNTRACKED_CACHE", 0);
+				git_env_bool("GIT_FORCE_UNTRACKED_CACHE", -1);
+		if (force_untracked_cache < 0)
+			force_untracked_cache = (istate->repo->settings.core_untracked_cache == UNTRACKED_CACHE_WRITE);
 		if (force_untracked_cache &&
 			dir->untracked == istate->untracked &&
 		    (dir->untracked->dir_opened ||


### PR DESCRIPTION
We have seen users in the wild that have had `core.untrackedCache` enabled, but never actually have an untracked cache created for them. We have a test in t7063 that shows `git status` should write the untracked cache, so I'm not exactly sure how users are in this state for long.

This patch fixes the situation. I also know of another group that sets `GIT_FORCE_UNTRACKED_CACHE=1` in their developer environment in order to get this behavior.

-Stolee

Update in v2
------------

* Edited the commit message to be clearer.

cc: gitster@pobox.com
cc: pclouds@gmail.com
