### PR TITLE
t6429: fix use of non-existent function

### DIFF
--- a/t/t6429-merge-sequence-rename-caching.sh
+++ b/t/t6429-merge-sequence-rename-caching.sh
@@ -760,7 +760,7 @@ test_expect_success 'avoid assuming we detected renames' '
 		test_must_fail git -c merge.renameLimit=1 rebase upstream &&
 
 		git ls-files -u >actual &&
-		! test_file_is_empty actual
+		test_line_count = 2 actual
 	)
 '
 


### PR DESCRIPTION
This test had a line reading

    ! test_file_is_empty actual

which was meant to be

    ! test_must_be_empty actual

The test worked despite the error, because even though
test_file_is_empty is a non-existent function, the '!' negated the
return value and made it pass.  It'd be better to avoid the negation,
so something like

    test_file_not_empty actual

would be better, but perhaps it makes even more sense to specify the
number of lines of expected output to make the test a bit tighter.

Reported-by: SZEDER Gábor <szeder.dev@gmail.com>
Signed-off-by: Elijah Newren <newren@palantir.com>