### PR TITLE
New options to support "simple" centralized workflow

### DIFF
--- a/Documentation/config/branch.txt
+++ b/Documentation/config/branch.txt
@@ -9,7 +9,9 @@ branch.autoSetupMerge::
 	automatic setup is done when the starting point is either a
 	local branch or remote-tracking branch; `inherit` -- if the starting point
 	has a tracking configuration, it is copied to the new
-	branch. This option defaults to true.
+	branch; `simple` -- automatic setup is done only when the starting point
+	is a remote-tracking branch and the new branch has the same name as the
+	remote branch. This option defaults to true.
 
 branch.autoSetupRebase::
 	When a new branch is created with 'git branch', 'git switch' or 'git checkout'

--- a/Documentation/config/branch.txt
+++ b/Documentation/config/branch.txt
@@ -40,8 +40,9 @@ branch.<name>.remote::
 	may be overridden with `remote.pushDefault` (for all branches).
 	The remote to push to, for the current branch, may be further
 	overridden by `branch.<name>.pushRemote`.  If no remote is
-	configured, or if you are not on any branch, it defaults to
-	`origin` for fetching and `remote.pushDefault` for pushing.
+	configured, or if you are not on any branch and there is more than
+	one remote defined in the repository, it defaults to `origin` for
+	fetching and `remote.pushDefault` for pushing.
 	Additionally, `.` (a period) is the current local repository
 	(a dot-repository), see `branch.<name>.merge`'s final note below.
 

--- a/Documentation/config/push.txt
+++ b/Documentation/config/push.txt
@@ -1,3 +1,14 @@
+push.autoSetupRemote::
+	If set to "true" assume `--set-upstream` on default push when no
+	upstream tracking exists for the current branch; this option
+	takes effect with push.default options 'simple', 'upstream',
+	and 'current'. It is useful if by default you want new branches
+	to be pushed to the default remote (like the behavior of
+	'push.default=current') and you also want the upstream tracking
+	to be set. Workflows most likely to benefit from this option are
+	'simple' central workflows where all branches are expected to
+	have the same name on the remote.
+
 push.default::
 	Defines the action `git push` should take if no refspec is
 	given (whether from the command-line, config, or elsewhere).

--- a/Documentation/git-branch.txt
+++ b/Documentation/git-branch.txt
@@ -221,13 +221,17 @@ The exact upstream branch is chosen depending on the optional argument:
 itself as the upstream; `--track=inherit` means to copy the upstream
 configuration of the start-point branch.
 +
-`--track=direct` is the default when the start point is a remote-tracking branch.
-Set the branch.autoSetupMerge configuration variable to `false` if you
-want `git switch`, `git checkout` and `git branch` to always behave as if `--no-track`
-were given. Set it to `always` if you want this behavior when the
-start-point is either a local or remote-tracking branch. Set it to
-`inherit` if you want to copy the tracking configuration from the
-branch point.
+The branch.autoSetupMerge configuration variable specifies how `git switch`,
+`git checkout` and `git branch` should behave when neither `--track` nor
+`--no-track` are specified:
++
+The default option, `true`, behaves as though `--track=direct`
+were given whenever the start-point is a remote-tracking branch.
+`false` behaves as if `--no-track` were given. `always` behaves as though
+`--track=direct` were given. `inherit` behaves as though `--track=inherit`
+were given. `simple` behaves as though `--track=direct` were given only when
+the start-point is a remote-tracking branch and the new branch has the same
+name as the remote branch.
 +
 See linkgit:git-pull[1] and linkgit:git-config[1] for additional discussion on
 how the `branch.<name>.remote` and `branch.<name>.merge` options are used.

--- a/branch.h
+++ b/branch.h
@@ -12,6 +12,7 @@ enum branch_track {
 	BRANCH_TRACK_EXPLICIT,
 	BRANCH_TRACK_OVERRIDE,
 	BRANCH_TRACK_INHERIT,
+	BRANCH_TRACK_SIMPLE,
 };
 
 extern enum branch_track git_branch_track;

