### PR TITLE
Update the die() preserve-merges messages to help some users

### DIFF
--- a/builtin/rebase.c
+++ b/builtin/rebase.c
@@ -1205,7 +1205,10 @@ int cmd_rebase(int argc, const char **argv, const char *prefix)
 			     builtin_rebase_usage, 0);
 
 	if (preserve_merges_selected)
-		die(_("--preserve-merges was replaced by --rebase-merges"));
+		die(_("--preserve-merges was replaced by --rebase-merges\n"
+			"Also, check your `pull` configuration settings\n"
+			"`git config --show-scope --show-origin --get-regexp 'pull.*'`\n"
+			"which may also invoke this option."));
 
 	if (action != ACTION_NONE && total_argc != 2) {
 		usage_with_options(builtin_rebase_usage,

--- a/builtin/rebase.c
+++ b/builtin/rebase.c
@@ -1181,7 +1181,9 @@ int cmd_rebase(int argc, const char **argv, const char *prefix)
 		strbuf_reset(&buf);
 		strbuf_addf(&buf, "%s/rewritten", merge_dir());
 		if (is_directory(buf.buf)) {
-			die("`rebase -p` is no longer supported");
+			die("`rebase --preserve-merges` (-p) is no longer supported.\n"
+			"You still have a `.git/rebase-merge/rewritten` directory, \n"
+			"indicating a `rebase preserve-merge` is still in progress.\n");
 		} else {
 			strbuf_reset(&buf);
 			strbuf_addf(&buf, "%s/interactive", merge_dir());


### PR DESCRIPTION
This small update to the die() preserve-merges messages is a response to the reported edge case in the Git-for-Windows [googlegroups thread ](https://groups.google.com/g/git-for-windows/c/3jMWbBlXXHM) where even `git rebase --continue` would die.

It is most relevant for Windows because Visual Studio still offers the option to run `git pull --preserve`, therefore Git for Windows already applied these patches. The improvements are not specific to Windows, though, and should therefore also get into core Git, albeit at a more leisurely pace.

This is a companion patch series to https://github.com/git-for-windows/git/pull/3708

cc: Ævar Arnfjörð Bjarmason <avarab@gmail.com>
cc: Phillip Wood <phillip.wood123@gmail.com>
cc: Philip Oakley <philipoakley@iee.email>