### PR TITLE
am: support `--empty=(stop|drop|keep)` option and `--allow-empty` option to handle empty patches

### DIFF
--- a/Documentation/git-am.txt
+++ b/Documentation/git-am.txt
@@ -18,7 +18,7 @@ SYNOPSIS
 	 [--quoted-cr=<action>]
 	 [--empty=(stop|drop|keep)]
 	 [(<mbox> | <Maildir>)...]
-'git am' (--continue | --skip | --abort | --quit | --show-current-patch[=(diff|raw)])
+'git am' (--continue | --skip | --abort | --quit | --show-current-patch[=(diff|raw)] | --allow-empty)
 
 DESCRIPTION
 -----------
@@ -199,6 +199,11 @@ default.   You can use `--no-utf8` to override this.
 	conflicts.  If `raw` is specified, show the raw contents of
 	the e-mail message; if `diff`, show the diff portion only.
 	Defaults to `raw`.
+
+--allow-empty::
+	After a patch failure on an input e-mail message lacking a patch,
+	create an empty commit with the contents of the e-mail message
+	as its log message.
 
 DISCUSSION
 ----------

--- a/Documentation/git-am.txt
+++ b/Documentation/git-am.txt
@@ -16,6 +16,7 @@ SYNOPSIS
 	 [--exclude=<path>] [--include=<path>] [--reject] [-q | --quiet]
 	 [--[no-]scissors] [-S[<keyid>]] [--patch-format=<format>]
 	 [--quoted-cr=<action>]
+	 [--empty=(stop|drop|keep)]
 	 [(<mbox> | <Maildir>)...]
 'git am' (--continue | --skip | --abort | --quit | --show-current-patch[=(diff|raw)])
 
@@ -62,6 +63,14 @@ OPTIONS
 
 --quoted-cr=<action>::
 	This flag will be passed down to 'git mailinfo' (see linkgit:git-mailinfo[1]).
+
+--empty=(stop|drop|keep)::
+	By default, or when the option is set to 'stop', the command
+	errors out on an input e-mail message lacking a patch
+	and stops into the middle of the current am session. When this
+	option is set to 'drop', skip such an e-mail message instead.
+	When this option is set to 'keep', create an empty commit,
+	recording the contents of the e-mail message as its log.
 
 -m::
 --message-id::

--- a/Documentation/git-format-patch.txt
+++ b/Documentation/git-format-patch.txt
@@ -18,7 +18,7 @@ SYNOPSIS
 		   [-n | --numbered | -N | --no-numbered]
 		   [--start-number <n>] [--numbered-files]
 		   [--in-reply-to=<message id>] [--suffix=.<sfx>]
-		   [--ignore-if-in-upstream]
+		   [--ignore-if-in-upstream] [--always]
 		   [--cover-from-description=<mode>]
 		   [--rfc] [--subject-prefix=<subject prefix>]
 		   [(--reroll-count|-v) <n>]
@@ -191,6 +191,10 @@ will want to ensure that threading is disabled for `git send-email`.
 	from <since> but not from <until> and compare them with the
 	patches being generated, and any patch that matches is
 	ignored.
+
+--always::
+	Include patches for commits that do not introduce any change,
+	which are omitted by default.
 
 --cover-from-description=<mode>::
 	Controls which parts of the cover letter will be automatically

--- a/t/t4150-am.sh
+++ b/t/t4150-am.sh
@@ -196,6 +196,12 @@ test_expect_success setup '
 
 	git format-patch -M --stdout lorem^ >rename-add.patch &&
 
+	git checkout -b empty-commit &&
+	git commit -m "empty commit" --allow-empty &&
+
+	: >empty.patch &&
+	git format-patch --always --stdout empty-commit^ >empty-commit.patch &&
+
 	# reset time
 	sane_unset test_tick &&
 	test_tick
@@ -1150,6 +1156,50 @@ test_expect_success 'apply binary blob in partial clone' '
 
 	# Exercise to make sure that it works
 	git -C client am ../patch
+'
+
+test_expect_success 'an empty input file is error regardless of --empty option' '
+	test_when_finished "git am --abort || :" &&
+	test_must_fail git am --empty=drop empty.patch 2>actual &&
+	echo "Patch format detection failed." >expected &&
+	test_cmp expected actual
+'
+
+test_expect_success 'invalid when passing the --empty option alone' '
+	test_when_finished "git am --abort || :" &&
+	git checkout empty-commit^ &&
+	test_must_fail git am --empty empty-commit.patch 2>err &&
+	echo "error: Invalid value for --empty: empty-commit.patch" >expected &&
+	test_cmp expected err
+'
+
+test_expect_success 'a message without a patch is an error (default)' '
+	test_when_finished "git am --abort || :" &&
+	test_must_fail git am empty-commit.patch >err &&
+	grep "Patch is empty" err
+'
+
+test_expect_success 'a message without a patch is an error where an explicit "--empty=stop" is given' '
+	test_when_finished "git am --abort || :" &&
+	test_must_fail git am --empty=stop empty-commit.patch >err &&
+	grep "Patch is empty." err
+'
+
+test_expect_success 'a message without a patch will be skipped when "--empty=drop" is given' '
+	git am --empty=drop empty-commit.patch >output &&
+	git rev-parse empty-commit^ >expected &&
+	git rev-parse HEAD >actual &&
+	test_cmp expected actual &&
+	grep "Skipping: empty commit" output
+'
+
+test_expect_success 'record as an empty commit when meeting e-mail message that lacks a patch' '
+	git am --empty=keep empty-commit.patch >output &&
+	test_path_is_missing .git/rebase-apply &&
+	git show empty-commit --format="%B" >expected &&
+	git show HEAD --format="%B" >actual &&
+	grep -f actual expected &&
+	grep "Creating an empty commit: empty commit" output
 '
 
 test_done

