### PR TITLE
async_die_is_recursing: fix use of pthread_getspecific for Fedora

### DIFF
--- a/run-command.c
+++ b/run-command.c
@@ -1099,7 +1099,7 @@ static NORETURN void die_async(const char *err, va_list params)
 static int async_die_is_recursing(void)
 {
 	void *ret = pthread_getspecific(async_die_counter);
-	pthread_setspecific(async_die_counter, (void *)1);
+	pthread_setspecific(async_die_counter, &async_die_counter); /* set to any non-NULL valid pointer */
 	return ret != NULL;
 }
 


### PR DESCRIPTION
Following up on Johannes' report earlier [1], this patch fixes a compiler error in the Fedora CI build (the same issue was identified in a local developer build about a week ago [2]). This fix changes the second argument in the call to `pthread_setspecific` from '(void *)1' to a valid pointer, thus preventing the error in the use of `__attr_access_none`.

## Changes since V1
- Change `&ret` to `&async_die_counter` ("dummy" argument to `pthread_setspecific`) so that it's using a global (rather than local) variable
- Fix typo in commit message (`pthread_getspecific` -> `pthread_setspecific`)

[1] https://lore.kernel.org/git/nycvar.QRO.7.76.6.2111040007170.56@tvgsbejvaqbjf.bet/
[2] https://lore.kernel.org/git/43fe6d5c-bdb2-585c-c601-1da7a1b3ff8b@archlinux.org/

CC: gitster@pobox.com
CC: philipoakley@iee.email
CC: eschwartz@archlinux.org
cc: Carlo Arenas <carenas@gmail.com>
cc: Jeff King <peff@peff.net>
cc: Johannes Schindelin <Johannes.Schindelin@gmx.de>
cc: Ævar Arnfjörð Bjarmason <avarab@gmail.com>
cc: Derrick Stolee <stolee@gmail.com>