### PR TITLE
clone: ignore invalid local refs in remote

### DIFF
--- a/refs.c
+++ b/refs.c
@@ -1111,8 +1111,10 @@ int ref_transaction_create(struct ref_transaction *transaction,
 			   unsigned int flags, const char *msg,
 			   struct strbuf *err)
 {
-	if (!new_oid || is_null_oid(new_oid))
-		BUG("create called without valid new_oid");
+	if (!new_oid || is_null_oid(new_oid)) {
+		strbuf_addf(err, "'%s' has a null OID", refname);
+		return 1;
+	}
 	return ref_transaction_update(transaction, refname, new_oid,
 				      null_oid(), flags, msg, err);
 }

--- a/t/t5605-clone-local.sh
+++ b/t/t5605-clone-local.sh
@@ -141,4 +141,13 @@ test_expect_success 'cloning locally respects "-u" for fetching refs' '
 	test_must_fail git clone --bare -u false a should_not_work.git
 '
 
+test_expect_success 'local clone from repo with corrupt refs fails gracefully' '
+	git init corrupt &&
+	test_commit -C corrupt one &&
+	echo a >corrupt/.git/refs/heads/topic &&
+
+	test_must_fail git clone corrupt working 2>err &&
+	grep "has a null OID" err
+'
+
 test_done


### PR DESCRIPTION
Update in v2:

* Subject line is improved to better match the message and fix.
* I did not explore Ævar's idea to optimistically continue the clone as much as possible. That seems like a bigger change that could be investigated independently.

cc: gitster@pobox.com
cc: me@ttaylorr.com
cc: Ævar Arnfjörð Bjarmason <avarab@gmail.com>