### PR TITLE
2.35.1.txt: clarify the rebase/stash regression

### DIFF
--- a/Documentation/RelNotes/2.35.1.txt
+++ b/Documentation/RelNotes/2.35.1.txt
@@ -2,5 +2,5 @@ Git v2.35.1 Release Notes
 =========================
 
 Git 2.35 shipped with a regression that broke use of "rebase" and
-"stash" in a secondary worktree.  This maintenance release ought to
-fix it.
+"stash" when run from a subdirectory within a secondary worktree.
+This maintenance release fixes it.


### PR DESCRIPTION
I haven't seen the release notes go out; I'm hoping this patch is seen in time...