### PR TITLE
(fix): make all die() error messages lowercase

### DIFF
--- a/Documentation/RelNotes/2.36.0.txt
+++ b/Documentation/RelNotes/2.36.0.txt
@@ -356,6 +356,13 @@ Fixes since v2.35
    in the current checkout of the superproject.  We now do so for all
    submodules that have been run "git submodule init" on.
 
+ * "git rebase $base $non_branch_commit", when $base is an ancestor or
+   the $non_branch_commit, modified the current branch, which has been
+   corrected.
+
+ * When "shallow" information is updated, we forgot to update the
+   in-core equivalent, which has been corrected.
+
  * Other code cleanup, docfix, build fix, etc.
    (merge cfc5cf428b jc/find-header later to maint).
    (merge 40e7cfdd46 jh/p4-fix-use-of-process-error-exception later to maint).

--- a/abspath.c
+++ b/abspath.c
@@ -86,7 +86,7 @@ static char *strbuf_realpath_1(struct strbuf *resolved, const char *path,
 
 	if (!*path) {
 		if (flags & REALPATH_DIE_ON_ERROR)
-			die("The empty string is not a valid path");
+			die("the empty string is not a valid path");
 		else
 			goto error_out;
 	}
@@ -141,7 +141,7 @@ static char *strbuf_realpath_1(struct strbuf *resolved, const char *path,
 				errno = ELOOP;
 
 				if (flags & REALPATH_DIE_ON_ERROR)
-					die("More than %d nested symlinks "
+					die("more than %d nested symlinks "
 					    "on path '%s'", MAXSYMLINKS, path);
 				else
 					goto error_out;

--- a/advice.c
+++ b/advice.c
@@ -203,7 +203,7 @@ int error_resolve_conflict(const char *me)
 void NORETURN die_resolve_conflict(const char *me)
 {
 	error_resolve_conflict(me);
-	die(_("Exiting because of an unresolved conflict."));
+	die(_("exiting because of an unresolved conflict."));
 }
 
 void NORETURN die_conclude_merge(void)
@@ -211,12 +211,12 @@ void NORETURN die_conclude_merge(void)
 	error(_("You have not concluded your merge (MERGE_HEAD exists)."));
 	if (advice_enabled(ADVICE_RESOLVE_CONFLICT))
 		advise(_("Please, commit your changes before merging."));
-	die(_("Exiting because of unfinished merge."));
+	die(_("exiting because of unfinished merge."));
 }
 
 void NORETURN die_ff_impossible(void)
 {
-	die(_("Not possible to fast-forward, aborting."));
+	die(_("not possible to fast-forward, aborting."));
 }
 
 void advise_on_updating_sparse_paths(struct string_list *pathspec_list)

--- a/archive.c
+++ b/archive.c
@@ -519,9 +519,9 @@ static int add_file_cb(const struct option *opt, const char *arg, int unset)
 	item->util = info = xmalloc(sizeof(*info));
 	info->base = xstrdup_or_null(base);
 	if (stat(path, &info->stat))
-		die(_("File not found: %s"), path);
+		die(_("file not found: %s"), path);
 	if (!S_ISREG(info->stat.st_mode))
-		die(_("Not a regular file: %s"), path);
+		die(_("not a regular file: %s"), path);
 	return 0;
 }
 
@@ -575,11 +575,11 @@ static int parse_archive_args(int argc, const char **argv,
 	argc = parse_options(argc, argv, NULL, opts, archive_usage, 0);
 
 	if (remote)
-		die(_("Unexpected option --remote"));
+		die(_("unexpected option --remote"));
 	if (exec)
 		die(_("the option '%s' requires '%s'"), "--exec", "--remote");
 	if (output)
-		die(_("Unexpected option --output"));
+		die(_("unexpected option --output"));
 	if (is_remote && args->extra_files.nr)
 		die(_("options '%s' and '%s' cannot be used together"), "--add-file", "--remote");
 
@@ -603,7 +603,7 @@ static int parse_archive_args(int argc, const char **argv,
 		usage_with_options(archive_usage, opts);
 	*ar = lookup_archiver(format);
 	if (!*ar || (is_remote && !((*ar)->flags & ARCHIVER_REMOTE)))
-		die(_("Unknown archive format '%s'"), format);
+		die(_("unknown archive format '%s'"), format);
 
 	args->compression_level = Z_DEFAULT_COMPRESSION;
 	if (compression_level != -1) {
@@ -612,7 +612,7 @@ static int parse_archive_args(int argc, const char **argv,
 		if (levels_ok && (compression_level <= 9 || high_ok))
 			args->compression_level = compression_level;
 		else {
-			die(_("Argument not supported for format '%s': -%d"),
+			die(_("argument not supported for format '%s': -%d"),
 					format, compression_level);
 		}
 	}

--- a/bisect.c
+++ b/bisect.c
@@ -485,7 +485,7 @@ static void read_bisect_paths(struct strvec *array)
 	while (strbuf_getline_lf(&str, fp) != EOF) {
 		strbuf_trim(&str);
 		if (sq_dequote_to_strvec(str.buf, array))
-			die(_("Badly quoted content in file '%s': %s"),
+			die(_("badly quoted content in file '%s': %s"),
 			    filename, str.buf);
 	}
 
@@ -762,7 +762,7 @@ static struct commit *get_commit_reference(struct repository *r,
 {
 	struct commit *c = lookup_commit_reference(r, oid);
 	if (!c)
-		die(_("Not a valid commit name %s"), oid_to_hex(oid));
+		die(_("not a valid commit name %s"), oid_to_hex(oid));
 	return c;
 }
 

--- a/blame.c
+++ b/blame.c
@@ -1033,7 +1033,7 @@ static void fill_origin_blob(struct diff_options *opt,
 		file->size = file_size;
 
 		if (!file->ptr)
-			die("Cannot read blob %s for path %s",
+			die("cannot read blob %s for path %s",
 			    oid_to_hex(&o->blob_oid),
 			    o->path);
 		o->file = *file;
@@ -2667,9 +2667,9 @@ static struct commit *find_single_final(struct rev_info *revs,
 			continue;
 		obj = deref_tag(revs->repo, obj, NULL, 0);
 		if (!obj || obj->type != OBJ_COMMIT)
-			die("Non commit %s?", revs->pending.objects[i].name);
+			die("non commit %s?", revs->pending.objects[i].name);
 		if (found)
-			die("More than one commit to dig from %s and %s?",
+			die("more than one commit to dig from %s and %s?",
 			    revs->pending.objects[i].name, name);
 		found = (struct commit *)obj;
 		name = revs->pending.objects[i].name;
@@ -2734,9 +2734,9 @@ static struct commit *find_single_initial(struct rev_info *revs,
 			continue;
 		obj = deref_tag(revs->repo, obj, NULL, 0);
 		if (!obj || obj->type != OBJ_COMMIT)
-			die("Non commit %s?", revs->pending.objects[i].name);
+			die("non commit %s?", revs->pending.objects[i].name);
 		if (found)
-			die("More than one commit to dig up from, %s and %s?",
+			die("more than one commit to dig up from, %s and %s?",
 			    revs->pending.objects[i].name, name);
 		found = (struct commit *) obj;
 		name = revs->pending.objects[i].name;
@@ -2745,7 +2745,7 @@ static struct commit *find_single_initial(struct rev_info *revs,
 	if (!name)
 		found = dwim_reverse_initial(revs, &name);
 	if (!name)
-		die("No commit to dig up from?");
+		die("no commit to dig up from?");
 
 	if (name_p)
 		*name_p = xstrdup(name);

--- a/builtin/add.c
+++ b/builtin/add.c
@@ -201,7 +201,7 @@ static int refresh(int verbose, const struct pathspec *pathspec)
 
 	seen = xcalloc(pathspec->nr, 1);
 	refresh_index(&the_index, flags, pathspec, seen,
-		      _("Unstaged changes after refreshing the index:"));
+		      _("unstaged changes after refreshing the index:"));
 	for (i = 0; i < pathspec->nr; i++) {
 		if (!seen[i]) {
 			const char *path = pathspec->items[i].original;
@@ -309,7 +309,7 @@ static int edit_patch(int argc, const char **argv, const char *prefix)
 	git_config(git_diff_basic_config, NULL); /* no "diff" UI options */
 
 	if (read_cache() < 0)
-		die(_("Could not read the index"));
+		die(_("could not read the index"));
 
 	repo_init_revisions(the_repository, &rev, prefix);
 	rev.diffopt.context = 7;
@@ -322,7 +322,7 @@ static int edit_patch(int argc, const char **argv, const char *prefix)
 	rev.diffopt.file = xfdopen(out, "w");
 	rev.diffopt.close_file = 1;
 	if (run_diff_files(&rev, 0))
-		die(_("Could not write patch"));
+		die(_("could not write patch"));
 
 	if (launch_editor(file, NULL, NULL))
 		die(_("editing patch failed"));
@@ -330,13 +330,13 @@ static int edit_patch(int argc, const char **argv, const char *prefix)
 	if (stat(file, &st))
 		die_errno(_("Could not stat '%s'"), file);
 	if (!st.st_size)
-		die(_("Empty patch. Aborted."));
+		die(_("empty patch. Aborted."));
 
 	child.git_cmd = 1;
 	strvec_pushl(&child.args, "apply", "--recount", "--cached", file,
 		     NULL);
 	if (run_command(&child))
-		die(_("Could not apply '%s'"), file);
+		die(_("could not apply '%s'"), file);
 
 	unlink(file);
 	free(file);
@@ -687,7 +687,7 @@ int cmd_add(int argc, const char **argv, const char *prefix)
 finish:
 	if (write_locked_index(&the_index, &lock_file,
 			       COMMIT_LOCK | SKIP_IF_UNCHANGED))
-		die(_("Unable to write new index file"));
+		die(_("unable to write new index file"));
 
 	dir_clear(&dir);
 	UNLEAK(pathspec);

--- a/builtin/am.c
+++ b/builtin/am.c
@@ -1002,7 +1002,7 @@ static void am_setup(struct am_state *state, enum patch_format patch_format,
 
 	if (split_mail(state, patch_format, paths, keep_cr) < 0) {
 		am_destroy(state);
-		die(_("Failed to split patches."));
+		die(_("failed to split patches."));
 	}
 
 	if (state->rebasing)
@@ -1783,7 +1783,7 @@ static void am_run(struct am_state *state, int resume)
 
 	if (repo_index_has_changes(the_repository, NULL, &sb)) {
 		write_state_bool(state, "dirtyindex", 1);
-		die(_("Dirty index: cannot apply patches (dirty: %s)"), sb.buf);
+		die(_("dirty index: cannot apply patches (dirty: %s)"), sb.buf);
 	}
 
 	strbuf_release(&sb);
@@ -2487,13 +2487,13 @@ int cmd_am(int argc, const char **argv, const char *prefix)
 				return 0;
 			}
 
-			die(_("Stray %s directory found.\n"
-				"Use \"git am --abort\" to remove it."),
+			die(_("stray %s directory found.\n"
+				"use \"git am --abort\" to remove it."),
 				state.dir);
 		}
 
 		if (resume.mode)
-			die(_("Resolve operation not in progress, we are not resuming."));
+			die(_("resolve operation not in progress, we are not resuming."));
 
 		for (i = 0; i < argc; i++) {
 			if (is_absolute_path(argv[i]) || !prefix)

--- a/builtin/archive.c
+++ b/builtin/archive.c
@@ -32,7 +32,7 @@ static int run_remote_archiver(int argc, const char **argv,
 
 	_remote = remote_get(remote);
 	if (!_remote->url[0])
-		die(_("git archive: Remote with no URL"));
+		die(_("git archive: remote with no URL"));
 	transport = transport_get(_remote, _remote->url[0]);
 	transport_connect(transport, "git-upload-archive", exec, fd);
 

--- a/builtin/bisect--helper.c
+++ b/builtin/bisect--helper.c
@@ -901,7 +901,7 @@ static enum bisect_error bisect_state(struct bisect_terms *terms, const char **a
 
 		commit = lookup_commit_reference(the_repository, &oid);
 		if (!commit)
-			die(_("Bad rev input (not a commit): %s"), *argv);
+			die(_("bad rev input (not a commit): %s"), *argv);
 
 		oid_array_append(&revs, &commit->object.oid);
 	}

--- a/builtin/blame.c
+++ b/builtin/blame.c
@@ -660,7 +660,7 @@ static void sanity_check_on_fail(struct blame_scoreboard *sb, int baa)
 	int opt = OUTPUT_SHOW_SCORE | OUTPUT_SHOW_NUMBER | OUTPUT_SHOW_NAME;
 	find_alignment(sb, &opt);
 	output(sb, opt);
-	die("Baa %d!", baa);
+	die("baa %d!", baa);
 }
 
 static unsigned parse_score(const char *arg)

--- a/builtin/branch.c
+++ b/builtin/branch.c
@@ -239,7 +239,7 @@ static int delete_branches(int argc, const char **argv, int force, int kinds,
 	if (!force) {
 		head_rev = lookup_commit_reference(the_repository, &head_oid);
 		if (!head_rev)
-			die(_("Couldn't look up commit object for HEAD"));
+			die(_("couldn't look up commit object for HEAD"));
 	}
 
 	worktrees = get_worktrees();
@@ -506,11 +506,11 @@ static void reject_rebase_or_bisect_branch(const char *target)
 			continue;
 
 		if (is_worktree_being_rebased(wt, target))
-			die(_("Branch %s is being rebased at %s"),
+			die(_("branch %s is being rebased at %s"),
 			    target, wt->path);
 
 		if (is_worktree_being_bisected(wt, target))
-			die(_("Branch %s is being bisected at %s"),
+			die(_("branch %s is being bisected at %s"),
 			    target, wt->path);
 	}
 
@@ -540,7 +540,7 @@ static void copy_or_rename_branch(const char *oldname, const char *newname, int 
 		if (ref_exists(oldref.buf))
 			recovery = 1;
 		else
-			die(_("Invalid branch name: '%s'"), oldname);
+			die(_("invalid branch name: '%s'"), oldname);
 	}
 
 	/*
@@ -560,31 +560,31 @@ static void copy_or_rename_branch(const char *oldname, const char *newname, int 
 	}
 
 	if (copy)
-		strbuf_addf(&logmsg, "Branch: copied %s to %s",
+		strbuf_addf(&logmsg, "branch: copied %s to %s",
 			    oldref.buf, newref.buf);
 	else
-		strbuf_addf(&logmsg, "Branch: renamed %s to %s",
+		strbuf_addf(&logmsg, "branch: renamed %s to %s",
 			    oldref.buf, newref.buf);
 
 	if (!copy &&
 	    (!head || strcmp(oldname, head) || !is_null_oid(&head_oid)) &&
 	    rename_ref(oldref.buf, newref.buf, logmsg.buf))
-		die(_("Branch rename failed"));
+		die(_("branch rename failed"));
 	if (copy && copy_existing_ref(oldref.buf, newref.buf, logmsg.buf))
-		die(_("Branch copy failed"));
+		die(_("branch copy failed"));
 
 	if (recovery) {
 		if (copy)
-			warning(_("Created a copy of a misnamed branch '%s'"),
+			warning(_("created a copy of a misnamed branch '%s'"),
 				interpreted_oldname);
 		else
-			warning(_("Renamed a misnamed branch '%s' away"),
+			warning(_("renamed a misnamed branch '%s' away"),
 				interpreted_oldname);
 	}
 
 	if (!copy &&
 	    replace_each_worktree_head_symref(oldref.buf, newref.buf, logmsg.buf))
-		die(_("Branch renamed to %s, but HEAD is not updated!"), newname);
+		die(_("branch renamed to %s, but HEAD is not updated!"), newname);
 
 	strbuf_release(&logmsg);
 
@@ -593,9 +593,9 @@ static void copy_or_rename_branch(const char *oldname, const char *newname, int 
 	strbuf_addf(&newsection, "branch.%s", interpreted_newname);
 	strbuf_release(&newref);
 	if (!copy && git_config_rename_section(oldsection.buf, newsection.buf) < 0)
-		die(_("Branch is renamed, but update of config-file failed"));
+		die(_("branch is renamed, but update of config-file failed"));
 	if (copy && strcmp(oldname, newname) && git_config_copy_section(oldsection.buf, newsection.buf) < 0)
-		die(_("Branch is copied, but update of config-file failed"));
+		die(_("branch is copied, but update of config-file failed"));
 	strbuf_release(&oldsection);
 	strbuf_release(&newsection);
 }
@@ -611,9 +611,9 @@ static int edit_branch_description(const char *branch_name)
 	if (!buf.len || buf.buf[buf.len-1] != '\n')
 		strbuf_addch(&buf, '\n');
 	strbuf_commented_addf(&buf,
-		    _("Please edit the description for the branch\n"
+		    _("please edit the description for the branch\n"
 		      "  %s\n"
-		      "Lines starting with '%c' will be stripped.\n"),
+		      "lines starting with '%c' will be stripped.\n"),
 		    branch_name, comment_line_char);
 	write_file_buf(edit_description(), buf.buf, buf.len);
 	strbuf_reset(&buf);
@@ -711,7 +711,7 @@ int cmd_branch(int argc, const char **argv, const char *prefix)
 
 	head = resolve_refdup("HEAD", 0, &head_oid, NULL);
 	if (!head)
-		die(_("Failed to resolve HEAD as a valid ref."));
+		die(_("failed to resolve HEAD as a valid ref."));
 	if (!strcmp(head, "HEAD"))
 		filter.detached = 1;
 	else if (!skip_prefix(head, "refs/heads/", &head))
@@ -799,7 +799,7 @@ int cmd_branch(int argc, const char **argv, const char *prefix)
 
 		if (!argc) {
 			if (filter.detached)
-				die(_("Cannot give description to detached HEAD"));
+				die(_("cannot give description to detached HEAD"));
 			branch_name = head;
 		} else if (argc == 1)
 			branch_name = argv[0];
@@ -811,10 +811,10 @@ int cmd_branch(int argc, const char **argv, const char *prefix)
 			strbuf_release(&branch_ref);
 
 			if (!argc)
-				return error(_("No commit on branch '%s' yet."),
+				return error(_("no commit on branch '%s' yet."),
 					     branch_name);
 			else
-				return error(_("No branch named '%s'."),
+				return error(_("no branch named '%s'."),
 					     branch_name);
 		}
 		strbuf_release(&branch_ref);
@@ -874,7 +874,7 @@ int cmd_branch(int argc, const char **argv, const char *prefix)
 		}
 
 		if (!branch_has_merge_config(branch))
-			die(_("Branch '%s' has no upstream information"), branch->name);
+			die(_("branch '%s' has no upstream information"), branch->name);
 
 		strbuf_addf(&buf, "branch.%s.remote", branch->name);
 		git_config_set_multivar(buf.buf, NULL, NULL, CONFIG_FLAGS_MULTI_REPLACE);

--- a/builtin/bundle.c
+++ b/builtin/bundle.c
@@ -91,7 +91,7 @@ static int cmd_bundle_create(int argc, const char **argv, const char *prefix) {
 		strvec_push(&pack_opts, "--all-progress-implied");
 
 	if (!startup_info->have_repository)
-		die(_("Need a repository to create a bundle."));
+		die(_("need a repository to create a bundle."));
 	ret = !!create_bundle(the_repository, bundle_file, argc, argv, &pack_opts, version);
 	strvec_clear(&pack_opts);
 	free(bundle_file);
@@ -180,7 +180,7 @@ static int cmd_bundle_unbundle(int argc, const char **argv, const char *prefix) 
 		goto cleanup;
 	}
 	if (!startup_info->have_repository)
-		die(_("Need a repository to unbundle."));
+		die(_("need a repository to unbundle."));
 	if (progress)
 		strvec_pushl(&extra_index_pack_args, "-v", "--progress-title",
 			     _("Unbundling objects"), NULL);

--- a/builtin/cat-file.c
+++ b/builtin/cat-file.c
@@ -90,7 +90,7 @@ static int cat_one_file(int opt, const char *exp_type, const char *obj_name,
 
 	if (get_oid_with_context(the_repository, obj_name, get_oid_flags, &oid,
 				 &obj_context))
-		die("Not a valid object name %s", obj_name);
+		die("not a valid object name %s", obj_name);
 
 	if (!path)
 		path = obj_context.path;
@@ -136,7 +136,7 @@ static int cat_one_file(int opt, const char *exp_type, const char *obj_name,
 	case 'p':
 		type = oid_object_info(the_repository, &oid, NULL);
 		if (type < 0)
-			die("Not a valid object name %s", obj_name);
+			die("not a valid object name %s", obj_name);
 
 		/* custom pretty-print here */
 		if (type == OBJ_TREE) {
@@ -150,7 +150,7 @@ static int cat_one_file(int opt, const char *exp_type, const char *obj_name,
 			return stream_blob(&oid);
 		buf = read_object_file(&oid, &type, &size);
 		if (!buf)
-			die("Cannot read object %s", obj_name);
+			die("cannot read object %s", obj_name);
 
 		/* otherwise just spit out the data */
 		break;

--- a/builtin/checkout.c
+++ b/builtin/checkout.c
@@ -476,7 +476,7 @@ static int checkout_paths(const struct checkout_opts *opts,
 		    opts->ignore_unmerged_opt, "-m");
 
 	if (opts->new_branch)
-		die(_("Cannot update paths and switch to branch '%s' at the same time."),
+		die(_("cannot update paths and switch to branch '%s' at the same time."),
 		    opts->new_branch);
 
 	if (!opts->checkout_worktree && !opts->checkout_index)

--- a/builtin/clean.c
+++ b/builtin/clean.c
@@ -351,7 +351,7 @@ static void print_highlight_menu_stuff(struct menu_stuff *stuff, int **chosen)
 
 	switch (stuff->type) {
 	default:
-		die("Bad type of menu_stuff when print menu");
+		die("bad type of menu_stuff when print menu");
 	case MENU_STUFF_TYPE_MENU_ITEM:
 		menu_item = (struct menu_item *)stuff->stuff;
 		for (i = 0; i < stuff->nr; i++, menu_item++) {
@@ -405,7 +405,7 @@ static int find_unique(const char *choice, struct menu_stuff *menu_stuff)
 	len = strlen(choice);
 	switch (menu_stuff->type) {
 	default:
-		die("Bad type of menu_stuff when parse choice");
+		die("bad type of menu_stuff when parse choice");
 	case MENU_STUFF_TYPE_MENU_ITEM:
 
 		menu_item = (struct menu_item *)menu_stuff->stuff;

--- a/builtin/clone.c
+++ b/builtin/clone.c
@@ -1274,7 +1274,7 @@ int cmd_clone(int argc, const char **argv, const char *prefix)
 				find_remote_branch(mapped_refs, option_branch);
 
 			if (!our_head_points_at)
-				die(_("Remote branch %s not found in upstream %s"),
+				die(_("remote branch %s not found in upstream %s"),
 				    option_branch, remote_name);
 		}
 		else
@@ -1286,10 +1286,10 @@ int cmd_clone(int argc, const char **argv, const char *prefix)
 		char *ref_free = NULL;
 
 		if (option_branch)
-			die(_("Remote branch %s not found in upstream %s"),
+			die(_("remote branch %s not found in upstream %s"),
 					option_branch, remote_name);
 
-		warning(_("You appear to have cloned an empty repository."));
+		warning(_("you appear to have cloned an empty repository."));
 		our_head_points_at = NULL;
 		remote_head_points_at = NULL;
 		remote_head = NULL;

--- a/builtin/commit.c
+++ b/builtin/commit.c
@@ -981,7 +981,7 @@ static int prepare_to_commit(const char *index_file, const char *prefix,
 		const char *parent = "HEAD";
 
 		if (!active_nr && read_cache() < 0)
-			die(_("Cannot read index"));
+			die(_("cannot read index"));
 
 		if (amend)
 			parent = "HEAD^1";
@@ -1139,7 +1139,7 @@ static void handle_ignored_arg(struct wt_status *s)
 	else if (!strcmp(ignored_arg, "matching"))
 		s->show_ignored_mode = SHOW_MATCHING_IGNORED;
 	else
-		die(_("Invalid ignored mode '%s'"), ignored_arg);
+		die(_("invalid ignored mode '%s'"), ignored_arg);
 }
 
 static void handle_untracked_files_arg(struct wt_status *s)
@@ -1157,7 +1157,7 @@ static void handle_untracked_files_arg(struct wt_status *s)
 	 * git-completion.bash when you add new options
 	 */
 	else
-		die(_("Invalid untracked files mode '%s'"), untracked_files_arg);
+		die(_("invalid untracked files mode '%s'"), untracked_files_arg);
 }
 
 static const char *read_commit_message(const char *name)
@@ -1228,9 +1228,9 @@ static void finalize_deferred_config(struct wt_status *s)
 static void check_fixup_reword_options(int argc, const char *argv[]) {
 	if (whence != FROM_COMMIT) {
 		if (whence == FROM_MERGE)
-			die(_("You are in the middle of a merge -- cannot reword."));
+			die(_("you are in the middle of a merge -- cannot reword."));
 		else if (is_from_cherry_pick(whence))
-			die(_("You are in the middle of a cherry-pick -- cannot reword."));
+			die(_("you are in the middle of a cherry-pick -- cannot reword."));
 	}
 	if (argc)
 		die(_("reword option of '%s' and path '%s' cannot be used together"), "--fixup", *argv);
@@ -1260,14 +1260,14 @@ static int parse_and_validate_options(int argc, const char *argv[],
 
 	/* Sanity check options */
 	if (amend && !current_head)
-		die(_("You have nothing to amend."));
+		die(_("you have nothing to amend."));
 	if (amend && whence != FROM_COMMIT) {
 		if (whence == FROM_MERGE)
-			die(_("You are in the middle of a merge -- cannot amend."));
+			die(_("you are in the middle of a merge -- cannot amend."));
 		else if (is_from_cherry_pick(whence))
-			die(_("You are in the middle of a cherry-pick -- cannot amend."));
+			die(_("you are in the middle of a cherry-pick -- cannot amend."));
 		else if (whence == FROM_REBASE_PICK)
-			die(_("You are in the middle of a rebase -- cannot amend."));
+			die(_("you are in the middle of a rebase -- cannot amend."));
 	}
 	if (fixup_message && squash_message)
 		die(_("options '%s' and '%s' cannot be used together"), "--squash", "--fixup");
@@ -1534,7 +1534,7 @@ int cmd_status(int argc, const char **argv, const char *prefix)
 
 	if (s.show_ignored_mode == SHOW_MATCHING_IGNORED &&
 	    s.show_untracked_files == SHOW_NO_UNTRACKED_FILES)
-		die(_("Unsupported combination of ignored and untracked-files arguments"));
+		die(_("unsupported combination of ignored and untracked-files arguments"));
 
 	parse_pathspec(&s.pathspec, 0,
 		       PATHSPEC_PREFER_FULL,
@@ -1749,7 +1749,7 @@ int cmd_commit(int argc, const char **argv, const char *prefix)
 
 			parent = get_merge_parent(m.buf);
 			if (!parent)
-				die(_("Corrupt MERGE_HEAD file (%s)"), m.buf);
+				die(_("corrupt MERGE_HEAD file (%s)"), m.buf);
 			pptr = commit_list_append(parent, pptr);
 		}
 		fclose(fp);

--- a/builtin/describe.c
+++ b/builtin/describe.c
@@ -421,12 +421,12 @@ static void describe_commit(struct object_id *oid, struct strbuf *dst)
 			return;
 		}
 		if (unannotated_cnt)
-			die(_("No annotated tags can describe '%s'.\n"
-			    "However, there were unannotated tags: try --tags."),
+			die(_("no annotated tags can describe '%s'.\n"
+			    "however, there were unannotated tags: try --tags."),
 			    oid_to_hex(cmit_oid));
 		else
-			die(_("No tags can describe '%s'.\n"
-			    "Try --always, or create some tags."),
+			die(_("no tags can describe '%s'.\n"
+			    "try --always, or create some tags."),
 			    oid_to_hex(cmit_oid));
 	}
 
@@ -529,7 +529,7 @@ static void describe(const char *arg, int last_one)
 		fprintf(stderr, _("describe %s\n"), arg);
 
 	if (get_oid(arg, &oid))
-		die(_("Not a valid object name %s"), arg);
+		die(_("not a valid object name %s"), arg);
 	cmit = lookup_commit_reference_gently(the_repository, &oid, 1);
 
 	if (cmit)
@@ -619,7 +619,7 @@ int cmd_describe(int argc, const char **argv, const char *prefix)
 	hashmap_init(&names, commit_name_neq, NULL, 0);
 	for_each_rawref(get_name, NULL);
 	if (!hashmap_get_size(&names) && !always)
-		die(_("No names found, cannot describe anything."));
+		die(_("no names found, cannot describe anything."));
 
 	if (argc == 0) {
 		if (broken) {

--- a/builtin/diff.c
+++ b/builtin/diff.c
@@ -488,7 +488,7 @@ int cmd_diff(int argc, const char **argv, const char *prefix)
 	rev.diffopt.ita_invisible_in_index = 1;
 
 	if (nongit)
-		die(_("Not a git repository"));
+		die(_("not a git repository"));
 	argc = setup_revisions(argc, argv, &rev, NULL);
 	if (!rev.diffopt.output_format) {
 		rev.diffopt.output_format = DIFF_FORMAT_PATCH;

--- a/builtin/fast-export.c
+++ b/builtin/fast-export.c
@@ -307,7 +307,7 @@ static void export_blob(const struct object_id *oid)
 	}
 
 	if (!object)
-		die("Could not read blob %s", oid_to_hex(oid));
+		die("could not read blob %s", oid_to_hex(oid));
 
 	mark_next_object(object);
 
@@ -479,7 +479,7 @@ static void show_filemodify(struct diff_queue_struct *q,
 			break;
 
 		default:
-			die("Unexpected comparison status '%c' for %s, %s",
+			die("unexpected comparison status '%c' for %s, %s",
 				q->queue[i]->status,
 				ospec->path ? ospec->path : "none",
 				spec->path ? spec->path : "none");
@@ -840,7 +840,7 @@ static void handle_tag(const char *name, struct tag *tag)
 			return;
 		case REWRITE:
 			if (tagged->type == OBJ_TAG && !mark_tags) {
-				die(_("Error: Cannot export nested tags unless --mark-tags is specified."));
+				die(_("error: cannot export nested tags unless --mark-tags is specified."));
 			} else if (tagged->type == OBJ_COMMIT) {
 				p = rewrite_commit((struct commit *)tagged);
 				if (!p) {

--- a/builtin/fast-import.c
+++ b/builtin/fast-import.c
@@ -613,9 +613,9 @@ static struct branch *new_branch(const char *name)
 	struct branch *b = lookup_branch(name);
 
 	if (b)
-		die("Invalid attempt to create duplicate branch: %s", name);
+		die("invalid attempt to create duplicate branch: %s", name);
 	if (check_refname_format(name, REFNAME_ALLOW_ONELEVEL))
-		die("Branch name doesn't conform to GIT standards: %s", name);
+		die("branch name doesn't conform to GIT standards: %s", name);
 
 	b = mem_pool_calloc(&fi_mem_pool, 1, sizeof(struct branch));
 	b->name = mem_pool_strdup(&fi_mem_pool, name);
@@ -1258,16 +1258,16 @@ static void load_tree(struct tree_entry *root)
 	myoe = find_object(oid);
 	if (myoe && myoe->pack_id != MAX_PACK_ID) {
 		if (myoe->type != OBJ_TREE)
-			die("Not a tree: %s", oid_to_hex(oid));
+			die("not a tree: %s", oid_to_hex(oid));
 		t->delta_depth = myoe->depth;
 		buf = gfi_unpack_entry(myoe, &size);
 		if (!buf)
-			die("Can't load tree %s", oid_to_hex(oid));
+			die("can't load tree %s", oid_to_hex(oid));
 	} else {
 		enum object_type type;
 		buf = read_object_file(oid, &type, &size);
 		if (!buf || type != OBJ_TREE)
-			die("Can't load tree %s", oid_to_hex(oid));
+			die("can't load tree %s", oid_to_hex(oid));
 	}
 
 	c = buf;
@@ -1281,7 +1281,7 @@ static void load_tree(struct tree_entry *root)
 		e->tree = NULL;
 		c = get_mode(c, &e->versions[1].mode);
 		if (!c)
-			die("Corrupt mode in %s", oid_to_hex(oid));
+			die("corrupt mode in %s", oid_to_hex(oid));
 		e->versions[0].mode = e->versions[1].mode;
 		e->name = to_atom(c, strlen(c));
 		c += e->name->str_len + 1;
@@ -1391,7 +1391,7 @@ static void tree_content_replace(
 	struct tree_content *newtree)
 {
 	if (!S_ISDIR(mode))
-		die("Root cannot be a non-directory");
+		die("root cannot be a non-directory");
 	oidclr(&root->versions[0].oid);
 	oidcpy(&root->versions[1].oid, oid);
 	if (root->tree)
@@ -1414,9 +1414,9 @@ static int tree_content_set(
 	slash1 = strchrnul(p, '/');
 	n = slash1 - p;
 	if (!n)
-		die("Empty path component found in input");
+		die("empty path component found in input");
 	if (!*slash1 && !S_ISDIR(mode) && subtree)
-		die("Non-directories cannot have subtrees");
+		die("non-directories cannot have subtrees");
 
 	if (!root->tree)
 		load_tree(root);
@@ -1567,7 +1567,7 @@ static int tree_content_get(
 	slash1 = strchrnul(p, '/');
 	n = slash1 - p;
 	if (!n && !allow_root)
-		die("Empty path component found in input");
+		die("empty path component found in input");
 
 	if (!root->tree)
 		load_tree(root);
@@ -1868,7 +1868,7 @@ static int parse_data(struct strbuf *sb, uintmax_t limit, uintmax_t *len_res)
 	strbuf_reset(sb);
 
 	if (!skip_prefix(command_buf.buf, "data ", &data))
-		die("Expected 'data n' command, found: %s", command_buf.buf);
+		die("expected 'data n' command, found: %s", command_buf.buf);
 
 	if (skip_prefix(data, "<<", &data)) {
 		char *term = xstrdup(data);
@@ -1956,15 +1956,15 @@ static char *parse_ident(const char *buf)
 
 	ltgt = buf + strcspn(buf, "<>");
 	if (*ltgt != '<')
-		die("Missing < in ident string: %s", buf);
+		die("missing < in ident string: %s", buf);
 	if (ltgt != buf && ltgt[-1] != ' ')
-		die("Missing space before < in ident string: %s", buf);
+		die("missing space before < in ident string: %s", buf);
 	ltgt = ltgt + 1 + strcspn(ltgt + 1, "<>");
 	if (*ltgt != '>')
-		die("Missing > in ident string: %s", buf);
+		die("missing > in ident string: %s", buf);
 	ltgt++;
 	if (*ltgt != ' ')
-		die("Missing space after > in ident string: %s", buf);
+		die("missing space after > in ident string: %s", buf);
 	ltgt++;
 	name_len = ltgt - buf;
 	strbuf_add(&ident, buf, name_len);
@@ -1972,19 +1972,19 @@ static char *parse_ident(const char *buf)
 	switch (whenspec) {
 	case WHENSPEC_RAW:
 		if (validate_raw_date(ltgt, &ident, 1) < 0)
-			die("Invalid raw date \"%s\" in ident: %s", ltgt, buf);
+			die("invalid raw date \"%s\" in ident: %s", ltgt, buf);
 		break;
 	case WHENSPEC_RAW_PERMISSIVE:
 		if (validate_raw_date(ltgt, &ident, 0) < 0)
-			die("Invalid raw date \"%s\" in ident: %s", ltgt, buf);
+			die("invalid raw date \"%s\" in ident: %s", ltgt, buf);
 		break;
 	case WHENSPEC_RFC2822:
 		if (parse_date(ltgt, &ident) < 0)
-			die("Invalid rfc2822 date \"%s\" in ident: %s", ltgt, buf);
+			die("invalid rfc2822 date \"%s\" in ident: %s", ltgt, buf);
 		break;
 	case WHENSPEC_NOW:
 		if (strcmp("now", ltgt))
-			die("Date in ident must be 'now': %s", buf);
+			die("date in ident must be 'now': %s", buf);
 		datestamp(&ident);
 		break;
 	}
@@ -2078,7 +2078,7 @@ static void construct_path_with_fanout(const char *hex_sha1,
 {
 	unsigned int i = 0, j = 0;
 	if (fanout >= the_hash_algo->rawsz)
-		die("Too large fanout (%u)", fanout);
+		die("too large fanout (%u)", fanout);
 	while (fanout) {
 		path[i++] = hex_sha1[j++];
 		path[i++] = hex_sha1[j++];
@@ -2152,7 +2152,7 @@ static uintmax_t do_change_note_fanout(
 
 			/* Rename fullpath to realpath */
 			if (!tree_content_remove(orig_root, fullpath, &leaf, 0))
-				die("Failed to remove path %s", fullpath);
+				die("failed to remove path %s", fullpath);
 			tree_content_set(orig_root, realpath,
 				&leaf.versions[1].oid,
 				leaf.versions[1].mode,
@@ -2225,7 +2225,7 @@ static uintmax_t parse_mark_ref(const char *p, char **endptr)
 	p++;
 	mark = strtoumax(p, endptr, 10);
 	if (*endptr == p)
-		die("No value after ':' in mark: %s", command_buf.buf);
+		die("no value after ':' in mark: %s", command_buf.buf);
 	return mark;
 }
 
@@ -2240,7 +2240,7 @@ static uintmax_t parse_mark_ref_eol(const char *p)
 
 	mark = parse_mark_ref(p, &end);
 	if (*end != '\0')
-		die("Garbage after mark: %s", command_buf.buf);
+		die("garbage after mark: %s", command_buf.buf);
 	return mark;
 }
 
@@ -2255,7 +2255,7 @@ static uintmax_t parse_mark_ref_space(const char **p)
 
 	mark = parse_mark_ref(*p, &end);
 	if (*end++ != ' ')
-		die("Missing space after mark: %s", command_buf.buf);
+		die("nissing space after mark: %s", command_buf.buf);
 	*p = end;
 	return mark;
 }
@@ -2270,7 +2270,7 @@ static void file_change_m(const char *p, struct branch *b)
 
 	p = get_mode(p, &mode);
 	if (!p)
-		die("Corrupt mode: %s", command_buf.buf);
+		die("corrupt mode: %s", command_buf.buf);
 	switch (mode) {
 	case 0644:
 	case 0755:
@@ -2283,7 +2283,7 @@ static void file_change_m(const char *p, struct branch *b)
 		/* ok */
 		break;
 	default:
-		die("Corrupt mode: %s", command_buf.buf);
+		die("corrupt mode: %s", command_buf.buf);
 	}
 
 	if (*p == ':') {
@@ -2294,16 +2294,16 @@ static void file_change_m(const char *p, struct branch *b)
 		oe = NULL; /* not used with inline_data, but makes gcc happy */
 	} else {
 		if (parse_mapped_oid_hex(p, &oid, &p))
-			die("Invalid dataref: %s", command_buf.buf);
+			die("invalid dataref: %s", command_buf.buf);
 		oe = find_object(&oid);
 		if (*p++ != ' ')
-			die("Missing space after SHA1: %s", command_buf.buf);
+			die("missing space after SHA1: %s", command_buf.buf);
 	}
 
 	strbuf_reset(&uq);
 	if (!unquote_c_style(&uq, p, &endp)) {
 		if (*endp)
-			die("Garbage after path in: %s", command_buf.buf);
+			die("garbage after path in: %s", command_buf.buf);
 		p = uq.buf;
 	}
 
@@ -2315,11 +2315,11 @@ static void file_change_m(const char *p, struct branch *b)
 
 	if (S_ISGITLINK(mode)) {
 		if (inline_data)
-			die("Git links cannot be specified 'inline': %s",
+			die("git links cannot be specified 'inline': %s",
 				command_buf.buf);
 		else if (oe) {
 			if (oe->type != OBJ_COMMIT)
-				die("Not a commit (actually a %s): %s",
+				die("not a commit (actually a %s): %s",
 					type_name(oe->type), command_buf.buf);
 		}
 		/*
@@ -2328,7 +2328,7 @@ static void file_change_m(const char *p, struct branch *b)
 		 */
 	} else if (inline_data) {
 		if (S_ISDIR(mode))
-			die("Directories cannot be specified 'inline': %s",
+			die("directories cannot be specified 'inline': %s",
 				command_buf.buf);
 		if (p != uq.buf) {
 			strbuf_addstr(&uq, p);
@@ -2354,7 +2354,7 @@ static void file_change_m(const char *p, struct branch *b)
 					S_ISDIR(mode) ?  "Tree" : "Blob",
 					command_buf.buf);
 		if (type != expected)
-			die("Not a %s (actually a %s): %s",
+			die("not a %s (actually a %s): %s",
 				type_name(expected), type_name(type),
 				command_buf.buf);
 	}
@@ -2374,7 +2374,7 @@ static void file_change_d(const char *p, struct branch *b)
 	strbuf_reset(&uq);
 	if (!unquote_c_style(&uq, p, &endp)) {
 		if (*endp)
-			die("Garbage after path in: %s", command_buf.buf);
+			die("garbage after path in: %s", command_buf.buf);
 		p = uq.buf;
 	}
 	tree_content_remove(&b->branch_tree, p, NULL, 1);
@@ -2391,24 +2391,24 @@ static void file_change_cr(const char *s, struct branch *b, int rename)
 	strbuf_reset(&s_uq);
 	if (!unquote_c_style(&s_uq, s, &endp)) {
 		if (*endp != ' ')
-			die("Missing space after source: %s", command_buf.buf);
+			die("missing space after source: %s", command_buf.buf);
 	} else {
 		endp = strchr(s, ' ');
 		if (!endp)
-			die("Missing space after source: %s", command_buf.buf);
+			die("missing space after source: %s", command_buf.buf);
 		strbuf_add(&s_uq, s, endp - s);
 	}
 	s = s_uq.buf;
 
 	endp++;
 	if (!*endp)
-		die("Missing dest: %s", command_buf.buf);
+		die("missing dest: %s", command_buf.buf);
 
 	d = endp;
 	strbuf_reset(&d_uq);
 	if (!unquote_c_style(&d_uq, d, &endp)) {
 		if (*endp)
-			die("Garbage after dest in: %s", command_buf.buf);
+			die("garbage after dest in: %s", command_buf.buf);
 		d = d_uq.buf;
 	}
 
@@ -2418,7 +2418,7 @@ static void file_change_cr(const char *s, struct branch *b, int rename)
 	else
 		tree_content_get(&b->branch_tree, s, &leaf, 1);
 	if (!leaf.versions[1].mode)
-		die("Path %s not in branch", s);
+		die("path %s not in branch", s);
 	if (!*d) {	/* C "path/to/subdir" "" */
 		tree_content_replace(&b->branch_tree,
 			&leaf.versions[1].oid,
@@ -2468,23 +2468,23 @@ static void note_change_n(const char *p, struct branch *b, unsigned char *old_fa
 		oe = NULL; /* not used with inline_data, but makes gcc happy */
 	} else {
 		if (parse_mapped_oid_hex(p, &oid, &p))
-			die("Invalid dataref: %s", command_buf.buf);
+			die("invalid dataref: %s", command_buf.buf);
 		oe = find_object(&oid);
 		if (*p++ != ' ')
-			die("Missing space after SHA1: %s", command_buf.buf);
+			die("missing space after SHA1: %s", command_buf.buf);
 	}
 
 	/* <commit-ish> */
 	s = lookup_branch(p);
 	if (s) {
 		if (is_null_oid(&s->oid))
-			die("Can't add a note on empty branch.");
+			die("can't add a note on empty branch.");
 		oidcpy(&commit_oid, &s->oid);
 	} else if (*p == ':') {
 		uintmax_t commit_mark = parse_mark_ref_eol(p);
 		struct object_entry *commit_oe = find_mark(marks, commit_mark);
 		if (commit_oe->type != OBJ_COMMIT)
-			die("Mark :%" PRIuMAX " not a commit", commit_mark);
+			die("mark :%" PRIuMAX " not a commit", commit_mark);
 		oidcpy(&commit_oid, &commit_oe->idx.oid);
 	} else if (!get_oid(p, &commit_oid)) {
 		unsigned long size;
@@ -2493,10 +2493,10 @@ static void note_change_n(const char *p, struct branch *b, unsigned char *old_fa
 						       OBJ_COMMIT, &size,
 						       &commit_oid);
 		if (!buf || size < the_hash_algo->hexsz + 6)
-			die("Not a valid commit: %s", p);
+			die("not a valid commit: %s", p);
 		free(buf);
 	} else
-		die("Invalid ref name or SHA1 expression: %s", p);
+		die("invalid ref name or SHA1 expression: %s", p);
 
 	if (inline_data) {
 		if (p != uq.buf) {
@@ -2507,15 +2507,15 @@ static void note_change_n(const char *p, struct branch *b, unsigned char *old_fa
 		parse_and_store_blob(&last_blob, &oid, 0);
 	} else if (oe) {
 		if (oe->type != OBJ_BLOB)
-			die("Not a blob (actually a %s): %s",
+			die("not a blob (actually a %s): %s",
 				type_name(oe->type), command_buf.buf);
 	} else if (!is_null_oid(&oid)) {
 		enum object_type type = oid_object_info(the_repository, &oid,
 							NULL);
 		if (type < 0)
-			die("Blob not found: %s", command_buf.buf);
+			die("blob not found: %s", command_buf.buf);
 		if (type != OBJ_BLOB)
-			die("Not a blob (actually a %s): %s",
+			die("not a blob (actually a %s): %s",
 			    type_name(type), command_buf.buf);
 	}
 
@@ -2544,10 +2544,10 @@ static void file_change_deleteall(struct branch *b)
 static void parse_from_commit(struct branch *b, char *buf, unsigned long size)
 {
 	if (!buf || size < the_hash_algo->hexsz + 6)
-		die("Not a valid commit: %s", oid_to_hex(&b->oid));
+		die("not a valid commit: %s", oid_to_hex(&b->oid));
 	if (memcmp("tree ", buf, 5)
 		|| get_oid_hex(buf + 5, &b->branch_tree.versions[1].oid))
-		die("The commit %s is corrupt", oid_to_hex(&b->oid));
+		die("the commit %s is corrupt", oid_to_hex(&b->oid));
 	oidcpy(&b->branch_tree.versions[0].oid,
 	       &b->branch_tree.versions[1].oid);
 }
@@ -2578,7 +2578,7 @@ static int parse_objectish(struct branch *b, const char *objectish)
 
 	s = lookup_branch(objectish);
 	if (b == s)
-		die("Can't create a branch from itself: %s", b->name);
+		die("can't create a branch from itself: %s", b->name);
 	else if (s) {
 		struct object_id *t = &s->branch_tree.versions[1].oid;
 		oidcpy(&b->oid, &s->oid);
@@ -2588,7 +2588,7 @@ static int parse_objectish(struct branch *b, const char *objectish)
 		uintmax_t idnum = parse_mark_ref_eol(objectish);
 		struct object_entry *oe = find_mark(marks, idnum);
 		if (oe->type != OBJ_COMMIT)
-			die("Mark :%" PRIuMAX " not a commit", idnum);
+			die("mark :%" PRIuMAX " not a commit", idnum);
 		if (!oideq(&b->oid, &oe->idx.oid)) {
 			oidcpy(&b->oid, &oe->idx.oid);
 			if (oe->pack_id != MAX_PACK_ID) {
@@ -2605,7 +2605,7 @@ static int parse_objectish(struct branch *b, const char *objectish)
 			b->delete = 1;
 	}
 	else
-		die("Invalid ref name or SHA1 expression: %s", objectish);
+		die("invalid ref name or SHA1 expression: %s", objectish);
 
 	if (b->branch_tree.tree && !oideq(&oid, &b->branch_tree.versions[1].oid)) {
 		release_tree_content_recursive(b->branch_tree.tree);
@@ -2652,7 +2652,7 @@ static struct hash_list *parse_merge(unsigned int *count)
 			uintmax_t idnum = parse_mark_ref_eol(from);
 			struct object_entry *oe = find_mark(marks, idnum);
 			if (oe->type != OBJ_COMMIT)
-				die("Mark :%" PRIuMAX " not a commit", idnum);
+				die("mark :%" PRIuMAX " not a commit", idnum);
 			oidcpy(&n->oid, &oe->idx.oid);
 		} else if (!get_oid(from, &n->oid)) {
 			unsigned long size;
@@ -2661,10 +2661,10 @@ static struct hash_list *parse_merge(unsigned int *count)
 							       OBJ_COMMIT,
 							       &size, &n->oid);
 			if (!buf || size < the_hash_algo->hexsz + 6)
-				die("Not a valid commit: %s", from);
+				die("not a valid commit: %s", from);
 			free(buf);
 		} else
-			die("Invalid ref name or SHA1 expression: %s", from);
+			die("invalid ref name or SHA1 expression: %s", from);
 
 		n->next = NULL;
 		*tail = n;
@@ -2704,7 +2704,7 @@ static void parse_new_commit(const char *arg)
 		read_next_command();
 	}
 	if (!committer)
-		die("Expected committer but didn't get one");
+		die("expected committer but didn't get one");
 	if (skip_prefix(command_buf.buf, "encoding ", &v)) {
 		encoding = xstrdup(v);
 		read_next_command();
@@ -2814,11 +2814,11 @@ static void parse_new_tag(const char *arg)
 
 	/* from ... */
 	if (!skip_prefix(command_buf.buf, "from ", &from))
-		die("Expected from command, got %s", command_buf.buf);
+		die("expected from command, got %s", command_buf.buf);
 	s = lookup_branch(from);
 	if (s) {
 		if (is_null_oid(&s->oid))
-			die("Can't tag an empty branch.");
+			die("can't tag an empty branch.");
 		oidcpy(&oid, &s->oid);
 		type = OBJ_COMMIT;
 	} else if (*from == ':') {
@@ -2832,11 +2832,11 @@ static void parse_new_tag(const char *arg)
 		if (!oe) {
 			type = oid_object_info(the_repository, &oid, NULL);
 			if (type < 0)
-				die("Not a valid object: %s", from);
+				die("not a valid object: %s", from);
 		} else
 			type = oe->type;
 	} else
-		die("Invalid ref name or SHA1 expression: %s", from);
+		die("invalid ref name or SHA1 expression: %s", from);
 	read_next_command();
 
 	/* original-oid ... */
@@ -2954,9 +2954,9 @@ static void cat_blob(struct object_entry *oe, struct object_id *oid)
 		return;
 	}
 	if (!buf)
-		die("Can't read object %s", oid_to_hex(oid));
+		die("can't read object %s", oid_to_hex(oid));
 	if (type != OBJ_BLOB)
-		die("Object %s is a %s but a blob was expected.",
+		die("object %s is a %s but a blob was expected.",
 		    oid_to_hex(oid), type_name(type));
 	strbuf_reset(&line);
 	strbuf_addf(&line, "%s %s %"PRIuMAX"\n", oid_to_hex(oid),
@@ -2980,11 +2980,11 @@ static void parse_get_mark(const char *p)
 
 	/* get-mark SP <object> LF */
 	if (*p != ':')
-		die("Not a mark: %s", p);
+		die("not a mark: %s", p);
 
 	oe = find_mark(marks, parse_mark_ref_eol(p));
 	if (!oe)
-		die("Unknown mark: %s", command_buf.buf);
+		die("unknown mark: %s", command_buf.buf);
 
 	xsnprintf(output, sizeof(output), "%s\n", oid_to_hex(&oe->idx.oid));
 	cat_blob_write(output, the_hash_algo->hexsz + 1);
@@ -2999,13 +2999,13 @@ static void parse_cat_blob(const char *p)
 	if (*p == ':') {
 		oe = find_mark(marks, parse_mark_ref_eol(p));
 		if (!oe)
-			die("Unknown mark: %s", command_buf.buf);
+			die("unknown mark: %s", command_buf.buf);
 		oidcpy(&oid, &oe->idx.oid);
 	} else {
 		if (parse_mapped_oid_hex(p, &oid, &p))
-			die("Invalid dataref: %s", command_buf.buf);
+			die("invalid dataref: %s", command_buf.buf);
 		if (*p)
-			die("Garbage after SHA1: %s", command_buf.buf);
+			die("garbage after SHA1: %s", command_buf.buf);
 		oe = find_object(&oid);
 	}
 
@@ -3037,7 +3037,7 @@ static struct object_entry *dereference(struct object_entry *oe,
 	case OBJ_TAG:
 		break;
 	default:
-		die("Not a tree-ish: %s", command_buf.buf);
+		die("not a tree-ish: %s", command_buf.buf);
 	}
 
 	if (oe->pack_id != MAX_PACK_ID) {	/* in a pack being written */
@@ -3047,19 +3047,19 @@ static struct object_entry *dereference(struct object_entry *oe,
 		buf = read_object_file(oid, &unused, &size);
 	}
 	if (!buf)
-		die("Can't load object %s", oid_to_hex(oid));
+		die("can't load object %s", oid_to_hex(oid));
 
 	/* Peel one layer. */
 	switch (oe->type) {
 	case OBJ_TAG:
 		if (size < hexsz + strlen("object ") ||
 		    get_oid_hex(buf + strlen("object "), oid))
-			die("Invalid SHA1 in tag: %s", command_buf.buf);
+			die("invalid SHA1 in tag: %s", command_buf.buf);
 		break;
 	case OBJ_COMMIT:
 		if (size < hexsz + strlen("tree ") ||
 		    get_oid_hex(buf + strlen("tree "), oid))
-			die("Invalid SHA1 in commit: %s", command_buf.buf);
+			die("invalid SHA1 in commit: %s", command_buf.buf);
 	}
 
 	free(buf);
@@ -3094,9 +3094,9 @@ static void build_mark_map(struct string_list *from, struct string_list *to)
 	for_each_string_list_item(fromp, from) {
 		top = string_list_lookup(to, fromp->string);
 		if (!fromp->util) {
-			die(_("Missing from marks for submodule '%s'"), fromp->string);
+			die(_("missing from marks for submodule '%s'"), fromp->string);
 		} else if (!top || !top->util) {
-			die(_("Missing to marks for submodule '%s'"), fromp->string);
+			die(_("missing to marks for submodule '%s'"), fromp->string);
 		}
 		build_mark_map_one(fromp->util, top->util);
 	}
@@ -3110,14 +3110,14 @@ static struct object_entry *parse_treeish_dataref(const char **p)
 	if (**p == ':') {	/* <mark> */
 		e = find_mark(marks, parse_mark_ref_space(p));
 		if (!e)
-			die("Unknown mark: %s", command_buf.buf);
+			die("unknown mark: %s", command_buf.buf);
 		oidcpy(&oid, &e->idx.oid);
 	} else {	/* <sha1> */
 		if (parse_mapped_oid_hex(*p, &oid, p))
-			die("Invalid dataref: %s", command_buf.buf);
+			die("invalid dataref: %s", command_buf.buf);
 		e = find_object(&oid);
 		if (*(*p)++ != ' ')
-			die("Missing space after tree-ish: %s", command_buf.buf);
+			die("missing space after tree-ish: %s", command_buf.buf);
 	}
 
 	while (!e || e->type != OBJ_TREE)
@@ -3160,7 +3160,7 @@ static void parse_ls(const char *p, struct branch *b)
 	/* ls SP (<tree-ish> SP)? <path> */
 	if (*p == '"') {
 		if (!b)
-			die("Not in a commit: %s", command_buf.buf);
+			die("not in a commit: %s", command_buf.buf);
 		root = &b->branch_tree;
 	} else {
 		struct object_entry *e = parse_treeish_dataref(&p);
@@ -3175,9 +3175,9 @@ static void parse_ls(const char *p, struct branch *b)
 		const char *endp;
 		strbuf_reset(&uq);
 		if (unquote_c_style(&uq, p, &endp))
-			die("Invalid path: %s", command_buf.buf);
+			die("invalid path: %s", command_buf.buf);
 		if (*endp)
-			die("Garbage after path in: %s", command_buf.buf);
+			die("garbage after path in: %s", command_buf.buf);
 		p = uq.buf;
 	}
 	tree_content_get(root, p, &leaf, 1);
@@ -3231,12 +3231,12 @@ static void parse_alias(void)
 	/* mark ... */
 	parse_mark();
 	if (!next_mark)
-		die(_("Expected 'mark' command, got %s"), command_buf.buf);
+		die(_("expected 'mark' command, got %s"), command_buf.buf);
 
 	/* to ... */
 	memset(&b, 0, sizeof(b));
 	if (!parse_objectish_with_prefix(&b, "to "))
-		die(_("Expected 'to' command, got %s"), command_buf.buf);
+		die(_("expected 'to' command, got %s"), command_buf.buf);
 	e = find_object(&b.oid);
 	assert(e);
 	insert_mark(&marks, next_mark, e);
@@ -3254,7 +3254,7 @@ static void option_import_marks(const char *marks,
 {
 	if (import_marks_file) {
 		if (from_stream)
-			die("Only one import-marks command allowed per stream");
+			die("only one import-marks command allowed per stream");
 
 		/* read previous mark file */
 		if(!import_marks_file_from_stream)
@@ -3328,7 +3328,7 @@ static void option_rewrite_submodules(const char *arg, struct string_list *list)
 	char *s = xstrdup(arg);
 	char *f = strchr(s, ':');
 	if (!f)
-		die(_("Expected format name:filename for submodule rewrite option"));
+		die(_("expected format name:filename for submodule rewrite option"));
 	*f = '\0';
 	f++;
 	CALLOC_ARRAY(ms, 1);
@@ -3432,23 +3432,23 @@ static int parse_one_feature(const char *feature, int from_stream)
 static void parse_feature(const char *feature)
 {
 	if (seen_data_command)
-		die("Got feature command '%s' after data command", feature);
+		die("got feature command '%s' after data command", feature);
 
 	if (parse_one_feature(feature, 1))
 		return;
 
-	die("This version of fast-import does not support feature %s.", feature);
+	die("this version of fast-import does not support feature %s.", feature);
 }
 
 static void parse_option(const char *option)
 {
 	if (seen_data_command)
-		die("Got option command '%s' after data command", option);
+		die("got option command '%s' after data command", option);
 
 	if (parse_one_option(option))
 		return;
 
-	die("This version of fast-import does not support option: %s", option);
+	die("this version of fast-import does not support option: %s", option);
 }
 
 static void git_pack_config(void)
@@ -3591,7 +3591,7 @@ int cmd_fast_import(int argc, const char **argv, const char *prefix)
 		else if (starts_with(command_buf.buf, "option "))
 			/* ignore non-git options*/;
 		else
-			die("Unsupported command: %s", command_buf.buf);
+			die("unsupported command: %s", command_buf.buf);
 
 		if (checkpoint_requested)
 			checkpoint();

--- a/builtin/index-pack.c
+++ b/builtin/index-pack.c
@@ -864,7 +864,7 @@ static void sha1_object(const void *data, struct object_entry *obj_entry,
 			    fsck_object(obj, buf, size, &fsck_options))
 				die(_("fsck error in packed object"));
 			if (strict && fsck_walk(obj, NULL, &fsck_options))
-				die(_("Not all child objects of %s are reachable"), oid_to_hex(&obj->oid));
+				die(_("not all child objects of %s are reachable"), oid_to_hex(&obj->oid));
 
 			if (obj->type == OBJ_TREE) {
 				struct tree *item = (struct tree *) obj;
@@ -1297,7 +1297,7 @@ static void conclude_pack(int fix_thin_pack, const char *curr_pack, unsigned cha
 					 curr_pack, nr_objects,
 					 read_hash, consumed_bytes-the_hash_algo->rawsz);
 		if (!hasheq(read_hash, tail_hash))
-			die(_("Unexpected tail checksum for %s "
+			die(_("unexpected tail checksum for %s "
 			      "(disk corruption?)"), curr_pack);
 	}
 	if (nr_ofs_deltas + nr_ref_deltas != nr_resolved_deltas)
@@ -1645,9 +1645,9 @@ static void read_idx_option(struct pack_idx_option *opts, const char *pack_name)
 	struct packed_git *p = add_packed_git(pack_name, strlen(pack_name), 1);
 
 	if (!p)
-		die(_("Cannot open existing pack file '%s'"), pack_name);
+		die(_("cannot open existing pack file '%s'"), pack_name);
 	if (open_pack_index(p))
-		die(_("Cannot open existing pack idx file for '%s'"), pack_name);
+		die(_("cannot open existing pack idx file for '%s'"), pack_name);
 
 	/* Read the attributes from the existing idx file */
 	opts->version = p->index_version;
@@ -1745,7 +1745,7 @@ int cmd_index_pack(int argc, const char **argv, const char *prefix)
 	reset_pack_idx_option(&opts);
 	git_config(git_index_pack_config, &opts);
 	if (prefix && chdir(prefix))
-		die(_("Cannot come back to cwd"));
+		die(_("cannot come back to cwd"));
 
 	if (git_env_bool(GIT_TEST_WRITE_REV_INDEX, 0))
 		rev_index = 1;

--- a/builtin/ls-remote.c
+++ b/builtin/ls-remote.c
@@ -103,7 +103,7 @@ int cmd_ls_remote(int argc, const char **argv, const char *prefix)
 	if (!remote) {
 		if (dest)
 			die("bad repository '%s'", dest);
-		die("No remote configured to list refs from.");
+		die("no remote configured to list refs from.");
 	}
 	if (!remote->url_nr)
 		die("remote %s has no configured URL", dest);

--- a/builtin/ls-tree.c
+++ b/builtin/ls-tree.c
@@ -167,7 +167,7 @@ int cmd_ls_tree(int argc, const char **argv, const char *prefix)
 	if (argc < 1)
 		usage_with_options(ls_tree_usage, ls_tree_options);
 	if (get_oid(argv[0], &oid))
-		die("Not a valid object name %s", argv[0]);
+		die("not a valid object name %s", argv[0]);
 
 	/*
 	 * show_recursive() rolls its own matching code and is

--- a/builtin/merge-base.c
+++ b/builtin/merge-base.c
@@ -43,10 +43,10 @@ static struct commit *get_commit_reference(const char *arg)
 	struct commit *r;
 
 	if (get_oid(arg, &revkey))
-		die("Not a valid object name %s", arg);
+		die("not a valid object name %s", arg);
 	r = lookup_commit_reference(the_repository, &revkey);
 	if (!r)
-		die("Not a valid commit name %s", arg);
+		die("not a valid commit name %s", arg);
 
 	return r;
 }
@@ -119,7 +119,7 @@ static int handle_fork_point(int argc, const char **argv)
 
 	commitname = (argc == 2) ? argv[1] : "HEAD";
 	if (get_oid(commitname, &oid))
-		die("Not a valid object name: '%s'", commitname);
+		die("not a valid object name: '%s'", commitname);
 
 	derived = lookup_commit_reference(the_repository, &oid);
 

--- a/builtin/merge.c
+++ b/builtin/merge.c
@@ -602,7 +602,7 @@ static void parse_branch_merge_options(char *bmo)
 		return;
 	argc = split_cmdline(bmo, &argv);
 	if (argc < 0)
-		die(_("Bad branch.%s.mergeoptions string: %s"), branch,
+		die(_("bad branch.%s.mergeoptions string: %s"), branch,
 		    _(split_cmdline_strerror(argc)));
 	REALLOC_ARRAY(argv, argc + 2);
 	MOVE_ARRAY(argv + 1, argv, argc + 1);
@@ -1012,16 +1012,16 @@ static int setup_with_upstream(const char ***argv)
 	const char **args;
 
 	if (!branch)
-		die(_("No current branch."));
+		die(_("no current branch."));
 	if (!branch->remote_name)
-		die(_("No remote for the current branch."));
+		die(_("no remote for the current branch."));
 	if (!branch->merge_nr)
-		die(_("No default upstream defined for the current branch."));
+		die(_("no default upstream defined for the current branch."));
 
 	args = xcalloc(st_add(branch->merge_nr, 1), sizeof(char *));
 	for (i = 0; i < branch->merge_nr; i++) {
 		if (!branch->merge[i]->dst)
-			die(_("No remote-tracking branch for %s from %s"),
+			die(_("no remote-tracking branch for %s from %s"),
 			    branch->merge[i]->src, branch->remote_name);
 		args[i] = branch->merge[i]->dst;
 	}
@@ -1078,7 +1078,7 @@ static int default_edit_option(void)
 	if (e) {
 		int v = git_parse_maybe_bool(e);
 		if (v < 0)
-			die(_("Bad value '%s' in environment '%s'"), e, name);
+			die(_("bad value '%s' in environment '%s'"), e, name);
 		return v;
 	}
 
@@ -1331,7 +1331,7 @@ int cmd_merge(int argc, const char **argv, const char *prefix)
 			      builtin_merge_usage, builtin_merge_options);
 
 		if (!file_exists(git_path_merge_head(the_repository)))
-			die(_("There is no merge to abort (MERGE_HEAD missing)."));
+			die(_("there is no merge to abort (MERGE_HEAD missing)."));
 
 		if (read_oneliner(&stash_oid, git_path_merge_autostash(the_repository),
 		    READ_ONELINER_SKIP_IF_EMPTY))
@@ -1366,7 +1366,7 @@ int cmd_merge(int argc, const char **argv, const char *prefix)
 			      builtin_merge_usage, builtin_merge_options);
 
 		if (!file_exists(git_path_merge_head(the_repository)))
-			die(_("There is no merge in progress (MERGE_HEAD missing)."));
+			die(_("there is no merge in progress (MERGE_HEAD missing)."));
 
 		/* Invoke 'git commit' */
 		ret = cmd_commit(nargc, nargv, prefix);
@@ -1382,17 +1382,17 @@ int cmd_merge(int argc, const char **argv, const char *prefix)
 		 * add/rm <file>', just 'git commit'.
 		 */
 		if (advice_enabled(ADVICE_RESOLVE_CONFLICT))
-			die(_("You have not concluded your merge (MERGE_HEAD exists).\n"
-				  "Please, commit your changes before you merge."));
+			die(_("you have not concluded your merge (MERGE_HEAD exists).\n"
+				  "please, commit your changes before you merge."));
 		else
-			die(_("You have not concluded your merge (MERGE_HEAD exists)."));
+			die(_("you have not concluded your merge (MERGE_HEAD exists)."));
 	}
 	if (ref_exists("CHERRY_PICK_HEAD")) {
 		if (advice_enabled(ADVICE_RESOLVE_CONFLICT))
-			die(_("You have not concluded your cherry-pick (CHERRY_PICK_HEAD exists).\n"
-			    "Please, commit your changes before you merge."));
+			die(_("you have not concluded your cherry-pick (CHERRY_PICK_HEAD exists).\n"
+			    "please, commit your changes before you merge."));
 		else
-			die(_("You have not concluded your cherry-pick (CHERRY_PICK_HEAD exists)."));
+			die(_("you have not concluded your cherry-pick (CHERRY_PICK_HEAD exists)."));
 	}
 	resolve_undo_clear();
 
@@ -1424,7 +1424,7 @@ int cmd_merge(int argc, const char **argv, const char *prefix)
 		if (default_to_upstream)
 			argc = setup_with_upstream(&argv);
 		else
-			die(_("No commit specified and merge.defaultToUpstream not set."));
+			die(_("no commit specified and merge.defaultToUpstream not set."));
 	} else if (argc == 1 && !strcmp(argv[0], "-")) {
 		argv[0] = "@{-1}";
 	}
@@ -1441,16 +1441,16 @@ int cmd_merge(int argc, const char **argv, const char *prefix)
 		 */
 		struct object_id *remote_head_oid;
 		if (squash)
-			die(_("Squash commit into empty head not supported yet"));
+			die(_("squash commit into empty head not supported yet"));
 		if (fast_forward == FF_NO)
-			die(_("Non-fast-forward commit does not make sense into "
+			die(_("non-fast-forward commit does not make sense into "
 			    "an empty head"));
 		remoteheads = collect_parents(head_commit, &head_subsumed,
 					      argc, argv, NULL);
 		if (!remoteheads)
 			die(_("%s - not something we can merge"), argv[0]);
 		if (remoteheads->next)
-			die(_("Can merge only exactly one commit into empty head"));
+			die(_("can merge only exactly one commit into empty head"));
 
 		if (verify_signatures)
 			verify_merge_signature(remoteheads->item, verbosity,

--- a/builtin/mv.c
+++ b/builtin/mv.c
@@ -80,9 +80,9 @@ static void prepare_move_submodule(const char *src, int first,
 {
 	struct strbuf submodule_dotgit = STRBUF_INIT;
 	if (!S_ISGITLINK(active_cache[first]->ce_mode))
-		die(_("Directory %s is in index and no submodule?"), src);
+		die(_("directory %s is in index and no submodule?"), src);
 	if (!is_staging_gitmodules_ok(&the_index))
-		die(_("Please stage your changes to .gitmodules or stash them to proceed"));
+		die(_("please stage your changes to .gitmodules or stash them to proceed"));
 	strbuf_addf(&submodule_dotgit, "%s/.git", src);
 	*submodule_gitfile = read_gitfile(submodule_dotgit.buf);
 	if (*submodule_gitfile)
@@ -335,7 +335,7 @@ remove_entry:
 
 	if (write_locked_index(&the_index, &lock_file,
 			       COMMIT_LOCK | SKIP_IF_UNCHANGED))
-		die(_("Unable to write new index file"));
+		die(_("unable to write new index file"));
 
 	string_list_clear(&src_for_dst, 0);
 	UNLEAK(source);

--- a/builtin/pack-redundant.c
+++ b/builtin/pack-redundant.c
@@ -537,14 +537,14 @@ static struct pack_list * add_pack_file(const char *filename)
 	struct packed_git *p = get_all_packs(the_repository);
 
 	if (strlen(filename) < 40)
-		die("Bad pack filename: %s", filename);
+		die("bad pack filename: %s", filename);
 
 	while (p) {
 		if (strstr(p->pack_name, filename))
 			return add_pack(p);
 		p = p->next;
 	}
-	die("Filename %s not found in packed_git", filename);
+	die("filename %s not found in packed_git", filename);
 }
 
 static void load_all(void)
@@ -612,7 +612,7 @@ int cmd_pack_redundant(int argc, const char **argv, const char *prefix)
 			add_pack_file(*(argv + i++));
 
 	if (local_packs == NULL)
-		die("Zero packs found!");
+		die("zero packs found");
 
 	load_all_objects();
 
@@ -625,7 +625,7 @@ int cmd_pack_redundant(int argc, const char **argv, const char *prefix)
 		while (fgets(buf, sizeof(buf), stdin)) {
 			oid = xmalloc(sizeof(*oid));
 			if (get_oid_hex(buf, oid))
-				die("Bad object ID on stdin: %s", buf);
+				die("bad object ID on stdin: %s", buf);
 			llist_insert_sorted_unique(ignore, oid, NULL);
 		}
 	}

--- a/builtin/pull.c
+++ b/builtin/pull.c
@@ -1044,7 +1044,7 @@ int cmd_pull(int argc, const char **argv, const char *prefix)
 			opt_autostash = config_autostash;
 
 		if (is_null_oid(&orig_head) && !is_cache_unborn())
-			die(_("Updating an unborn branch with changes added to the index."));
+			die(_("updating an unborn branch with changes added to the index."));
 
 		if (!opt_autostash)
 			require_clean_work_tree(the_repository,
@@ -1080,8 +1080,8 @@ int cmd_pull(int argc, const char **argv, const char *prefix)
 
 		if (checkout_fast_forward(the_repository, &orig_head,
 					  &curr_head, 0))
-			die(_("Cannot fast-forward your working tree.\n"
-				"After making sure that you saved anything precious from\n"
+			die(_("cannot fast-forward your working tree.\n"
+				"after making sure that you saved anything precious from\n"
 				"$ git diff %s\n"
 				"output, run\n"
 				"$ git reset --hard\n"
@@ -1095,14 +1095,14 @@ int cmd_pull(int argc, const char **argv, const char *prefix)
 
 	if (is_null_oid(&orig_head)) {
 		if (merge_heads.nr > 1)
-			die(_("Cannot merge multiple branches into empty head."));
+			die(_("cannot merge multiple branches into empty head."));
 		return pull_into_void(merge_heads.oid, &curr_head);
 	}
 	if (merge_heads.nr > 1) {
 		if (opt_rebase)
-			die(_("Cannot rebase onto multiple branches."));
+			die(_("cannot rebase onto multiple branches."));
 		if (opt_ff && !strcmp(opt_ff, "--ff-only"))
-			die(_("Cannot fast-forward to multiple branches."));
+			die(_("cannot fast-forward to multiple branches."));
 	}
 
 	can_ff = get_can_ff(&orig_head, &merge_heads);
@@ -1117,7 +1117,7 @@ int cmd_pull(int argc, const char **argv, const char *prefix)
 	/* If no action specified and we can't fast forward, then warn. */
 	if (!opt_ff && rebase_unspecified && divergent) {
 		show_advice_pull_non_ff();
-		die(_("Need to specify how to reconcile divergent branches."));
+		die(_("need to specify how to reconcile divergent branches."));
 	}
 
 	if (opt_rebase) {

--- a/builtin/push.c
+++ b/builtin/push.c
@@ -162,9 +162,9 @@ static NORETURN void die_push_simple(struct branch *branch,
 	 */
 	if (push_default == PUSH_DEFAULT_UNSPECIFIED)
 		advice_maybe = _("\n"
-				 "To choose either option permanently, "
+				 "to choose either option permanently, "
 				 "see push.default in 'git help config'.");
-	die(_("The upstream branch of your current branch does not match\n"
+	die(_("the upstream branch of your current branch does not match\n"
 	      "the name of your current branch.  To push to the upstream branch\n"
 	      "on the remote, use\n"
 	      "\n"
@@ -188,15 +188,15 @@ static const char message_detached_head_die[] =
 static const char *get_upstream_ref(struct branch *branch, const char *remote_name)
 {
 	if (!branch->merge_nr || !branch->merge || !branch->remote_name)
-		die(_("The current branch %s has no upstream branch.\n"
-		    "To push the current branch and set the remote as upstream, use\n"
+		die(_("the current branch %s has no upstream branch.\n"
+		    "to push the current branch and set the remote as upstream, use\n"
 		    "\n"
 		    "    git push --set-upstream %s %s\n"),
 		    branch->name,
 		    remote_name,
 		    branch->name);
 	if (branch->merge_nr != 1)
-		die(_("The current branch %s has multiple upstream branches, "
+		die(_("the current branch %s has multiple upstream branches, "
 		    "refusing to push."), branch->name);
 
 	return branch->merge[0]->src;
@@ -214,7 +214,7 @@ static void setup_default_push_refspecs(struct remote *remote)
 		return;
 
 	case PUSH_DEFAULT_NOTHING:
-		die(_("You didn't specify any refspecs to push, and "
+		die(_("you didn't specify any refspecs to push, and "
 		    "push.default is \"nothing\"."));
 		return;
 	default:
@@ -240,7 +240,7 @@ static void setup_default_push_refspecs(struct remote *remote)
 
 	case PUSH_DEFAULT_UPSTREAM:
 		if (!same_remote)
-			die(_("You are pushing to remote '%s', which is not the upstream of\n"
+			die(_("you are pushing to remote '%s', which is not the upstream of\n"
 			      "your current branch '%s', without telling me what to push\n"
 			      "to update which remote branch."),
 			    remote->name, branch->name);
@@ -612,8 +612,8 @@ int cmd_push(int argc, const char **argv, const char *prefix)
 	if (!remote) {
 		if (repo)
 			die(_("bad repository '%s'"), repo);
-		die(_("No configured push destination.\n"
-		    "Either specify the URL from the command-line or configure a remote repository using\n"
+		die(_("no configured push destination.\n"
+		    "either specify the URL from the command-line or configure a remote repository using\n"
 		    "\n"
 		    "    git remote add <name> <url>\n"
 		    "\n"

--- a/builtin/read-tree.c
+++ b/builtin/read-tree.c
@@ -29,7 +29,7 @@ static int list_tree(struct object_id *oid)
 	struct tree *tree;
 
 	if (nr_trees >= MAX_UNPACK_TREES)
-		die("I cannot read more than %d trees", MAX_UNPACK_TREES);
+		die("i cannot read more than %d trees", MAX_UNPACK_TREES);
 	tree = parse_tree_indirect(oid);
 	if (!tree)
 		return -1;
@@ -162,11 +162,11 @@ int cmd_read_tree(int argc, const char **argv, const char *cmd_prefix)
 
 	prefix_set = opts.prefix ? 1 : 0;
 	if (1 < opts.merge + opts.reset + prefix_set)
-		die("Which one? -m, --reset, or --prefix?");
+		die("which one? -m, --reset, or --prefix?");
 
 	/* Prefix should not start with a directory separator */
 	if (opts.prefix && opts.prefix[0] == '/')
-		die("Invalid prefix, prefix cannot start with '/'");
+		die("invalid prefix, prefix cannot start with '/'");
 
 	if (opts.reset)
 		opts.reset = UNPACK_RESET_OVERWRITE_UNTRACKED;
@@ -196,7 +196,7 @@ int cmd_read_tree(int argc, const char **argv, const char *cmd_prefix)
 		const char *arg = argv[i];
 
 		if (get_oid(arg, &oid))
-			die("Not a valid object name %s", arg);
+			die("not a valid object name %s", arg);
 		if (list_tree(&oid) < 0)
 			die("failed to unpack tree object %s", arg);
 		stage++;

--- a/builtin/rebase.c
+++ b/builtin/rebase.c
@@ -765,7 +765,7 @@ static int run_specific_rebase(struct rebase_options *opts, enum action action)
 		strbuf_addstr(&dir, opts->state_dir);
 		remove_dir_recursively(&dir, 0);
 		strbuf_release(&dir);
-		die("Nothing to do");
+		die("nothing to do");
 	}
 
 	return status ? -1 : 0;
@@ -1174,7 +1174,7 @@ int cmd_rebase(int argc, const char **argv, const char *prefix)
 	strbuf_reset(&buf);
 	strbuf_addf(&buf, "%s/applying", apply_dir());
 	if(file_exists(buf.buf))
-		die(_("It looks like 'git am' is in progress. Cannot rebase."));
+		die(_("it looks like 'git am' is in progress. Cannot rebase."));
 
 	if (is_directory(apply_dir())) {
 		options.type = REBASE_APPLY;
@@ -1254,7 +1254,7 @@ int cmd_rebase(int argc, const char **argv, const char *prefix)
 
 		/* Sanity check */
 		if (get_oid("HEAD", &head))
-			die(_("Cannot read HEAD"));
+			die(_("cannot read HEAD"));
 
 		fd = hold_locked_index(&lock_file, 0);
 		if (repo_read_index(the_repository) < 0)
@@ -1421,7 +1421,7 @@ int cmd_rebase(int argc, const char **argv, const char *prefix)
 		else if (!strcmp("rebase-cousins", rebase_merges))
 			options.rebase_cousins = 1;
 		else if (strcmp("no-rebase-cousins", rebase_merges))
-			die(_("Unknown mode: %s"), rebase_merges);
+			die(_("unknown mode: %s"), rebase_merges);
 		options.rebase_merges = 1;
 		imply_merge(&options, "--rebase-merges");
 	}
@@ -1568,7 +1568,7 @@ int cmd_rebase(int argc, const char **argv, const char *prefix)
 		if (!options.onto_name) {
 			if (commit_tree("", 0, the_hash_algo->empty_tree, NULL,
 					&squash_onto, NULL, NULL) < 0)
-				die(_("Could not create new root commit"));
+				die(_("could not create new root commit"));
 			options.squash_onto = &squash_onto;
 			options.onto_name = squash_onto_name =
 				xstrdup(oid_to_hex(&squash_onto));
@@ -1606,7 +1606,7 @@ int cmd_rebase(int argc, const char **argv, const char *prefix)
 		options.onto =
 			lookup_commit_reference_by_name(options.onto_name);
 		if (!options.onto)
-			die(_("Does not point to a valid commit '%s'"),
+			die(_("does not point to a valid commit '%s'"),
 				options.onto_name);
 	}
 
@@ -1655,7 +1655,7 @@ int cmd_rebase(int argc, const char **argv, const char *prefix)
 			branch_name = "HEAD";
 		}
 		if (get_oid("HEAD", &options.orig_head))
-			die(_("Could not resolve HEAD to a revision"));
+			die(_("could not resolve HEAD to a revision"));
 	} else
 		BUG("unexpected number of arguments left to parse");
 
@@ -1731,7 +1731,7 @@ int cmd_rebase(int argc, const char **argv, const char *prefix)
 	if (!ok_to_skip_pre_rebase &&
 	    run_hooks_l("pre-rebase", options.upstream_arg,
 			argc ? argv[0] : NULL, NULL))
-		die(_("The pre-rebase hook refused to rebase."));
+		die(_("the pre-rebase hook refused to rebase."));
 
 	if (options.flags & REBASE_DIFFSTAT) {
 		struct diff_options opts;
@@ -1778,7 +1778,7 @@ int cmd_rebase(int argc, const char **argv, const char *prefix)
 	ropts.head_msg = msg.buf;
 	ropts.default_reflog_action = DEFAULT_REFLOG_ACTION;
 	if (reset_head(the_repository, &ropts))
-		die(_("Could not detach HEAD"));
+		die(_("could not detach HEAD"));
 	strbuf_release(&msg);
 
 	/*

--- a/builtin/remote-ext.c
+++ b/builtin/remote-ext.c
@@ -59,7 +59,7 @@ static char *strip_escapes(const char *str, const char *service,
 					break;
 				/* fallthrough */
 			default:
-				die("Bad remote-ext placeholder '%%%c'.",
+				die("bad remote-ext placeholder '%%%c'.",
 					str[rpos]);
 			}
 			escape = 0;
@@ -148,7 +148,7 @@ static int run_child(const char *arg, const char *service)
 	parse_argv(&child.args, arg, service);
 
 	if (start_command(&child) < 0)
-		die("Can't run specified command");
+		die("can't run specified command");
 
 	if (git_req)
 		send_git_request(child.in, service, git_req, git_req_vhost);
@@ -171,7 +171,7 @@ static int command_loop(const char *child)
 		size_t i;
 		if (!fgets(buffer, MAXCOMMAND - 1, stdin)) {
 			if (ferror(stdin))
-				die("Command input error");
+				die("command input error");
 			exit(0);
 		}
 		/* Strip end of line characters. */

--- a/builtin/remote-fd.c
+++ b/builtin/remote-fd.c
@@ -29,7 +29,7 @@ static void command_loop(int input_fd, int output_fd)
 		size_t i;
 		if (!fgets(buffer, MAXCOMMAND - 1, stdin)) {
 			if (ferror(stdin))
-				die("Input error");
+				die("input error");
 			return;
 		}
 		/* Strip end of line characters. */
@@ -45,10 +45,10 @@ static void command_loop(int input_fd, int output_fd)
 			fflush(stdout);
 			if (bidirectional_transfer_loop(input_fd,
 				output_fd))
-				die("Copying data between file descriptors failed");
+				die("copying data between file descriptors failed");
 			return;
 		} else {
-			die("Bad command: %s", buffer);
+			die("bad command: %s", buffer);
 		}
 	}
 }
@@ -65,7 +65,7 @@ int cmd_remote_fd(int argc, const char **argv, const char *prefix)
 	input_fd = (int)strtoul(argv[2], &end, 10);
 
 	if ((end == argv[2]) || (*end != ',' && *end != '/' && *end))
-		die("Bad URL syntax");
+		die("bad URL syntax");
 
 	if (*end == '/' || !*end) {
 		output_fd = input_fd;
@@ -74,7 +74,7 @@ int cmd_remote_fd(int argc, const char **argv, const char *prefix)
 		output_fd = (int)strtoul(end + 1, &end2, 10);
 
 		if ((end2 == end + 1) || (*end2 != '/' && *end2))
-			die("Bad URL syntax");
+			die("bad URL syntax");
 	}
 
 	command_loop(input_fd, output_fd);

--- a/builtin/remote.c
+++ b/builtin/remote.c
@@ -364,7 +364,7 @@ static int get_ref_states(const struct ref *remote_refs, struct ref_states *stat
 
 	for (i = 0; i < states->remote->fetch.nr; i++)
 		if (get_fetch_map(remote_refs, &states->remote->fetch.items[i], &tail, 1))
-			die(_("Could not get fetch map for refspec %s"),
+			die(_("could not get fetch map for refspec %s"),
 				states->remote->fetch.raw[i]);
 
 	for (ref = fetch_map; ref; ref = ref->next) {
@@ -1697,7 +1697,7 @@ static int set_url(int argc, const char **argv)
 
 	/* Old URL specified. Demand that one matches. */
 	if (regcomp(&old_regex, oldurl, REG_EXTENDED))
-		die(_("Invalid old URL pattern: %s"), oldurl);
+		die(_("invalid old URL pattern: %s"), oldurl);
 
 	for (i = 0; i < urlset_nr; i++)
 		if (!regexec(&old_regex, urlset[i], 0, NULL, 0))
@@ -1705,9 +1705,9 @@ static int set_url(int argc, const char **argv)
 		else
 			negative_matches++;
 	if (!delete_mode && !matches)
-		die(_("No such URL found: %s"), oldurl);
+		die(_("no such URL found: %s"), oldurl);
 	if (delete_mode && !negative_matches && !push_mode)
-		die(_("Will not delete all non-push URLs"));
+		die(_("will not delete all non-push URLs"));
 
 	regfree(&old_regex);
 

--- a/builtin/reset.c
+++ b/builtin/reset.c
@@ -301,7 +301,7 @@ static void set_reflog_message(struct strbuf *sb, const char *action,
 static void die_if_unmerged_cache(int reset_type)
 {
 	if (is_merge() || unmerged_cache())
-		die(_("Cannot do a %s reset in the middle of a merge."),
+		die(_("cannot do a %s reset in the middle of a merge."),
 		    _(reset_type_names[reset_type]));
 
 }
@@ -447,18 +447,18 @@ int cmd_reset(int argc, const char **argv, const char *prefix)
 	} else if (!pathspec.nr && !patch_mode) {
 		struct commit *commit;
 		if (get_oid_committish(rev, &oid))
-			die(_("Failed to resolve '%s' as a valid revision."), rev);
+			die(_("failed to resolve '%s' as a valid revision"), rev);
 		commit = lookup_commit_reference(the_repository, &oid);
 		if (!commit)
-			die(_("Could not parse object '%s'."), rev);
+			die(_("could not parse object '%s'"), rev);
 		oidcpy(&oid, &commit->object.oid);
 	} else {
 		struct tree *tree;
 		if (get_oid_treeish(rev, &oid))
-			die(_("Failed to resolve '%s' as a valid tree."), rev);
+			die(_("failed to resolve '%s' as a valid tree"), rev);
 		tree = parse_tree_indirect(&oid);
 		if (!tree)
-			die(_("Could not parse object '%s'."), rev);
+			die(_("could not parse object '%s'"), rev);
 		oidcpy(&oid, &tree->object.oid);
 	}
 
@@ -476,7 +476,7 @@ int cmd_reset(int argc, const char **argv, const char *prefix)
 		if (reset_type == MIXED)
 			warning(_("--mixed with paths is deprecated; use 'git reset -- <paths>' instead."));
 		else if (reset_type != NONE)
-			die(_("Cannot do %s reset with paths."),
+			die(_("cannot do %s reset with paths"),
 					_(reset_type_names[reset_type]));
 	}
 	if (reset_type == NONE)
@@ -543,12 +543,12 @@ int cmd_reset(int argc, const char **argv, const char *prefix)
 			if (reset_type == KEEP && !err)
 				err = reset_index(ref, &oid, MIXED, quiet);
 			if (err)
-				die(_("Could not reset index file to revision '%s'."), rev);
+				die(_("could not reset index file to revision '%s'"), rev);
 			free(ref);
 		}
 
 		if (write_locked_index(&the_index, &lock, COMMIT_LOCK))
-			die(_("Could not write new index file."));
+			die(_("could not write new index file"));
 	}
 
 	if (!pathspec.nr && !unborn) {

--- a/builtin/rev-parse.c
+++ b/builtin/rev-parse.c
@@ -990,7 +990,7 @@ int cmd_rev_parse(int argc, const char **argv, const char *prefix)
 			}
 			if (!strcmp(arg, "--shared-index-path")) {
 				if (read_cache() < 0)
-					die(_("Could not read the index"));
+					die(_("could not read the index"));
 				if (the_index.split_index) {
 					const struct object_id *oid = &the_index.split_index->base_oid;
 					const char *path = git_path("sharedindex.%s", oid_to_hex(oid));

--- a/builtin/rm.c
+++ b/builtin/rm.c
@@ -282,7 +282,7 @@ int cmd_rm(int argc, const char **argv, const char *prefix)
 	}
 
 	if (!pathspec.nr)
-		die(_("No pathspec was given. Which files should I remove?"));
+		die(_("no pathspec was given. Which files should I remove?"));
 
 	if (!index_only)
 		setup_work_tree();
@@ -427,7 +427,7 @@ int cmd_rm(int argc, const char **argv, const char *prefix)
 
 	if (write_locked_index(&the_index, &lock_file,
 			       COMMIT_LOCK | SKIP_IF_UNCHANGED))
-		die(_("Unable to write new index file"));
+		die(_("unable to write new index file"));
 
 	return ret;
 }

--- a/builtin/send-pack.c
+++ b/builtin/send-pack.c
@@ -260,7 +260,7 @@ int cmd_send_pack(int argc, const char **argv, const char *prefix)
 	if (remote_name) {
 		remote = remote_get(remote_name);
 		if (!remote_has_url(remote, dest)) {
-			die("Destination %s is not a uri for %s",
+			die("destination %s is not a uri for %s",
 			    dest, remote_name);
 		}
 	}

--- a/builtin/show-index.c
+++ b/builtin/show-index.c
@@ -28,7 +28,7 @@ int cmd_show_index(int argc, const char **argv, const char *prefix)
 	if (hash_name) {
 		hash_algo = hash_algo_by_name(hash_name);
 		if (hash_algo == GIT_HASH_UNKNOWN)
-			die(_("Unknown hash algorithm"));
+			die(_("unknown hash algorithm"));
 		repo_set_hash_algo(the_repository, hash_algo);
 	}
 

--- a/builtin/stash.c
+++ b/builtin/stash.c
@@ -450,7 +450,7 @@ static void unstage_changes_unless_new(struct object_id *orig_tree)
 					 "         to make room.\n"),
 				       ce->name, new_path.buf);
 				if (rename(ce->name, new_path.buf))
-					die("Failed to move %s to %s\n",
+					die("failed to move %s to %s\n",
 					    ce->name, new_path.buf);
 				strbuf_release(&new_path);
 			}

--- a/builtin/submodule--helper.c
+++ b/builtin/submodule--helper.c
@@ -40,14 +40,14 @@ static char *repo_get_default_remote(struct repository *repo)
 						      NULL);
 
 	if (!refname)
-		die(_("No such ref: %s"), "HEAD");
+		die(_("no such ref: %s"), "HEAD");
 
 	/* detached HEAD */
 	if (!strcmp(refname, "HEAD"))
 		return xstrdup("origin");
 
 	if (!skip_prefix(refname, "refs/heads/", &refname))
-		die(_("Expecting a full ref name, got %s"), refname);
+		die(_("expecting a full ref name, got %s"), refname);
 
 	strbuf_addf(&sb, "branch.%s.remote", refname);
 	if (repo_config_get_string(repo, sb.buf, &dest))
@@ -473,7 +473,7 @@ static void runcommand_in_submodule_cb(const struct cache_entry *list_item,
 	sub = submodule_from_path(the_repository, null_oid(), path);
 
 	if (!sub)
-		die(_("No url found for submodule path '%s' in .gitmodules"),
+		die(_("no url found for submodule path '%s' in .gitmodules"),
 			displaypath);
 
 	if (!is_submodule_populated_gently(path, NULL))
@@ -614,7 +614,7 @@ static void init_submodule(const char *path, const char *prefix,
 	sub = submodule_from_path(the_repository, null_oid(), path);
 
 	if (!sub)
-		die(_("No url found for submodule path '%s' in .gitmodules"),
+		die(_("no url found for submodule path '%s' in .gitmodules"),
 			displaypath);
 
 	/*
@@ -637,7 +637,7 @@ static void init_submodule(const char *path, const char *prefix,
 	strbuf_addf(&sb, "submodule.%s.url", sub->name);
 	if (git_config_get_string(sb.buf, &url)) {
 		if (!sub->url)
-			die(_("No url found for submodule path '%s' in .gitmodules"),
+			die(_("no url found for submodule path '%s' in .gitmodules"),
 				displaypath);
 
 		url = xstrdup(sub->url);
@@ -651,7 +651,7 @@ static void init_submodule(const char *path, const char *prefix,
 		}
 
 		if (git_config_set_gently(sb.buf, url))
-			die(_("Failed to register url for submodule path '%s'"),
+			die(_("failed to register url for submodule path '%s'"),
 			    displaypath);
 		if (!(flags & OPT_QUIET))
 			fprintf(stderr,
@@ -672,7 +672,7 @@ static void init_submodule(const char *path, const char *prefix,
 			upd = xstrdup(submodule_strategy_to_string(&sub->update_strategy));
 
 		if (git_config_set_gently(sb.buf, upd))
-			die(_("Failed to register update mode for submodule path '%s'"), displaypath);
+			die(_("failed to register update mode for submodule path '%s'"), displaypath);
 	}
 	strbuf_release(&sb);
 	free(displaypath);
@@ -1527,7 +1527,7 @@ static void deinit_submodule(const char *path, const char *prefix,
 				     path, NULL);
 
 			if (run_command(&cp_rm))
-				die(_("Submodule work tree '%s' contains local "
+				die(_("submodule work tree '%s' contains local "
 				      "modifications; use '-f' to discard them"),
 				      displaypath);
 		}
@@ -1535,9 +1535,9 @@ static void deinit_submodule(const char *path, const char *prefix,
 		strbuf_addstr(&sb_rm, path);
 
 		if (!remove_dir_recursively(&sb_rm, 0))
-			format = _("Cleared directory '%s'\n");
+			format = _("cleared directory '%s'\n");
 		else
-			format = _("Could not remove submodule work tree '%s'\n");
+			format = _("could not remove submodule work tree '%s'\n");
 
 		if (!(flags & OPT_QUIET))
 			printf(format, displaypath);
@@ -1613,7 +1613,7 @@ static int module_deinit(int argc, const char **argv, const char *prefix)
 	}
 
 	if (!argc && !all)
-		die(_("Use '--all' if you really want to deinitialize all submodules"));
+		die(_("use '--all' if you really want to deinitialize all submodules"));
 
 	if (module_list_compute(argc, argv, prefix, &pathspec, &list) < 0)
 		return 1;
@@ -1743,14 +1743,14 @@ static void prepare_possible_alternates(const char *sm_name,
 	else if (!strcmp(error_strategy, "ignore"))
 		sas.error_mode = SUBMODULE_ALTERNATE_ERROR_IGNORE;
 	else
-		die(_("Value '%s' for submodule.alternateErrorStrategy is not recognized"), error_strategy);
+		die(_("value '%s' for submodule.alternateErrorStrategy is not recognized"), error_strategy);
 
 	if (!strcmp(sm_alternate, "superproject"))
 		foreach_alt_odb(add_possible_reference_from_superproject, &sas);
 	else if (!strcmp(sm_alternate, "no"))
 		; /* do nothing */
 	else
-		die(_("Value '%s' for submodule.alternateLocation is not recognized"), sm_alternate);
+		die(_("value '%s' for submodule.alternateLocation is not recognized"), sm_alternate);
 
 	free(sm_alternate);
 	free(error_strategy);
@@ -1937,11 +1937,11 @@ static void determine_submodule_update_strategy(struct repository *r,
 
 	if (update) {
 		if (parse_submodule_update_strategy(update, out) < 0)
-			die(_("Invalid update mode '%s' for submodule path '%s'"),
+			die(_("invalid update mode '%s' for submodule path '%s'"),
 				update, path);
 	} else if (!repo_config_get_string_tmp(r, key, &val)) {
 		if (parse_submodule_update_strategy(val, out) < 0)
-			die(_("Invalid update mode '%s' configured for submodule path '%s'"),
+			die(_("invalid update mode '%s' configured for submodule path '%s'"),
 				val, path);
 	} else if (sub->update_strategy.type != SM_UPDATE_UNSPECIFIED) {
 		if (sub->update_strategy.type == SM_UPDATE_COMMAND)
@@ -2449,7 +2449,7 @@ static int do_run_update_procedure(struct update_data *ud)
 		 */
 		if (!is_tip_reachable(ud->sm_path, &ud->oid) &&
 		    fetch_in_submodule(ud->sm_path, ud->depth, ud->quiet, &ud->oid))
-			die(_("Fetched in submodule path '%s', but it did not "
+			die(_("fetched in submodule path '%s', but it did not "
 			      "contain %s. Direct fetching of that commit failed."),
 			    ud->displaypath, oid_to_hex(&ud->oid));
 	}
@@ -2708,16 +2708,16 @@ static const char *remote_submodule_branch(const char *path)
 		const char *refname = resolve_ref_unsafe("HEAD", 0, NULL, NULL);
 
 		if (!refname)
-			die(_("No such ref: %s"), "HEAD");
+			die(_("no such ref: %s"), "HEAD");
 
 		/* detached HEAD */
 		if (!strcmp(refname, "HEAD"))
-			die(_("Submodule (%s) branch configured to inherit "
+			die(_("submodule (%s) branch configured to inherit "
 			      "branch from superproject, but the superproject "
 			      "is not on any branch"), sub->name);
 
 		if (!skip_prefix(refname, "refs/heads/", &refname))
-			die(_("Expecting a full ref name, got %s"), refname);
+			die(_("expecting a full ref name, got %s"), refname);
 		return refname;
 	}
 
@@ -2746,7 +2746,7 @@ static int push_check(int argc, const char **argv, const char *prefix)
 	/* Get the submodule's head ref and determine if it is detached */
 	head = resolve_refdup("HEAD", 0, &head_oid, NULL);
 	if (!head)
-		die(_("Failed to resolve HEAD as a valid ref."));
+		die(_("failed to resolve HEAD as a valid ref."));
 	if (!strcmp(head, "HEAD"))
 		detached_head = 1;
 
@@ -3055,7 +3055,7 @@ static int update_submodule2(struct update_data *update_data)
 	if (update_data->just_cloned)
 		oidcpy(&update_data->suboid, null_oid());
 	else if (resolve_gitlink_ref(update_data->sm_path, "HEAD", &update_data->suboid))
-		die(_("Unable to find current revision in submodule path '%s'"),
+		die(_("unable to find current revision in submodule path '%s'"),
 			update_data->displaypath);
 
 	if (update_data->remote) {
@@ -3066,12 +3066,12 @@ static int update_submodule2(struct update_data *update_data)
 		if (!update_data->nofetch) {
 			if (fetch_in_submodule(update_data->sm_path, update_data->depth,
 					      0, NULL))
-				die(_("Unable to fetch in submodule path '%s'"),
+				die(_("unable to fetch in submodule path '%s'"),
 				    update_data->sm_path);
 		}
 
 		if (resolve_gitlink_ref(update_data->sm_path, remote_ref, &update_data->oid))
-			die(_("Unable to find %s revision in submodule path '%s'"),
+			die(_("unable to find %s revision in submodule path '%s'"),
 			    remote_ref, update_data->sm_path);
 
 		free(remote_ref);
@@ -3245,16 +3245,16 @@ static void configure_added_submodule(struct add_data *add_data)
 	strvec_pushl(&add_submod.args, "--", add_data->sm_path, NULL);
 
 	if (run_command(&add_submod))
-		die(_("Failed to add submodule '%s'"), add_data->sm_path);
+		die(_("failed to add submodule '%s'"), add_data->sm_path);
 
 	if (config_submodule_in_gitmodules(add_data->sm_name, "path", add_data->sm_path) ||
 	    config_submodule_in_gitmodules(add_data->sm_name, "url", add_data->repo))
-		die(_("Failed to register submodule '%s'"), add_data->sm_path);
+		die(_("failed to register submodule '%s'"), add_data->sm_path);
 
 	if (add_data->branch) {
 		if (config_submodule_in_gitmodules(add_data->sm_name,
 						   "branch", add_data->branch))
-			die(_("Failed to register submodule '%s'"), add_data->sm_path);
+			die(_("failed to register submodule '%s'"), add_data->sm_path);
 	}
 
 	add_gitmodules.git_cmd = 1;
@@ -3262,7 +3262,7 @@ static void configure_added_submodule(struct add_data *add_data)
 		     "add", "--force", "--", ".gitmodules", NULL);
 
 	if (run_command(&add_gitmodules))
-		die(_("Failed to register submodule '%s'"), add_data->sm_path);
+		die(_("failed to register submodule '%s'"), add_data->sm_path);
 
 	/*
 	 * NEEDSWORK: In a multi-working-tree world this needs to be
@@ -3395,7 +3395,7 @@ static int module_add(int argc, const char **argv, const char *prefix)
 	if (starts_with_dot_dot_slash(add_data.repo) ||
 	    starts_with_dot_slash(add_data.repo)) {
 		if (prefix)
-			die(_("Relative path can only be used from the toplevel "
+			die(_("relative path can only be used from the toplevel "
 			      "of the working tree"));
 
 		/* dereference source url relative to parent's url */

--- a/builtin/symbolic-ref.c
+++ b/builtin/symbolic-ref.c
@@ -16,7 +16,7 @@ static int check_symref(const char *HEAD, int quiet, int shorten, int print)
 	const char *refname = resolve_ref_unsafe(HEAD, 0, NULL, &flag);
 
 	if (!refname)
-		die("No such ref: %s", HEAD);
+		die("no such ref: %s", HEAD);
 	else if (!(flag & REF_ISSYMREF)) {
 		if (!quiet)
 			die("ref %s is not a symbolic ref", HEAD);
@@ -50,14 +50,14 @@ int cmd_symbolic_ref(int argc, const char **argv, const char *prefix)
 	argc = parse_options(argc, argv, prefix, options,
 			     git_symbolic_ref_usage, 0);
 	if (msg && !*msg)
-		die("Refusing to perform update with empty message");
+		die("refusing to perform update with empty message");
 
 	if (delete) {
 		if (argc != 1)
 			usage_with_options(git_symbolic_ref_usage, options);
 		ret = check_symref(argv[0], 1, 0, 0);
 		if (ret)
-			die("Cannot delete %s, not a symbolic ref", argv[0]);
+			die("cannot delete %s, not a symbolic ref", argv[0]);
 		if (!strcmp(argv[0], "HEAD"))
 			die("deleting '%s' is not allowed", argv[0]);
 		return delete_ref(NULL, argv[0], NULL, REF_NO_DEREF);
@@ -70,7 +70,7 @@ int cmd_symbolic_ref(int argc, const char **argv, const char *prefix)
 	case 2:
 		if (!strcmp(argv[0], "HEAD") &&
 		    !starts_with(argv[1], "refs/"))
-			die("Refusing to point HEAD outside of refs/");
+			die("refusing to point HEAD outside of refs/");
 		ret = !!create_symref(argv[0], argv[1], msg);
 		break;
 	default:

--- a/builtin/tag.c
+++ b/builtin/tag.c
@@ -612,7 +612,7 @@ int cmd_tag(int argc, const char **argv, const char *prefix)
 	else if (!strcmp(cleanup_arg, "whitespace"))
 		opt.cleanup_mode = CLEANUP_SPACE;
 	else
-		die(_("Invalid cleanup mode %s"), cleanup_arg);
+		die(_("invalid cleanup mode %s"), cleanup_arg);
 
 	create_reflog_msg(&object, &reflog_msg);
 

--- a/builtin/unpack-file.c
+++ b/builtin/unpack-file.c
@@ -29,7 +29,7 @@ int cmd_unpack_file(int argc, const char **argv, const char *prefix)
 	if (argc != 2 || !strcmp(argv[1], "-h"))
 		usage("git unpack-file <sha1>");
 	if (get_oid(argv[1], &oid))
-		die("Not a valid object name %s", argv[1]);
+		die("not a valid object name %s", argv[1]);
 
 	git_config(git_default_config, NULL);
 

--- a/builtin/unpack-objects.c
+++ b/builtin/unpack-objects.c
@@ -217,7 +217,7 @@ static int check_object(struct object *obj, enum object_type type,
 		die("fsck error in packed object");
 	fsck_options.walk = check_object;
 	if (fsck_walk(obj, NULL, &fsck_options))
-		die("Error on reachable objects of %s", oid_to_hex(&obj->oid));
+		die("error on reachable objects of %s", oid_to_hex(&obj->oid));
 	write_cached_object(obj, obj_buf);
 	return 0;
 }

--- a/builtin/update-index.c
+++ b/builtin/update-index.c
@@ -459,22 +459,22 @@ static void update_one(const char *path)
 	} /* else stat is valid */
 
 	if (!verify_path(path, st.st_mode)) {
-		fprintf(stderr, "Ignoring path %s\n", path);
+		fprintf(stderr, "ignoring path %s\n", path);
 		return;
 	}
 	if (mark_valid_only) {
 		if (mark_ce_flags(path, CE_VALID, mark_valid_only == MARK_FLAG))
-			die("Unable to mark file %s", path);
+			die("unable to mark file %s", path);
 		return;
 	}
 	if (mark_skip_worktree_only) {
 		if (mark_ce_flags(path, CE_SKIP_WORKTREE, mark_skip_worktree_only == MARK_FLAG))
-			die("Unable to mark file %s", path);
+			die("unable to mark file %s", path);
 		return;
 	}
 	if (mark_fsmonitor_only) {
 		if (mark_ce_flags(path, CE_FSMONITOR_VALID, mark_fsmonitor_only == MARK_FLAG))
-			die("Unable to mark file %s", path);
+			die("unable to mark file %s", path);
 		return;
 	}
 
@@ -485,7 +485,7 @@ static void update_one(const char *path)
 		return;
 	}
 	if (process_path(path, &st, stat_errno))
-		die("Unable to process path %s", path);
+		die("unable to process path %s", path);
 	report("add '%s'", path);
 }
 
@@ -696,9 +696,9 @@ static int unresolve_one(const char *path)
 static void read_head_pointers(void)
 {
 	if (read_ref("HEAD", &head_oid))
-		die("No HEAD -- no initial commit yet?");
+		die("no HEAD -- no initial commit yet?");
 	if (read_ref("MERGE_HEAD", &merge_head_oid)) {
-		fprintf(stderr, "Not in the middle of a merge.\n");
+		fprintf(stderr, "not in the middle of a merge.\n");
 		exit(0);
 	}
 }
@@ -1258,7 +1258,7 @@ int cmd_update_index(int argc, const char **argv, const char *prefix)
 			unable_to_lock_die(get_index_file(), lock_error);
 		}
 		if (write_locked_index(&the_index, &lock_file, COMMIT_LOCK))
-			die("Unable to write new index file");
+			die("unable to write new index file");
 	}
 
 	rollback_lock_file(&lock_file);

--- a/builtin/update-ref.c
+++ b/builtin/update-ref.c
@@ -516,7 +516,7 @@ int cmd_update_ref(int argc, const char **argv, const char *prefix)
 	argc = parse_options(argc, argv, prefix, options, git_update_ref_usage,
 			     0);
 	if (msg && !*msg)
-		die("Refusing to perform update with empty message.");
+		die("refusing to perform update with empty message.");
 
 	create_reflog_flag = create_reflog ? REF_FORCE_CREATE_REFLOG : 0;
 

--- a/builtin/var.c
+++ b/builtin/var.c
@@ -14,7 +14,7 @@ static const char *editor(int flag)
 	const char *pgm = git_editor();
 
 	if (!pgm && flag & IDENT_STRICT)
-		die("Terminal is dumb, but EDITOR unset");
+		die("terminal is dumb, but EDITOR unset");
 
 	return pgm;
 }

--- a/bundle.c
+++ b/bundle.c
@@ -596,7 +596,7 @@ int create_bundle(struct repository *r, const char *path,
 	/* write bundle refs */
 	ref_count = write_bundle_refs(bundle_fd, &revs_copy);
 	if (!ref_count)
-		die(_("Refusing to create empty bundle."));
+		die(_("refusing to create empty bundle."));
 	else if (ref_count < 0)
 		goto err;
 

--- a/commit.c
+++ b/commit.c
@@ -972,11 +972,11 @@ struct commit *get_fork_point(const char *refname, struct commit *commit)
 
 	switch (dwim_ref(refname, strlen(refname), &oid, &full_refname, 0)) {
 	case 0:
-		die("No such ref: '%s'", refname);
+		die("no such ref: '%s'", refname);
 	case 1:
 		break; /* good */
 	default:
-		die("Ambiguous refname: '%s'", refname);
+		die("ambiguous refname: '%s'", refname);
 	}
 
 	memset(&revs, 0, sizeof(revs));
@@ -1249,17 +1249,17 @@ void verify_merge_signature(struct commit *commit, int verbosity,
 	switch (signature_check.result) {
 	case 'G':
 		if (ret || (check_trust && signature_check.trust_level < TRUST_MARGINAL))
-			die(_("Commit %s has an untrusted GPG signature, "
+			die(_("commit %s has an untrusted GPG signature, "
 			      "allegedly by %s."), hex, signature_check.signer);
 		break;
 	case 'B':
-		die(_("Commit %s has a bad GPG signature "
+		die(_("commit %s has a bad GPG signature "
 		      "allegedly by %s."), hex, signature_check.signer);
 	default: /* 'N' */
-		die(_("Commit %s does not have a GPG signature."), hex);
+		die(_("commit %s does not have a GPG signature."), hex);
 	}
 	if (verbosity >= 0 && signature_check.result == 'G')
-		printf(_("Commit %s has a good GPG signature by %s\n"),
+		printf(_("commit %s has a good GPG signature by %s\n"),
 		       hex, signature_check.signer);
 
 	signature_check_clear(&signature_check);

--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -1943,7 +1943,7 @@ char *mingw_getenv(const char *name)
 	/* We cannot use xcalloc() here because that uses getenv() itself */
 	w_key = calloc(len_key, sizeof(wchar_t));
 	if (!w_key)
-		die("Out of memory, (tried to allocate %u wchar_t's)", len_key);
+		die("out of memory, (tried to allocate %u wchar_t's)", len_key);
 	xutftowcs(w_key, name, len_key);
 	/* GetEnvironmentVariableW() only sets the last error upon failure */
 	SetLastError(ERROR_SUCCESS);
@@ -1958,7 +1958,7 @@ char *mingw_getenv(const char *name)
 	/* We cannot use xcalloc() here because that uses getenv() itself */
 	value = calloc(len_value, sizeof(char));
 	if (!value)
-		die("Out of memory, (tried to allocate %u bytes)", len_value);
+		die("out of memory, (tried to allocate %u bytes)", len_value);
 	xwcstoutf(value, w_value, len_value);
 
 	/*
@@ -1986,7 +1986,7 @@ int mingw_putenv(const char *namevalue)
 	size = strlen(namevalue) * 2 + 1;
 	wide = calloc(size, sizeof(wchar_t));
 	if (!wide)
-		die("Out of memory, (tried to allocate %u wchar_t's)", size);
+		die("out of memory, (tried to allocate %u wchar_t's)", size);
 	xutftowcs(wide, namevalue, size);
 	equal = wcschr(wide, L'=');
 	if (!equal)

--- a/compat/mmap.c
+++ b/compat/mmap.c
@@ -5,7 +5,7 @@ void *git_mmap(void *start, size_t length, int prot, int flags, int fd, off_t of
 	size_t n = 0;
 
 	if (start != NULL || flags != MAP_PRIVATE || prot != PROT_READ)
-		die("Invalid usage of mmap when built with NO_MMAP");
+		die("invalid usage of mmap when built with NO_MMAP");
 
 	if (length == 0) {
 		errno = EINVAL;

--- a/compat/win32mmap.c
+++ b/compat/win32mmap.c
@@ -17,7 +17,7 @@ void *git_mmap(void *start, size_t length, int prot, int flags, int fd, off_t of
 		length = xsize_t(len.QuadPart - offset);
 
 	if (!(flags & MAP_PRIVATE))
-		die("Invalid usage of mmap when built with USE_WIN32_MMAP");
+		die("invalid usage of mmap when built with USE_WIN32_MMAP");
 
 	hmap = CreateFileMapping(osfhandle, NULL,
 		prot == PROT_READ ? PAGE_READONLY : PAGE_WRITECOPY, 0, 0, NULL);

--- a/compat/winansi.c
+++ b/compat/winansi.c
@@ -632,7 +632,7 @@ void winansi_init(void)
 	/* create a named pipe to communicate with the console thread */
 	if (swprintf(name, ARRAY_SIZE(name) - 1, L"\\\\.\\pipe\\winansi%lu",
 		     GetCurrentProcessId()) < 0)
-		die("Could not initialize winansi pipe name");
+		die("could not initialize winansi pipe name");
 	hwrite = CreateNamedPipeW(name, PIPE_ACCESS_OUTBOUND,
 		PIPE_TYPE_BYTE | PIPE_WAIT, 1, BUFFER_SIZE, 0, 0, NULL);
 	if (hwrite == INVALID_HANDLE_VALUE)

--- a/contrib/credential/osxkeychain/git-credential-osxkeychain.c
+++ b/contrib/credential/osxkeychain/git-credential-osxkeychain.c
@@ -26,7 +26,7 @@ static void *xstrdup(const char *s1)
 {
 	void *ret = strdup(s1);
 	if (!ret)
-		die("Out of memory");
+		die("out of memory");
 	return ret;
 }
 

--- a/contrib/credential/wincred/git-credential-wincred.c
+++ b/contrib/credential/wincred/git-credential-wincred.c
@@ -29,7 +29,7 @@ static void *xmalloc(size_t size)
 	if (!ret && !size)
 		ret = malloc(1);
 	if (!ret)
-		 die("Out of memory");
+		 die("out of memory");
 	return ret;
 }
 

--- a/contrib/mw-to-git/git-remote-mediawiki.perl
+++ b/contrib/mw-to-git/git-remote-mediawiki.perl
@@ -169,28 +169,28 @@ sub parse_command {
 		return 0;
 	}
 	if ($cmd[0] eq 'capabilities') {
-		die("Too many arguments for capabilities\n")
+		die("too many arguments for capabilities\n")
 		    if (defined($cmd[1]));
 		mw_capabilities();
 	} elsif ($cmd[0] eq 'list') {
-		die("Too many arguments for list\n") if (defined($cmd[2]));
+		die("too many arguments for list\n") if (defined($cmd[2]));
 		mw_list($cmd[1]);
 	} elsif ($cmd[0] eq 'import') {
-		die("Invalid argument for import\n")
+		die("invalid argument for import\n")
 		    if ($cmd[1] eq EMPTY);
-		die("Too many arguments for import\n")
+		die("too many arguments for import\n")
 		    if (defined($cmd[2]));
 		mw_import($cmd[1]);
 	} elsif ($cmd[0] eq 'option') {
-		die("Invalid arguments for option\n")
+		die("invalid arguments for option\n")
 		    if ($cmd[1] eq EMPTY || $cmd[2] eq EMPTY);
-		die("Too many arguments for option\n")
+		die("too many arguments for option\n")
 		    if (defined($cmd[3]));
 		mw_option($cmd[1],$cmd[2]);
 	} elsif ($cmd[0] eq 'push') {
 		mw_push($cmd[1]);
 	} else {
-		print {*STDERR} "Unknown command. Aborting...\n";
+		print {*STDERR} "unknown command. Aborting...\n";
 		return 0;
 	}
 	return 1;
@@ -808,7 +808,7 @@ sub get_more_refs {
 		} elsif ($line eq "\n") {
 			return @refs;
 		} else {
-			die("Invalid command in a '$cmd' batch: $_\n");
+			die("invalid command in a '$cmd' batch: $_\n");
 		}
 	}
 	return;
@@ -1145,17 +1145,17 @@ sub mw_push {
 	my $pushed;
 	for my $refspec (@refsspecs) {
 		my ($force, $local, $remote) = $refspec =~ /^(\+)?([^:]*):([^:]*)$/
-		    or die("Invalid refspec for push. Expected <src>:<dst> or +<src>:<dst>\n");
+		    or die("invalid refspec for push. Expected <src>:<dst> or +<src>:<dst>\n");
 		if ($force) {
-			print {*STDERR} "Warning: forced push not allowed on a MediaWiki.\n";
+			print {*STDERR} "warning: forced push not allowed on a MediaWiki.\n";
 		}
 		if ($local eq EMPTY) {
-			print {*STDERR} "Cannot delete remote branch on a MediaWiki\n";
+			print {*STDERR} "cannot delete remote branch on a MediaWiki\n";
 			print {*STDOUT} "error ${remote} cannot delete\n";
 			next;
 		}
 		if ($remote ne 'refs/heads/master') {
-			print {*STDERR} "Only push to the branch 'master' is supported on a MediaWiki\n";
+			print {*STDERR} "only push to the branch 'master' is supported on a MediaWiki\n";
 			print {*STDOUT} "error ${remote} only master allowed\n";
 			next;
 		}
@@ -1272,7 +1272,7 @@ sub mw_push_revision {
 				return error_non_fast_forward($remote);
 			}
 			if ($status ne 'ok') {
-				die("Unknown error from mw_push_file()\n");
+				die("unknown error from mw_push_file()\n");
 			}
 		}
 		if (!$dumb_push) {

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -216,7 +216,7 @@ static int add_or_remove_enlistment(int add)
 	int res;
 
 	if (!the_repository->worktree)
-		die(_("Scalar enlistments require a worktree"));
+		die(_("scalar enlistments require a worktree"));
 
 	res = run_git("config", "--global", "--get", "--fixed-value",
 		      "scalar.repo", the_repository->worktree, NULL);

--- a/daemon.c
+++ b/daemon.c
@@ -524,7 +524,7 @@ static void enable_service(const char *name, int ena)
 			return;
 		}
 	}
-	die("No such service %s", name);
+	die("no such service %s", name);
 }
 
 static void make_service_overridable(const char *name, int ena)
@@ -536,7 +536,7 @@ static void make_service_overridable(const char *name, int ena)
 			return;
 		}
 	}
-	die("No such service %s", name);
+	die("no such service %s", name);
 }
 
 static void parse_host_and_port(char *hostport, char **host,
@@ -547,7 +547,7 @@ static void parse_host_and_port(char *hostport, char **host,
 
 		end = strchr(hostport, ']');
 		if (!end)
-			die("Invalid request ('[' without ']')");
+			die("invalid request ('[' without ']')");
 		*end = '\0';
 		*host = hostport + 1;
 		if (!end[1])
@@ -555,7 +555,7 @@ static void parse_host_and_port(char *hostport, char **host,
 		else if (end[1] == ':')
 			*port = end + 2;
 		else
-			die("Garbage after end of host part");
+			die("garbage after end of host part");
 	} else {
 		*host = hostport;
 		*port = strrchr(hostport, ':');
@@ -629,7 +629,7 @@ static char *parse_host_arg(struct hostinfo *hi, char *extra_args, int buflen)
 			extra_args = val + vallen;
 		}
 		if (extra_args < end && *extra_args)
-			die("Invalid request");
+			die("invalid request");
 	}
 
 	return extra_args;

--- a/date.c
+++ b/date.c
@@ -50,13 +50,13 @@ static time_t gm_time_t(timestamp_t time, int tz)
 
 	if (minutes > 0) {
 		if (unsigned_add_overflows(time, minutes * 60))
-			die("Timestamp+tz too large: %"PRItime" +%04d",
+			die("timestamp+tz too large: %"PRItime" +%04d",
 			    time, tz);
 	} else if (time < -minutes * 60)
-		die("Timestamp before Unix epoch: %"PRItime" %04d", time, tz);
+		die("timestamp before Unix epoch: %"PRItime" %04d", time, tz);
 	time += minutes * 60;
 	if (date_overflows(time))
-		die("Timestamp too large for this system: %"PRItime, time);
+		die("timestamp too large for this system: %"PRItime, time);
 	return (time_t)time;
 }
 
@@ -111,7 +111,7 @@ static int local_tzoffset(timestamp_t time)
 	struct tm tm;
 
 	if (date_overflows(time))
-		die("Timestamp too large for this system: %"PRItime, time);
+		die("timestamp too large for this system: %"PRItime, time);
 
 	return local_time_tzoffset((time_t)time, &tm);
 }

--- a/dir.c
+++ b/dir.c
@@ -3116,8 +3116,8 @@ char *git_url_basename(const char *repo, int is_bundle, int is_bare)
 	strip_suffix_mem(start, &len, is_bundle ? ".bundle" : ".git");
 
 	if (!len || (len == 1 && *start == '/'))
-		die(_("No directory name could be guessed.\n"
-		      "Please specify a directory on the command line"));
+		die(_("no directory name could be guessed.\n"
+		      "please specify a directory on the command line"));
 
 	if (is_bare)
 		dir = xstrfmt("%.*s.git", (int)len, start);

--- a/fetch-pack.c
+++ b/fetch-pack.c
@@ -1046,11 +1046,11 @@ static struct ref *do_fetch_pack(struct fetch_pack_args *args,
 	if (server_supports("shallow"))
 		print_verbose(args, _("Server supports %s"), "shallow");
 	else if (args->depth > 0 || is_repository_shallow(r))
-		die(_("Server does not support shallow clients"));
+		die(_("server does not support shallow clients"));
 	if (args->depth > 0 || args->deepen_since || args->deepen_not)
 		args->deepen = 1;
 	if (server_supports("multi_ack_detailed")) {
-		print_verbose(args, _("Server supports %s"), "multi_ack_detailed");
+		print_verbose(args, _("server supports %s"), "multi_ack_detailed");
 		multi_ack = 2;
 		if (server_supports("no-done")) {
 			print_verbose(args, _("Server supports %s"), "no-done");
@@ -1106,18 +1106,18 @@ static struct ref *do_fetch_pack(struct fetch_pack_args *args,
 		print_verbose(args, _("Server supports %s"), "deepen-since");
 		deepen_since_ok = 1;
 	} else if (args->deepen_since)
-		die(_("Server does not support --shallow-since"));
+		die(_("server does not support --shallow-since"));
 	if (server_supports("deepen-not")) {
 		print_verbose(args, _("Server supports %s"), "deepen-not");
 		deepen_not_ok = 1;
 	} else if (args->deepen_not)
-		die(_("Server does not support --shallow-exclude"));
+		die(_("server does not support --shallow-exclude"));
 	if (server_supports("deepen-relative"))
 		print_verbose(args, _("Server supports %s"), "deepen-relative");
 	else if (args->deepen_relative)
-		die(_("Server does not support --deepen"));
+		die(_("server does not support --deepen"));
 	if (!server_supports_hash(the_hash_algo->name, NULL))
-		die(_("Server does not support this repository's object format"));
+		die(_("server does not support this repository's object format"));
 
 	mark_complete_and_common_ref(negotiator, args, &ref);
 	filter_refs(args, &ref, sought, nr_sought);

--- a/fsck.c
+++ b/fsck.c
@@ -118,7 +118,7 @@ static enum fsck_msg_type parse_msg_type(const char *str)
 	else if (!strcmp(str, "ignore"))
 		return FSCK_IGNORE;
 	else
-		die("Unknown fsck message type: '%s'", str);
+		die("unknown fsck message type: '%s'", str);
 }
 
 int is_valid_msg_type(const char *msg_id, const char *msg_type)
@@ -152,10 +152,10 @@ void fsck_set_msg_type(struct fsck_options *options,
 	enum fsck_msg_type msg_type = parse_msg_type(msg_type_str);
 
 	if (msg_id < 0)
-		die("Unhandled message id: %s", msg_id_str);
+		die("unhandled message id: %s", msg_id_str);
 
 	if (msg_type != FSCK_ERROR && msg_id_info[msg_id].msg_type == FSCK_FATAL)
-		die("Cannot demote %s to %s", msg_id_str, msg_type_str);
+		die("cannot demote %s to %s", msg_id_str, msg_type_str);
 
 	fsck_set_msg_type_from_ids(options, msg_id, msg_type);
 }
@@ -190,7 +190,7 @@ void fsck_set_msg_types(struct fsck_options *options, const char *values)
 		}
 
 		if (equal == len)
-			die("Missing '=': '%s'", buf);
+			die("missing '=': '%s'", buf);
 
 		fsck_set_msg_type(options, buf, buf + equal + 1);
 		buf += len + 1;

--- a/git-compat-util.h
+++ b/git-compat-util.h
@@ -1047,7 +1047,7 @@ static inline char *xstrdup_or_null(const char *str)
 static inline size_t xsize_t(off_t len)
 {
 	if (len < 0 || (uintmax_t) len > SIZE_MAX)
-		die("Cannot handle files this big");
+		die("cannot handle files this big");
 	return (size_t) len;
 }
 

--- a/git-cvsimport.perl
+++ b/git-cvsimport.perl
@@ -90,7 +90,7 @@ sub read_author_info($) {
 sub write_author_info($) {
 	my ($file) = @_;
 	open my $f, '>', $file or
-	  die("Failed to open $file for writing: $!");
+	  die("failed to open $file for writing: $!");
 
 	foreach (keys %conv_author_name) {
 		print $f "$_=$conv_author_name{$_} <$conv_author_email{$_}>";
@@ -316,7 +316,7 @@ sub conn {
 			}
 
 			if (1 < @loc) {
-				die("Multiple cvs password files have ".
+				die("multiple cvs password files have ".
 				    "entries for CVSROOT $opt_d: @loc");
 			} elsif (!$pass) {
 				$pass = "A";

--- a/git-cvsserver.perl
+++ b/git-cvsserver.perl
@@ -267,7 +267,7 @@ while (<STDIN>)
         # a response. If it is, the client will hang, we'll hang, and the whole
         # thing will be custard.
         $log->fatal("Don't understand command $_\n");
-        die("Unknown command $_");
+        die("unknown command $_");
     }
 }
 
@@ -2890,7 +2890,7 @@ sub transmitfile
         }
         close $fh or die ("Couldn't close filehandle for transmitfile(): $!");
     } else {
-        die("Couldn't execute git-cat-file");
+        die("couldn't execute git-cat-file");
     }
 }
 
@@ -3842,7 +3842,7 @@ sub update
     my $commitinfo = ::safe_pipe_capture('git', 'cat-file', 'commit', $self->{module});
     unless ( $commitinfo =~ /tree\s+[a-zA-Z0-9]{$state->{hexsz}}/ )
     {
-        die("Invalid module '$self->{module}'");
+        die("invalid module '$self->{module}'");
     }
 
 
@@ -3856,7 +3856,7 @@ sub update
     }
 
     # Start exclusive lock here...
-    $self->{dbh}->begin_work() or die "Cannot lock database for BEGIN";
+    $self->{dbh}->begin_work() or die "cannot lock database for BEGIN";
 
     # TODO: log processing is memory bound
     # if we can parse into a 2nd file that is in reverse order
@@ -3982,7 +3982,7 @@ sub update
 		chomp;
                 unless ( /^:\d{6}\s+([0-7]{6})\s+[a-f0-9]{$state->{hexsz}}\s+([a-f0-9]{$state->{hexsz}})\s+(\w)$/o )
                 {
-                    die("Couldn't process git-diff-tree line : $_");
+                    die("couldn't process git-diff-tree line : $_");
                 }
 		my ($mode, $hash, $change) = ($1, $2, $3);
 		my $name = <FILELIST>;
@@ -4052,7 +4052,7 @@ sub update
 		chomp;
                 unless ( /^(\d+)\s+(\w+)\s+([a-zA-Z0-9]+)\t(.*)$/o )
                 {
-                    die("Couldn't process git-ls-tree line : $_");
+                    die("couldn't process git-ls-tree line : $_");
                 }
 
                 my ( $mode, $git_type, $git_hash, $git_filename ) = ( $1, $2, $3, $4 );
@@ -4351,7 +4351,7 @@ sub getAnyHead
     my @files;
     {
         open(my $filePipe, '-|', 'git', 'ls-tree', '-z', '-r', $hash)
-                or die("Cannot call git-ls-tree : $!");
+                or die("cannot call git-ls-tree : $!");
         local $/ = "\0";
         @files=<$filePipe>;
         close $filePipe;
@@ -4364,7 +4364,7 @@ sub getAnyHead
         $line=~s/\0$//;
         unless ( $line=~/^(\d+)\s+(\w+)\s+([a-zA-Z0-9]+)\t(.*)$/o )
         {
-            die("Couldn't process git-ls-tree line : $_");
+            die("couldn't process git-ls-tree line : $_");
         }
 
         my($mode, $git_type, $git_hash, $git_filename) = ($1, $2, $3, $4);
@@ -4430,14 +4430,14 @@ sub getRevisionDirMap
         }
 
         open(my $filePipe, '-|', 'git', 'ls-tree', '-z', '-r', $hash)
-                or die("Cannot call git-ls-tree : $!");
+                or die("cannot call git-ls-tree : $!");
         local $/ = "\0";
         while ( <$filePipe> )
         {
             chomp;
             unless ( /^(\d+)\s+(\w+)\s+([a-zA-Z0-9]+)\t(.*)$/o )
             {
-                die("Couldn't process git-ls-tree line : $_");
+                die("couldn't process git-ls-tree line : $_");
             }
 
             my($mode, $git_type, $git_hash, $git_filename) = ($1, $2, $3, $4);
@@ -4835,20 +4835,20 @@ sub getMetaFromCommithash
     # meta data about $filename:
     open(my $filePipe, '-|', 'git', 'ls-tree', '-z',
                 $commit->{hash}, '--', $filename)
-            or die("Cannot call git-ls-tree : $!");
+            or die("cannot call git-ls-tree : $!");
     local $/ = "\0";
     my $line;
     $line=<$filePipe>;
     if(defined(<$filePipe>))
     {
-        die "Expected only a single file for git-ls-tree $filename\n";
+        die "expected only a single file for git-ls-tree $filename\n";
     }
     close $filePipe;
 
     chomp $line;
     unless ( $line=~m/^(\d+)\s+(\w+)\s+([a-zA-Z0-9]+)\t(.*)$/o )
     {
-        die("Couldn't process git-ls-tree line : $line\n");
+        die("couldn't process git-ls-tree line : $line\n");
     }
     my ( $mode, $git_type, $git_hash, $git_filename ) = ( $1, $2, $3, $4 );
 
@@ -4932,7 +4932,7 @@ sub commitmessage
     my $commithash = shift;
     my $tablename = $self->tablename("commitmsgs");
 
-    die("Need commithash") unless ( defined($commithash) and $commithash =~ /^[a-zA-Z0-9]{$state->{hexsz}}$/ );
+    die("need commithash") unless ( defined($commithash) and $commithash =~ /^[a-zA-Z0-9]{$state->{hexsz}}$/ );
 
     my $db_query;
     $db_query = $self->{dbh}->prepare_cached("SELECT value FROM $tablename WHERE key=?",{},1);

--- a/git-p4.py
+++ b/git-p4.py
@@ -236,7 +236,7 @@ def write_pipe(c, stdin, *k, **kw):
     val = pipe.write(stdin)
     pipe.close()
     if p.wait():
-        die('Command failed: {}'.format(' '.join(c)))
+        die('command failed: {}'.format(' '.join(c)))
 
     return val
 
@@ -271,7 +271,7 @@ def read_pipe(c, ignore_error=False, raw=False, *k, **kw):
         if ignore_error:
             out = ""
         else:
-            die('Command failed: {}\nError: {}'.format(' '.join(c), err))
+            die('command failed: {}\nError: {}'.format(' '.join(c), err))
     if not raw:
         out = decode_text_stream(out)
     return out
@@ -300,7 +300,7 @@ def read_pipe_lines(c, raw=False, *k, **kw):
     if not raw:
         lines = [decode_text_stream(line) for line in lines]
     if pipe.close() or p.wait():
-        die('Command failed: {}'.format(' '.join(c)))
+        die('command failed: {}'.format(' '.join(c)))
     return lines
 
 def p4_read_pipe_lines(c, *k, **kw):
@@ -1088,7 +1088,7 @@ def p4ChangesForPaths(depotPaths, changeRange, requestedBlockSize):
             if verbose: print("block size error, retrying with block size {0}".format(block_size))
             continue
         except P4Exception as e:
-            die('Error retrieving changes description ({0})'.format(e.p4ExitCode))
+            die('error retrieving changes description ({0})'.format(e.p4ExitCode))
 
         # Insert changes in chronological order
         for entry in reversed(result):
@@ -1125,7 +1125,7 @@ def getClientSpec():
 
     specList = p4CmdList(["client", "-o"])
     if len(specList) != 1:
-        die('Output from "client -o" is %d lines, expecting 1' %
+        die('output from "client -o" is %d lines, expecting 1' %
             len(specList))
 
     # dictionary of all client parameters
@@ -1144,7 +1144,7 @@ def getClientSpec():
     for view_num in range(len(view_keys)):
         k = "View%d" % view_num
         if k not in view_keys:
-            die("Expected view key %s missing" % k)
+            die("expected view key %s missing" % k)
         view.append(entry[k])
 
     return view
@@ -1154,11 +1154,11 @@ def getClientRoot():
 
     output = p4CmdList(["client", "-o"])
     if len(output) != 1:
-        die('Output from "client -o" is %d lines, expecting 1' % len(output))
+        die('output from "client -o" is %d lines, expecting 1' % len(output))
 
     entry = output[0]
     if "Root" not in entry:
-        die('Client has no "Root"')
+        die('client has no "Root"')
 
     return entry["Root"]
 
@@ -1412,7 +1412,7 @@ class P4UserMap:
             if 'User' in r:
                 self.myP4UserId = r['User']
                 return r['User']
-        die("Could not find your p4 user id")
+        die("could not find your p4 user id")
 
     def p4UserIsMe(self, p4User):
         # return True if the given p4 user is actually me
@@ -1553,11 +1553,11 @@ class P4Submit(Command, P4UserMap):
         self.no_verify = False
 
         if gitConfig('git-p4.largeFileSystem'):
-            die("Large file system not supported for git-p4 submit command. Please remove it from config.")
+            die("large file system not supported for git-p4 submit command. Please remove it from config.")
 
     def check(self):
         if len(p4CmdList(["opened", "..."])) > 0:
-            die("You have files opened with perforce! Close them before starting the sync.")
+            die("you have files opened with perforce! Close them before starting the sync.")
 
     def separate_jobs_from_description(self, message):
         """Extract and return a possible Jobs field in the commit
@@ -1649,11 +1649,11 @@ class P4Submit(Command, P4UserMap):
         for id in commits:
             (user,email) = self.p4UserForCommit(id)
             if not user:
-                msg = "Cannot find p4 user for email %s in commit %s." % (email, id)
+                msg = "cannot find p4 user for email %s in commit %s." % (email, id)
                 if gitConfigBool("git-p4.allowMissingP4Users"):
                     print("%s" % msg)
                 else:
-                    die("Error: %s\nSet git-p4.allowMissingP4Users to true to allow this." % msg)
+                    die("error: %s\nset git-p4.allowMissingP4Users to true to allow this." % msg)
 
     def lastP4Changelist(self):
         # Get back the last changelist number submitted in this client spec. This
@@ -1672,13 +1672,13 @@ class P4Submit(Command, P4UserMap):
         for r in results:
             if 'change' in r:
                 return r['change']
-        die("Could not get changelist number for last submit - cannot patch up user details")
+        die("could not get changelist number for last submit - cannot patch up user details")
 
     def modifyChangelistUser(self, changelist, newUser):
         # fixup the user field of a changelist after it has been submitted.
         changes = p4CmdList(["change", "-o", changelist])
         if len(changes) != 1:
-            die("Bad output from p4 change modifying %s to user %s" %
+            die("bad output from p4 change modifying %s to user %s" %
                 (changelist, newUser))
 
         c = changes[0]
@@ -1691,11 +1691,11 @@ class P4Submit(Command, P4UserMap):
         for r in result:
             if 'code' in r:
                 if r['code'] == 'error':
-                    die("Could not modify user field of changelist %s to %s:%s" % (changelist, newUser, r['data']))
+                    die("could not modify user field of changelist %s to %s:%s" % (changelist, newUser, r['data']))
             if 'data' in r:
                 print("Updated user field for changelist %s to %s" % (changelist, newUser))
                 return
-        die("Could not modify user field of changelist %s to %s" % (changelist, newUser))
+        die("could not modify user field of changelist %s to %s" % (changelist, newUser))
 
     def canChangeChangelists(self):
         # check to see if we have p4 admin or super-user permissions, either of
@@ -1748,7 +1748,7 @@ class P4Submit(Command, P4UserMap):
                 change_entry = entry
                 break
         if not change_entry:
-            die('Failed to decode output of p4 change -o')
+            die('failed to decode output of p4 change -o')
         for key, value in change_entry.items():
             if key.startswith('File'):
                 if 'depot-paths' in settings:
@@ -2224,7 +2224,7 @@ class P4Submit(Command, P4UserMap):
         elif len(args) == 1:
             self.master = args[0]
             if not branchExists(self.master):
-                die("Branch %s does not exist" % self.master)
+                die("branch %s does not exist" % self.master)
         else:
             return False
 
@@ -2247,14 +2247,14 @@ class P4Submit(Command, P4UserMap):
 
         if self.preserveUser:
             if not self.canChangeChangelists():
-                die("Cannot preserve user names without p4 super-user or admin permissions")
+                die("cannot preserve user names without p4 super-user or admin permissions")
 
         # if not set from the command line, try the config file
         if self.conflict_behavior is None:
             val = gitConfig("git-p4.conflict")
             if val:
                 if val not in self.conflict_behavior_choices:
-                    die("Invalid value '%s' for config git-p4.conflict" % val)
+                    die("invalid value '%s' for config git-p4.conflict" % val)
             else:
                 val = "ask"
             self.conflict_behavior = val
@@ -2263,7 +2263,7 @@ class P4Submit(Command, P4UserMap):
             print("Origin branch is " + self.origin)
 
         if len(self.depotPath) == 0:
-            print("Internal error: cannot locate perforce depot path from existing branches")
+            print("internal error: cannot locate perforce depot path from existing branches")
             sys.exit(128)
 
         self.useClientSpec = False
@@ -2282,7 +2282,7 @@ class P4Submit(Command, P4UserMap):
             self.clientPath = p4Where(self.depotPath)
 
         if self.clientPath == "":
-            die("Error: Cannot locate perforce checkout of %s in client view" % self.depotPath)
+            die("error: cannot locate perforce checkout of %s in client view" % self.depotPath)
 
         print("Perforce checkout for depot path %s located at %s" % (self.depotPath, self.clientPath))
         self.oldWorkingDirectory = os.getcwd()
@@ -2413,7 +2413,7 @@ class P4Submit(Command, P4UserMap):
                     elif self.conflict_behavior == "quit":
                         response = "q"
                     else:
-                        die("Unknown conflict_behavior '%s'" %
+                        die("unknown conflict_behavior '%s'" %
                             self.conflict_behavior)
 
                     if response == "s":
@@ -2503,14 +2503,14 @@ class View(object):
             # First word is double quoted.  Find its end.
             close_quote_index = view_line.find('"', 1)
             if close_quote_index <= 0:
-                die("No first-word closing quote found: %s" % view_line)
+                die("no first-word closing quote found: %s" % view_line)
             depot_side = view_line[1:close_quote_index]
             # skip closing quote and space
             rhs_index = close_quote_index + 1 + 1
         else:
             space_index = view_line.find(" ")
             if space_index <= 0:
-                die("No word-splitting space found: %s" % view_line)
+                die("no word-splitting space found: %s" % view_line)
             depot_side = view_line[0:space_index]
             rhs_index = space_index + 1
 
@@ -2530,7 +2530,7 @@ class View(object):
     def convert_client_path(self, clientFile):
         # chop off //client/ part to make it relative
         if not decode_path(clientFile).startswith(self.client_prefix):
-            die("No prefix '%s' on clientFile '%s'" %
+            die("no prefix '%s' on clientFile '%s'" %
                 (self.client_prefix, clientFile))
         return clientFile[len(self.client_prefix):]
 
@@ -2549,7 +2549,7 @@ class View(object):
                 # assume error is "... file(s) not in client view"
                 continue
             if "clientFile" not in res:
-                die("No clientFile in 'p4 where' output")
+                die("no clientFile in 'p4 where' output")
             if "unmap" in res:
                 # it will list all of them, but only one not unmap-ped
                 continue
@@ -2577,7 +2577,7 @@ class View(object):
         if depot_path in self.client_spec_path_cache:
             return self.client_spec_path_cache[depot_path]
 
-        die( "Error: %s is not found in client spec path" % depot_path )
+        die( "error: %s is not found in client spec path" % depot_path )
         return ""
 
 def cloneExcludeCallback(option, opt_str, value, parser):
@@ -2935,9 +2935,9 @@ class P4Sync(Command, P4UserMap):
             # ignore errors, but make sure it exits first
             self.importProcess.wait()
             if f:
-                die("Error from p4 print for %s: %s" % (f, err))
+                die("error from p4 print for %s: %s" % (f, err))
             else:
-                die("Error from p4 print: %s" % err)
+                die("error from p4 print: %s" % err)
 
         if 'depotFile' in marshalled and self.stream_have_file_info:
             # start of a new file - output the old one first
@@ -3423,7 +3423,7 @@ class P4Sync(Command, P4UserMap):
                 earliestCommit = "^%s" % next
             else:
                 if next == latestCommit:
-                    die("Infinite loop while looking in ref %s for change %s. Check your branch mappings" % (ref, change))
+                    die("infinite loop while looking in ref %s for change %s. Check your branch mappings" % (ref, change))
                 latestCommit = "%s^@" % next
 
         return ""
@@ -3839,7 +3839,7 @@ class P4Sync(Command, P4UserMap):
                     bad_changesfile = True
                     break
         if bad_changesfile:
-            die("Option --changesfile is incompatible with revision specifiers")
+            die("option --changesfile is incompatible with revision specifiers")
 
         newPaths = []
         for p in self.depotPaths:
@@ -3961,13 +3961,13 @@ class P4Rebase(Command):
 
     def rebase(self):
         if os.system("git update-index --refresh") != 0:
-            die("Some files in your working directory are modified and different than what is in your index. You can use git update-index <filename> to bring the index up to date or stash away all your changes with git stash.");
+            die("some files in your working directory are modified and different than what is in your index. You can use git update-index <filename> to bring the index up to date or stash away all your changes with git stash.");
         if len(read_pipe(["git", "diff-index", "HEAD", "--"])) > 0:
-            die("You have uncommitted changes. Please commit them before rebasing or stash them away with git stash.");
+            die("you have uncommitted changes. Please commit them before rebasing or stash them away with git stash.");
 
         [upstream, settings] = findUpstreamBranchPoint()
         if len(upstream) == 0:
-            die("Cannot find upstream branchpoint for rebase")
+            die("cannot find upstream branchpoint for rebase")
 
         # the branchpoint may be p4/foo~3, so strip off the parent
         upstream = re.sub("~[0-9]+$", "", upstream)

--- a/grep.c
+++ b/grep.c
@@ -281,7 +281,7 @@ static void compile_pcre2_pattern(struct grep_pat *p, const struct grep_opt *opt
 	p->pcre2_general_context = pcre2_general_context_create(
 		pcre2_malloc, pcre2_free, NULL);
 	if (!p->pcre2_general_context)
-		die("Couldn't allocate PCRE2 general context");
+		die("couldn't allocate PCRE2 general context");
 
 	if (opt->ignore_case) {
 		if (!opt->ignore_locale && has_non_ascii(p->pattern)) {
@@ -308,7 +308,7 @@ static void compile_pcre2_pattern(struct grep_pat *p, const struct grep_opt *opt
 	if (p->pcre2_pattern) {
 		p->pcre2_match_data = pcre2_match_data_create_from_pattern(p->pcre2_pattern, p->pcre2_general_context);
 		if (!p->pcre2_match_data)
-			die("Couldn't allocate PCRE2 match data");
+			die("couldn't allocate PCRE2 match data");
 	} else {
 		pcre2_get_error_message(error, errbuf, sizeof(errbuf));
 		compile_regexp_failed(p, (const char *)&errbuf);
@@ -318,7 +318,7 @@ static void compile_pcre2_pattern(struct grep_pat *p, const struct grep_opt *opt
 	if (p->pcre2_jit_on) {
 		jitret = pcre2_jit_compile(p->pcre2_pattern, PCRE2_JIT_COMPLETE);
 		if (jitret)
-			die("Couldn't JIT the PCRE2 pattern '%s', got '%d'\n", p->pattern, jitret);
+			die("couldn't JIT the PCRE2 pattern '%s', got '%d'\n", p->pattern, jitret);
 
 		/*
 		 * The pcre2_config(PCRE2_CONFIG_JIT, ...) call just
@@ -972,7 +972,7 @@ static int match_expr_eval(struct grep_opt *opt, struct grep_expr *x,
 	int h = 0;
 
 	if (!x)
-		die("Not a valid grep expression");
+		die("not a valid grep expression");
 	switch (x->node) {
 	case GREP_NODE_TRUE:
 		h = 1;
@@ -1028,7 +1028,7 @@ static int match_expr_eval(struct grep_opt *opt, struct grep_expr *x,
 				     icol, collect_hits);
 		break;
 	default:
-		die("Unexpected node type (internal error) %d", x->node);
+		die("unexpected node type (internal error) %d", x->node);
 	}
 	if (collect_hits)
 		x->hit |= h;

--- a/help.c
+++ b/help.c
@@ -629,7 +629,7 @@ const char *help_unknown_cmd(const char *cmd)
 	QSORT(main_cmds.names, main_cmds.cnt, levenshtein_compare);
 
 	if (!main_cmds.cnt)
-		die(_("Uh oh. Your system reports no Git commands at all."));
+		die(_("uh oh. Your system reports no Git commands at all."));
 
 	/* skip and count prefix matches */
 	for (n = 0; n < main_cmds.cnt && !main_cmds.names[n]->len; n++)

--- a/http-backend.c
+++ b/http-backend.c
@@ -696,7 +696,7 @@ static char* getdir(void)
 	} else if (path && *path) {
 		return xstrdup(path);
 	} else
-		die("No GIT_PROJECT_ROOT or PATH_TRANSLATED from server");
+		die("no GIT_PROJECT_ROOT or PATH_TRANSLATED from server");
 	return NULL;
 }
 
@@ -750,7 +750,7 @@ int cmd_main(int argc, const char **argv)
 	set_die_is_recursing_routine(die_webcgi_recursing);
 
 	if (!method)
-		die("No REQUEST_METHOD from server");
+		die("no REQUEST_METHOD from server");
 	if (!strcmp(method, "HEAD"))
 		method = "GET";
 	dir = getdir();
@@ -761,7 +761,7 @@ int cmd_main(int argc, const char **argv)
 		regmatch_t out[1];
 
 		if (regcomp(&re, c->pattern, REG_EXTENDED))
-			die("Bogus regex in service table: %s", c->pattern);
+			die("bogus regex in service table: %s", c->pattern);
 		if (!regexec(&re, dir, 1, out, 0)) {
 			size_t n;
 

--- a/http-fetch.c
+++ b/http-fetch.c
@@ -77,7 +77,7 @@ static void fetch_single_packfile(struct object_id *packfile_hash,
 			}
 		}
 	} else {
-		die("Unable to start request");
+		die("unable to start request");
 	}
 
 	if ((ret = finish_http_pack_request(preq)))

--- a/http-push.c
+++ b/http-push.c
@@ -1541,7 +1541,7 @@ static void fetch_symref(const char *path, char **symref, struct object_id *oid)
 	const char *name;
 
 	if (http_get_strbuf(url, &buffer, NULL) != HTTP_OK)
-		die("Couldn't get %s for remote symref\n%s", url,
+		die("couldn't get %s for remote symref\n%s", url,
 		    curl_errorstr);
 	free(url);
 
@@ -1757,7 +1757,7 @@ int cmd_main(int argc, const char **argv)
 		usage(http_push_usage);
 
 	if (delete_branch && rs.nr != 1)
-		die("You must specify only one branch name when deleting a remote branch");
+		die("you must specify only one branch name when deleting a remote branch");
 
 	setup_git_directory();
 

--- a/http.c
+++ b/http.c
@@ -964,7 +964,7 @@ static CURL *get_curl_handle(void)
 		}
 
 		if (!proxy_auth.host)
-			die("Invalid proxy URL '%s'", curl_http_proxy);
+			die("invalid proxy URL '%s'", curl_http_proxy);
 
 		curl_easy_setopt(result, CURLOPT_PROXY, proxy_auth.host);
 		var_override(&curl_no_proxy, getenv("NO_PROXY"));
@@ -1020,11 +1020,11 @@ void http_init(struct remote *remote, const char *url, int proactive_auth)
 				strbuf_addf(&buf, "\n\t%s", backends[i]->name);
 			die("%s", buf.buf);
 		case CURLSSLSET_NO_BACKENDS:
-			die(_("Could not set SSL backend to '%s': "
+			die(_("could not set SSL backend to '%s': "
 			      "cURL was built without SSL backends"),
 			    http_ssl_backend);
 		case CURLSSLSET_TOO_LATE:
-			die(_("Could not set SSL backend to '%s': already set"),
+			die(_("could not set SSL backend to '%s': already set"),
 			    http_ssl_backend);
 		case CURLSSLSET_OK:
 			break; /* Okay! */

--- a/imap-send.c
+++ b/imap-send.c
@@ -76,7 +76,7 @@ static int nfvasprintf(char **strp, const char *fmt, va_list ap)
 
 	len = vsnprintf(tmp, sizeof(tmp), fmt, ap);
 	if (len < 0)
-		die("Fatal: Out of memory");
+		die("fatal: Out of memory");
 	if (len >= sizeof(tmp))
 		die("imap command overflow!");
 	*strp = xmemdupz(tmp, len);
@@ -907,7 +907,7 @@ static char *cram(const char *challenge_64, const char *user, const char *pass)
 
 static char *cram(const char *challenge_64, const char *user, const char *pass)
 {
-	die("If you want to use CRAM-MD5 authenticate method, "
+	die("if you want to use CRAM-MD5 authenticate method, "
 	    "you have to build git-imap-send with OpenSSL library.");
 }
 

--- a/line-log.c
+++ b/line-log.c
@@ -482,9 +482,9 @@ static struct commit *check_single_commit(struct rev_info *revs)
 			continue;
 		obj = deref_tag(revs->repo, obj, NULL, 0);
 		if (!obj || obj->type != OBJ_COMMIT)
-			die("Non commit %s?", revs->pending.objects[i].name);
+			die("non commit %s?", revs->pending.objects[i].name);
 		if (commit)
-			die("More than one commit to dig from: %s and %s?",
+			die("more than one commit to dig from: %s and %s?",
 			    revs->pending.objects[i].name,
 			    revs->pending.objects[found].name);
 		commit = obj;
@@ -492,7 +492,7 @@ static struct commit *check_single_commit(struct rev_info *revs)
 	}
 
 	if (!commit)
-		die("No commit specified?");
+		die("no commit specified?");
 
 	return (struct commit *) commit;
 }
@@ -504,7 +504,7 @@ static void fill_blob_sha1(struct repository *r, struct commit *commit,
 	struct object_id oid;
 
 	if (get_tree_entry(r, &commit->object.oid, spec->path, &oid, &mode))
-		die("There is no path %s in the commit", spec->path);
+		die("there is no path %s in the commit", spec->path);
 	fill_filespec(spec, &oid, 1, mode);
 
 	return;
@@ -521,7 +521,7 @@ static void fill_line_ends(struct repository *r,
 	char *data = NULL;
 
 	if (diff_populate_filespec(r, spec, NULL))
-		die("Cannot read blob %s", oid_to_hex(&spec->oid));
+		die("cannot read blob %s", oid_to_hex(&spec->oid));
 
 	ALLOC_ARRAY(ends, size);
 	ends[cur++] = 0;

--- a/notes-merge.c
+++ b/notes-merge.c
@@ -273,14 +273,14 @@ static void check_notes_merge_worktree(struct notes_merge_options *o)
 		if (file_exists(git_path(NOTES_MERGE_WORKTREE)) &&
 		    !is_empty_dir(git_path(NOTES_MERGE_WORKTREE))) {
 			if (advice_enabled(ADVICE_RESOLVE_CONFLICT))
-				die(_("You have not concluded your previous "
+				die(_("you have not concluded your previous "
 				    "notes merge (%s exists).\nPlease, use "
 				    "'git notes merge --commit' or 'git notes "
 				    "merge --abort' to commit/abort the "
 				    "previous merge before you start a new "
 				    "notes merge."), git_path("NOTES_MERGE_*"));
 			else
-				die(_("You have not concluded your notes merge "
+				die(_("you have not concluded your notes merge "
 				    "(%s exists)."), git_path("NOTES_MERGE_*"));
 		}
 
@@ -358,10 +358,10 @@ static int ll_merge_in_worktree(struct notes_merge_options *o,
 	free(remote.ptr);
 
 	if (status == LL_MERGE_BINARY_CONFLICT)
-		warning("Cannot merge binary files: %s (%s vs. %s)",
+		warning("cannot merge binary files: %s (%s vs. %s)",
 			oid_to_hex(&p->obj), o->local_ref, o->remote_ref);
 	if ((status < 0) || !result_buf.ptr)
-		die("Failed to execute internal merge");
+		die("failed to execute internal merge");
 
 	write_buf_to_worktree(&p->obj, result_buf.ptr, result_buf.size);
 	free(result_buf.ptr);
@@ -469,7 +469,7 @@ static int merge_one_change(struct notes_merge_options *o,
 			    "(combine_notes_cat_sort_uniq)");
 		return 0;
 	}
-	die("Unknown strategy (%i).", o->strategy);
+	die("unknown strategy (%i).", o->strategy);
 }
 
 static int merge_changes(struct notes_merge_options *o,
@@ -556,12 +556,12 @@ int notes_merge(struct notes_merge_options *o,
 
 	/* Dereference o->local_ref into local_sha1 */
 	if (read_ref_full(o->local_ref, 0, &local_oid, NULL))
-		die("Failed to resolve local notes ref '%s'", o->local_ref);
+		die("failed to resolve local notes ref '%s'", o->local_ref);
 	else if (!check_refname_format(o->local_ref, 0) &&
 		is_null_oid(&local_oid))
 		local = NULL; /* local_oid == null_oid indicates unborn ref */
 	else if (!(local = lookup_commit_reference(o->repo, &local_oid)))
-		die("Could not parse local commit %s (%s)",
+		die("could not parse local commit %s (%s)",
 		    oid_to_hex(&local_oid), o->local_ref);
 	trace_printf("\tlocal commit: %.7s\n", oid_to_hex(&local_oid));
 
@@ -575,17 +575,17 @@ int notes_merge(struct notes_merge_options *o,
 			oidclr(&remote_oid);
 			remote = NULL;
 		} else {
-			die("Failed to resolve remote notes ref '%s'",
+			die("failed to resolve remote notes ref '%s'",
 			    o->remote_ref);
 		}
 	} else if (!(remote = lookup_commit_reference(o->repo, &remote_oid))) {
-		die("Could not parse remote commit %s (%s)",
+		die("could not parse remote commit %s (%s)",
 		    oid_to_hex(&remote_oid), o->remote_ref);
 	}
 	trace_printf("\tremote commit: %.7s\n", oid_to_hex(&remote_oid));
 
 	if (!local && !remote)
-		die("Cannot merge empty notes ref (%s) into empty notes ref "
+		die("cannot merge empty notes ref (%s) into empty notes ref "
 		    "(%s)", o->remote_ref, o->local_ref);
 	if (!local) {
 		/* result == remote commit */
@@ -711,11 +711,11 @@ int notes_merge_commit(struct notes_merge_options *o,
 		strbuf_addstr(&path, e->d_name);
 		/* write file as blob, and add to partial_tree */
 		if (stat(path.buf, &st))
-			die_errno("Failed to stat '%s'", path.buf);
+			die_errno("failed to stat '%s'", path.buf);
 		if (index_path(o->repo->index, &blob_oid, path.buf, &st, HASH_WRITE_OBJECT))
-			die("Failed to write blob object from '%s'", path.buf);
+			die("failed to write blob object from '%s'", path.buf);
 		if (add_note(partial_tree, &obj_oid, &blob_oid, NULL))
-			die("Failed to add resolved note '%s' to notes tree",
+			die("failed to add resolved note '%s' to notes tree",
 			    path.buf);
 		if (o->verbosity >= 4)
 			printf("Added resolved note for object %s: %s\n",

--- a/notes-utils.c
+++ b/notes-utils.c
@@ -16,7 +16,7 @@ void create_notes_commit(struct repository *r,
 	assert(t->initialized);
 
 	if (write_notes_tree(t, &tree_oid))
-		die("Failed to write notes tree to database");
+		die("failed to write notes tree to database");
 
 	if (!parents) {
 		/* Deduce parent commit from t->ref */
@@ -24,7 +24,7 @@ void create_notes_commit(struct repository *r,
 		if (!read_ref(t->ref, &parent_oid)) {
 			struct commit *parent = lookup_commit(r, &parent_oid);
 			if (parse_commit(parent))
-				die("Failed to find/parse commit %s", t->ref);
+				die("failed to find/parse commit %s", t->ref);
 			commit_list_insert(parent, &parents);
 		}
 		/* else: t->ref points to nothing, assume root/orphan commit */
@@ -32,7 +32,7 @@ void create_notes_commit(struct repository *r,
 
 	if (commit_tree(msg, msg_len, &tree_oid, parents, result_oid, NULL,
 			NULL))
-		die("Failed to commit notes tree to database");
+		die("failed to commit notes tree to database");
 }
 
 void commit_notes(struct repository *r, struct notes_tree *t, const char *msg)
@@ -43,7 +43,7 @@ void commit_notes(struct repository *r, struct notes_tree *t, const char *msg)
 	if (!t)
 		t = &default_notes_tree;
 	if (!t->initialized || !t->update_ref || !*t->update_ref)
-		die(_("Cannot commit uninitialized/unreferenced notes tree"));
+		die(_("cannot commit uninitialized/unreferenced notes tree"));
 	if (!t->dirty)
 		return; /* don't have to commit an unchanged tree */
 

--- a/notes.c
+++ b/notes.c
@@ -401,7 +401,7 @@ static void load_subtree(struct notes_tree *t, struct leaf_node *subtree,
 
 	buf = fill_tree_descriptor(the_repository, &desc, &subtree->val_oid);
 	if (!buf)
-		die("Could not read %s for notes-index",
+		die("could not read %s for notes-index",
 		     oid_to_hex(&subtree->val_oid));
 
 	prefix_len = subtree->key_oid.hash[KEY_INDEX];
@@ -459,7 +459,7 @@ static void load_subtree(struct notes_tree *t, struct leaf_node *subtree,
 		oid_set_algo(&l->val_oid, the_hash_algo);
 		if (note_tree_insert(t, node, n, l, type,
 				     combine_notes_concatenate))
-			die("Failed to load %s %s into notes tree "
+			die("failed to load %s %s into notes tree "
 			    "from %s",
 			    type == PTR_TYPE_NOTE ? "note" : "subtree",
 			    oid_to_hex(&object_oid), t->ref);
@@ -1022,9 +1022,9 @@ void init_notes(struct notes_tree *t, const char *notes_ref,
 	    get_oid_treeish(notes_ref, &object_oid))
 		return;
 	if (flags & NOTES_INIT_WRITABLE && read_ref(notes_ref, &object_oid))
-		die("Cannot use notes ref %s", notes_ref);
+		die("cannot use notes ref %s", notes_ref);
 	if (get_tree_entry(the_repository, &object_oid, "", &oid, &mode))
-		die("Failed to read notes tree referenced by %s (%s)",
+		die("failed to read notes tree referenced by %s (%s)",
 		    notes_ref, oid_to_hex(&object_oid));
 
 	oidclr(&root_tree.key_oid);

--- a/pack-bitmap-write.c
+++ b/pack-bitmap-write.c
@@ -100,7 +100,7 @@ void bitmap_writer_build_type_index(struct packing_data *to_pack,
 			break;
 
 		default:
-			die("Missing type information for %s (%d/%d)",
+			die("missing type information for %s (%d/%d)",
 			    oid_to_hex(&entry->idx.oid), real_type,
 			    oe_type(entry));
 		}
@@ -451,7 +451,7 @@ static void store_selected(struct bb_commit *ent, struct commit *commit)
 
 	hash_pos = kh_put_oid_map(writer.bitmaps, commit->object.oid, &hash_ret);
 	if (hash_ret == 0)
-		die("Duplicate entry when writing index: %s",
+		die("duplicate entry when writing index: %s",
 		    oid_to_hex(&commit->object.oid));
 	kh_value(writer.bitmaps, hash_pos) = stored;
 }
@@ -638,7 +638,7 @@ static int hashwrite_ewah_helper(void *f, const void *buf, size_t len)
 static inline void dump_bitmap(struct hashfile *f, struct ewah_bitmap *bitmap)
 {
 	if (ewah_serialize_to(bitmap, hashwrite_ewah_helper, f) < 0)
-		die("Failed to write bitmap index");
+		die("failed to write bitmap index");
 }
 
 static const struct object_id *oid_access(size_t pos, const void *table)

--- a/pack-bitmap.c
+++ b/pack-bitmap.c
@@ -1648,7 +1648,7 @@ static void test_show_object(struct object *object, const char *name,
 
 	bitmap_pos = bitmap_position(tdata->bitmap_git, &object->oid);
 	if (bitmap_pos < 0)
-		die("Object not in bitmap: %s\n", oid_to_hex(&object->oid));
+		die("object not in bitmap: %s\n", oid_to_hex(&object->oid));
 	test_bitmap_type(tdata, object, bitmap_pos);
 
 	bitmap_set(tdata->base, bitmap_pos);
@@ -1663,7 +1663,7 @@ static void test_show_commit(struct commit *commit, void *data)
 	bitmap_pos = bitmap_position(tdata->bitmap_git,
 				     &commit->object.oid);
 	if (bitmap_pos < 0)
-		die("Object not in bitmap: %s\n", oid_to_hex(&commit->object.oid));
+		die("object not in bitmap: %s\n", oid_to_hex(&commit->object.oid));
 	test_bitmap_type(tdata, &commit->object, bitmap_pos);
 
 	bitmap_set(tdata->base, bitmap_pos);
@@ -1692,14 +1692,14 @@ void test_bitmap_walk(struct rev_info *revs)
 	bm = bitmap_for_commit(bitmap_git, (struct commit *)root);
 
 	if (bm) {
-		fprintf(stderr, "Found bitmap for %s. %d bits / %08x checksum\n",
+		fprintf(stderr, "found bitmap for %s. %d bits / %08x checksum\n",
 			oid_to_hex(&root->oid), (int)bm->bit_size, ewah_checksum(bm));
 
 		result = ewah_to_bitmap(bm);
 	}
 
 	if (result == NULL)
-		die("Commit %s doesn't have an indexed bitmap", oid_to_hex(&root->oid));
+		die("commit %s doesn't have an indexed bitmap", oid_to_hex(&root->oid));
 
 	revs->tag_objects = 1;
 	revs->tree_objects = 1;

--- a/pack-write.c
+++ b/pack-write.c
@@ -119,7 +119,7 @@ const char *write_idx_file(const char *index_name, struct pack_idx_entry **objec
 		hashwrite(f, obj->oid.hash, the_hash_algo->rawsz);
 		if ((opts->flags & WRITE_IDX_STRICT) &&
 		    (i && oideq(&list[-2]->oid, &obj->oid)))
-			die("The same object %s appears twice in the pack",
+			die("the same object %s appears twice in the pack",
 			    oid_to_hex(&obj->oid));
 	}
 

--- a/pathspec.c
+++ b/pathspec.c
@@ -147,7 +147,7 @@ static char *attr_value_unescape(const char *value)
 	for (src = value, dst = ret; *src; src++, dst++) {
 		if (*src == '\\') {
 			if (!src[1])
-				die(_("Escape character '\\' not allowed as "
+				die(_("escape character '\\' not allowed as "
 				      "last character in attr value"));
 			src++;
 		}
@@ -165,7 +165,7 @@ static void parse_pathspec_attr_match(struct pathspec_item *item, const char *va
 	struct string_list list = STRING_LIST_INIT_DUP;
 
 	if (item->attr_check || item->attr_match)
-		die(_("Only one 'attr:' specification is allowed."));
+		die(_("only one 'attr:' specification is allowed."));
 
 	if (!value || !*value)
 		die(_("attr spec must not be empty"));
@@ -344,12 +344,12 @@ static const char *parse_long_magic(unsigned *magic, int *prefix_len,
 		}
 
 		if (ARRAY_SIZE(pathspec_magic) <= i)
-			die(_("Invalid pathspec magic '%.*s' in '%s'"),
+			die(_("invalid pathspec magic '%.*s' in '%s'"),
 			    (int) len, pos, elem);
 	}
 
 	if (*pos != ')')
-		die(_("Missing ')' at the end of pathspec magic in '%s'"),
+		die(_("missing ')' at the end of pathspec magic in '%s'"),
 		    elem);
 	pos++;
 
@@ -387,7 +387,7 @@ static const char *parse_short_magic(unsigned *magic, const char *elem)
 		}
 
 		if (ARRAY_SIZE(pathspec_magic) <= i)
-			die(_("Unimplemented pathspec magic '%c' in '%s'"),
+			die(_("unimplemented pathspec magic '%c' in '%s'"),
 			    ch, elem);
 	}
 

--- a/ref-filter.c
+++ b/ref-filter.c
@@ -1546,7 +1546,7 @@ static void grab_values(struct atom_value *val, int deref, struct object *obj, s
 		grab_sub_body_contents(val, deref, data);
 		break;
 	default:
-		die("Eh?  Object of type %d?", obj->type);
+		die("eh?  Object of type %d?", obj->type);
 	}
 }
 

--- a/refs.h
+++ b/refs.h
@@ -899,7 +899,7 @@ struct ref_store *get_main_ref_store(struct repository *r);
  *
  * 	const char *path = "path/to/submodule"
  * 	if (add_submodule_odb(path))
- * 		die("Error submodule '%s' not populated.", path);
+ * 		die("error submodule '%s' not populated.", path);
  *
  * `add_submodule_odb()` will return zero on success. If you
  * do not do this you will get an error for each ref that it does not point

--- a/refs/ref-cache.c
+++ b/refs/ref-cache.c
@@ -213,12 +213,12 @@ static int is_dup_ref(const struct ref_entry *ref1, const struct ref_entry *ref2
 
 	if ((ref1->flag & REF_DIR) || (ref2->flag & REF_DIR))
 		/* This is impossible by construction */
-		die("Reference directory conflict: %s", ref1->name);
+		die("reference directory conflict: %s", ref1->name);
 
 	if (!oideq(&ref1->u.value.oid, &ref2->u.value.oid))
-		die("Duplicated ref, and SHA1s don't match: %s", ref1->name);
+		die("duplicated ref, and SHA1s don't match: %s", ref1->name);
 
-	warning("Duplicated ref: %s", ref1->name);
+	warning("duplicated ref: %s", ref1->name);
 	return 1;
 }
 

--- a/remote-curl.c
+++ b/remote-curl.c
@@ -497,7 +497,7 @@ static struct discovery *discover_refs(const char *service, int for_push)
 		    transport_anonymize_url(url.buf));
 	case HTTP_NOAUTH:
 		show_http_message(&type, &charset, &buffer);
-		die(_("Authentication failed for '%s'"),
+		die(_("authentication failed for '%s'"),
 		    transport_anonymize_url(url.buf));
 	case HTTP_NOMATCHPUBLICKEY:
 		show_http_message(&type, &charset, &buffer);

--- a/remote.c
+++ b/remote.c
@@ -695,7 +695,7 @@ static void handle_duplicate(struct ref *ref1, struct ref *ref2)
 	if (strcmp(ref1->name, ref2->name)) {
 		if (ref1->fetch_head_status != FETCH_HEAD_IGNORE &&
 		    ref2->fetch_head_status != FETCH_HEAD_IGNORE) {
-			die(_("Cannot fetch both %s and %s to %s"),
+			die(_("cannot fetch both %s and %s to %s"),
 			    ref1->name, ref2->name, ref2->peer_ref->name);
 		} else if (ref1->fetch_head_status != FETCH_HEAD_IGNORE &&
 			   ref2->fetch_head_status == FETCH_HEAD_IGNORE) {

--- a/sequencer.c
+++ b/sequencer.c
@@ -571,7 +571,7 @@ enum commit_msg_cleanup_mode get_cleanup_mode(const char *cleanup_arg,
 		return use_editor ? COMMIT_MSG_CLEANUP_SCISSORS :
 				    COMMIT_MSG_CLEANUP_SPACE;
 	else
-		die(_("Invalid cleanup mode %s"), cleanup_arg);
+		die(_("invalid cleanup mode %s"), cleanup_arg);
 }
 
 /*
@@ -4107,19 +4107,19 @@ void create_autostash(struct repository *r, const char *path)
 		stash.no_stdin = 1;
 		strbuf_reset(&buf);
 		if (capture_command(&stash, &buf, GIT_MAX_HEXSZ))
-			die(_("Cannot autostash"));
+			die(_("cannot autostash"));
 		strbuf_trim_trailing_newline(&buf);
 		if (get_oid(buf.buf, &oid))
-			die(_("Unexpected stash response: '%s'"),
+			die(_("unexpected stash response: '%s'"),
 			    buf.buf);
 		strbuf_reset(&buf);
 		strbuf_add_unique_abbrev(&buf, &oid, DEFAULT_ABBREV);
 
 		if (safe_create_leading_directories_const(path))
-			die(_("Could not create directory for '%s'"),
+			die(_("could not create directory for '%s'"),
 			    path);
 		write_file(path, "%s", oid_to_hex(&oid));
-		printf(_("Created autostash: %s\n"), buf.buf);
+		printf(_("created autostash: %s\n"), buf.buf);
 		if (reset_head(r, &ropts) < 0)
 			die(_("could not reset --hard"));
 		if (discard_index(r->index) < 0 ||

--- a/submodule.c
+++ b/submodule.c
@@ -112,11 +112,11 @@ int update_path_in_gitmodules(const char *oldpath, const char *newpath)
 		return -1;
 
 	if (is_gitmodules_unmerged(the_repository->index))
-		die(_("Cannot change unmerged .gitmodules, resolve merge conflicts first"));
+		die(_("cannot change unmerged .gitmodules, resolve merge conflicts first"));
 
 	submodule = submodule_from_path(the_repository, null_oid(), oldpath);
 	if (!submodule || !submodule->name) {
-		warning(_("Could not find section in .gitmodules where path=%s"), oldpath);
+		warning(_("could not find section in .gitmodules where path=%s"), oldpath);
 		return -1;
 	}
 	strbuf_addstr(&entry, "submodule.");
@@ -374,7 +374,7 @@ void die_path_inside_submodule(struct index_state *istate,
 			if (item->len == ce_len + 1)
 				continue;
 
-			die(_("Pathspec '%s' is in submodule '%.*s'"),
+			die(_("pathspec '%s' is in submodule '%.*s'"),
 			    item->original, ce_len, ce->name);
 		}
 	}
@@ -1066,7 +1066,7 @@ static int submodule_needs_pushing(struct repository *r,
 		cp.out = -1;
 		cp.dir = path;
 		if (start_command(&cp))
-			die(_("Could not run 'git rev-list <commits> --not --remotes -n 1' command in submodule %s"),
+			die(_("could not run 'git rev-list <commits> --not --remotes -n 1' command in submodule %s"),
 					path);
 		if (strbuf_read(&buf, cp.out, the_hash_algo->hexsz + 1))
 			needs_pushing = 1;
@@ -1218,7 +1218,7 @@ int push_unpushed_submodules(struct repository *r,
 
 		head = resolve_refdup("HEAD", 0, &head_oid, NULL);
 		if (!head)
-			die(_("Failed to resolve HEAD as a valid ref."));
+			die(_("failed to resolve HEAD as a valid ref."));
 
 		for (i = 0; i < needs_pushing.nr; i++)
 			submodule_push_check(needs_pushing.items[i].string,

--- a/t/helper/test-config.c
+++ b/t/helper/test-config.c
@@ -178,7 +178,7 @@ int cmd__config(int argc, const char **argv)
 		goto exit0;
 	}
 
-	die("%s: Please check the syntax and the function name", argv[0]);
+	die("%s: please check the syntax and the function name", argv[0]);
 
 exit0:
 	git_configset_clear(&cs);

--- a/t/helper/test-fake-ssh.c
+++ b/t/helper/test-fake-ssh.c
@@ -12,11 +12,11 @@ int cmd_main(int argc, const char **argv)
 
 	/* First, print all parameters into $TRASH_DIRECTORY/ssh-output */
 	if (!trash_directory)
-		die("Need a TRASH_DIRECTORY!");
+		die("need a TRASH_DIRECTORY!");
 	strbuf_addf(&buf, "%s/ssh-output", trash_directory);
 	f = fopen(buf.buf, "w");
 	if (!f)
-		die("Could not write to %s", buf.buf);
+		die("could not write to %s", buf.buf);
 	for (i = 0; i < argc; i++)
 		fprintf(f, "%s%s", i > 0 ? " " : "", i > 0 ? argv[i] : "ssh:");
 	fprintf(f, "\n");

--- a/t/helper/test-fast-rebase.c
+++ b/t/helper/test-fast-rebase.c
@@ -119,12 +119,12 @@ int cmd__fast_rebase(int argc, const char **argv)
 
 	/* Sanity check */
 	if (get_oid("HEAD", &head))
-		die(_("Cannot read HEAD"));
+		die(_("cannot read HEAD"));
 	assert(oideq(&onto->object.oid, &head));
 
 	hold_locked_index(&lock, LOCK_DIE_ON_ERROR);
 	if (repo_read_index(the_repository) < 0)
-		BUG("Could not read index");
+		BUG("could not read index");
 
 	repo_init_revisions(the_repository, &revs, NULL);
 	revs.verbose_header = 1;
@@ -215,7 +215,7 @@ int cmd__fast_rebase(int argc, const char **argv)
 			       &head,
 			       REF_NO_DEREF, UPDATE_REFS_MSG_ON_ERR)) {
 			error(_("could not update %s"), argv[4]);
-			die("Failed to update %s", argv[4]);
+			die("failed to update %s", argv[4]);
 		}
 	}
 	if (write_locked_index(&the_index, &lock,

--- a/t/helper/test-run-command.c
+++ b/t/helper/test-run-command.c
@@ -151,7 +151,7 @@ static int testsuite(int argc, const char **argv)
 
 	dir = opendir(".");
 	if (!dir)
-		die("Could not open the current directory");
+		die("could not open the current directory");
 	while ((d = readdir(dir))) {
 		const char *p = d->d_name;
 
@@ -175,7 +175,7 @@ static int testsuite(int argc, const char **argv)
 	closedir(dir);
 
 	if (!suite.tests.nr)
-		die("No tests match!");
+		die("no tests match!");
 	if (max_jobs > suite.tests.nr)
 		max_jobs = suite.tests.nr;
 
@@ -342,15 +342,15 @@ static int inherit_handle(const char *argv0)
 	cp.in = -1;
 	cp.no_stdout = cp.no_stderr = 1;
 	if (start_command(&cp) < 0)
-		die("Could not start child process");
+		die("could not start child process");
 
 	/* Then close it, and try to delete it. */
 	close(tmp);
 	if (unlink(path))
-		die("Could not delete '%s'", path);
+		die("could not delete '%s'", path);
 
 	if (close(cp.in) < 0 || finish_command(&cp) < 0)
-		die("Child did not finish");
+		die("child did not finish");
 
 	return 0;
 }
@@ -360,7 +360,7 @@ static int inherit_handle_child(void)
 	struct strbuf buf = STRBUF_INIT;
 
 	if (strbuf_read(&buf, 0, 0) < 0)
-		die("Could not read stdin");
+		die("could not read stdin");
 	printf("Received %s\n", buf.buf);
 	strbuf_release(&buf);
 

--- a/t/helper/test-simple-ipc.c
+++ b/t/helper/test-simple-ipc.c
@@ -681,6 +681,6 @@ int cmd__simple_ipc(int argc, const char **argv)
 		return !!client__multiple();
 	}
 
-	die("Unhandled subcommand: '%s'", cl_args.subcommand);
+	die("unhandled subcommand: '%s'", cl_args.subcommand);
 }
 #endif

--- a/t/helper/test-subprocess.c
+++ b/t/helper/test-subprocess.c
@@ -9,7 +9,7 @@ int cmd__subprocess(int argc, const char **argv)
 
 	setup_git_directory_gently(&nogit);
 	if (nogit)
-		die("No git repo found");
+		die("no git repo found");
 	if (argc > 1 && !strcmp(argv[1], "--setup-work-tree")) {
 		setup_work_tree();
 		argv++;

--- a/t/t0212/parse_events.perl
+++ b/t/t0212/parse_events.perl
@@ -49,7 +49,7 @@ GetOptions("children!" => \$show_children,
 	   "threads!"  => \$show_threads,
 	   "HEREDOC!"  => \$gen_heredoc,
 	   "VERSION=s" => \$gen_version    )
-    or die("Error in command line arguments\n");
+    or die("error in command line arguments\n");
 
 
 # SIDs contains timestamps and PIDs of the process and its parents.

--- a/transport.c
+++ b/transport.c
@@ -1201,7 +1201,7 @@ static void die_with_unpushed_submodules(struct string_list *needs_pushing)
 
 	string_list_clear(needs_pushing, 0);
 
-	die(_("Aborting."));
+	die(_("aborting"));
 }
 
 static int run_pre_push_hook(struct transport *transport,

--- a/tree.c
+++ b/tree.c
@@ -54,12 +54,12 @@ int read_tree_at(struct repository *r,
 
 			commit = lookup_commit(r, &entry.oid);
 			if (!commit)
-				die("Commit %s in submodule path %s%s not found",
+				die("commit %s in submodule path %s%s not found",
 				    oid_to_hex(&entry.oid),
 				    base->buf, entry.path);
 
 			if (parse_commit(commit))
-				die("Invalid commit %s in submodule path %s%s",
+				die("invalid commit %s in submodule path %s%s",
 				    oid_to_hex(&entry.oid),
 				    base->buf, entry.path);
 

--- a/upload-pack.c
+++ b/upload-pack.c
@@ -950,7 +950,7 @@ static int process_deepen(const char *line, int *depth)
 		char *end = NULL;
 		*depth = (int)strtol(arg, &end, 0);
 		if (!end || *end || *depth <= 0)
-			die("Invalid deepen: %s", line);
+			die("invalid deepen: %s", line);
 		return 1;
 	}
 
@@ -966,7 +966,7 @@ static int process_deepen_since(const char *line, timestamp_t *deepen_since, int
 		if (!end || *end || !deepen_since ||
 		    /* revisions.c's max_age -1 is special */
 		    *deepen_since == -1)
-			die("Invalid deepen-since: %s", line);
+			die("invalid deepen-since: %s", line);
 		*deepen_rev_list = 1;
 		return 1;
 	}

--- a/worktree.c
+++ b/worktree.c
@@ -76,7 +76,7 @@ static struct worktree *get_linked_worktree(const char *id)
 	struct strbuf worktree_path = STRBUF_INIT;
 
 	if (!id)
-		die("Missing linked worktree name");
+		die("missing linked worktree name");
 
 	strbuf_git_common_path(&path, the_repository, "worktrees/%s/gitdir", id);
 	if (strbuf_read_file(&worktree_path, path.buf, 0) <= 0)

--- a/wrapper.c
+++ b/wrapper.c
@@ -35,7 +35,7 @@ char *xstrdup(const char *str)
 {
 	char *ret = strdup(str);
 	if (!ret)
-		die("Out of memory, strdup failed");
+		die("out of memory, strdup failed");
 	return ret;
 }
 
@@ -50,10 +50,10 @@ static void *do_xmalloc(size_t size, int gentle)
 		ret = malloc(1);
 	if (!ret) {
 		if (!gentle)
-			die("Out of memory, malloc failed (tried to allocate %lu bytes)",
+			die("out of memory, malloc failed (tried to allocate %lu bytes)",
 			    (unsigned long)size);
 		else {
-			error("Out of memory, malloc failed (tried to allocate %lu bytes)",
+			error("out of memory, malloc failed (tried to allocate %lu bytes)",
 			      (unsigned long)size);
 			return NULL;
 		}
@@ -74,10 +74,10 @@ static void *do_xmallocz(size_t size, int gentle)
 	void *ret;
 	if (unsigned_add_overflows(size, 1)) {
 		if (gentle) {
-			error("Data too large to fit into virtual memory space.");
+			error("data too large to fit into virtual memory space.");
 			return NULL;
 		} else
-			die("Data too large to fit into virtual memory space.");
+			die("data too large to fit into virtual memory space.");
 	}
 	ret = do_xmalloc(size + 1, gentle);
 	if (ret)
@@ -132,7 +132,7 @@ void *xrealloc(void *ptr, size_t size)
 	memory_limit_check(size, 0);
 	ret = realloc(ptr, size);
 	if (!ret)
-		die("Out of memory, realloc failed");
+		die("out of memory, realloc failed");
 	return ret;
 }
 
@@ -148,7 +148,7 @@ void *xcalloc(size_t nmemb, size_t size)
 	if (!ret && (!nmemb || !size))
 		ret = calloc(1, 1);
 	if (!ret)
-		die("Out of memory, calloc failed");
+		die("out of memory, calloc failed");
 	return ret;
 }
 

--- a/xdiff-interface.c
+++ b/xdiff-interface.c
@@ -264,7 +264,7 @@ void xdiff_set_find_func(xdemitconf_t *xecfg, const char *value, int cflags)
 
 		reg->negate = (*value == '!');
 		if (reg->negate && i == regs->nr - 1)
-			die("Last expression must not be negated: %s", value);
+			die("last expression must not be negated: %s", value);
 		if (*value == '!')
 			value++;
 		if (ep)
@@ -272,7 +272,7 @@ void xdiff_set_find_func(xdemitconf_t *xecfg, const char *value, int cflags)
 		else
 			expression = value;
 		if (regcomp(&reg->re, expression, cflags))
-			die("Invalid regexp to look for hunk header: %s", expression);
+			die("invalid regexp to look for hunk header: %s", expression);
 		free(buffer);
 		value = ep ? ep + 1 : NULL;
 	}


### PR DESCRIPTION
Related issues:
https://github.com/gitgitgadget/git/issues/635

The Git suite CodingGuidelines suggest [this](https://github.com/git/git/blob/v2.26.2/Documentation/CodingGuidelines#L496) about Error messages:

> Error Messages
> 
> Do not end error messages with a full stop.

This fixes the die() error messages so they follow this guideline.

Signed-off-by: EthanDevelops [git@ethanlibs.co](mailto:git@ethanlibs.co)