### PR TITLE
Die preserve ggg

### DIFF
--- a/builtin/rebase.c
+++ b/builtin/rebase.c
@@ -1205,7 +1205,9 @@ int cmd_rebase(int argc, const char **argv, const char *prefix)
 			     builtin_rebase_usage, 0);
 
 	if (preserve_merges_selected)
-		die(_("--preserve-merges was replaced by --rebase-merges"));
+		die(_("--preserve-merges was replaced by --rebase-merges\n"
+			"Note: Your `pull.rebase` configuration may also be  set to 'preserve',\n"
+			"which is no longer supported; use 'merges' instead"));
 
 	if (action != ACTION_NONE && total_argc != 2) {
 		usage_with_options(builtin_rebase_usage,

--- a/builtin/rebase.c
+++ b/builtin/rebase.c
@@ -1110,8 +1110,8 @@ int cmd_rebase(int argc, const char **argv, const char *prefix)
 			PARSE_OPT_NOARG | PARSE_OPT_NONEG,
 			parse_opt_interactive),
 		OPT_SET_INT_F('p', "preserve-merges", &preserve_merges_selected,
-			      N_("(DEPRECATED) try to recreate merges instead of "
-				 "ignoring them"),
+			      N_("(REMOVED) was: try to recreate merges "
+				 "instead of ignoring them"),
 			      1, PARSE_OPT_HIDDEN),
 		OPT_RERERE_AUTOUPDATE(&options.allow_rerere_autoupdate),
 		OPT_CALLBACK_F(0, "empty", &options, "{drop,keep,ask}",

--- a/builtin/rebase.c
+++ b/builtin/rebase.c
@@ -1182,8 +1182,10 @@ int cmd_rebase(int argc, const char **argv, const char *prefix)
 	} else if (is_directory(merge_dir())) {
 		strbuf_reset(&buf);
 		strbuf_addf(&buf, "%s/rewritten", merge_dir());
-		if (is_directory(buf.buf)) {
-			die("`rebase -p` is no longer supported");
+		if (!(action == ACTION_ABORT) && is_directory(buf.buf)) {
+			die("`rebase --preserve-merges` (-p) is no longer supported.\n"
+			"Use `git rebase --abort` to terminate current rebase.\n"
+			"Or downgrade to v2.33, or earlier, to complete the rebase.");
 		} else {
 			strbuf_reset(&buf);
 			strbuf_addf(&buf, "%s/interactive", merge_dir());

--- a/builtin/rebase.c
+++ b/builtin/rebase.c
@@ -1183,9 +1183,9 @@ int cmd_rebase(int argc, const char **argv, const char *prefix)
 		strbuf_reset(&buf);
 		strbuf_addf(&buf, "%s/rewritten", merge_dir());
 		if (!(action == ACTION_ABORT) && is_directory(buf.buf)) {
-			die("`rebase --preserve-merges` (-p) is no longer supported.\n"
+			die(_("`rebase --preserve-merges` (-p) is no longer supported.\n"
 			"Use `git rebase --abort` to terminate current rebase.\n"
-			"Or downgrade to v2.33, or earlier, to complete the rebase.");
+			"Or downgrade to v2.33, or earlier, to complete the rebase."));
 		} else {
 			strbuf_reset(&buf);
 			strbuf_addf(&buf, "%s/interactive", merge_dir());


### PR DESCRIPTION
This [2] short series is a follow up to GitGitGadget "Update the die() preserve-merges messages to help some users (PR #1155)" [1].

Since v1: Additional patch to translate the user facing die message.
Bring the `--abort` preclusion to the start of the `if &&` condition for clarity.
Clarify that the pull.rebase config is complementary to this particular 'die'.
Updates to the commit messages.

v0:
The first patch is a tidy up of the `--preserve` option to highlight that it is now Deleted, rather than Deprecated.

In response to Avar's comments that the former error message merely 'tantilised without telling' the user what to do, it became obvious that the underling problem was that the user was unable to `git rebase --abort` which was also fatal, when a preserve-rebase was in progress.

Thus the main update is to allow the rebase --abort command, even when a --preserve is in progress, to proceed. The --abort code was unchanged by the removal of the preserve option, as the resetting and clean up of internal state is common to the other rebase options.

The user facing fatal message now simply advises to abort, or downgrade to a version that has preserve-merges to complete the rebase.

The final patch highlights that some IDEs still allow the setting of the `preserve-merges` option as a pull config setup.

Philip Oakly

[1] GitLore ref [pull.1155.git.1645526016.gitgitgadget@gmail.com](mailto:pull.1155.git.1645526016.gitgitgadget@gmail.com)
https://lore.kernel.org/git/pull.1155.git.1645526016.gitgitgadget@gmail.com/

[2] https://lore.kernel.org/git/pull.1242.git.1653556865.gitgitgadget@gmail.com/t/#u 

cc: Ævar Arnfjörð Bjarmason <avarab@gmail.com>
cc: Philip Oakley <philipoakley@iee.email>
cc: René Scharfe <l.s.r@web.de>