### PR TITLE
Fix the `lstat()` emulation on Windows

### DIFF
--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -471,8 +471,8 @@ static int has_valid_directory_prefix(wchar_t *wfilename)
 		wfilename[n] = L'\0';
 		attributes = GetFileAttributesW(wfilename);
 		wfilename[n] = c;
-		if (attributes == FILE_ATTRIBUTE_DIRECTORY ||
-				attributes == FILE_ATTRIBUTE_DEVICE)
+		if (attributes &
+		    (FILE_ATTRIBUTE_DIRECTORY | FILE_ATTRIBUTE_DEVICE))
 			return 1;
 		if (attributes == INVALID_FILE_ATTRIBUTES)
 			switch (GetLastError()) {


### PR DESCRIPTION
One particular code path in the `lstat()` emulation on Windows was broken.

This fixes https://github.com/git-for-windows/git/issues/3727

Changes since v2:
- Fixed typos in the commit message (I wanted to write "led" but had written "let" instead, thanks once again, Eric!, and I managed to misspell a function name).

Changes since v1:
- Thanks to Eric's excellent review, the reporter and I dug deeper and figured out the _real_ bug (and fix).

cc: Eric Sunshine <sunshine@sunshineco.com>