### PR TITLE
Really retire `git-legacy-stash.sh`

### DIFF
--- a/Documentation/config/stash.txt
+++ b/Documentation/config/stash.txt
@@ -1,10 +1,3 @@
-stash.useBuiltin::
-	Unused configuration variable.  Used in Git versions 2.22 to
-	2.26 as an escape hatch to enable the legacy shellscript
-	implementation of stash.  Now the built-in rewrite of it in C
-	is always used. Setting this will emit a warning, to alert any
-	remaining users that setting this now does nothing.
-
 stash.showIncludeUntracked::
 	If this is set to true, the `git stash show` command will show
 	the untracked files of a stash entry.  Defaults to false. See

--- a/builtin/add.c
+++ b/builtin/add.c
@@ -32,7 +32,6 @@ static int add_renormalize;
 static int pathspec_file_nul;
 static int include_sparse;
 static const char *pathspec_from_file;
-static int legacy_stash_p; /* support for the scripted `git stash` */
 
 struct update_callback_data {
 	int flags;
@@ -388,8 +387,6 @@ static struct option builtin_add_options[] = {
 		   N_("override the executable bit of the listed files")),
 	OPT_HIDDEN_BOOL(0, "warn-embedded-repo", &warn_on_embedded_repo,
 			N_("warn when adding an embedded repository")),
-	OPT_HIDDEN_BOOL(0, "legacy-stash-p", &legacy_stash_p,
-			N_("backend for `git stash -p`")),
 	OPT_PATHSPEC_FROM_FILE(&pathspec_from_file),
 	OPT_PATHSPEC_FILE_NUL(&pathspec_file_nul),
 	OPT_END(),
@@ -511,17 +508,6 @@ int cmd_add(int argc, const char **argv, const char *prefix)
 		if (pathspec_from_file)
 			die(_("options '%s' and '%s' cannot be used together"), "--pathspec-from-file", "--interactive/--patch");
 		exit(interactive_add(argv + 1, prefix, patch_interactive));
-	}
-	if (legacy_stash_p) {
-		struct pathspec pathspec;
-
-		parse_pathspec(&pathspec, 0,
-			PATHSPEC_PREFER_FULL |
-			PATHSPEC_SYMLINK_LEADING_PATH |
-			PATHSPEC_PREFIX_ORIGIN,
-			prefix, argv);
-
-		return run_add_interactive(NULL, "--patch=stash", &pathspec);
 	}
 
 	if (edit_interactive) {

--- a/builtin/stash.c
+++ b/builtin/stash.c
@@ -788,7 +788,6 @@ static int list_stash(int argc, const char **argv, const char *prefix)
 static int show_stat = 1;
 static int show_patch;
 static int show_include_untracked;
-static int use_legacy_stash;
 
 static int git_stash_config(const char *var, const char *value, void *cb)
 {
@@ -802,10 +801,6 @@ static int git_stash_config(const char *var, const char *value, void *cb)
 	}
 	if (!strcmp(var, "stash.showincludeuntracked")) {
 		show_include_untracked = git_config_bool(var, value);
-		return 0;
-	}
-	if (!strcmp(var, "stash.usebuiltin")) {
-		use_legacy_stash = !git_config_bool(var, value);
 		return 0;
 	}
 	return git_diff_basic_config(var, value, cb);
@@ -1777,11 +1772,6 @@ int cmd_stash(int argc, const char **argv, const char *prefix)
 	};
 
 	git_config(git_stash_config, NULL);
-
-	if (use_legacy_stash ||
-	    !git_env_bool("GIT_TEST_STASH_USE_BUILTIN", -1))
-		warning(_("the stash.useBuiltin support has been removed!\n"
-			  "See its entry in 'git help config' for details."));
 
 	argc = parse_options(argc, argv, prefix, options, git_stash_usage,
 			     PARSE_OPT_KEEP_UNKNOWN | PARSE_OPT_KEEP_DASHDASH);

--- a/git-sh-setup.sh
+++ b/git-sh-setup.sh
@@ -101,7 +101,6 @@ $LONG_USAGE")"
 	case "$1" in
 		-h)
 		echo "$LONG_USAGE"
-		case "$0" in *git-legacy-stash) exit 129;; esac
 		exit
 	esac
 fi

--- a/t/t3903-stash.sh
+++ b/t/t3903-stash.sh
@@ -1272,7 +1272,6 @@ test_expect_success 'stash works when user.name and user.email are not set' '
 	>2 &&
 	git add 2 &&
 	test_config user.useconfigonly true &&
-	test_config stash.usebuiltin true &&
 	(
 		sane_unset GIT_AUTHOR_NAME &&
 		sane_unset GIT_AUTHOR_EMAIL &&
@@ -1321,20 +1320,6 @@ test_expect_success 'stash handles skip-worktree entries nicely' '
 	git stash &&
 
 	git rev-parse --verify refs/stash:A.t
-'
-
-test_expect_success 'stash -c stash.useBuiltin=false warning ' '
-	expected="stash.useBuiltin support has been removed" &&
-
-	git -c stash.useBuiltin=false stash 2>err &&
-	test_i18ngrep "$expected" err &&
-	env GIT_TEST_STASH_USE_BUILTIN=false git stash 2>err &&
-	test_i18ngrep "$expected" err &&
-
-	git -c stash.useBuiltin=true stash 2>err &&
-	test_must_be_empty err &&
-	env GIT_TEST_STASH_USE_BUILTIN=true git stash 2>err &&
-	test_must_be_empty err
 '
 
 test_expect_success 'git stash succeeds despite directory/file change' '


### PR DESCRIPTION
After proving out `git stash` for a _very_ long time as a shell script, we eventually converted it to a proper built-in, leaving an escape hatch in place to call the scripted version.

After another very long time, we removed that escape hatch, leaving behind a warning.

Now, almost two years later, let's remove even that warning (and a couple of tidbits that we inadvertently left in the code base).