### PR TITLE
mv: refresh stat info for moved entry

### DIFF
--- a/read-cache.c
+++ b/read-cache.c
@@ -134,7 +134,7 @@ static void replace_index_entry(struct index_state *istate, int nr, struct cache
 
 void rename_index_entry_at(struct index_state *istate, int nr, const char *new_name)
 {
-	struct cache_entry *old_entry = istate->cache[nr], *new_entry;
+	struct cache_entry *old_entry = istate->cache[nr], *new_entry, *refreshed;
 	int namelen = strlen(new_name);
 
 	new_entry = make_empty_cache_entry(istate, namelen);
@@ -147,7 +147,20 @@ void rename_index_entry_at(struct index_state *istate, int nr, const char *new_n
 	cache_tree_invalidate_path(istate, old_entry->name);
 	untracked_cache_remove_from_index(istate, old_entry->name);
 	remove_index_entry_at(istate, nr);
-	add_index_entry(istate, new_entry, ADD_CACHE_OK_TO_ADD|ADD_CACHE_OK_TO_REPLACE);
+
+	/*
+	 * Refresh the new index entry. Using 'refresh_cache_entry' ensures
+	 * we only update stat info if the entry is otherwise up-to-date (i.e.,
+	 * the contents/mode haven't changed). This ensures that we reflect the
+	 * 'ctime' of the rename in the index without (incorrectly) updating
+	 * the cached stat info to reflect unstaged changes on disk.
+	 */
+	refreshed = refresh_cache_entry(istate, new_entry, CE_MATCH_REFRESH);
+	if (refreshed && refreshed != new_entry) {
+		add_index_entry(istate, refreshed, ADD_CACHE_OK_TO_ADD|ADD_CACHE_OK_TO_REPLACE);
+		discard_cache_entry(new_entry);
+	} else
+		add_index_entry(istate, new_entry, ADD_CACHE_OK_TO_ADD|ADD_CACHE_OK_TO_REPLACE);
 }
 
 void fill_stat_data(struct stat_data *sd, struct stat *st)

--- a/t/t7001-mv.sh
+++ b/t/t7001-mv.sh
@@ -4,6 +4,25 @@ test_description='git mv in subdirs'
 . ./test-lib.sh
 . "$TEST_DIRECTORY"/lib-diff-data.sh
 
+test_expect_success 'mv -f refreshes updated index entry' '
+	echo test >bar &&
+	git add bar &&
+	git commit -m test &&
+
+	echo foo >foo &&
+	git add foo &&
+
+	# Wait one second to ensure ctime of rename will differ from original
+	# file creation ctime.
+	sleep 1 &&
+	git mv -f foo bar &&
+	git reset --merge HEAD &&
+
+	# Verify the index has been reset
+	git diff-files >out &&
+	test_must_be_empty out
+'
+
 test_expect_success 'prepare reference tree' '
 	mkdir path0 path1 &&
 	COPYING_test_data >path0/COPYING &&


### PR DESCRIPTION
This patch fixes a bug [1] encountered when executing 'git reset --merge HEAD' immediately after 'git mv'. Because the stat info of the original entry is copied to the new one, including all cached stat information, the 'ctime' isn't updated corresponding to the rename. If the index entry is otherwise up-to-date with the contents on-disk, the incorrect 'ctime' makes subsequent operations (e.g., 'git reset --merge') identify the index entry as out-of-date, failing when they should succeed. 

Note, however, that we use 'refresh_cache_entry()' to refresh the stat information rather than 'fill_stat_cache_info()' directly because the stat information should only be updated if the index entry is up-to-date with the file on-disk. If we ignored this distinction, the stat info would match the state of unstaged changes on-disk, not the entry in the index as it should.

To avoid exiting 'git mv' with a stale index that may affect subsequent commands, 'rename_index_entry_at()' (used internally by 'git mv') is updated to refresh the destination index entry's stat information after the move is complete.

[1] https://lore.kernel.org/git/84FF8F9A-3A9A-4F2A-8D8E-5D50F2F06203@icloud.com/

## Changes since V1
- Determined the exact cause of the failure (the mismatched 'ctime'), as well as the reasoning for why the stat information cannot always be updated; revised the implementation accordingly.
- Fixed usage of 'refresh_cache_entry()'; because it does not update cache entries in-place, insert its return value into the index (if valid), and discard the no-longer-needed 'new_entry' cache entry.
- Updated the test for the bug report scenario to wait long enough such that the 'ctime' of the 'mv' is distinct from the original file creation time. 

CC: reichemn@icloud.com
CC: gitster@pobox.com
cc: Derrick Stolee <derrickstolee@github.com>