### PR TITLE
Allow for CR in the output of ssh-keygen

### DIFF
--- a/gpg-interface.c
+++ b/gpg-interface.c
@@ -497,7 +497,7 @@ static int verify_ssh_signed_buffer(struct signature_check *sigc,
 			if (!*line)
 				break;
 
-			trust_size = strcspn(line, "\n");
+			trust_size = strcspn(line, "\r\n");
 			principal = xmemdupz(line, trust_size);
 
 			child_process_init(&ssh_keygen);


### PR DESCRIPTION
This came in via https://github.com/git-for-windows/git/pull/3561. It affects current Windows versions of OpenSSH (but apparently not the MSYS2 version included in Git for Windows).