### PR TITLE
completion: sparse-checkout updates

### DIFF
--- a/contrib/completion/git-completion.bash
+++ b/contrib/completion/git-completion.bash
@@ -2988,7 +2988,7 @@ _git_show_branch ()
 
 _git_sparse_checkout ()
 {
-	local subcommands="list init set disable"
+	local subcommands="list init set disable add reapply"
 	local subcommand="$(__git_find_on_cmdline "$subcommands")"
 	if [ -z "$subcommand" ]; then
 		__gitcomp "$subcommands"
@@ -2996,14 +2996,14 @@ _git_sparse_checkout ()
 	fi
 
 	case "$subcommand,$cur" in
-	init,--*)
-		__gitcomp "--cone"
+	*,--*)
+		__gitcomp_builtin sparse-checkout_$subcommand "" "--"
 		;;
-	set,--*)
-		__gitcomp "--stdin"
-		;;
-	*)
-		;;
+	set,*|add,*)
+		if [ "$(__git config core.sparseCheckoutCone)" == "true" ] ||
+		[ -n "$(__git_find_on_cmdline --cone)" ]; then
+			__gitcomp "$(git ls-tree -d -r HEAD --name-only)"
+		fi
 	esac
 }
 

--- a/t/t9902-completion.sh
+++ b/t/t9902-completion.sh
@@ -1447,6 +1447,89 @@ test_expect_success 'git checkout - with --detach, complete only references' '
 	EOF
 '
 
+test_expect_success 'setup sparse-checkout tests' '
+	# set up sparse-checkout repo
+	git init sparse-checkout &&
+	(
+		cd sparse-checkout &&
+		mkdir -p folder1/0/1 folder2/0 folder3 &&
+		touch folder1/0/1/t.txt &&
+		touch folder2/0/t.txt &&
+		touch folder3/t.txt &&
+		git add . &&
+		git commit -am "Initial commit"
+	)
+'
+
+test_expect_success 'sparse-checkout completes subcommands' '
+	test_completion "git sparse-checkout " <<-\EOF
+	list Z
+	init Z
+	set Z
+	add Z
+	reapply Z
+	disable Z
+	EOF
+'
+
+test_expect_success 'cone mode sparse-checkout completes directory names' '
+	# initialize sparse-checkout definitions
+	git -C sparse-checkout sparse-checkout set --cone folder1/0 folder3 &&
+
+	# test tab completion
+	(
+		cd sparse-checkout &&
+		test_completion "git sparse-checkout set f" <<-\EOF
+		folder1 Z
+		folder1/0 Z
+		folder1/0/1 Z
+		folder2 Z
+		folder2/0 Z
+		folder3 Z
+		EOF
+	) &&
+
+	(
+		cd sparse-checkout/folder1 &&
+		test_completion "git sparse-checkout add " <<-\EOF
+		./ Z
+		0 Z
+		0/1 Z
+		EOF
+	)
+'
+
+test_expect_success 'non-cone mode sparse-checkout uses bash completion' '
+	# reset sparse-checkout repo to non-cone mode
+	git -C sparse-checkout sparse-checkout disable &&
+	git -C sparse-checkout sparse-checkout set --no-cone &&
+
+	(
+		cd sparse-checkout &&
+		# expected to be empty since we have not configured
+		# custom completion for non-cone mode
+		test_completion "git sparse-checkout set f" <<-\EOF
+
+		EOF
+	)
+'
+
+test_expect_success 'git sparse-checkout set --cone completes directory names' '
+	git -C sparse-checkout sparse-checkout disable &&
+
+	(
+		cd sparse-checkout &&
+		test_completion "git sparse-checkout set --cone f" <<-\EOF
+		folder1 Z
+		folder1/0 Z
+		folder1/0/1 Z
+		folder2 Z
+		folder2/0 Z
+		folder3 Z
+		EOF
+	)
+'
+
 test_expect_success 'git switch - with -d, complete all references' '
 	test_completion "git switch -d " <<-\EOF
 	HEAD Z

