### PR TITLE
checkout/fetch/pull/pack-objects: allow `-h` outside a repository again

### DIFF
--- a/builtin/checkout.c
+++ b/builtin/checkout.c
@@ -1602,9 +1602,10 @@ static int checkout_main(int argc, const char **argv, const char *prefix,
 	opts->show_progress = -1;
 
 	git_config(git_checkout_config, opts);
-
-	prepare_repo_settings(the_repository);
-	the_repository->settings.command_requires_full_index = 0;
+	if (the_repository->gitdir) {
+		prepare_repo_settings(the_repository);
+		the_repository->settings.command_requires_full_index = 0;
+	}
 
 	opts->track = BRANCH_TRACK_UNSPECIFIED;
 

--- a/builtin/fetch.c
+++ b/builtin/fetch.c
@@ -2014,8 +2014,10 @@ int cmd_fetch(int argc, const char **argv, const char *prefix)
 	}
 
 	git_config(git_fetch_config, NULL);
-	prepare_repo_settings(the_repository);
-	the_repository->settings.command_requires_full_index = 0;
+	if (the_repository->gitdir) {
+		prepare_repo_settings(the_repository);
+		the_repository->settings.command_requires_full_index = 0;
+	}
 
 	argc = parse_options(argc, argv, prefix,
 			     builtin_fetch_options, builtin_fetch_usage, 0);

--- a/builtin/pack-objects.c
+++ b/builtin/pack-objects.c
@@ -3976,9 +3976,11 @@ int cmd_pack_objects(int argc, const char **argv, const char *prefix)
 	read_replace_refs = 0;
 
 	sparse = git_env_bool("GIT_TEST_PACK_SPARSE", -1);
-	prepare_repo_settings(the_repository);
-	if (sparse < 0)
-		sparse = the_repository->settings.pack_use_sparse;
+	if (the_repository->gitdir) {
+		prepare_repo_settings(the_repository);
+		if (sparse < 0)
+			sparse = the_repository->settings.pack_use_sparse;
+	}
 
 	reset_pack_idx_option(&pack_idx_opts);
 	git_config(git_pack_config, NULL);

--- a/builtin/pull.c
+++ b/builtin/pull.c
@@ -994,8 +994,10 @@ int cmd_pull(int argc, const char **argv, const char *prefix)
 		set_reflog_message(argc, argv);
 
 	git_config(git_pull_config, NULL);
-	prepare_repo_settings(the_repository);
-	the_repository->settings.command_requires_full_index = 0;
+	if (the_repository->gitdir) {
+		prepare_repo_settings(the_repository);
+		the_repository->settings.command_requires_full_index = 0;
+	}
 
 	argc = parse_options(argc, argv, prefix, pull_options, pull_usage, 0);
 

--- a/t/t0012-help.sh
+++ b/t/t0012-help.sh
@@ -139,13 +139,18 @@ test_expect_success 'git help --config-sections-for-completion' '
 '
 
 test_expect_success 'generate builtin list' '
+	mkdir -p sub &&
 	git --list-cmds=builtins >builtins
 '
 
 while read builtin
 do
 	test_expect_success "$builtin can handle -h" '
-		test_expect_code 129 git $builtin -h >output 2>&1 &&
+		(
+			GIT_CEILING_DIRECTORIES=$(pwd) &&
+			export GIT_CEILING_DIRECTORIES &&
+			test_expect_code 129 git -C sub $builtin -h >output 2>&1
+		) &&
 		test_i18ngrep usage output
 	'
 done <builtins


### PR DESCRIPTION
As reported in https://github.com/git-for-windows/git/issues/3688, calling `git fetch -h` outside a repository now results in a very ugly

```
 BUG: repo-settings.c:23: Cannot add settings for uninitialized repository
```

The reason is that the `prepare_repo_settings()` calls (that we introduced to support sparse index) assume that there is a `gitdir`, but the hack to allow `parse_options()` to handle `-h` even outside a repository invalidates that assumption.

One strategy I considered was to move the `prepare_repo_settings()` calls _after_ `parse_options()`. This would work because when `parse_options()` handles `-h`, it exits without returning.

However, this strategy failed in my tests because e.g. `cmd_unpack_objects()` does need the `pack_use_sparse` to be populated correctly before even parsing the options so that it can be overridden via `--sparse`/`--no-sparse`.

Hence the current strategy where the code that prepares the repo settings and then accesses them is guarded behind the condition that we must have a `gitdir` to do so.

Note: There are other instances where `prepare_repo_settings()` is called before `parse_options()`, e.g. in `cmd_status()`, in `seen` there are even more instances (e.g. `cmd_checkout_index()`). All of those instances that are not touched by this here patch _do_ have special code to handle `-h` early, though, _before_ calling `prepare_repo_settings()` let alone `parse_options()`.