### PR TITLE
trace2: add stats for fsync operations

### DIFF
--- a/git-compat-util.h
+++ b/git-compat-util.h
@@ -1282,6 +1282,11 @@ enum fsync_action {
 int git_fsync(int fd, enum fsync_action action);
 
 /*
+ * Writes out trace statistics for fsync using the trace2 API.
+ */
+void trace_git_fsync_stats(void);
+
+/*
  * Preserves errno, prints a message, but gives no warning for ENOENT.
  * Returns 0 on success, which includes trying to unlink an object that does
  * not exist.

--- a/t/t0211/scrub_perf.perl
+++ b/t/t0211/scrub_perf.perl
@@ -59,6 +59,10 @@ while (<>) {
 	    # and highly variable.  Just omit them.
 	    goto SKIP_LINE;
 	}
+	if ($tokens[$col_category] =~ m/fsync/) {
+	    # fsync events aren't interesting for the test
+	    goto SKIP_LINE;
+	}
     }
 
     # t_abs and t_rel are either blank or a float.  Replace the float

--- a/trace2.c
+++ b/trace2.c
@@ -214,6 +214,7 @@ int trace2_cmd_exit_fl(const char *file, int line, int code)
 	if (!trace2_enabled)
 		return code;
 
+	trace_git_fsync_stats();
 	trace2_collect_process_info(TRACE2_PROCESS_INFO_EXIT);
 
 	tr2main_exit_code = code;


### PR DESCRIPTION
Add some global trace2 statistics for the number of fsyncs performed
during the lifetime of a Git process.

These stats are printed as part of trace2_cmd_exit_fl, which is
presumably where we might want to print any other cross-cutting
statistics.

Signed-off-by: Neeraj Singh <neerajsi@microsoft.com>

CC: jeffhost@microsoft.com
cc: Ævar Arnfjörð Bjarmason <avarab@gmail.com>
cc: Neeraj Singh <nksingh85@gmail.com>