### PR TITLE
remote: create fetch.credentialsInUrl config

### DIFF
--- a/Documentation/config/fetch.txt
+++ b/Documentation/config/fetch.txt
@@ -96,3 +96,17 @@ fetch.writeCommitGraph::
 	merge and the write may take longer. Having an updated commit-graph
 	file helps performance of many Git commands, including `git merge-base`,
 	`git push -f`, and `git log --graph`. Defaults to false.
+
+fetch.credentialsInUrl::
+	A URL can contain plaintext credentials in the form
+	`<protocol>://<user>:<password>@<domain>/<path>`. Using such URLs
+	is not recommended as it exposes the password in multiple ways,
+	including Git storing the URL as plaintext in the repository config.
+	The `fetch.credentialsInUrl` option provides instruction for how Git
+	should react to seeing such a URL, with these values:
++
+* `allow` (default): Git will proceed with its activity without warning.
+* `warn`: Git will write a warning message to `stderr` when parsing a URL
+  with a plaintext credential.
+* `die`: Git will write a failure message to `stderr` when parsing a URL
+  with a plaintext credential.

--- a/remote.c
+++ b/remote.c
@@ -1,6 +1,7 @@
 #include "cache.h"
 #include "config.h"
 #include "remote.h"
+#include "urlmatch.h"
 #include "refs.h"
 #include "refspec.h"
 #include "object-store.h"
@@ -614,6 +615,50 @@ const char *remote_ref_for_branch(struct branch *branch, int for_push)
 	return NULL;
 }
 
