### PR TITLE
Create branch_checked_out() helper

### DIFF
--- a/branch.c
+++ b/branch.c
@@ -385,6 +385,7 @@ static void prepare_checked_out_branches(void)
 	worktrees = get_worktrees();
 
 	while (worktrees[i]) {
+		struct wt_status_state state = { 0 };
 		struct worktree *wt = worktrees[i++];
 
 		if (wt->is_bare)
@@ -394,6 +395,29 @@ static void prepare_checked_out_branches(void)
 			strmap_put(&current_checked_out_branches,
 				   wt->head_ref,
 				   xstrdup(wt->path));
+
+		if (wt_status_check_rebase(wt, &state) &&
+		    (state.rebase_in_progress || state.rebase_interactive_in_progress) &&
+		    state.branch) {
+			struct strbuf ref = STRBUF_INIT;
+			strbuf_addf(&ref, "refs/heads/%s", state.branch);
+			strmap_put(&current_checked_out_branches,
+				   ref.buf,
+				   xstrdup(wt->path));
+			strbuf_release(&ref);
+		}
+		wt_status_state_free_buffers(&state);
+
+		if (wt_status_check_bisect(wt, &state) &&
+		    state.branch) {
+			struct strbuf ref = STRBUF_INIT;
+			strbuf_addf(&ref, "refs/heads/%s", state.branch);
+			strmap_put(&current_checked_out_branches,
+				   ref.buf,
+				   xstrdup(wt->path));
+			strbuf_release(&ref);
+		}
+		wt_status_state_free_buffers(&state);
 	}
 
 	free_worktrees(worktrees);
@@ -413,9 +437,7 @@ const char *branch_checked_out(const char *refname)
  */
 int validate_new_branchname(const char *name, struct strbuf *ref, int force)
 {
-	struct worktree **worktrees;
-	const struct worktree *wt;
-
+	const char *path;
 	if (!validate_branchname(name, ref))
 		return 0;
 
@@ -423,13 +445,10 @@ int validate_new_branchname(const char *name, struct strbuf *ref, int force)
 		die(_("a branch named '%s' already exists"),
 		    ref->buf + strlen("refs/heads/"));
 
-	worktrees = get_worktrees();
-	wt = find_shared_symref(worktrees, "HEAD", ref->buf);
-	if (wt && !wt->is_bare)
+	if ((path = branch_checked_out(ref->buf)))
 		die(_("cannot force update the branch '%s' "
 		      "checked out at '%s'"),
-		    ref->buf + strlen("refs/heads/"), wt->path);
-	free_worktrees(worktrees);
+		    ref->buf + strlen("refs/heads/"), path);
 
 	return 1;
 }

--- a/branch.c
+++ b/branch.c
@@ -10,6 +10,7 @@
 #include "worktree.h"
 #include "submodule-config.h"
 #include "run-command.h"
