### PR TITLE
subtree: fix argument handling in check_parents

### DIFF
--- a/contrib/subtree/git-subtree.sh
+++ b/contrib/subtree/git-subtree.sh
@@ -296,10 +296,9 @@ cache_miss () {
 	done
 }
 
-# Usage: check_parents PARENTS_EXPR
+# Usage: check_parents [REVS...]
 check_parents () {
-	assert test $# = 1
-	missed=$(cache_miss "$1") || exit $?
+	missed=$(cache_miss "$@") || exit $?
 	local indent=$(($indent + 1))
 	for miss in $missed
 	do
@@ -753,7 +752,7 @@ process_split_commit () {
 	fi
 	createcount=$(($createcount + 1))
 	debug "parents: $parents"
-	check_parents "$parents"
+	check_parents $parents
 	newparents=$(cache_get $parents) || exit $?
 	debug "newparents: $newparents"
 


### PR DESCRIPTION
>I saw that you sent a v3, but did not see any of this information (which took a good while to assemble, as you might have guessed) in the commit message. However, I think that message would make for the best home for this information.

Sorry Dscho - it wasn't 100% clear to me which details were required. I've rerolled and tried again.
Also sorry if I'm not replying to the mail correctly - I'm not actually subscribed to the list, and this seems like the only easy way to get text onto it through gitgitgadget without fighting Outlook.

cc: Johannes Schindelin <Johannes.Schindelin@gmx.de>