--- a/t/t7512-status-help.sh
+++ b/t/t7512-status-help.sh
@@ -659,6 +659,7 @@ On branch am_empty
 You are in the middle of an am session.
 The current patch is empty.
   (use "git am --skip" to skip this patch)
+  (use "git am --allow-empty" to record this patch as an empty commit)
   (use "git am --abort" to restore the original branch)
 
 nothing to commit (use -u to show untracked files)

--- a/wt-status.c
+++ b/wt-status.c
@@ -1218,17 +1218,23 @@ static void show_merge_in_progress(struct wt_status *s,
 static void show_am_in_progress(struct wt_status *s,
 				const char *color)
 {
+	int am_empty_patch;
+
 	status_printf_ln(s, color,
 		_("You are in the middle of an am session."));
 	if (s->state.am_empty_patch)
 		status_printf_ln(s, color,
 			_("The current patch is empty."));
 	if (s->hints) {
-		if (!s->state.am_empty_patch)
+		am_empty_patch = s->state.am_empty_patch;
+		if (!am_empty_patch)
 			status_printf_ln(s, color,
 				_("  (fix conflicts and then run \"git am --continue\")"));
 		status_printf_ln(s, color,
 			_("  (use \"git am --skip\" to skip this patch)"));
+		if (am_empty_patch)
+			status_printf_ln(s, color,
+				_("  (use \"git am --allow-empty\" to record this patch as an empty commit)"));
 		status_printf_ln(s, color,
 			_("  (use \"git am --abort\" to restore the original branch)"));
 	}


### PR DESCRIPTION
Since that git has supported the `--always` option for the `git-format-patch` command to create a patch with an empty commit message, `git-am` should support applying and committing with empty patches.

---
Changes since v1:
1. add a case when not passing the `--always` option.
2. rename the `--always` option to `--allow-empty`.
---
Changes since v2:
1. rename the `--allow-empty` option to `--empty-commit`.
2. introduce three different strategies (`die`|`skip`|`asis`) when trying to record empty patches as empty commits.
---
Changes since v3:
1. generate the missed file for test cases.
2. `grep -f` cannot be used under Mac OS.
---
Changes since v4:
1. rename the `--empty-commit` option to `--empty`.
2. rename three different strategies (`die`|`skip`|`asis`) to `die`, `drop` and `keep` correspondingly.
---
Changes since v5:
1. throw an error when passing --empty option without value.
---
Changes since v6:
1. add i18n resources.
---
Changes since v7:
1. update code according to the `seen` branch.
2. fix the wrong document of `git-am`.
3. sign off commits by a real name.
---
Changes since v8:
1. update the committer's name with my real name to fix DCO of GGG.
---
Changes since v9:
1. imitate the signed name format of https://lore.kernel.org/git/pull.1143.git.git.1637347813367.gitgitgadget@gmail.com .
---
Changes since v11:
1. introduce an interactive option `--allow-empty` for `git-am` to record empty patches in the middle of an am session.
---
Changes since v12:
1. record the empty patch as an empty commit only when there are no changes.
2. fix indentation problems.
3. simplify "to keep recording" to "to record".
4. add a test case for skipping empty patches via the `--skip` option.
---
Changes since v13:
1. add an additional description about the 'die' value.
---
Changes since v14:
1. reimplement the 'die' value and stop the whole session. (**Expected a reroll**)
2. the `--allow-empty` option is a valid resume value only when:  (**Expected a reroll**)
    - index has not changed
    - lacking a patch
---
Changes since v15:
1. rename "die" to "stop".
---
Changes since v16:
1. fix the typo from "had" to "has" in the comment.
---
Changes since v17:
1. add trailing comma, show tips of creating an empty commit, and use "%B" to construct test cases.
2. remove the error "Invalid resume value.".
3. hint "--allow-empty" after "--skip".
---
Changes since v18:
1. remove strict checking of "--allow-empty".

cc: René Scharfe <l.s.r@web.de>
cc: Phillip Wood <phillip.wood123@gmail.com>
cc: Johannes Schindelin <Johannes.Schindelin@gmx.de>
cc: Elijah Newren <newren@gmail.com>
cc: Aleen 徐沛文 <pwxu@coremail.cn>
cc: Bagas Sanjaya <bagasdotme@gmail.com>