### PR TITLE
read-cache.c: reduce unnecessary cache entry name copying

### DIFF
--- a/read-cache.c
+++ b/read-cache.c
@@ -1944,8 +1944,6 @@ static struct cache_entry *create_from_disk(struct mem_pool *ce_mem_pool,
 	ce->ce_namelen = len;
 	ce->index = 0;
 	oidread(&ce->oid, ondisk->data);
-	memcpy(ce->name, name, len);
-	ce->name[len] = '\0';
 
 	if (expand_name_field) {
 		if (copy_len)


### PR DESCRIPTION
Index cache entries name are copied twice wrongly, so reduce the first one
to fix it.

cc: Junio C Hamano gitster@pobox.com
cc:  brian m. carlson sandals@crustytoothpaste.net
cc: Christian Couder christian.couder@gmail.com
cc: René Scharfe <l.s.r@web.de>