--- a/builtin/push.c
+++ b/builtin/push.c
@@ -195,16 +195,32 @@ static const char message_detached_head_die[] =
 	   "\n"
 	   "    git push %s HEAD:<name-of-remote-branch>\n");
 
-static const char *get_upstream_ref(struct branch *branch, const char *remote_name)
+static const char *get_upstream_ref(int flags, struct branch *branch, const char *remote_name)
 {
-	if (!branch->merge_nr || !branch->merge || !branch->remote_name)
+	if (branch->merge_nr == 0 && (flags & TRANSPORT_PUSH_AUTO_UPSTREAM)) {
+		/* if missing, assume same; set_upstream will be defined later */
+		return branch->refname;
+	}
+
+	if (!branch->merge_nr || !branch->merge || !branch->remote_name) {
+		const char *advice_autosetup_maybe = "";
+		if (!(flags & TRANSPORT_PUSH_AUTO_UPSTREAM)) {
+			advice_autosetup_maybe = _("\n"
+					   "To have this happen automatically for "
+					   "branches without a tracking\n"
+					   "upstream, see 'push.autoSetupRemote' "
+					   "in 'git help config'.\n");
+		}
 		die(_("The current branch %s has no upstream branch.\n"
 		    "To push the current branch and set the remote as upstream, use\n"
 		    "\n"
-		    "    git push --set-upstream %s %s\n"),
+		    "    git push --set-upstream %s %s\n"
+		    "%s"),
 		    branch->name,
 		    remote_name,
-		    branch->name);
+		    branch->name,
+		    advice_autosetup_maybe);
+	}
 	if (branch->merge_nr != 1)
 		die(_("The current branch %s has multiple upstream branches, "
 		    "refusing to push."), branch->name);
@@ -212,7 +228,7 @@ static const char *get_upstream_ref(struct branch *branch, const char *remote_na
 	return branch->merge[0]->src;
 }
 
-static void setup_default_push_refspecs(struct remote *remote)
+static void setup_default_push_refspecs(int *flags, struct remote *remote)
 {
 	struct branch *branch;
 	const char *dst;
@@ -244,7 +260,7 @@ static void setup_default_push_refspecs(struct remote *remote)
 	case PUSH_DEFAULT_SIMPLE:
 		if (!same_remote)
 			break;
-		if (strcmp(branch->refname, get_upstream_ref(branch, remote->name)))
+		if (strcmp(branch->refname, get_upstream_ref(*flags, branch, remote->name)))
 			die_push_simple(branch, remote);
 		break;
 
@@ -254,12 +270,20 @@ static void setup_default_push_refspecs(struct remote *remote)
 			      "your current branch '%s', without telling me what to push\n"
 			      "to update which remote branch."),
 			    remote->name, branch->name);
-		dst = get_upstream_ref(branch, remote->name);
+		dst = get_upstream_ref(*flags, branch, remote->name);
 		break;
 
 	case PUSH_DEFAULT_CURRENT:
 		break;
 	}
+
+	/*
+	 * this is a default push - if auto-upstream is enabled and there is
+	 * no upstream defined, then set it (with options 'simple', 'upstream',
+	 * and 'current').
+	 */
+	if ((*flags & TRANSPORT_PUSH_AUTO_UPSTREAM) && branch->merge_nr == 0)
+		*flags |= TRANSPORT_PUSH_SET_UPSTREAM;
 
 	refspec_appendf(&rs, "%s:%s", branch->refname, dst);
 }
@@ -411,7 +435,7 @@ static int do_push(int flags,
 		if (remote->push.nr) {
 			push_refspec = &remote->push;
 		} else if (!(flags & TRANSPORT_PUSH_MIRROR))
-			setup_default_push_refspecs(remote);
+			setup_default_push_refspecs(&flags, remote);
 	}
 	errs = 0;
 	url_nr = push_url_of_remote(remote, &url);
