### PR TITLE
remotes: apply pushInsteadOf's rewrites after insteadOf's

### DIFF
--- a/remote.c
+++ b/remote.c
@@ -487,13 +487,13 @@ static void alias_all_urls(struct remote_state *remote_state)
 		}
 		add_pushurl_aliases = remote_state->remotes[i]->pushurl_nr == 0;
 		for (j = 0; j < remote_state->remotes[i]->url_nr; j++) {
+			remote_state->remotes[i]->url[j] =
+				alias_url(remote_state->remotes[i]->url[j],
+					  &remote_state->rewrites);
 			if (add_pushurl_aliases)
 				add_pushurl_alias(
 					remote_state, remote_state->remotes[i],
 					remote_state->remotes[i]->url[j]);
-			remote_state->remotes[i]->url[j] =
-				alias_url(remote_state->remotes[i]->url[j],
-					  &remote_state->rewrites);
 		}
 	}
 }

--- a/t/t5516-fetch-push.sh
+++ b/t/t5516-fetch-push.sh
@@ -175,6 +175,23 @@ test_expect_success 'fetch with pushInsteadOf (should not rewrite)' '
 	)
 '
 
+test_expect_success 'fetch with insteadOf and pushInsteadOf (insteadOf should rewrite)' '
+	mk_empty testrepo &&
+	(
+		TRASH=$(pwd)/ &&
+		cd testrepo &&
+		git config "url.$TRASH.insteadOf" trash/ &&
+		git config "url.trash/.pushInsteadOf" "$TRASH" &&
+		git config remote.up.url "$TRASH" &&
+		git config remote.up.fetch "refs/heads/*:refs/remotes/origin/*" &&
+		git fetch up &&
+
+		echo "$the_commit commit	refs/remotes/origin/main" >expect &&
+		git for-each-ref refs/remotes/origin >actual &&
+		test_cmp expect actual
+	)
+'
+
 grep_wrote () {
 	object_count=$1
 	file_name=$2
@@ -267,6 +284,20 @@ test_expect_success 'push with pushInsteadOf' '
 	TRASH="$(pwd)/" &&
 	test_config "url.$TRASH.pushInsteadOf" trash/ &&
 	git push trash/testrepo refs/heads/main:refs/remotes/origin/main &&
+	(
+		cd testrepo &&
+		echo "$the_commit commit	refs/remotes/origin/main" >expect &&
+		git for-each-ref refs/remotes/origin >actual &&
+		test_cmp expect actual
+	)
+'
+
+test_expect_success 'push with pushInsteadOf and insteadOf (pushInsteadOf should rewrite)' '
+	mk_empty testrepo &&
+	test_config "url.testrepo/.pushInsteadOf" trash/ &&
+	test_config "url.trash/.insteadOf" testrepo/ &&
+	test_config remote.r.url testrepo/ &&
+	git push r refs/heads/main:refs/remotes/origin/main &&
 	(
 		cd testrepo &&
 		echo "$the_commit commit	refs/remotes/origin/main" >expect &&


### PR DESCRIPTION
This change allows a `pushInsteadOf` to apply over a url that's already
been rewritten via `insteadOf`. It's a bit circular, but this allows
forcing a remote's pulls to one URL and pushes to another.

For instance, GitHub allows unauthenticated users to pull code via
HTTPS, but requires authentication to push. Or, you could use SSH, but
if you're storing your SSH keys in a Yubico security key then you'll
have to touch the key every time you pull or push. With this change, we
can now specify that pulls happen over HTTPS and pushes happen over
SSH.

```
[url "https://github.com/"]
  insteadOf = "git@github.com:"
[url "git@github.com:"]
  pushInsteadOf = "https://github.com/"
```

Before, given an initial URL of `git@github.com:git/git.git`, the
`pushInsteadOf` would not match. Immediately after, the `insteadOf`
would match and rewrite the URL to `https://github.com/git/git.git`.
And given an initial URL of `https://github.com/git/git.git`, the
`pushInsteadOf` would rewrite it to `git@github.com:git/git.git`. But,
the `insteadOf` would then apply and rewrite it back to
`https://github.com/git/git.git`. Essentially, the `insteadOf` has the
final say in both pulls and pushes.

Now, an initial URL of `git@github.com:git/git.git` gets rewritten to
`https://github.com/git/git.git` by `insteadOf`, and then rewritten back
to `git@github.com:git/git.git` by `pushInsteadOf`. And an initial URL
of `https://github.com/git/git.git` gets is skipped by `insteadOf`, and
then rewritten to `git@github.com:git/git.git` by `pushInsteadOf`. Now
`insteadOf` only has the final say for pulls, and `pushInsteadOf` has
the final say for pushes.

See also: https://lore.kernel.org/git/CABURp0qdq_Ch0bpz82707iEOQ2catCUWF_dbc6T_q=qF03ypMw@mail.gmail.com/

Signed-off-by: Justin Ridgewell <justin@ridgewell.name>