### PR TITLE
sparse-index: expand/collapse based on 'index.sparse'

### DIFF
--- a/read-cache.c
+++ b/read-cache.c
@@ -2337,9 +2337,17 @@ int do_read_index(struct index_state *istate, const char *path, int must_exist)
 
 	if (!istate->repo)
 		istate->repo = the_repository;
+
+	/*
+	 * If the command explicitly requires a full index, force it
+	 * to be full. Otherwise, correct the sparsity based on repository
+	 * settings and other properties of the index (if necessary).
+	 */
 	prepare_repo_settings(istate->repo);
 	if (istate->repo->settings.command_requires_full_index)
 		ensure_full_index(istate);
+	else
+		ensure_correct_sparsity(istate);
 
 	return istate->cache_nr;
 

--- a/sparse-index.c
+++ b/sparse-index.c
@@ -175,17 +175,20 @@ int convert_to_sparse(struct index_state *istate, int flags)
 	if (index_has_unmerged_entries(istate))
 		return 0;
 
-	/* Clear and recompute the cache-tree */
-	cache_tree_free(&istate->cache_tree);
-	/*
-	 * Silently return if there is a problem with the cache tree update,
-	 * which might just be due to a conflict state in some entry.
-	 *
-	 * This might create new tree objects, so be sure to use
-	 * WRITE_TREE_MISSING_OK.
-	 */
-	if (cache_tree_update(istate, WRITE_TREE_MISSING_OK))
-		return 0;
+	if (!cache_tree_fully_valid(istate->cache_tree)) {
+		/* Clear and recompute the cache-tree */
+		cache_tree_free(&istate->cache_tree);
+
+		/*
+		 * Silently return if there is a problem with the cache tree update,
+		 * which might just be due to a conflict state in some entry.
+		 *
+		 * This might create new tree objects, so be sure to use
+		 * WRITE_TREE_MISSING_OK.
+		 */
+		if (cache_tree_update(istate, WRITE_TREE_MISSING_OK))
+			return 0;
+	}
 
 	remove_fsmonitor(istate);
 

--- a/sparse-index.c
+++ b/sparse-index.c
@@ -122,17 +122,17 @@ static int index_has_unmerged_entries(struct index_state *istate)
 	return 0;
 }
 