@@ -481,6 +505,10 @@ static int git_push_config(const char *k, const char *v, void *cb)
 			*flags |= TRANSPORT_PUSH_FOLLOW_TAGS;
 		else
 			*flags &= ~TRANSPORT_PUSH_FOLLOW_TAGS;
+		return 0;
+	} else if (!strcmp(k, "push.autosetupremote")) {
+		if (git_config_bool(k, v))
+			*flags |= TRANSPORT_PUSH_AUTO_UPSTREAM;
 		return 0;
 	} else if (!strcmp(k, "push.gpgsign")) {
 		const char *value;

--- a/builtin/push.c
+++ b/builtin/push.c
@@ -2,6 +2,7 @@
  * "git push"
  */
 #include "cache.h"
+#include "branch.h"
 #include "config.h"
 #include "refs.h"
 #include "refspec.h"
@@ -151,7 +152,8 @@ static NORETURN void die_push_simple(struct branch *branch,
 	 * upstream to a non-branch, we should probably be showing
 	 * them the big ugly fully qualified ref.
 	 */
-	const char *advice_maybe = "";
+	const char *advice_pushdefault_maybe = "";
+	const char *advice_automergesimple_maybe = "";
 	const char *short_upstream = branch->merge[0]->src;
 
 	skip_prefix(short_upstream, "refs/heads/", &short_upstream);
@@ -161,9 +163,16 @@ static NORETURN void die_push_simple(struct branch *branch,
 	 * push.default.
 	 */
 	if (push_default == PUSH_DEFAULT_UNSPECIFIED)
-		advice_maybe = _("\n"
+		advice_pushdefault_maybe = _("\n"
 				 "To choose either option permanently, "
-				 "see push.default in 'git help config'.");
+				 "see push.default in 'git help config'.\n");
+	if (git_branch_track != BRANCH_TRACK_SIMPLE)
+		advice_automergesimple_maybe = _("\n"
+				 "To avoid automatically configuring "
+				 "upstream branches when their name\n"
+				 "doesn't match the local branch, see option "
+				 "'simple' of branch.autosetupmerge\n"
+				 "in 'git help config'.\n");
 	die(_("The upstream branch of your current branch does not match\n"
 	      "the name of your current branch.  To push to the upstream branch\n"
 	      "on the remote, use\n"
@@ -173,9 +182,10 @@ static NORETURN void die_push_simple(struct branch *branch,
 	      "To push to the branch of the same name on the remote, use\n"
 	      "\n"
 	      "    git push %s HEAD\n"
-	      "%s"),
+	      "%s%s"),
 	    remote->name, short_upstream,
-	    remote->name, advice_maybe);
+	    remote->name, advice_pushdefault_maybe,
+	    advice_automergesimple_maybe);
 }
 
 static const char message_detached_head_die[] =

--- a/config.c
+++ b/config.c
@@ -1781,6 +1781,9 @@ static int git_default_branch_config(const char *var, const char *value)
 		} else if (value && !strcmp(value, "inherit")) {
 			git_branch_track = BRANCH_TRACK_INHERIT;
 			return 0;
+		} else if (value && !strcmp(value, "simple")) {
+			git_branch_track = BRANCH_TRACK_SIMPLE;
+			return 0;
 		}
 		git_branch_track = git_config_bool(var, value);
 		return 0;

--- a/remote.c
+++ b/remote.c
@@ -543,6 +543,8 @@ static const char *remotes_remote_for_branch(struct remote_state *remote_state,
 	}
 	if (explicit)
 		*explicit = 0;
+	if (remote_state->remotes_nr == 1)
+		return remote_state->remotes[0]->name;
 	return "origin";
 }
 

--- a/t/t5512-ls-remote.sh
+++ b/t/t5512-ls-remote.sh
@@ -15,6 +15,10 @@ generate_references () {
 	done
 }
 
+test_expect_success 'dies when no remote found' '
+	test_must_fail git ls-remote
+'
+
 test_expect_success setup '
 	>file &&
 	git add file &&
@@ -30,7 +34,8 @@ test_expect_success setup '
 	git show-ref -d	>refs &&
 	sed -e "s/ /	/" refs >>expected.all &&
 
