### PR TITLE
tests(JUnit): fix a regression introduced by refactoring

### DIFF
--- a/t/test-lib-junit.sh
+++ b/t/test-lib-junit.sh
@@ -46,7 +46,7 @@ finalize_test_case_output () {
 	shift
 	case "$test_case_result" in
 	ok)
-		set "$*"
+		set -- "$*"
 		;;
 	failure)
 		junit_insert="<failure message=\"not ok $test_count -"
@@ -65,17 +65,17 @@ finalize_test_case_output () {
 			junit_insert="$junit_insert<system-err>$(xml_attr_encode \
 				"$(cat "$GIT_TEST_TEE_OUTPUT_FILE")")</system-err>"
 		fi
-		set "$1" "      $junit_insert"
+		set -- "$1" "      $junit_insert"
 		;;
 	fixed)
-		set "$* (breakage fixed)"
+		set -- "$* (breakage fixed)"
 		;;
 	broken)
-		set "$* (known breakage)"
+		set -- "$* (known breakage)"
 		;;
 	skip)
 		message="$(xml_attr_encode --no-lf "$skipped_reason")"
-		set "$1" "      <skipped message=\"$message\" />"
+		set -- "$1" "      <skipped message=\"$message\" />"
 		;;
 	esac
 


### PR DESCRIPTION
As if another data point was needed to corroborate my claim that refactorings are neither free of cost nor of risk, this patch fixes a regression I myself introduced while refactoring the JUnit XML output code. At least this refactoring was motivated by an ulterior goal to improve Git's contributor experience, not just refactoring for refactoring's sake.

Unfortunately, I noticed this regression no earlier than when I needed to validate Git for Windows v2.37.1. Since v2.37.1 was an embargoed release, I could not use GitHub Actions for the CI testing, so I had to reinstate Git's Azure Pipeline.

It will probably surprise only few, if at all, that this is far from the only regression in the CI code that I had to fix just so I could run the Azure Pipeline successfully. I plan on contributing all of these regression fixes, of course, packaged into neat little, logically-separate patch series that should be easy on reviewers.

cc: Ævar Arnfjörð Bjarmason <avarab@gmail.com>