### PR TITLE
winansi: check result before using Name for pty

### DIFF
--- a/compat/winansi.c
+++ b/compat/winansi.c
@@ -573,6 +573,8 @@ static void detect_msys_tty(int fd)
 	if (!NT_SUCCESS(NtQueryObject(h, ObjectNameInformation,
 			buffer, sizeof(buffer) - 2, &result)))
 		return;
+	if (result <= sizeof(*nameinfo))
+		return;
 	name = nameinfo->Name.Buffer;
 	name[nameinfo->Name.Length / sizeof(*name)] = 0;
 


### PR DESCRIPTION
Unsure which branch to really base this off, so I have used maint.

Should be a simple fix for checking if NtQueryObject() actually returned a name under very
specific circumstances under Wine staging, however, I am not very confident if it's the best option.
Alternatives have been listed in the commit message.

CC: Johannes Schindelin <johannes.schindelin@gmx.de>