### PR TITLE
core.fsyncmethod: correctly camel-case warning message

### DIFF
--- a/config.c
+++ b/config.c
@@ -1695,7 +1695,7 @@ static int git_default_core_config(const char *var, const char *value, void *cb)
 
 	if (!strcmp(var, "core.fsyncobjectfiles")) {
 		if (fsync_object_files < 0)
-			warning(_("core.fsyncobjectfiles is deprecated; use core.fsync instead"));
+			warning(_("core.fsyncObjectFiles is deprecated; use core.fsync instead"));
 		fsync_object_files = git_config_bool(var, value);
 		return 0;
 	}


### PR DESCRIPTION
The warning for an unrecognized fsyncMethod was not
camel-cased.

Reported-by: Jiang Xin <worldhello.net@gmail.com>
Signed-off-by: Neeraj Singh <neerajsi@microsoft.com>

---

See https://lore.kernel.org/git/CANYiYbFjRMV-_opvFn78mq7tgtZFMrfPyDjDa+kyaZZfk_LmWQ@mail.gmail.com/ where this was reported.

This fixes a problem in ns/core-fsyncmethod.  Please apply to 'master'.

cc: worldhello.net@gmail.com