### PR TITLE
builtin/remote.c: teach `-v` to list filters for promisor remotes

### DIFF
--- a/Documentation/git-remote.txt
+++ b/Documentation/git-remote.txt
@@ -35,6 +35,8 @@ OPTIONS
 -v::
 --verbose::
 	Be a little more verbose and show remote url after name.
+	For promisor remotes, also show which filter (`blob:none` etc.)
+	are configured.
 	NOTE: This must be placed between `remote` and subcommand.
 
 


### PR DESCRIPTION
Fixes #1211 [1]

Changes since v3:
- tests are moved to `t5505-remote.sh`
- Documentation improved
- Added `Closes` trailer in the commit message

Changes since v2:
- added more test cases
- fixed broken indentations

Changes since v1:
- updated documentation
- renamed url_buf into remote_info_buf

[1] https://github.com/gitgitgadget/git/issues/1211

cc: Philip Oakley <philipoakley@iee.email>
cc: Junio C Hamano <gitster@pobox.com>
cc: Philippe Blain <levraiphilippeblain@gmail.com>
cc: Taylor Blau <me@ttaylorr.com>