### PR TITLE
test-lib-functions: fix test_subcommand_inexact

### DIFF
--- a/t/test-lib-functions.sh
+++ b/t/test-lib-functions.sh
@@ -1789,40 +1789,6 @@ test_subcommand () {
 }
 
 # Check that the given command was invoked as part of the
-# trace2-format trace on stdin, but without an exact set of
-# arguments.
-#
-#	test_subcommand [!] <command> <args>... < <trace>
-#
-# For example, to look for an invocation of "git pack-objects"
-# with the "--honor-pack-keep" argument, use
-#
-#	GIT_TRACE2_EVENT=event.log git repack ... &&
-#	test_subcommand git pack-objects --honor-pack-keep <event.log
-#
-# If the first parameter passed is !, this instead checks that
-# the given command was not called.
-#
-test_subcommand_inexact () {
-	local negate=
-	if test "$1" = "!"
-	then
-		negate=t
-		shift
-	fi
-
-	local expr=$(printf '"%s".*' "$@")
-	expr="${expr%,}"
-
-	if test -n "$negate"
-	then
-		! grep "\"event\":\"child_start\".*\[$expr\]"
-	else
-		grep "\"event\":\"child_start\".*\[$expr\]"
-	fi
-}
-
-# Check that the given command was invoked as part of the
 # trace2-format trace on stdin.
 #
 #	test_region [!] <category> <label> git <command> <args>...


### PR DESCRIPTION
Junio discovered in [1] that test_subcommand_inexact is more flexible than initially intended.

[1] https://lore.kernel.org/git/xmqq4k41vdwe.fsf@gitster.g/

The intention was that we do not need to specify the remaining arguments for a subcommand, but instead the current behavior is to allow the given arguments to appear as any subsequence within the command (except that the first "git" instance must be the first argument).

By changing the test that needed the helper, we can avoid the helper in the first place. Modify the test and remove the helper.

Changes in v3
-------------

* Significant edits to the test in t7700 based on Junio and Taylor's feedback.

* Patch 2 now deletes the helper as it is not used anywhere.

Thanks,
-Stolee

cc: gitster@pobox.com
cc: chakrabortyabhradeep79@gmail.com
cc: Taylor Blau <me@ttaylorr.com>