--- a/t/t9902-completion.sh
+++ b/t/t9902-completion.sh
@@ -1480,21 +1480,30 @@ test_expect_success 'cone mode sparse-checkout completes directory names' '
 	(
 		cd sparse-checkout &&
 		test_completion "git sparse-checkout set f" <<-\EOF
-		folder1 Z
-		folder1/0 Z
-		folder1/0/1 Z
-		folder2 Z
-		folder2/0 Z
-		folder3 Z
+		folder1/
+		folder2/
+		folder3/
+		EOF
+	) &&
+
+	(
+		cd sparse-checkout &&
+		test_completion "git sparse-checkout set folder1/" <<-\EOF
+		folder1/0/
+		EOF
+	) &&
+
+	(
+		cd sparse-checkout &&
+		test_completion "git sparse-checkout set folder1/0/" <<-\EOF
+		folder1/0/1/
 		EOF
 	) &&
 
 	(
 		cd sparse-checkout/folder1 &&
-		test_completion "git sparse-checkout add " <<-\EOF
-		./ Z
-		0 Z
-		0/1 Z
+		test_completion "git sparse-checkout add 0" <<-\EOF
+		0/
 		EOF
 	)
 '
@@ -1520,12 +1529,9 @@ test_expect_success 'git sparse-checkout set --cone completes directory names' '
 	(
 		cd sparse-checkout &&
 		test_completion "git sparse-checkout set --cone f" <<-\EOF
-		folder1 Z
-		folder1/0 Z
-		folder1/0/1 Z
-		folder2 Z
-		folder2/0 Z
-		folder3 Z
+		folder1/
+		folder2/
+		folder3/
 		EOF
 	)
 '

--- a/t/t9902-completion.sh
+++ b/t/t9902-completion.sh
@@ -1508,6 +1508,55 @@ test_expect_success 'cone mode sparse-checkout completes directory names' '
 	)
 '
 
+test_expect_success 'cone mode sparse-checkout completes directory names with spaces and accents' '
+	# reset sparse-checkout
+	git -C sparse-checkout sparse-checkout disable &&
+	(
+		cd sparse-checkout &&
+		mkdir "directory with spaces" &&
+		mkdir "directory-with-áccent" &&
+		>"directory with spaces/randomfile" &&
+		>"directory-with-áccent/randomfile" &&
+		git add . &&
+		git commit -m "Add directory with spaces and directory with accent" &&
+		git sparse-checkout set --cone "directory with spaces" \
+			"directory-with-áccent" &&
+		test_completion "git sparse-checkout add dir" <<-\EOF &&
+		directory with spaces/
+		directory-with-áccent/
+		EOF
+		rm -rf "directory with spaces" &&
+		rm -rf "directory-with-áccent" &&
+		git add . &&
+		git commit -m "Remove directory with spaces and directory with accent"
+	)
+'
+
+# use FUNNYNAMES to avoid running on Windows, which doesn't permit backslashes or tabs in paths
+test_expect_success FUNNYNAMES 'cone mode sparse-checkout completes directory names with backslashes and tabs' '
+	# reset sparse-checkout
+	git -C sparse-checkout sparse-checkout disable &&
+	(
+		cd sparse-checkout &&
+		mkdir "directory\with\backslashes" &&
+		mkdir "$(printf "directory\twith\ttabs")" &&
+		>"directory\with\backslashes/randomfile" &&
+		>"$(printf "directory\twith\ttabs")/randomfile" &&
+		git add . &&
+		git commit -m "Add directory with backslashes and directory with tabs" &&
+		git sparse-checkout set --cone "directory\with\backslashes" \
+			"$(printf "directory\twith\ttabs")" &&
+		test_completion "git sparse-checkout add dir" <<-\EOF &&
+		directory\with\backslashes/
+		directory	with	tabs/
+		EOF
+		rm -rf "directory\with\backslashes" &&
+		rm -rf "$(printf "directory\twith\ttabs")" &&
+		git add . &&
+		git commit -m "Remove directory with backslashes and directory with tabs"
+	)
+'
+
 test_expect_success 'non-cone mode sparse-checkout uses bash completion' '
 	# reset sparse-checkout repo to non-cone mode
 	git -C sparse-checkout sparse-checkout disable &&