+#include "strmap.h"
 
 struct tracking {
 	struct refspec_item spec;
@@ -367,6 +368,41 @@ int validate_branchname(const char *name, struct strbuf *ref)
 		die(_("'%s' is not a valid branch name"), name);
 
 	return ref_exists(ref->buf);
+}
+
+static int initialized_checked_out_branches;
+static struct strmap current_checked_out_branches = STRMAP_INIT;
+
+static void prepare_checked_out_branches(void)
+{
+	int i = 0;
+	struct worktree **worktrees;
+
+	if (initialized_checked_out_branches)
+		return;
+	initialized_checked_out_branches = 1;
+
+	worktrees = get_worktrees();
+
+	while (worktrees[i]) {
+		struct worktree *wt = worktrees[i++];
+
+		if (wt->is_bare)
+			continue;
+
+		if (wt->head_ref)
+			strmap_put(&current_checked_out_branches,
+				   wt->head_ref,
+				   xstrdup(wt->path));
+	}
+
+	free_worktrees(worktrees);
+}
+
+const char *branch_checked_out(const char *refname)
+{
+	prepare_checked_out_branches();
+	return strmap_get(&current_checked_out_branches, refname);
 }
 
 /*

--- a/branch.c
+++ b/branch.c
@@ -385,25 +385,29 @@ static void prepare_checked_out_branches(void)
 	worktrees = get_worktrees();
 
 	while (worktrees[i]) {
+		char *old;
 		struct wt_status_state state = { 0 };
 		struct worktree *wt = worktrees[i++];
 
 		if (wt->is_bare)
 			continue;
 
-		if (wt->head_ref)
-			strmap_put(&current_checked_out_branches,
-				   wt->head_ref,
-				   xstrdup(wt->path));
+		if (wt->head_ref) {
+			old = strmap_put(&current_checked_out_branches,
+					 wt->head_ref,
+					 xstrdup(wt->path));
+			free(old);
+		}
 
 		if (wt_status_check_rebase(wt, &state) &&
 		    (state.rebase_in_progress || state.rebase_interactive_in_progress) &&
 		    state.branch) {
 			struct strbuf ref = STRBUF_INIT;
 			strbuf_addf(&ref, "refs/heads/%s", state.branch);
-			strmap_put(&current_checked_out_branches,
-				   ref.buf,
-				   xstrdup(wt->path));
+			old = strmap_put(&current_checked_out_branches,
+					 ref.buf,
+					 xstrdup(wt->path));
+			free(old);
 			strbuf_release(&ref);
 		}
 		wt_status_state_free_buffers(&state);
@@ -412,9 +416,10 @@ static void prepare_checked_out_branches(void)
 		    state.branch) {
 			struct strbuf ref = STRBUF_INIT;
 			strbuf_addf(&ref, "refs/heads/%s", state.branch);
-			strmap_put(&current_checked_out_branches,
-				   ref.buf,
-				   xstrdup(wt->path));
+			old = strmap_put(&current_checked_out_branches,
+					 ref.buf,
+					 xstrdup(wt->path));
+			free(old);
 			strbuf_release(&ref);
 		}
 		wt_status_state_free_buffers(&state);

--- a/branch.h
+++ b/branch.h
@@ -101,6 +101,13 @@ void create_branches_recursively(struct repository *r, const char *name,
 				 const char *tracking_name, int force,
 				 int reflog, int quiet, enum branch_track track,
 				 int dry_run);
+
+/*
+ * If the branch at 'refname' is currently checked out in a worktree,
+ * then return the path to that worktree.
+ */
+const char *branch_checked_out(const char *refname);
+
 /*
  * Check if 'name' can be a valid name for a branch; die otherwise.
  * Return 1 if the named branch already exists; return 0 otherwise.

--- a/builtin/branch.c
+++ b/builtin/branch.c
@@ -253,12 +253,11 @@ static int delete_branches(int argc, const char **argv, int force, int kinds,
 		name = mkpathdup(fmt, bname.buf);
 
 		if (kinds == FILTER_REFS_BRANCHES) {
-			const struct worktree *wt =
-				find_shared_symref(worktrees, "HEAD", name);
-			if (wt) {
+			const char *path;
+			if ((path = branch_checked_out(name))) {
 				error(_("Cannot delete branch '%s' "
 					"checked out at '%s'"),
-				      bname.buf, wt->path);
+				      bname.buf, path);
 				ret = 1;
 				continue;
 			}

--- a/t/t2407-worktree-heads.sh
+++ b/t/t2407-worktree-heads.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+test_description='test operations trying to overwrite refs at worktree HEAD'
+
+TEST_PASSES_SANITIZE_LEAK=true
+. ./test-lib.sh
+
+test_expect_success 'setup' '
+	test_commit init &&
+	git branch -f fake-1 &&
+	git branch -f fake-2 &&
+
+	for i in 1 2 3 4
+	do
+		test_commit $i &&
+		git branch wt-$i &&
+		git worktree add wt-$i wt-$i || return 1
+	done
+'
+
+test_expect_success 'refuse to overwrite: checked out in worktree' '
+	for i in 1 2 3 4
+	do
+		test_must_fail git branch -f wt-$i HEAD 2>err
+		grep "cannot force update the branch" err || return 1
+	done
+'
+
+test_done

--- a/t/t2407-worktree-heads.sh
+++ b/t/t2407-worktree-heads.sh
@@ -26,4 +26,26 @@ test_expect_success 'refuse to overwrite: checked out in worktree' '
 	done
 '
 
+test_expect_success 'refuse to overwrite: worktree in bisect' '
+	test_when_finished rm -rf .git/worktrees/wt-*/BISECT_* &&
+
+	touch .git/worktrees/wt-4/BISECT_LOG &&
+	echo refs/heads/fake-2 >.git/worktrees/wt-4/BISECT_START &&
+
+	test_must_fail git branch -f fake-2 HEAD 2>err &&
+	grep "cannot force update the branch '\''fake-2'\'' checked out at.*wt-4" err
+'
+
+test_expect_success 'refuse to overwrite: worktree in rebase' '
+	test_when_finished rm -rf .git/worktrees/wt-*/rebase-merge &&
+
+	mkdir -p .git/worktrees/wt-3/rebase-merge &&
+	touch .git/worktrees/wt-3/rebase-merge/interactive &&
+	echo refs/heads/fake-1 >.git/worktrees/wt-3/rebase-merge/head-name &&
+	echo refs/heads/fake-2 >.git/worktrees/wt-3/rebase-merge/onto &&
+
+	test_must_fail git branch -f fake-1 HEAD 2>err &&
+	grep "cannot force update the branch '\''fake-1'\'' checked out at.*wt-3" err
+'
+
 test_done

