### PR TITLE
shortlog: use a stable sort

### DIFF
--- a/builtin/shortlog.c
+++ b/builtin/shortlog.c
@@ -443,7 +443,7 @@ void shortlog_output(struct shortlog *log)
 	struct strbuf sb = STRBUF_INIT;
 
 	if (log->sort_by_number)
-		QSORT(log->list.items, log->list.nr,
+		STABLE_QSORT(log->list.items, log->list.nr,
 		      log->summary ? compare_by_counter : compare_by_list);
 	for (i = 0; i < log->list.nr; i++) {
 		const struct string_list_item *item = &log->list.items[i];


### PR DESCRIPTION
This is another fall-out from validating Git for Windows v2.37.1 via the reinstated Azure Pipeline.

The most valid question a reviewer might have about this patch is: "But why does our current CI not fail in the `vs-test` job?". The answer is surprisingly trivial: Because [our CMake-based definition universally defines `INTERNAL_QSORT`](https://github.com/git/git/blob/v2.37.1/contrib/buildsystems/CMakeLists.txt#L227), which should actually not even be necessary, while the Azure Pipeline I used still calls `make vcxproj` to generate the Visual Studio build definition and does _not_ define that flag.