### PR TITLE
completion: add human and auto: date format

### DIFF
--- a/contrib/completion/git-completion.bash
+++ b/contrib/completion/git-completion.bash
@@ -2001,7 +2001,7 @@ __git_log_shortlog_options="
 "
 
 __git_log_pretty_formats="oneline short medium full fuller reference email raw format: tformat: mboxrd"
-__git_log_date_formats="relative iso8601 iso8601-strict rfc2822 short local default raw unix format:"
+__git_log_date_formats="relative iso8601 iso8601-strict rfc2822 short local default human raw unix auto: format:"
 
 _git_log ()
 {


### PR DESCRIPTION
In bash/zsh completion for `git log --date=`, following values are missing:

* human (introduced in acdd37769de8b0fe37a74bfc0475b63bdc55e9dc)
* auto:* (introduced in 2fd7c22992d37469db957e9a4d3884a6c0a4d182)

They did exist when other values were added to completion
at 5a59a2301f6ec9bcf1b101edb9ca33beb465842f

cc: Johannes Schindelin <Johannes.Schindelin@gmx.de>