### PR TITLE
ci: update Cirrus-CI image to FreeBSD 13.0

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -9,10 +9,10 @@ freebsd_12_task:
     DEFAULT_TEST_TARGET: prove
     DEVELOPER: 1
   freebsd_instance:
-    image_family: freebsd-12-2
+    image_family: freebsd-13-0
     memory: 2G
   install_script:
-    pkg install -y gettext gmake perl5
+    pkg install -y gettext gmake perl5 vim
   create_user_script:
     - pw useradd git
     - chown -R git:git .


### PR DESCRIPTION
Here is a proper patch following my earlier mail  [1].

[1] https://lore.kernel.org/git/CAPUEspgdAos4KC-3AwYDd5p+u0hGk73nGocBTFFSR7VB9+M5jw@mail.gmail.com/T/#t

CC: Carlo Marcelo Arenas Belón <carenas@gmail.com>
CC: Ed Maste <emaste@FreeBSD.org>