### PR TITLE
git-compat-util(msvc): C11 does not imply support for zero-sized arrays

### DIFF
--- a/git-compat-util.h
+++ b/git-compat-util.h
@@ -46,14 +46,20 @@
 /*
  * See if our compiler is known to support flexible array members.
  */
-#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) && (!defined(__SUNPRO_C) || (__SUNPRO_C > 0x580))
-# define FLEX_ARRAY /* empty */
+#if defined(__SUNPRO_C) && (__SUNPRO_C <= 0x580)
+/*
+ * According to 203ee91fd273 (git-compat-util.h: avoid using c99 flex array
+ * feature with Sun compiler 5.8, 2009-06-08), this version cannot handle
+ * flexible array members.
+ */
 #elif defined(__GNUC__)
 # if (__GNUC__ >= 3)
 #  define FLEX_ARRAY /* empty */
 # else
 #  define FLEX_ARRAY 0 /* older GNU extension */
 # endif
+#elif defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L)
+# define FLEX_ARRAY /* empty */
 #endif
 
 /*

--- a/git-compat-util.h
+++ b/git-compat-util.h
@@ -52,6 +52,12 @@
  * feature with Sun compiler 5.8, 2009-06-08), this version cannot handle
  * flexible array members.
  */
+#elif defined(_MSC_VER)
+/*
+ * MSVC handles flexible array members, but only if it is the last member. In
+ * the Windows-specific fork of Git, we have a construct in the FSCache code
+ * where that is not true.
+ */
 #elif defined(__GNUC__)
 # if (__GNUC__ >= 3)
 #  define FLEX_ARRAY /* empty */


### PR DESCRIPTION
In Git for Windows' continuously-rebased branches, I found [this problem](https://github.com/git-for-windows/git/runs/4431149285?check_suite_focus=true#step:9:14507) (which uses `FLEX_ARRAY` correctly, but fails because `FLEX_ARRAY` is no longer defined as required by MS Visual C).

This patch is based on `bc/require-c99`.

Changes since v1:
- Refactored the long conditional into edible chunks.
- The commit message now explains much better what is going on.

cc: Neeraj Singh <nksingh85@gmail.com>
cc: <rsbecker@nexbridge.com>
cc: Phillip Wood <phillip.wood123@gmail.com>