### PR TITLE
commit-graph: close file before returning NULL

### DIFF
--- a/commit-graph.c
+++ b/commit-graph.c
@@ -523,10 +523,13 @@ static struct commit_graph *load_commit_graph_chain(struct repository *r,
 	stat_res = stat(chain_name, &st);
 	free(chain_name);
 
-	if (!fp ||
-	    stat_res ||
-	    st.st_size <= the_hash_algo->hexsz)
+	if (!fp)
 		return NULL;
+	if (stat_res ||
+	    st.st_size <= the_hash_algo->hexsz) {
+		fclose(fp);
+		return NULL;
+	}
 
 	count = st.st_size / (the_hash_algo->hexsz + 1);
 	CALLOC_ARRAY(oids, count);


### PR DESCRIPTION
This change was originally submitted to the microsoft/git fork [1]. Kleber discovered this issue using some automated tool they are working on. We recommended that this change be submitted to the core Git group, but we have not had any word from the original author in some time. Hence, I am submitting it on their behalf.

[1] https://github.com/microsoft/git/pull/259

Thanks,
-Stolee

cc: gitster@pobox.com
cc: me@ttaylorr.com