### PR TITLE
http: support building on RHEL6

### DIFF
--- a/git-curl-compat.h
+++ b/git-curl-compat.h
@@ -29,6 +29,13 @@
  */
 
 /**
+ ** CURLOPT_RESOLVE was added in 7.21.3, released in December 2010.
+ */
+#if LIBCURL_VERSION_NUM >= 0x071503
+#define GIT_CURL_HAVE_CURLOPT_RESOLVE 1
+#endif
+
+/**
  * CURL_SOCKOPT_OK was added in 7.21.5, released in April 2011.
  */
 #if LIBCURL_VERSION_NUM < 0x071505

--- a/http.c
+++ b/http.c
@@ -1228,7 +1228,12 @@ struct active_request_slot *get_active_slot(void)
 	if (curl_save_cookies)
 		curl_easy_setopt(slot->curl, CURLOPT_COOKIEJAR, curl_cookie_file);
 	curl_easy_setopt(slot->curl, CURLOPT_HTTPHEADER, pragma_header);
+#ifdef GIT_CURL_HAVE_CURLOPT_RESOLVE
 	curl_easy_setopt(slot->curl, CURLOPT_RESOLVE, host_resolutions);
+#else
+	if (host_resolutions)
+		warning(_("lacking support for `http.curloptResolve`"));
+#endif
 	curl_easy_setopt(slot->curl, CURLOPT_ERRORBUFFER, curl_errorstr);
 	curl_easy_setopt(slot->curl, CURLOPT_CUSTOMREQUEST, NULL);
 	curl_easy_setopt(slot->curl, CURLOPT_READFUNCTION, NULL);


### PR DESCRIPTION
This came in via the awkward venue of a commit comment at https://github.com/git/git/commit/511cfd3bffa685fda0e7c25bfa08082aa0de3a30#commitcomment-77360864.

I looked [here](https://curl.se/libcurl/c/CURLOPT_RESOLVE.html) to find out since when cURL supports `CURLOPT_RESOLVE`.

cc: "brian m. carlson" <sandals@crustytoothpaste.net>
cc: Ævar Arnfjörð Bjarmason <avarab@gmail.com>