### PR TITLE
getcwd(mingw): handle the case when there is no current working directory

### DIFF
--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -1127,6 +1127,10 @@ char *mingw_getcwd(char *pointer, int len)
 	}
 	if (!ret || ret >= ARRAY_SIZE(wpointer))
 		return NULL;
+	if (GetFileAttributesW(wpointer) == INVALID_FILE_ATTRIBUTES) {
+		errno = ENOENT;
+		return NULL;
+	}
 	if (xwcstoutf(pointer, wpointer, len) < 0)
 		return NULL;
 	convert_slashes(pointer);


### PR DESCRIPTION
The bug fixed by this topic was noticed due to test failures while rebasing Microsoft's fork of Git onto v2.35.0-rc1. It may not be desirable to take it into Git v2.35.0 this late in the -rc phase, even though I do plan on integrating it into Git for Windows v2.35.0.