### PR TITLE
worktree: include repair cmd in usage

### DIFF
--- a/builtin/worktree.c
+++ b/builtin/worktree.c
@@ -22,6 +22,7 @@ static const char * const worktree_usage[] = {
 	N_("git worktree move <worktree> <new-path>"),
 	N_("git worktree prune [<options>]"),
 	N_("git worktree remove [<options>] <worktree>"),
+	N_("git worktree repair [<path>]"),
 	N_("git worktree unlock <path>"),
 	NULL
 };


### PR DESCRIPTION
The worktree repair command was not added to the usage menu for the
worktree command. This commit adds the usage of 'worktree repair'
according to the existing docs.

Signed-off-by: Des Preston <despreston@gmail.com>