--- a/t/t2407-worktree-heads.sh
+++ b/t/t2407-worktree-heads.sh
@@ -15,6 +15,21 @@ test_expect_success 'setup' '
 		test_commit $i &&
 		git branch wt-$i &&
 		git worktree add wt-$i wt-$i || return 1
+	done &&
+
+	# Create a server that updates each branch by one commit
+	git init server &&
+	test_commit -C server initial &&
+	git remote add server ./server &&
+	for i in 1 2 3 4
+	do
+		git -C server checkout -b wt-$i &&
+		test_commit -C server A-$i || return 1
+	done &&
+	for i in 1 2
+	do
+		git -C server checkout -b fake-$i &&
+		test_commit -C server f-$i || return 1
 	done
 '
 
@@ -46,6 +61,38 @@ test_expect_success 'refuse to overwrite: worktree in rebase' '
 
 	test_must_fail git branch -f fake-1 HEAD 2>err &&
 	grep "cannot force update the branch '\''fake-1'\'' checked out at.*wt-3" err
+'
+
+test_expect_success !SANITIZE_LEAK 'refuse to fetch over ref: checked out' '
+	test_must_fail git fetch server +refs/heads/wt-3:refs/heads/wt-3 2>err &&
+	grep "refusing to fetch into branch '\''refs/heads/wt-3'\''" err &&
+
+	# General fetch into refs/heads/ will fail on first ref,
+	# so use a generic error message check.
+	test_must_fail git fetch server +refs/heads/*:refs/heads/* 2>err &&
+	grep "refusing to fetch into branch" err
+'
+
+test_expect_success !SANITIZE_LEAK 'refuse to fetch over ref: worktree in bisect' '
+	test_when_finished rm -rf .git/worktrees/wt-*/BISECT_* &&
+
+	touch .git/worktrees/wt-4/BISECT_LOG &&
+	echo refs/heads/fake-2 >.git/worktrees/wt-4/BISECT_START &&
+
+	test_must_fail git fetch server +refs/heads/fake-2:refs/heads/fake-2 2>err &&
+	grep "refusing to fetch into branch" err
+'
+
+test_expect_success !SANITIZE_LEAK 'refuse to fetch over ref: worktree in rebase' '
+	test_when_finished rm -rf .git/worktrees/wt-*/rebase-merge &&
+
+	mkdir -p .git/worktrees/wt-4/rebase-merge &&
+	touch .git/worktrees/wt-4/rebase-merge/interactive &&
+	echo refs/heads/fake-1 >.git/worktrees/wt-4/rebase-merge/head-name &&
+	echo refs/heads/fake-2 >.git/worktrees/wt-4/rebase-merge/onto &&
+
+	test_must_fail git fetch server +refs/heads/fake-1:refs/heads/fake-1 2>err &&
+	grep "refusing to fetch into branch" err
 '
 
 test_done

