### PR TITLE
range-diff: show submodule changes irrespective of diff.submodule

### DIFF
--- a/range-diff.c
+++ b/range-diff.c
@@ -44,7 +44,7 @@ static int read_patches(const char *range, struct string_list *list,
 
 	strvec_pushl(&cp.args, "log", "--no-color", "-p", "--no-merges",
 		     "--reverse", "--date-order", "--decorate=no",
-		     "--no-prefix",
+		     "--no-prefix", "--submodule=short",
 		     /*
 		      * Choose indicators that are not used anywhere
 		      * else in diffs, but still look reasonable


### PR DESCRIPTION
Changes since v1:

- added a comparison without '--creation-factor' to the test, as suggested by
Ævar
- remove separate 'git add sub' invocations in favor of 'git commit -m msg
sub', as suggested by Dscho

CC: Johannes Schindelin <Johannes.Schindelin@gmx.de>
cc: Ævar Arnfjörð Bjarmason <avarab@gmail.com>