### PR TITLE
Provide config option to expect files outside sparse patterns

### DIFF
--- a/Documentation/config/sparse.txt
+++ b/Documentation/config/sparse.txt
@@ -1,0 +1,16 @@
+sparse.expectFilesOutsideOfPatterns::
+	Typically with sparse checkouts, we expect files outside the
+	sparsity patterns to be marked as SKIP_WORKTREE and be missing
+	from the working tree.  There are a few edge cases where this
+	can be violated and cause confusion, so in a sparse checkout,
+	Git will check whether SKIP_WORKTREE files are present and clear
+	the SKIP_WORKTREE bit if they are.  However, a special virtual
+	file system (VFS) can turn the normal expectation on its head:
+	all files are considered present in the working copy, though
+	they are not vivified until actually accessed.  With such a
+	virtual file system (VFS) layer, most of the files do not match
+	the sparsity patterns at first, and the VFS layer automatically
+	updates the sparsity patterns to add more files whenever files
+	are written.  This option can be set to true to tell Git to
+	avoid checking whether SKIP_WORKTREE files are present in a
+	sparse checkout.

--- a/cache.h
+++ b/cache.h
@@ -1003,6 +1003,7 @@ extern const char *core_fsmonitor;
 
 extern int core_apply_sparse_checkout;
 extern int core_sparse_checkout_cone;
+extern int sparse_expect_files_outside_of_patterns;
 
 /*
  * Returns the boolean value of $GIT_OPTIONAL_LOCKS (or the default value).

--- a/config.c
+++ b/config.c
@@ -1520,6 +1520,11 @@ static int git_default_core_config(const char *var, const char *value, void *cb)
 		return 0;
 	}
 
+	if (!strcmp(var, "sparse.expectfilesoutsideofpatterns")) {
+		sparse_expect_files_outside_of_patterns = git_config_bool(var, value);
+		return 0;
+	}
+
 	if (!strcmp(var, "core.precomposeunicode")) {
 		precomposed_unicode = git_config_bool(var, value);
 		return 0;
@@ -1631,7 +1636,8 @@ static int git_default_mailmap_config(const char *var, const char *value)
 
 int git_default_config(const char *var, const char *value, void *cb)
 {
-	if (starts_with(var, "core."))
+	if (starts_with(var, "core.") ||
+	    starts_with(var, "sparse."))
 		return git_default_core_config(var, value, cb);
 
 	if (starts_with(var, "user.") ||

--- a/environment.c
+++ b/environment.c
@@ -70,6 +70,7 @@ char *notes_ref_name;
 int grafts_replace_parents = 1;
 int core_apply_sparse_checkout;
 int core_sparse_checkout_cone;
+int sparse_expect_files_outside_of_patterns;
 int merge_log_config = -1;
 int precomposed_unicode = -1; /* see probe_utf8_pathname_composition() */
 unsigned long pack_size_limit_cfg;

--- a/sparse-index.c
+++ b/sparse-index.c
@@ -396,7 +396,8 @@ void clear_skip_worktree_from_present_files(struct index_state *istate)
 
 	int i;
 
-	if (!core_apply_sparse_checkout)
+	if (!core_apply_sparse_checkout ||
+	    sparse_expect_files_outside_of_patterns)
 		return;
 
 restart:

--- a/t/t1090-sparse-checkout-scope.sh
+++ b/t/t1090-sparse-checkout-scope.sh
@@ -84,4 +84,23 @@ test_expect_success 'in partial clone, sparse checkout only fetches needed blobs
 	test_cmp expect actual
 '
 
+test_expect_success 'skip-worktree on files outside sparse patterns' '
+	git sparse-checkout disable &&
+	git sparse-checkout set --no-cone "a*" &&
+	git checkout-index --all --ignore-skip-worktree-bits &&
+
+	git ls-files -t >output &&
+	! grep ^S output >actual &&
+	test_must_be_empty actual &&
+
+	test_config sparse.expectFilesOutsideOfPatterns true &&
+	cat <<-\EOF >expect &&
+	S b
+	S c
+	EOF
+	git ls-files -t >output &&
+	grep ^S output >actual &&
+	test_cmp expect actual
+'
+
 test_done


### PR DESCRIPTION
Builds on en/present-despite-skipped, and addresses issue reported at https://lore.kernel.org/git/YhBCsg2DCEd9FXjE@google.com/

Changes since v1:
  * Renamed config option to sparse.expectFilesOutsideOfPatterns
  * Added documentation of new option in Documentation/config/sparse.txt
  * Reworded the commit message as per suggestions

CC: Jonathan Nieder <jrnieder@gmail.com>
CC: Jonathan Tan <jonathantanmy@google.com>
CC: jabolopes@google.com
CC: Jeff Hostetler <jeffhostetler@github.com>
cc: Derrick Stolee <derrickstolee@github.com>
cc: Johannes Schindelin <Johannes.Schindelin@gmx.de>
cc: Ævar Arnfjörð Bjarmason <avarab@gmail.com>
cc: Elijah Newren <newren@gmail.com>