### PR TITLE
RelNotes: fix a couple of typos for the upcoming release

### DIFF
--- a/Documentation/RelNotes/2.34.0.txt
+++ b/Documentation/RelNotes/2.34.0.txt
@@ -182,7 +182,7 @@ Performance, Internal Implementation, Development Support etc.
  * Prevent "make sparse" from running for the source files that
    haven't been modified.
 
- * The codepath to write a new version of .midx multi-pack index files
+ * The code path to write a new version of .midx multi-pack index files
    has learned to release the mmaped memory holding the current
    version of .midx before removing them from the disk, as some
    platforms do not allow removal of a file that still has mapping.
@@ -405,7 +405,7 @@ Fixes since v2.33
    (merge 47bfdfb3fd ar/fix-git-pull-no-verify later to maint).
 
  * One CI task based on Fedora image noticed a not-quite-kosher
-   consturct recently, which has been corrected.
+   construct recently, which has been corrected.
    (merge 4b540cf913 vd/pthread-setspecific-g11-fix later to maint).
 
  * Other code cleanup, docfix, build fix, etc.


### PR DESCRIPTION
I noticed one of them while reviewing the Git for Windows rebase, and decided to give VS Code with cSpell a whirl.

Note: cSpell pointed out more words it deems not to be English, such as `docfix` and `leakfix` and `segfaulted`. I was on the fence, but figured that those are "Git speak", so I left them alone.
cc: Elijah Newren <newren@gmail.com>