### PR TITLE
mailmap: change primary address for Derrick Stolee

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -59,8 +59,9 @@ David Reiss <dreiss@facebook.com> <dreiss@dreiss-vmware.(none)>
 David S. Miller <davem@davemloft.net>
 David Turner <novalis@novalis.org> <dturner@twopensource.com>
 David Turner <novalis@novalis.org> <dturner@twosigma.com>
-Derrick Stolee <dstolee@microsoft.com> <stolee@gmail.com>
-Derrick Stolee <dstolee@microsoft.com> Derrick Stolee via GitGitGadget <gitgitgadget@gmail.com>
+Derrick Stolee <derrickstolee@github.com> <stolee@gmail.com>
+Derrick Stolee <derrickstolee@github.com> Derrick Stolee via GitGitGadget <gitgitgadget@gmail.com>
+Derrick Stolee <derrickstolee@github.com> <dstolee@microsoft.com>
 Deskin Miller <deskinm@umich.edu>
 Đoàn Trần Công Danh <congdanhqx@gmail.com> Doan Tran Cong Danh
 Dirk Süsserott <newsletter@dirk.my1.cc>


### PR DESCRIPTION
As mentioned, I'm transitioning my email to my `@github.com` address. I might still use `stolee@gmail.com` for some old threads that aren't completely available in my other account.

This also doesn't change any commits that were submitted before this, but should affect all commits that I submit afterwards.

Thanks,
-Stolee

cc: Ævar Arnfjörð Bjarmason <avarab@gmail.com>