### PR TITLE
submodule.h: use a named enum for RECURSE_SUBMODULES_*

### DIFF
--- a/submodule-config.h
+++ b/submodule-config.h
@@ -37,7 +37,7 @@ struct submodule {
 	const char *path;
 	const char *name;
 	const char *url;
-	int fetch_recurse;
+	enum submodule_recurse_mode fetch_recurse;
 	const char *ignore;
 	const char *branch;
 	struct submodule_update_strategy update_strategy;

--- a/submodule.h
+++ b/submodule.h
@@ -13,7 +13,7 @@ struct repository;
 struct string_list;
 struct strbuf;
 
-enum {
+enum submodule_recurse_mode {
 	RECURSE_SUBMODULES_ONLY = -5,
 	RECURSE_SUBMODULES_CHECK = -4,
 	RECURSE_SUBMODULES_ERROR = -3,


### PR DESCRIPTION
Changes since v1:
- converted one user of the enum from an 'int' to the new enum type,
  so the patch is not debug-only, as suggested by Glen.
- updated the commit message to use an 'int' as example of
  a local variable being compared with an enum constant, instead of
  using a struct member which is already of enum type, as pointed
  out by Junio
- added a little bit more explanation in the commit message as to
  how this patch can help when debugging.

CC: Emily Shaffer <emilyshaffer@google.com>
CC: Glen Choo <chooglen@google.com>