### PR TITLE
Two small 'git repack' fixes

### DIFF
--- a/Documentation/git-repack.txt
+++ b/Documentation/git-repack.txt
@@ -76,8 +76,9 @@ to the new separate pack will be written.
 	linkgit:git-pack-objects[1].
 
 -q::
-	Pass the `-q` option to 'git pack-objects'. See
-	linkgit:git-pack-objects[1].
+--quiet::
+	Show no progress over the standard error stream and pass the `-q`
+	option to 'git pack-objects'. See linkgit:git-pack-objects[1].
 
 -n::
 	Do not update the server information with

--- a/builtin/repack.c
+++ b/builtin/repack.c
@@ -693,7 +693,7 @@ int cmd_repack(int argc, const char **argv, const char *prefix)
 		write_bitmaps = 0;
 	}
 	if (pack_kept_objects < 0)
-		pack_kept_objects = write_bitmaps > 0;
+		pack_kept_objects = write_bitmaps > 0 && !write_midx;
 
 	if (write_bitmaps && !(pack_everything & ALL_INTO_ONE) && !write_midx)
 		die(_(incremental_bitmap_conflict_error));

--- a/builtin/repack.c
+++ b/builtin/repack.c
@@ -612,7 +612,7 @@ int cmd_repack(int argc, const char **argv, const char *prefix)
 	struct tempfile *refs_snapshot = NULL;
 	int i, ext, ret;
 	FILE *out;
-	int show_progress = isatty(2);
+	int show_progress;
 
 	/* variables to be filled by option parsing */
 	int pack_everything = 0;
@@ -724,6 +724,8 @@ int cmd_repack(int argc, const char **argv, const char *prefix)
 	sigchain_push_common(remove_pack_on_signal);
 
 	prepare_pack_objects(&cmd, &po_args);
+
+	show_progress = !po_args.quiet && isatty(2);
 
 	strvec_push(&cmd.args, "--keep-true-parents");
 	if (!pack_kept_objects)
@@ -926,7 +928,7 @@ int cmd_repack(int argc, const char **argv, const char *prefix)
 			}
 			strbuf_release(&buf);
 		}
-		if (!po_args.quiet && show_progress)
+		if (show_progress)
 			opts |= PRUNE_PACKED_VERBOSE;
 		prune_packed_objects(opts);
 

--- a/t/t7700-repack.sh
+++ b/t/t7700-repack.sh
@@ -5,6 +5,7 @@ test_description='git repack works correctly'
 . ./test-lib.sh
 . "${TEST_DIRECTORY}/lib-bitmap.sh"
 . "${TEST_DIRECTORY}/lib-midx.sh"
+. "${TEST_DIRECTORY}/lib-terminal.sh"
 
 commit_and_pack () {
 	test_commit "$@" 1>&2 &&
@@ -376,6 +377,12 @@ test_expect_success '--write-midx -b packs non-kept objects' '
 	GIT_TRACE2_EVENT="$(pwd)/trace.txt" \
 		git repack --write-midx -a -b &&
 	test_subcommand_inexact git pack-objects --honor-pack-keep <trace.txt
+'
+
+test_expect_success TTY '--quiet disables progress' '
+	test_terminal env GIT_PROGRESS_DELAY=0 \
+		git -C midx repack -ad --quiet --write-midx 2>stderr &&
+	test_must_be_empty stderr
 '
 
 test_done

--- a/t/t7700-repack.sh
+++ b/t/t7700-repack.sh
@@ -372,4 +372,10 @@ test_expect_success '--write-midx with preferred bitmap tips' '
 	)
 '
 
+test_expect_success '--write-midx -b packs non-kept objects' '
+	GIT_TRACE2_EVENT="$(pwd)/trace.txt" \
+		git repack --write-midx -a -b &&
+	test_subcommand_inexact git pack-objects --honor-pack-keep <trace.txt
+'
+
 test_done

--- a/t/test-lib-functions.sh
+++ b/t/test-lib-functions.sh
@@ -1760,6 +1760,40 @@ test_subcommand () {
 }
 
 # Check that the given command was invoked as part of the
+# trace2-format trace on stdin, but without an exact set of
+# arguments.
+#
+#	test_subcommand [!] <command> <args>... < <trace>
+#
+# For example, to look for an invocation of "git pack-objects"
+# with the "--honor-pack-keep" argument, use
+#
+#	GIT_TRACE2_EVENT=event.log git repack ... &&
+#	test_subcommand git pack-objects --honor-pack-keep <event.log
+#
+# If the first parameter passed is !, this instead checks that
+# the given command was not called.
+#
+test_subcommand_inexact () {
+	local negate=
+	if test "$1" = "!"
+	then
+		negate=t
+		shift
+	fi
+
+	local expr=$(printf '"%s".*' "$@")
+	expr="${expr%,}"
+
+	if test -n "$negate"
+	then
+		! grep "\"event\":\"child_start\".*\[$expr\]"
+	else
+		grep "\"event\":\"child_start\".*\[$expr\]"
+	fi
+}
+
+# Check that the given command was invoked as part of the
 # trace2-format trace on stdin.
 #
 #	test_region [!] <category> <label> git <command> <args>...


### PR DESCRIPTION
I was experimenting with some ideas in 'git repack' and discovered these two bugs.

The first is a "real" bug in that it repacks much more data than is necessary when repacking with '--write-midx -b' and there exists a .keep pack. The fix is simple, which is to change a condition that was added for the '-b' case before '--write-midx' existed.

The second is a UX bug in that '--quiet' did not disable all progress, at least when stderr was interactive.

Updates in v2
-------------

Thanks for the quick review!

* Test for --honor-pack-keep is cleaner with a reusable helper.
* TTY test is added.
* Docs are updated.


Thanks,
-Stolee

cc: me@ttaylorr.com
cc: gitster@pobox.com
cc: Jeff King <peff@peff.net>
cc: Ævar Arnfjörð Bjarmason <avarab@gmail.com>
cc: Derrick Stolee <stolee@gmail.com>