### PR TITLE
ci(GitHub): mark up compile errors, too

### DIFF
--- a/ci/lib.sh
+++ b/ci/lib.sh
@@ -29,8 +29,14 @@ else
 		set +x
 		begin_group "$1"
 		shift
-		"$@"
-		res=$?
+		# work around `dash` not supporting `set -o pipefail`
+		(
+			"$@" 2>&1
+			echo $? >exit.status
+		) |
+		sed 's/^\(\([^ ]*\):\([0-9]*\):\([0-9]*:\) \)\(error\|warning\): /::\5 file=\2,line=\3::\1/'
+		res=$(cat exit.status)
+		rm exit.status
 		end_group
 		return $res
 	}

--- a/ci/make-test-artifacts.sh
+++ b/ci/make-test-artifacts.sh
@@ -7,6 +7,6 @@ mkdir -p "$1" # in case ci/lib.sh decides to quit early
 
 . ${0%/*}/lib.sh
 
-make artifacts-tar ARTIFACTS_DIRECTORY="$1"
+group Build make artifacts-tar ARTIFACTS_DIRECTORY="$1"
 
 check_unignored_build_artifacts


### PR DESCRIPTION
Just like we mark up test failures, it makes sense to mark up compile errors, too.

In a sense, it makes even more sense with compile errors than with test failures because we can link directly to the corresponding source code in the former case (if said code has been touched by the Pull Request, that is). The only downside is that this link currently is kind of misleading if the Pull Request did not even touch the offending source code (such as was the case when a GCC upgrade in Git for Windows' SDK all of a sudden pointed out problems in the source code that had existed for a long time already). We will see how the GitHub Actions engineers will develop this feature further.

This patch series is based on `js/ci-github-workflow-markup`. Which also serves as an example how this looks like if the offending source code was _not_ touched by the Pull Request: https://github.com/dscho/git/actions/runs/2477526645 because it still triggers the above-referenced GCC build failure.

Changes since v1:
- Using a comma in the workflow command now, as described in the official documentation ;-) (Thank you, Ævar)
- The curly bracket construct was replaced by a proper subshell, to avoid jumbled output and a race where the `exit.status` file could be read before it was written.

cc: Ævar Arnfjörð Bjarmason <avarab@gmail.com>