+static void validate_remote_url(struct remote *remote)
+{
+	int i;
+	const char *value;
+	struct strbuf redacted = STRBUF_INIT;
+	int warn_not_die;
+
+	if (git_config_get_string_tmp("fetch.credentialsinurl", &value))
+		return;
+
+	if (!strcmp("warn", value))
+		warn_not_die = 1;
+	else if (!strcmp("die", value))
+		warn_not_die = 0;
+	else if (!strcmp("allow", value))
+		return;
+	else
+		die(_("unrecognized value fetch.credentialsInURL: '%s'"), value);
+
+	for (i = 0; i < remote->url_nr; i++) {
+		struct url_info url_info = { 0 };
+
+		if (!url_normalize(remote->url[i], &url_info) ||
+		    !url_info.passwd_off)
+			goto loop_cleanup;
+
+		strbuf_reset(&redacted);
+		strbuf_add(&redacted, url_info.url, url_info.passwd_off);
+		strbuf_addstr(&redacted, "<redacted>");
+		strbuf_addstr(&redacted,
+			      url_info.url + url_info.passwd_off + url_info.passwd_len);
+
+		if (warn_not_die)
+			warning(_("URL '%s' uses plaintext credentials"), redacted.buf);
+		else
+			die(_("URL '%s' uses plaintext credentials"), redacted.buf);
+
+loop_cleanup:
+		free(url_info.url);
+	}
+
+	strbuf_release(&redacted);
+}
+
 static struct remote *
 remotes_remote_get_1(struct remote_state *remote_state, const char *name,
 		     const char *(*get_default)(struct remote_state *,
@@ -639,6 +684,9 @@ remotes_remote_get_1(struct remote_state *remote_state, const char *name,
 		add_url_alias(remote_state, ret, name);
 	if (!valid_remote(ret))
 		return NULL;
+
+	validate_remote_url(ret);
+
 	return ret;
 }
 

--- a/t/t5516-fetch-push.sh
+++ b/t/t5516-fetch-push.sh
@@ -12,6 +12,7 @@ This test checks the following functionality:
 * --porcelain output format
 * hiderefs
 * reflogs
+* URL validation
 '
 
 GIT_TEST_DEFAULT_INITIAL_BRANCH_NAME=main
@@ -1811,6 +1812,37 @@ test_expect_success 'refuse to push a hidden ref, and make sure do not pollute t
 	git -C testrepo config receive.unpackLimit 1 &&
 	test_must_fail git push testrepo HEAD:refs/hidden/foo &&
 	test_dir_is_empty testrepo/.git/objects/pack
+'
+
+test_expect_success 'fetch warns or fails when using username:password' '
+	message="URL '\''https://username:<redacted>@localhost/'\'' uses plaintext credentials" &&
+	test_must_fail git -c fetch.credentialsInUrl=allow fetch https://username:password@localhost 2>err &&
+	! grep "$message" err &&
+
+	test_must_fail git -c fetch.credentialsInUrl=warn fetch https://username:password@localhost 2>err &&
+	grep "warning: $message" err >warnings &&
+	test_line_count = 3 warnings &&
+
+	test_must_fail git -c fetch.credentialsInUrl=die fetch https://username:password@localhost 2>err &&
+	grep "fatal: $message" err >warnings &&
+	test_line_count = 1 warnings &&
+
+	test_must_fail git -c fetch.credentialsInUrl=die fetch https://username:@localhost 2>err &&
+	grep "fatal: $message" err >warnings &&
+	test_line_count = 1 warnings
+'
+
+
+test_expect_success 'push warns or fails when using username:password' '
+	message="URL '\''https://username:<redacted>@localhost/'\'' uses plaintext credentials" &&
+	test_must_fail git -c fetch.credentialsInUrl=allow push https://username:password@localhost 2>err &&
+	! grep "$message" err &&
+
+	test_must_fail git -c fetch.credentialsInUrl=warn push https://username:password@localhost 2>err &&
+	grep "warning: $message" err >warnings &&
+	test_must_fail git -c fetch.credentialsInUrl=die push https://username:password@localhost 2>err &&
+	grep "fatal: $message" err >warnings &&
+	test_line_count = 1 warnings
 '
 
 test_done


### PR DESCRIPTION
Users can specify credentials in their URL using the `username:password@domain` format. This is potentially hazardous since the URL is stored in plaintext and can also appear in trace2 logs and other places. Add a new config option that allows warnings or failures when discovering URLs with this format. The default behavior does not change in this series, although we may want to move to the `warn` state by default in the future.

This is a modified version of the patch I submitted a while ago [1].

Based on the feedback, changing the behavior to fail by default was not a good approach. Further, the idea to stop storing the credentials in config and redirect them to a credential manager was already considered by Peff [2] but not merged.

This patch does what should be the simplest thing we can do: create a config option that will cause the user to get a warning or a failure, depending on its value. The default is to ignore the setting, identical to the current behavior. We can talk about changing this default to "warn" in the future, but it would be safest to release with ignore as the default until we are sure that we are not going to start warning on false positives.

This patch would be sufficient for the interested internal parties that want to prevent users from storing credentials this way. System administrators can modify system-level Git config into "die" mode to prevent this behavior.

[1] https://lore.kernel.org/git/pull.945.git.1619807844627.gitgitgadget@gmail.com
Reject passwords in URLs (April 2021).

[2] https://lore.kernel.org/git/20190519050724.GA26179@sigill.intra.peff.net/
Re: Git ransom campaign incident report - May 2019

Updates in v5
-------------

* Squashed in Junio's recommended changes.
* Noticed that the redacted strbuf wasn't reset between loop iterations, which only matters if there are multiple URLs for the remote.

Updates in v4
-------------

* The warn_once() patch is dropped in favor of using a different location for the check (remotes_remote_get_1() instead of valid_remote()).
* The parsing logic is removed in favor of using the output url_info from url_normalize().
* Tests for 'fetch' and 'push' are added.
* This requires updating the topic to be on a more-recent version of 'master' because some change since the previous base caused 'git push' to output the warning only once, not twice.

Updates in v3
-------------

* Because of some flaky behavior around SIGPIPE, the URL check needed to move to be earlier in the command.
* For this reason, I moved the cred check into remote.c's valid_remote() check. This changed the previous BUG() statements into early returns.
* I repeated the check with the test suite to see if this parsing fails on any existing cases, but it is worth double-checking the parsing rules.
* Documentation is more consistent about using placeholders.
* A test for the "allow" case is now included.
* A new patch is added that creates the `warn_once()` helper. This reduces multiple advisory warnings with the same text from being written by the same process.

Updates in v2
-------------

* Documentation is slightly expanded to include the fact that Git stores the given URL as plaintext in its config.
* The new method has a new documentation comment that details the necessary preconditions.
* "ignore" is now "allow"
* Additional checks on colon_ptr are added.
* Use strbuf_splice() instead of custom string-walking logic.
* Use "<redacted>" instead of asterisks.
* Config value checks are no longer case sensitive.

Thanks,
-Stolee

Cc: gitster@pobox.com
Cc: peff@peff.net
Cc: me@ttaylorr.com
Cc: avarab@gmail.com
Cc: christian.couder@gmail.com
Cc: johannes.schindelin@gmx.de
Cc: jrnieder@gmail.com
cc: "brian m. carlson" <sandals@crustytoothpaste.net>
cc: Robert Coup <robert.coup@koordinates.com>