### PR TITLE
repo-settings: fix checking for fetch.negotiationAlgorithm=default

### DIFF
--- a/repo-settings.c
+++ b/repo-settings.c
@@ -85,6 +85,8 @@ void prepare_repo_settings(struct repository *r)
 			r->settings.fetch_negotiation_algorithm = FETCH_NEGOTIATION_SKIPPING;
 		else if (!strcasecmp(strval, "noop"))
 			r->settings.fetch_negotiation_algorithm = FETCH_NEGOTIATION_NOOP;
+		else if (!strcasecmp(strval, "default"))
+			r->settings.fetch_negotiation_algorithm = FETCH_NEGOTIATION_DEFAULT;
 	}
 
 	/*

--- a/t/t5500-fetch-pack.sh
+++ b/t/t5500-fetch-pack.sh
@@ -928,6 +928,7 @@ test_expect_success 'fetching deepen' '
 '
 
 test_expect_success 'use ref advertisement to prune "have" lines sent' '
+	test_when_finished rm -rf clientv0 clientv2 &&
 	rm -rf server client &&
 	git init server &&
 	test_commit -C server both_have_1 &&
@@ -954,6 +955,45 @@ test_expect_success 'use ref advertisement to prune "have" lines sent' '
 	rm -f trace &&
 	cp -r client clientv2 &&
 	GIT_TRACE_PACKET="$(pwd)/trace" git -C clientv2 -c protocol.version=2 \
+		fetch origin server_has both_have_2 &&
+	grep "have $(git -C client rev-parse client_has)" trace &&
+	grep "have $(git -C client rev-parse both_have_2)" trace &&
+	! grep "have $(git -C client rev-parse both_have_2^)" trace
+'
+
+test_expect_success 'same as last but with config overrides' '
+	test_when_finished rm -rf clientv0 clientv2 &&
+	rm -rf server client &&
+	git init server &&
+	test_commit -C server both_have_1 &&
+	git -C server tag -d both_have_1 &&
+	test_commit -C server both_have_2 &&
+
+	git clone server client &&
+	test_commit -C server server_has &&
+	test_commit -C client client_has &&
+
+	# In both protocol v0 and v2, ensure that the parent of both_have_2 is
+	# not sent as a "have" line. The client should know that the server has
+	# both_have_2, so it only needs to inform the server that it has
+	# both_have_2, and the server can infer the rest.
+
+	rm -f trace &&
+	rm -rf clientv0 &&
+	cp -r client clientv0 &&
+	GIT_TRACE_PACKET="$(pwd)/trace" git -C clientv0 \
+		-c feature.experimental=true \
+		-c fetch.negotiationAlgorithm=default \
+		fetch origin server_has both_have_2 &&
+	grep "have $(git -C client rev-parse client_has)" trace &&
+	grep "have $(git -C client rev-parse both_have_2)" trace &&
+	! grep "have $(git -C client rev-parse both_have_2^)" trace &&
+
+	rm -f trace &&
+	cp -r client clientv2 &&
+	GIT_TRACE_PACKET="$(pwd)/trace" git -C clientv2 -c protocol.version=2 \
+		-c feature.experimental=true \
+		-c fetch.negotiationAlgorithm=default \
 		fetch origin server_has both_have_2 &&
 	grep "have $(git -C client rev-parse client_has)" trace &&
 	grep "have $(git -C client rev-parse both_have_2)" trace &&


### PR DESCRIPTION
"default" is a horrible name to give things; it was a mistake to use it here, but it's a bit too late.  A little anecdote about that...

Many years ago, in the Gnome community, there was a huge fight that erupted, in large part due to confusion over the word "default".  There was a journalist who had been a designer in a past life, who had a little friction with the rest of the community, but intended well and generally improved things.  At some point, they suggested some changes to improve the "default" theme, but not being a developer the changes weren't communicated in the form of  patch.  And the changes accidentally got applied to the wrong theme: the default one (yes, there was a theme named "default" which was not the default theme).  Now, basically no one used the default theme because it was so hideously ugly.  I think we suffered from a case of not being able to change the default (again?) because no one could get an agreement on what the default should be.  Who did actually use the default theme, though?  Well, turns out the person writing release notes just before the release used it, but only for the purpose of writing release notes.  So, with people under pressure for an imminent release, there were screenshots that looked like garbage due to changes meant for the "default" theme having accidentally been applied to the default theme.

Don't name settings/themes/things "default" if it describes something specific, since someone may come along and decide that something else should be the default, and then you're stuck with a non-default "default".