### PR TITLE
ci(GitHub workflow): bring back the 'print test failures' step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -119,6 +119,10 @@ jobs:
     - name: test
       shell: bash
       run: . /etc/profile && ci/run-test-slice.sh ${{matrix.nr}} 10
+    - name: print test failures
+      if: failure() && env.FAILED_TEST_ARTIFACTS != ''
+      shell: bash
+      run: ci/print-test-failures.sh
     - name: Upload failed tests' directories
       if: failure() && env.FAILED_TEST_ARTIFACTS != ''
       uses: actions/upload-artifact@v2
@@ -200,6 +204,10 @@ jobs:
       env:
         NO_SVN_TESTS: 1
       run: . /etc/profile && ci/run-test-slice.sh ${{matrix.nr}} 10
+    - name: print test failures
+      if: failure() && env.FAILED_TEST_ARTIFACTS != ''
+      shell: bash
+      run: ci/print-test-failures.sh
     - name: Upload failed tests' directories
       if: failure() && env.FAILED_TEST_ARTIFACTS != ''
       uses: actions/upload-artifact@v2
@@ -253,6 +261,10 @@ jobs:
     - uses: actions/checkout@v2
     - run: ci/install-dependencies.sh
     - run: ci/run-build-and-tests.sh
+    - name: print test failures
+      if: failure() && env.FAILED_TEST_ARTIFACTS != ''
+      shell: bash
+      run: ci/print-test-failures.sh
     - name: Upload failed tests' directories
       if: failure() && env.FAILED_TEST_ARTIFACTS != ''
       uses: actions/upload-artifact@v2
@@ -282,6 +294,10 @@ jobs:
     - uses: actions/checkout@v1
     - run: ci/install-docker-dependencies.sh
     - run: ci/run-build-and-tests.sh
+    - name: print test failures
+      if: failure() && env.FAILED_TEST_ARTIFACTS != ''
+      shell: bash
+      run: ci/print-test-failures.sh
     - name: Upload failed tests' directories
       if: failure() && env.FAILED_TEST_ARTIFACTS != ''
       uses: actions/upload-artifact@v1

--- a/ci/lib.sh
+++ b/ci/lib.sh
@@ -177,7 +177,8 @@ then
 			test_name="${test_exit%.exit}"
 			test_name="${test_name##*/}"
 			printf "\\e[33m\\e[1m=== Failed test: ${test_name} ===\\e[m\\n"
-			echo "The full logs are in the artifacts attached to this run."
+			echo "The full logs are in the 'print test failures' step below."
+			echo "See also the 'failed-tests-*' artifacts attached to this run."
 			cat "t/test-results/$test_name.markup"
 
 			trash_dir="t/trash directory.$test_name"


### PR DESCRIPTION
When an incorrectly-implemented test let a [CI build fail](https://github.com/git/git/runs/6703333447?check_suite_focus=true#step:4:1750) without any failing test _cases_, the output was not helpful for readers who wished to investigate the problem:

```
[...]
 751 ⏵Run tests
1746 === Failed test: t3105-ls-tree-output ===
1747 The full logs are in the artifacts attached to this run.
1748 Error: Process completed with exit code 1.
```

While this is still an improvement from before (where no output was shown in the `test` step at all, apart from the very high-level `prove` output), we can do better than point users to downloading the artifacts (which is a bit cumbersome).

With this patch, the `print test failures` step is reintroduced. To make sure that readers know to look at it, we now [print an explicit message](https://github.com/dscho/git/runs/6790035528?check_suite_focus=true#step:4:1741):

```
[...]
 749 ⏵Run tests
1737 === Failed test: t3105-ls-tree-output ===
1738 The full logs are in the 'print test failures' step below.
1739 See also the 'failed-tests-*' artifacts attached to this run.
1740 Error: Process completed with exit code 1.
```

The "print test failures" step is still not expanded by default, but at least the output is now so nicely uncluttered that it is really easy to spot it: it is right below the above-quoted error message.

cc: Ævar Arnfjörð Bjarmason <avarab@gmail.com>