### PR TITLE
reset: make --no-refresh the only way to skip index refresh 

### DIFF
--- a/Documentation/config.txt
+++ b/Documentation/config.txt
@@ -495,8 +495,6 @@ include::config/repack.txt[]
 
 include::config/rerere.txt[]
 
-include::config/reset.txt[]
-
 include::config/sendemail.txt[]
 
 include::config/sequencer.txt[]

--- a/Documentation/config/reset.txt
+++ b/Documentation/config/reset.txt
@@ -1,2 +1,0 @@
-reset.quiet::
-	When set to true, 'git reset' will default to the '--quiet' option.

--- a/Documentation/git-reset.txt
+++ b/Documentation/git-reset.txt
@@ -114,10 +114,7 @@ OPTIONS
 --no-refresh::
 	Proactively refresh the index after a mixed reset. If unspecified, the
 	behavior falls back on the `reset.refresh` config option. If neither
-	`--[no-]refresh` nor `reset.refresh` are set, the default behavior is
-	decided by the `--[no-]quiet` option and/or `reset.quiet` config.
-	If `--quiet` is specified or `reset.quiet` is set with no command-line
-	"quiet" setting, refresh is disabled. Otherwise, refresh is enabled.
+	`--[no-]refresh` nor `reset.refresh` are set, refresh is enabled.
 
 --pathspec-from-file=<file>::
 	Pathspec is passed in `<file>` instead of commandline args. If

--- a/Documentation/git-reset.txt
+++ b/Documentation/git-reset.txt
@@ -105,10 +105,7 @@ OPTIONS
 
 -q::
 --quiet::
---no-quiet::
-	Be quiet, only report errors. The default behavior is set by the
-	`reset.quiet` config option. `--quiet` and `--no-quiet` will
-	override the default behavior.
+	Be quiet, only report errors.
 
 --refresh::
 --no-refresh::

--- a/Documentation/git-reset.txt
+++ b/Documentation/git-reset.txt
@@ -109,9 +109,7 @@ OPTIONS
 
 --refresh::
 --no-refresh::
-	Proactively refresh the index after a mixed reset. If unspecified, the
-	behavior falls back on the `reset.refresh` config option. If neither
-	`--[no-]refresh` nor `reset.refresh` are set, refresh is enabled.
+	Refresh the index after a mixed reset. Enabled by default.
 
 --pathspec-from-file=<file>::
 	Pathspec is passed in `<file>` instead of commandline args. If

--- a/builtin/reset.c
+++ b/builtin/reset.c
@@ -423,7 +423,6 @@ int cmd_reset(int argc, const char **argv, const char *prefix)
 	};
 
 	git_config(git_reset_config, NULL);
-	git_config_get_bool("reset.quiet", &quiet);
 	git_config_get_bool("reset.refresh", &refresh);
 
 	argc = parse_options(argc, argv, prefix, options, git_reset_usage,

--- a/builtin/reset.c
+++ b/builtin/reset.c
@@ -423,7 +423,6 @@ int cmd_reset(int argc, const char **argv, const char *prefix)
 	};
 
 	git_config(git_reset_config, NULL);
-	git_config_get_bool("reset.refresh", &refresh);
 
 	argc = parse_options(argc, argv, prefix, options, git_reset_usage,
 						PARSE_OPT_KEEP_DASHDASH);