-	git remote add self "$(pwd)/.git"
+	git remote add self "$(pwd)/.git" &&
+	git remote add self2 "."
 '
 
 test_expect_success 'ls-remote --tags .git' '
@@ -83,11 +88,17 @@ test_expect_success 'ls-remote --sort="-refname" --tags self' '
 	test_cmp expect actual
 '
 
-test_expect_success 'dies when no remote specified and no default remotes found' '
+test_expect_success 'dies when no remote specified, multiple remotes found, and no default specified' '
 	test_must_fail git ls-remote
 '
 
-test_expect_success 'use "origin" when no remote specified' '
+test_expect_success 'succeeds when no remote specified but only one found' '
+	test_when_finished git remote add self2 "." &&
+	git remote remove self2 &&
+	git ls-remote
+'
+
+test_expect_success 'use "origin" when no remote specified and multiple found' '
 	URL="$(pwd)/.git" &&
 	echo "From $URL" >exp_err &&
 

--- a/t/t5528-push-default.sh
+++ b/t/t5528-push-default.sh
@@ -162,6 +162,20 @@ test_expect_success 'push from/to branch with tracking fails with nothing ' '
 	test_push_failure nothing
 '
 
+test_expect_success 'push from/to new branch succeeds with upstream if push.autoSetupRemote' '
+	git checkout -b new-branch-a &&
+	test_config push.autoSetupRemote true &&
+	test_config branch.new-branch-a.remote parent1 &&
+	test_push_success upstream new-branch-a
+'
+
+test_expect_success 'push from/to new branch succeeds with simple if push.autoSetupRemote' '
+	git checkout -b new-branch-c &&
+	test_config push.autoSetupRemote true &&
+	test_config branch.new-branch-c.remote parent1 &&
+	test_push_success simple new-branch-c
+'
+
 test_expect_success '"matching" fails if none match' '
 	git init --bare empty &&
 	test_must_fail git push empty : 2>actual &&

--- a/t/t5528-push-default.sh
+++ b/t/t5528-push-default.sh
@@ -94,11 +94,72 @@ test_expect_success '"upstream" does not push when remotes do not match' '
 	test_must_fail git push parent2
 '
 
-test_expect_success 'push from/to new branch with upstream, matching and simple' '
+test_expect_success '"current" does not push when multiple remotes and none origin' '
+	git checkout main &&
+	test_config push.default current &&
+	test_commit current-multi &&
+	test_must_fail git push
+'
+
+test_expect_success '"current" pushes when remote explicitly specified' '
+	git checkout main &&
+	test_config push.default current &&
+	test_commit current-specified &&
+	git push parent1
+'
+
+test_expect_success '"current" pushes to origin when no remote specified among multiple' '
+	git checkout main &&
+	test_config remote.origin.url repo1 &&
+	test_config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*" &&
+	test_commit current-origin &&
+	test_push_success current main
+'
+
+test_expect_success '"current" pushes to single remote even when not specified' '
+	git checkout main &&
+	test_when_finished git remote add parent1 repo1 &&
+	git remote remove parent1 &&
+	test_commit current-implied &&
+	test_push_success current main repo2
+'
+
+test_expect_success 'push from/to new branch with non-defaulted remote fails with upstream, matching, current and simple ' '
 	git checkout -b new-branch &&
 	test_push_failure simple &&
 	test_push_failure matching &&
+	test_push_failure upstream &&
+	test_push_failure current
+'
+
+test_expect_success 'push from/to new branch fails with upstream and simple ' '
+	git checkout -b new-branch-1 &&
+	test_config branch.new-branch-1.remote parent1 &&
+	test_push_failure simple &&
 	test_push_failure upstream
