### PR TITLE
add --interactive: fix bug in built-in variant

### DIFF
--- a/t/t3701-add-interactive.sh
+++ b/t/t3701-add-interactive.sh
@@ -103,6 +103,15 @@ test_expect_success 'status works (commit)' '
 	grep "+1/-0 *+2/-0 file" output
 '
 
+test_expect_success 'update can stage deletions' '
+	>to-delete &&
+	git add to-delete &&
+	rm to-delete &&
+	test_write_lines u t "" | git add -i &&
+	git ls-files to-delete >output &&
+	test_must_be_empty output
+'
+
 test_expect_success 'setup expected' '
 	cat >expected <<-\EOF
 	index 180b47c..b6f2c08 100644


### PR DESCRIPTION
This fixes a bug when using the built-in version of `git add -i` to update a file that has been deleted (in order to stage its deletion), where it fails with:

```
fatal: unable to stat 'myfile': No such file or directory
```

Since the built-in version of `git add -i` has been made the default in v2.37.0, from the users' point of view this is a regression, and this patch fixes it. I therefore consider this v2.37.1 material.

This addresses https://github.com/msys2/MSYS2-packages/issues/3066

Cc: Christoph Reiter <reiter.christoph@gmail.com>
cc: Taylor Blau <me@ttaylorr.com>
cc: Ævar Arnfjörð Bjarmason <avarab@gmail.com>