### PR TITLE
Reactions to v2.37.0-rc0 test coverage report

### DIFF
--- a/cache-tree.c
+++ b/cache-tree.c
@@ -101,33 +101,6 @@ struct cache_tree_sub *cache_tree_sub(struct cache_tree *it, const char *path)
 	return find_subtree(it, path, pathlen, 1);
 }
 
-struct cache_tree *cache_tree_find_path(struct cache_tree *it, const char *path)
-{
-	const char *slash;
-	int namelen;
-	struct cache_tree_sub it_sub = {
-		.cache_tree = it,
-	};
-	struct cache_tree_sub *down = &it_sub;
-
-	while (down) {
-		slash = strchrnul(path, '/');
-		namelen = slash - path;
-		down->cache_tree->entry_count = -1;
-		if (!*slash) {
-			int pos;
-			pos = cache_tree_subtree_pos(down->cache_tree, path, namelen);
-			if (0 <= pos)
-				return down->cache_tree->down[pos]->cache_tree;
-			return NULL;
-		}
-		down = find_subtree(it, path, namelen, 0);
-		path = slash + 1;
-	}
-
-	return NULL;
-}
-
 static int do_invalidate_path(struct cache_tree *it, const char *path)
 {
 	/* a/b/c

--- a/cache-tree.h
+++ b/cache-tree.h
@@ -29,8 +29,6 @@ struct cache_tree_sub *cache_tree_sub(struct cache_tree *, const char *);
 
 int cache_tree_subtree_pos(struct cache_tree *it, const char *path, int pathlen);
 
-struct cache_tree *cache_tree_find_path(struct cache_tree *it, const char *path);
-
 void cache_tree_write(struct strbuf *, struct cache_tree *root);
 struct cache_tree *cache_tree_read(const char *buffer, unsigned long size);
 

--- a/t/t5329-pack-objects-cruft.sh
+++ b/t/t5329-pack-objects-cruft.sh
@@ -451,11 +451,13 @@ test_expect_success 'expiring cruft objects with git gc' '
 		sort <reachable.raw >reachable &&
 		comm -13 reachable objects >unreachable &&
 
-		git repack --cruft -d &&
+		# Write a cruft pack containing all unreachable objects.
+		git gc --cruft --prune="01-01-1980" &&
 
 		mtimes=$(ls .git/objects/pack/pack-*.mtimes) &&
 		test_path_is_file $mtimes &&
 
+		# Prune all unreachable objects from the cruft pack.
 		git gc --cruft --prune=now &&
 
 		git cat-file --batch-all-objects --batch-check="%(objectname)" >objects &&


### PR DESCRIPTION
These patches add test coverage or simplify code based on discoveries in the test coverage report (specifically, some that I highlighted at [1]).

[1] https://lore.kernel.org/git/3d1c6dfd-1df6-3393-df5e-692719375772@github.com/

1. Add tests for 'git update-index --verbose'.
2. Add 'git gc --cruft' without '--prune=now' to test.
3. Drop an always-NULL parameter from an internal method.
4. Revert 080ab56a4 (cache-tree: implement cache_tree_find_path(), 2022-05-23).

Any subset of these could be taken (or dropped), but I thought they would be worth considering.

Updates in v2
-------------

* A useless addition of --verbose was removed from a test in patch 1.
* Comments are updated in patch 2 based on Taylor's recommendations.
* Added --prune="01-01-1980" to exercise the --cruft-expiration logic underneath 'git gc --cruft'.

Thanks,
-Stolee

cc: gitster@pobox.com
cc: me@ttaylorr.com
cc: Eric Sunshine <sunshine@sunshineco.com>