### PR TITLE
contrib/scalar: fix 'all' target in Makefile

### DIFF
--- a/contrib/scalar/Makefile
+++ b/contrib/scalar/Makefile
@@ -11,7 +11,7 @@ include ../../config.mak.uname
 TARGETS = scalar$(X) scalar.o
 GITLIBS = ../../common-main.o ../../libgit.a ../../xdiff/lib.a
 
-all: scalar$(X) ../../bin-wrappers/scalar
+all:: scalar$(X) ../../bin-wrappers/scalar
 
 $(GITLIBS):
 	$(QUIET_SUBDIR0)../.. $(QUIET_SUBDIR1) $(subst ../../,,$@)


### PR DESCRIPTION
This patch fixes an issue introduced in a36b575aab (scalar Makefile: use "The default target of..." pattern, 2022-03-03) in which an 'all::' target was added without converting the existing 'all:' (single-colon) target into an 'all::' (double-colon) target. This causes a build error, but only when compiling with 'INCLUDE_SCALAR' enabled. As a result, I only just found it when building 'scalar' on the 'microsoft/git' fork.

Although 'INCLUDE_SCALAR' isn't enabled by default, we should fix the build error for anyone that may intentionally build with it. If possible, it would be nice to have this merged before the final v2.36.0 so that users don't run into the error in the next release.

CC: Johannes.Schindelin@gmx.de
CC: gitster@pobox.com
cc: Ævar Arnfjörð Bjarmason <avarab@gmail.com>