### PR TITLE
sparse-checkout: remove stray trailing space

### DIFF
--- a/builtin/sparse-checkout.c
+++ b/builtin/sparse-checkout.c
@@ -759,7 +759,7 @@ static int sparse_checkout_set(int argc, const char **argv, const char *prefix)
 }
 
 static char const * const builtin_sparse_checkout_reapply_usage[] = {
-	N_("git sparse-checkout reapply [--[no-]cone] [--[no-]sparse-index] "),
+	N_("git sparse-checkout reapply [--[no-]cone] [--[no-]sparse-index]"),
 	NULL
 };
 


### PR DESCRIPTION
Reported at https://lore.kernel.org/git/CANYiYbE+1o-8KxY2UGaCMdZJEPtnbTWgBrcFf7E-_ra76=kWmQ@mail.gmail.com/.