### PR DESCRIPTION
This change updates custom tab completion for the sparse-checkout command. Specifically, it corrects the following issues with the current method:

1. `git sparse-checkout <TAB>` results in an incomplete list of subcommands (it is missing reapply and add).
2. Options for subcommands are not tab-completable.
3. git `sparse-checkout set <TAB>` and `git sparse-checkout add <TAB>` show both file names and directory names. While this may be a less surprising behavior for non-cone mode, we want to only show directories in cone mode.

The first commit in this series is an intermediate step that fixes issues 1 and 2 above and introduces a simple fix for issue 3 with some performance and unusual character-related caveats. The next commit adds a new __gitcomp_directories method that fixes the performance-related caveat from the first commit by completing just a single level of directories. The final commit modifies __gitcomp_directories to handle unusual characters in directory names.

Changes since V6
================
* Split tests for unusual characters so that spaces and accents are verified on Windows (in addition to macOS and Linux). Tabs and backslashes are still excluded on Windows (details on why are included in the third commit message).

Changes since V5
================
* Fix incorrect conditional that was causing failure of non-cone mode test (and causing 'seen' CI to fail).
* Remove __git_comp_directories indentation changes between the second and third commits.

Changes since V4
================
* Clarify that completing on files and directories is a less-surprising behavior in non-cone mode (rather than definitely the correct behavior) in commit message and cover letter.
* Add explicit `--no-cone` to non-cone mode sparse-checkout completion test.
* Replace use of __git_complete_index_file with a new version of __gitcomp_directories that is able to handle unusual characters.
* Ensure that users running `git sparse-checkout set --cone` get cone mode-style completion whether or not they already have the cone mode config set.
* Refactor creation of sparse-checkout test repo into a sparse-checkout setup test.

Changes since V3
================
* Update commit descriptions to begin with `completion` instead of `sparse-checkout`.
* Remove explicit completion of `--help`, as this is inconsistent with the rest of the completion script.
* Use `__gitcomp_builtin` to auto-complete subcommand options (and remove option completion test from previous iterations, as it is no longer necessary).
* Use `__git_complete_index_file` helper function in place of `__gitcomp "$(git ls-tree -d -r HEAD --name-only)`.
* If in cone-mode sparse checkout, only show directory completions. If in non-cone mode sparse checkout show both files and directories.

Changes since V2
================
* Change use of $prev to $subcommand in _git_sparse_checkout() method in git-completion.bash.
* State explicitly that directory completion applies in both cone and non-cone mode in 'sparse-checkout: custom tab completion' commit 
* Add new patch with __gitcomp_directories method to improve performance by only outputting directories at the current level.

Changes since V1
================
* Rebase onto en/sparse-checkout-set.
* Add subcommand options (including --no-cone) for set and reapply.
* Extend 'sparse-checkout completes subcommand options' test to validate new set/reapply subcommand options.
* No longer set index.sparse to false in 'sparse-checkout completes directory names' test.
* Refactor creation of sparse-checkout repo into a setup test.

Thanks,
Lessley

cc: stolee@gmail.com
cc: gitster@pobox.com
cc: johannes.schindelin@gmail.com
cc: Elijah Newren <newren@gmail.com>
cc: Taylor Blau <me@ttaylorr.com>
cc: SZEDER Gábor <szeder.dev@gmail.com>
cc: Ævar Arnfjörð Bjarmason <avarab@gmail.com>