-int convert_to_sparse(struct index_state *istate, int flags)
+static int is_sparse_index_allowed(struct index_state *istate, int flags)
 {
-	int test_env;
-	if (istate->sparse_index || !istate->cache_nr ||
-	    !core_apply_sparse_checkout || !core_sparse_checkout_cone)
+	if (!core_apply_sparse_checkout || !core_sparse_checkout_cone)
 		return 0;
 
 	if (!istate->repo)
 		istate->repo = the_repository;
 
 	if (!(flags & SPARSE_INDEX_MEMORY_ONLY)) {
+		int test_env;
+
 		/*
 		 * The sparse index is not (yet) integrated with a split index.
 		 */
@@ -166,6 +166,19 @@ int convert_to_sparse(struct index_state *istate, int flags)
 	 * bad patterns.
 	 */
 	if (!istate->sparse_checkout_patterns->use_cone_patterns)
+		return 0;
+
+	return 1;
+}
+
+int convert_to_sparse(struct index_state *istate, int flags)
+{
+	/*
+	 * If the index is already sparse, empty, or otherwise
+	 * cannot be converted to sparse, do not convert.
+	 */
+	if (istate->sparse_index || !istate->cache_nr ||
+	    !is_sparse_index_allowed(istate, flags))
 		return 0;
 
 	/*
@@ -314,6 +327,18 @@ void ensure_full_index(struct index_state *istate)
 	cache_tree_update(istate, 0);
 
 	trace2_region_leave("index", "ensure_full_index", istate->repo);
+}
+
+void ensure_correct_sparsity(struct index_state *istate)
+{
+	/*
+	 * If the index can be sparse, make it sparse. Otherwise,
+	 * ensure the index is full.
+	 */
+	if (is_sparse_index_allowed(istate, 0))
+		convert_to_sparse(istate, 0);
+	else
+		ensure_full_index(istate);
 }
 
 /*

--- a/sparse-index.h
+++ b/sparse-index.h
@@ -4,6 +4,7 @@
 struct index_state;
 #define SPARSE_INDEX_MEMORY_ONLY (1 << 0)
 int convert_to_sparse(struct index_state *istate, int flags);
+void ensure_correct_sparsity(struct index_state *istate);
 
 /*
  * Some places in the codebase expect to search for a specific path.

--- a/t/helper/test-read-cache.c
+++ b/t/helper/test-read-cache.c
@@ -39,8 +39,6 @@ int cmd__read_cache(int argc, const char **argv)
 	int table = 0, expand = 0;
 
 	initialize_the_repository();
-	prepare_repo_settings(r);
-	r->settings.command_requires_full_index = 0;
 
 	for (++argv, --argc; *argv && starts_with(*argv, "--"); ++argv, --argc) {
 		if (skip_prefix(*argv, "--print-and-refresh=", &name))
@@ -55,6 +53,9 @@ int cmd__read_cache(int argc, const char **argv)
 		cnt = strtol(argv[0], NULL, 0);
 	setup_git_directory();
 	git_config(git_default_config, NULL);
+
+	prepare_repo_settings(r);
+	r->settings.command_requires_full_index = 0;
 
 	for (i = 0; i < cnt; i++) {
 		repo_read_index(r);


### PR DESCRIPTION
This series updates `do_read_index` to use the `index.sparse` config setting when determining whether the index should be expanded or collapsed. If the command & repo allow use of a sparse index, `index.sparse` is enabled, and a full index is read from disk, the index is collapsed before returning to the caller. Conversely, if `index.sparse` is disabled but the index read from disk is sparse, the index is expanded before returning. This allows `index.sparse` to control *use of* the sparse index in addition to its existing control over how the index is written to disk. It also introduces the ability to enable/disable the sparse index on a command-by-command basis (e.g., allowing a user to troubleshoot a sparse-aware command with '-c index.sparse=false' [1]).

While testing this change, a bug was found in 'test-tool read-cache' in which config settings for the repository were not initialized before preparing the repo settings. This caused `index.sparse` to always be 'false' when using the test helper in a cone-mode sparse checkout, breaking tests in `t1091` and `t1092`. The issue is fixed by moving `prepare_repo_settings` after config setup.

## Changes since V1
- Add `ensure_correct_sparsity` function that ensures the index is sparse if the repository settings (including `index.sparse`) allow it, otherwise ensuring the index is expanded to full.
- Restructure condition in `do_read_index` to, rather than check specifically for the `index.sparse` config setting, call `ensure_correct_sparsity` unconditionally when `command_requires_full_index` is `false`.

## Changes since V2
- Rename `can_convert_to_sparse` to `is_sparse_index_allowed` to more accurately reflect what the function returns.
- Remove index-iterating checks from `is_sparse_index_allowed`, leaving only inexpensive checks on config settings & sparse checkout patterns. Checks are still part of `convert_to_sparse` to ensure it behaves exactly as it did before this series.
- Restructure `ensure_correct_sparsity` for better readability.
- Fix `test_env` variable scope.

## Changes since V3
- Add a new patch to avoid unnecessary cache tree free/recreation when possible in `convert_to_sparse`.

## Changes since V4
- Updated patch 4/4 commit message to better explain practical reasons for making this change.

[1] https://lore.kernel.org/git/cc60c6e7-ecef-ae22-8ec7-ab290ff2b830@gmail.com/

Thanks!
-Victoria

cc: stolee@gmail.com
cc: gitster@pobox.com
cc: Elijah Newren <newren@gmail.com>