@@ -529,8 +528,7 @@ int cmd_reset(int argc, const char **argv, const char *prefix)
 				t_delta_in_ms = (getnanotime() - t_begin) / 1000000;
 				if (!quiet && advice_enabled(ADVICE_RESET_NO_REFRESH_WARNING) && t_delta_in_ms > REFRESH_INDEX_DELAY_WARNING_IN_MS) {
 					advise(_("It took %.2f seconds to refresh the index after reset.  You can use\n"
-						 "'--no-refresh' to avoid this.  Set the config setting reset.refresh to false\n"
-						 "to make this the default."), t_delta_in_ms / 1000.0);
+						 "'--no-refresh' to avoid this."), t_delta_in_ms / 1000.0);
 				}
 			}
 		} else {

--- a/builtin/reset.c
+++ b/builtin/reset.c
@@ -392,7 +392,7 @@ static int git_reset_config(const char *var, const char *value, void *cb)
 int cmd_reset(int argc, const char **argv, const char *prefix)
 {
 	int reset_type = NONE, update_ref_status = 0, quiet = 0;
-	int refresh = -1;
+	int refresh = 1;
 	int patch_mode = 0, pathspec_file_nul = 0, unborn;
 	const char *rev, *pathspec_from_file = NULL;
 	struct object_id oid;
@@ -429,13 +429,6 @@ int cmd_reset(int argc, const char **argv, const char *prefix)
 	argc = parse_options(argc, argv, prefix, options, git_reset_usage,
 						PARSE_OPT_KEEP_DASHDASH);
 	parse_args(&pathspec, argv, prefix, patch_mode, &rev);
-
-	/*
-	 * If refresh is completely unspecified (either by config or by command
-	 * line option), decide based on 'quiet'.
-	 */
-	if (refresh < 0)
-		refresh = !quiet;
 
 	if (pathspec_from_file) {
 		if (patch_mode)

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -152,7 +152,6 @@ static int set_recommended_config(int reconfigure)
 		{ "pack.useBitmaps", "false", 1 },
 		{ "pack.useSparse", "true", 1 },
 		{ "receive.autoGC", "false", 1 },
-		{ "reset.quiet", "true", 1 },
 		{ "feature.manyFiles", "false", 1 },
 		{ "feature.experimental", "false", 1 },
 		{ "fetch.unpackLimit", "1", 1 },

--- a/t/t7102-reset.sh
+++ b/t/t7102-reset.sh
@@ -485,25 +485,12 @@ test_reset_refreshes_index () {
 }
 
 test_expect_success '--mixed refreshes the index' '
-	# Verify default behavior (with no config settings or command line
-	# options)
-	test_reset_refreshes_index
-'
-test_expect_success '--mixed --[no-]quiet sets default refresh behavior' '
-	# Verify that --[no-]quiet and `reset.quiet` (without --[no-]refresh)
-	# determine refresh behavior
+	# Verify default behavior (without --[no-]refresh or reset.refresh)
+	test_reset_refreshes_index &&
 
-	# Config setting
-	! test_reset_refreshes_index "-c reset.quiet=true" &&
-	test_reset_refreshes_index "-c reset.quiet=false" &&
-
-	# Command line option
-	! test_reset_refreshes_index "" --quiet &&
-	test_reset_refreshes_index "" --no-quiet &&
-
-	# Command line option overrides config setting
-	! test_reset_refreshes_index "-c reset.quiet=false" --quiet &&
-	test_reset_refreshes_index "-c reset.refresh=true" --no-quiet
+	# With --quiet & reset.quiet
+	test_reset_refreshes_index "-c reset.quiet=true" &&
+	test_reset_refreshes_index "" --quiet
 '
 
 test_expect_success '--mixed --[no-]refresh sets refresh behavior' '
@@ -520,15 +507,6 @@ test_expect_success '--mixed --[no-]refresh sets refresh behavior' '
 	# Command line option overrides config setting
 	test_reset_refreshes_index "-c reset.refresh=false" --refresh &&
 	! test_reset_refreshes_index "-c reset.refresh=true" --no-refresh
-'
-
-test_expect_success '--mixed --refresh overrides --quiet refresh behavior' '
-	# Verify that *both* --refresh and `reset.refresh` override the
-	# default non-refresh behavior of --quiet
-	test_reset_refreshes_index "" "--quiet --refresh" &&
-	test_reset_refreshes_index "-c reset.quiet=true" --refresh &&
-	test_reset_refreshes_index "-c reset.refresh=true" --quiet &&
-	test_reset_refreshes_index "-c reset.refresh=true -c reset.quiet=true"
 '
 
 test_expect_success '--mixed preserves skip-worktree' '

--- a/t/t7102-reset.sh
+++ b/t/t7102-reset.sh
@@ -493,19 +493,9 @@ test_expect_success '--mixed refreshes the index' '
 '
 
 test_expect_success '--mixed --[no-]refresh sets refresh behavior' '
-	# Verify that --[no-]refresh and `reset.refresh` control index refresh
-
-	# Config setting
-	test_reset_refreshes_index "-c reset.refresh=true" &&
-	! test_reset_refreshes_index "-c reset.refresh=false" &&
-
-	# Command line option
+	# Verify that --[no-]refresh controls index refresh
 	test_reset_refreshes_index "" --refresh &&
-	! test_reset_refreshes_index "" --no-refresh &&
-
-	# Command line option overrides config setting
-	test_reset_refreshes_index "-c reset.refresh=false" --refresh &&
-	! test_reset_refreshes_index "-c reset.refresh=true" --no-refresh
+	! test_reset_refreshes_index "" --no-refresh
 '
 
 test_expect_success '--mixed preserves skip-worktree' '

--- a/t/t7102-reset.sh
+++ b/t/t7102-reset.sh
@@ -488,8 +488,7 @@ test_expect_success '--mixed refreshes the index' '
 	# Verify default behavior (without --[no-]refresh or reset.refresh)
 	test_reset_refreshes_index &&
 
-	# With --quiet & reset.quiet
-	test_reset_refreshes_index "-c reset.quiet=true" &&
+	# With --quiet
 	test_reset_refreshes_index "" --quiet
 '
 


### PR DESCRIPTION
Maintainer's note: this is based on vd/stash-silence-reset (specifically, 4b8b0f6fa2 (stash: make internal resets quiet and refresh index, 2022-03-15)).

----------------------------------------------------------

This is a follow-up to the changes in vd/stash-silence-reset [1], in which index refreshing behavior was decoupled from log silencing in the '--quiet' option to 'git reset --mixed' by introducing a '--[no-]refresh' option and 'reset.refresh' config setting.

After some discussion [2] on the mailing list, both the backward-compatibility and use of global options in that series came into question:

* '--quiet' still skipped refresh if neither '--[no-]refresh' nor 'reset.refresh' were specified, meaning that users could still be left with an incorrect index state after reset.
* Having 'reset.quiet' and/or 'reset.refresh' potentially disable index refresh by default meant that developers would need to defensively add '--refresh' to all internal uses of 'git reset --mixed'. Without that option, different config setups could cause variability in index correctness from user to user.

In response, this series removes all methods of skipping index refresh in 'git reset --mixed' *except* for '--no-refresh' itself:

* Patch [1/3] removes the "fallback" behavior of 'reset.quiet' and '--quiet' implying '--no-refresh' if neither '--[no-]refresh' nor 'config.refresh' were specified. In other words, '--quiet' no longer does anything other than log silencing.
* Patch [2/3] removes 'reset.quiet', since its main use was to disable index refresh until that behavior was removed in [1/3].
* Patch [3/3] removes 'reset.refresh' to avoid users accidentally ending up with an incorrect index state after all resets as a result of a global setting's passive effects.

## Changes since V1
* Dropped patch that removed '--refresh', again allowing both '--no-refresh' and '--refresh' as valid options.
* Updated documentation of "--refresh" option to remove unnecessary "proactively".
* Reworded commit titles to change "deprecate" to the more accurate "remove".

[1] https://lore.kernel.org/git/pull.1170.v3.git.1647308982.gitgitgadget@gmail.com/
[2] https://lore.kernel.org/git/80a2a5a2-256f-6c3b-2430-10bef99ce1e9@github.com/

Thanks!
-Victoria 

CC: gitster@pobox.com
CC: phillip.wood123@gmail.com
cc: Derrick Stolee <derrickstolee@github.com>