--- a/t/t2407-worktree-heads.sh
+++ b/t/t2407-worktree-heads.sh
@@ -37,7 +37,10 @@ test_expect_success 'refuse to overwrite: checked out in worktree' '
 	for i in 1 2 3 4
 	do
 		test_must_fail git branch -f wt-$i HEAD 2>err
-		grep "cannot force update the branch" err || return 1
+		grep "cannot force update the branch" err &&
+
+		test_must_fail git branch -D wt-$i 2>err
+		grep "Cannot delete branch" err || return 1
 	done
 '
 


### PR DESCRIPTION
This is a replacement for some patches from v2 of my 'git rebase --update-refs' topic [1]. After some feedback from Philip, I've decided to pull that topic while I rework how I track the refs to rewrite [2]. This series moves forward with the `branch_checked_out()` helper that was a bit more complicated than expected at first glance. This series is a culmination of the discussion started by Junio at [3].

[1] https://lore.kernel.org/git/pull.1247.v2.git.1654634569.gitgitgadget@gmail.com
[2] https://lore.kernel.org/git/34264915-8a37-62db-f954-0b5297639b34@github.com/
[3] https://lore.kernel.org/git/xmqqr140t9am.fsf@gitster.g/

Here is the patch outline:

1. Add a basic form of branch_checked_out() that only looks at the HEAD of each worktree. Since this doesn't look at BISECT_HEAD or REBASE_HEAD, the helper isn't linked to any consumer in this patch. A test script is added that verifies the current behavior checks that are implemented, even if they are not connected yet.
2. Make branch_checked_out() actually look at BISECT_HEAD and REBASE_HEAD. Add tests for those cases, which was previously untested in the Git test suite. Use branch_checked_out() in 'git branch -f' to demonstrate this helper works as expected.
3. Use branch_checked_out() in 'git fetch' when checking refs that would be updated by the refspec. Add tests for that scenario, too.
4. Use branch_checked_out() in 'git branch -D' to prevent deleting refs from under an existing checkout. The commit message here describes some barriers to removing other uses of find_shared_symref() that could be good investigations for later.
5. Be careful when constructing the strmap to free old values, even though this should only happen in error scenarios. Add tests that verify this behavior.

Updates in v2
-------------

* branch_checked_out() has a new prototype where it returns a 'const char *' instead of copying the path.
* The test script is marked with TEST_PASSES_SANITIZE_LEAK and test are careful to avoid using 'git rebase' or 'git bisect' when possible.
* Tests that cannot avoid memory-loss from 'git fetch' are marked with the "!SANITIZE_LEAK" prereq.
* A previous replacement of 'wt->current' with 'path' is removed. This changes an error message, but it is a very rare scenario where this error would be output.

Thanks,
-Stolee


cc: gitster@pobox.com
cc: johannes.schindelin@gmx.de
cc: me@ttaylorr.com
cc: Jeff Hostetler <git@jeffhostetler.com>
cc: Phillip Wood <phillip.wood123@gmail.com>
cc: Elijah Newren <newren@gmail.com>
cc: Ævar Arnfjörð Bjarmason <avarab@gmail.com>