+'
+
+# The behavior here is surprising but not entirely wrong:
+#  - the current branch is used to determine the target remote
+#  - the "matching" push default pushes matching branches, *ignoring* the
+#       current new branch as it does not have upstream tracking
+#  - the default push succeeds
+#
+# A previous test expected this to fail, but for the wrong reasons:
+# it expected a fail becaause the branch is new and cannot be pushed, but
+# in fact it was failing because of an ambiguous remote
+#
+test_expect_failure 'push from/to new branch fails with matching ' '
+	git checkout -b new-branch-2 &&
+	test_config branch.new-branch-2.remote parent1 &&
+	test_push_failure matching
+'
+
+test_expect_success 'push from/to branch with tracking fails with nothing ' '
+	git checkout -b tracked-branch &&
+	test_config branch.tracked-branch.remote parent1 &&
+	test_config branch.tracked-branch.merge refs/heads/tracked-branch &&
+	test_push_failure nothing
 '
 
 test_expect_success '"matching" fails if none match' '

--- a/transport.h
+++ b/transport.h
@@ -145,6 +145,7 @@ struct transport {
 #define TRANSPORT_PUSH_OPTIONS			(1<<14)
 #define TRANSPORT_RECURSE_SUBMODULES_ONLY	(1<<15)
 #define TRANSPORT_PUSH_FORCE_IF_INCLUDES	(1<<16)
+#define TRANSPORT_PUSH_AUTO_UPSTREAM		(1<<17)
 
 int transport_summary_width(const struct ref *refs);
 


### PR DESCRIPTION
This patchset introduces two new configuration options, intended to be consistent with and complementary to the push.default "simple" option. It also improves remote-defaulting in "default push" scenarios.

In some "simple" centralized workflows, users expect remote tracking branch names to match local branch names. "git push" pushes to the remote version/instance of the branch, and "git pull" pulls any changes to the remote branch (changes made by the same user in another place, or by other users). The default push.default option, "simple", supports this kind of workflow by "raising eyebrows" if a user looks like they are trying to push to the "wrong" remote tracking branch.

None of the existing branch.autosetupmerge settings support this workflow/expectation well, so the new "branch.autosetupmerge=simple" option addresses this - acting like the default "remote" option only when the remote branch and (new) local branch have the same name. The new option is referred to in new advice in the push.default=simple mismatching remote branch error text.

At a later stage in the new-branch workflow, when a user first goes to push a new branch to the remote, the default "git push" will complain that there is no remote tracking branch (unless push.default=current). For users that always expect remote branch names to match local branch names, on a single remote, this is inconvenient. New config setting "push.autoSetupRemote" addresses this by automatically specifying "--set-upstream" (and allowing the push) when there is no configured remote for push.default options "simple", "upstream", and "current". In the case of "current", this helps make "pull" work correctly (under these workflow assumptions). For the other two options the primary benefit is being able to simply say "git push" and not be interrupted with an unnecessary "but this is a new branch!" error.

Along the way, we also enhance the remote-defaulting behavior for "git push" (and ls-remote) to not only support "origin" as the default remote, but rather any single configured remote. Default push should only fail for lack of a remote if there are none, or if there is more than one and none are called "origin".

Changes since v4:
* Changed patchset subject to "New options to support "simple" centralized workflow", reflecting the fact that there are now two new config options available
* Added some advice to the default push "mismatching remote tracking branch name" error, offering the new branch.autosetupmerge=simple option, so that new users can potentially discover and benefit from it
* Introduced a new commit improving the defaulting of remote for "default push" (and ls-remote), and fixing and adding related tests
* Introduced a new commit for new config setting push.autoSetupRemote, which will avoid the need for users to explicitly push to a specific origin, explicitly requesting tracking, when doing a default push for a new branch (with advice and tests).
* Rebased onto current 'master'

Open questions:
* The exact text of the two new pieces of advice should get some review, it is likely improvable
* The name and config help of the "push.autoSetupRemote" config setting should also be reviewed - there is confusion (at least in my mind) between "upstream", "remote tracking", and "remote merge" concepts.

cc: Tao Klerks <tao@klerks.biz>
cc: Ævar Arnfjörð Bjarmason <avarab@gmail.com>
cc: Eric Sunshine <sunshine@sunshineco.com>
cc: Josh Steadmon <steadmon@google.com>