### PR TITLE
[RFC] set LC_TIME even if locale dir is not present

### DIFF
--- a/gettext.c
+++ b/gettext.c
@@ -102,6 +102,21 @@ static void init_gettext_charset(const char *domain)
 		setlocale(LC_CTYPE, "C");
 }
 
+static void git_setup_gettext_no_podir(void)
+{
+	setlocale(LC_TIME, "");
+}
+
+static void git_setup_gettext_podir(const char *podir)
+{
+	bindtextdomain("git", podir);
+	setlocale(LC_MESSAGES, "");
+	init_gettext_charset("git");
+	textdomain("git");
+
+	git_gettext_enabled = 1;
+}
+
 int git_gettext_enabled = 0;
 
 void git_setup_gettext(void)
@@ -109,22 +124,16 @@ void git_setup_gettext(void)
 	const char *podir = getenv(GIT_TEXT_DOMAIN_DIR_ENVIRONMENT);
 	char *p = NULL;
 
+	git_setup_gettext_no_podir();
+
 	if (!podir)
 		podir = p = system_path(GIT_LOCALE_PATH);
 
-	if (!is_directory(podir)) {
-		free(p);
-		return;
-	}
+	if (!is_directory(podir))
+		goto done;
 
-	bindtextdomain("git", podir);
-	setlocale(LC_MESSAGES, "");
-	setlocale(LC_TIME, "");
-	init_gettext_charset("git");
-	textdomain("git");
-
-	git_gettext_enabled = 1;
-
+	git_setup_gettext_podir(podir);
+done:
 	free(p);
 }
 

--- a/gettext.c
+++ b/gettext.c
@@ -124,14 +124,13 @@ void git_setup_gettext(void)
 	const char *podir = getenv(GIT_TEXT_DOMAIN_DIR_ENVIRONMENT);
 	char *p = NULL;
 
-	git_setup_gettext_no_podir();
-
 	if (!podir)
 		podir = p = system_path(GIT_LOCALE_PATH);
 
 	if (!is_directory(podir))
 		goto done;
 
+	git_setup_gettext_no_podir();
 	git_setup_gettext_podir(podir);
 done:
 	free(p);

--- a/t/t0203-gettext-setlocale-sanity.sh
+++ b/t/t0203-gettext-setlocale-sanity.sh
@@ -23,4 +23,14 @@ test_expect_success GETTEXT_LOCALE 'git show a ISO-8859-1 commit under a UTF-8 l
 	grep -q "iso-utf8-commit" out
 '
 
+test_expect_success GETTEXT_LOCALE 'the %c date format works even without a localedir (LC_TIME)' '
+	LANGUAGE=is LC_ALL="$is_IS_locale" GIT_TEXTDOMAINDIR="$PWD/nonexisting" \
+		git log --pretty=format:%ad --date=format:%c HEAD^1..HEAD >actual &&
+
+	# Avoid testing the raw format (it might differ?). But
+	# Thursday is Fimmtudagur in Icelandic, so grepping "fim" is
+	# pretty certain to test that the locale was used.
+	grep -iF fim actual
+'
+
 test_done


### PR DESCRIPTION
This is a small bug fix with a large and unwieldy regression test. The whole prepare_time_locale() bit and and the Makefile change is obviously based on prepare_utf8_locale(), but I'm not really happy with it. I'm not even sure how to fully put the issues I have with the test in words. 

* I feel like it's not really testing anything on builds without gettext, but adding a GETTEXT prerequisite to a test that something works without gettext is very counter intuitive.

* I'm also not exactly happy about how I choose a locale, but can't think of a better way. It's a reasonable assumption that C locale uses a US date format on most, if not all supported systems, but I have no good way to make sure that the selected locale actually formats dates differently. Defining a custom locale would solve this, but seems like a convoluted way to go about things.

* I'm not entirely happy with testing the output of `git log -format=date:%c` against the output of the exact same command. I've tried a version of the test based on `date(1)` and got it working with the GNU version, but looking at the BSD version for our OS X based CI builds and the POSIX spec for that command, they share barely more than their name.

So, looking at the points above, I expect this to take a few re-rolls to get into a reasonable shape.

cc: Jeff King <peff@peff.net>
cc: Johannes Schindelin <johannes.schindelin@gmx.de>
cc: Ævar Arnfjörð Bjarmason <avarab@gmail.com>