### PR TITLE
Specify the actual pack size limit which is breached

### DIFF
--- a/builtin/index-pack.c
+++ b/builtin/index-pack.c
@@ -323,8 +323,12 @@ static void use(int bytes)
 	if (signed_add_overflows(consumed_bytes, bytes))
 		die(_("pack too large for current definition of off_t"));
 	consumed_bytes += bytes;
-	if (max_input_size && consumed_bytes > max_input_size)
-		die(_("pack exceeds maximum allowed size"));
+	if (max_input_size && consumed_bytes > max_input_size) {
+		struct strbuf size_limit = STRBUF_INIT;
+		strbuf_humanise_bytes(&size_limit, max_input_size);
+		die(_("pack exceeds maximum allowed size (%s)"),
+		    size_limit.buf);
+	}
 }
 
 static const char *open_pack_file(const char *pack_name)

--- a/t/t5302-pack-index.sh
+++ b/t/t5302-pack-index.sh
@@ -284,4 +284,12 @@ test_expect_success 'index-pack -v --stdin produces progress for both phases' '
 	test_i18ngrep "Resolving deltas" err
 '
 
+test_expect_success 'too-large packs report the breach' '
+	pack=$(git pack-objects --all pack </dev/null) &&
+	sz="$(test_file_size pack-$pack.pack)" &&
+	test "$sz" -gt 20 &&
+	test_must_fail git index-pack --max-input-size=20 pack-$pack.pack 2>err &&
+	grep "maximum allowed size (20 bytes)" err
+'
+
 test_done


### PR DESCRIPTION
Git allows configuring a maximum pack size. GitHub (like presumably other Git hosts) configures this setting to a generous but finite limit. When a user attempts to push an oversized pack, their connection is terminated with a message that they've exceeded the limit. The user has to find the limit value elsewhere, probably in the host's documentation. This change adds a small convenience -- specifying the limit itself in the error message -- so that users no longer have to search elsewhere to discover the limit.

v2 squashes the changes into one commit and corrects the commit trailer misordering.

cc: gitster@pobox.com
cc: me@ttaylorr.com
cc: derrickstolee@github.com
cc: Ævar Arnfjörð Bjarmason <avarab@gmail.com>