### PR TITLE
osx-keychain: fix compiler warning

### DIFF
--- a/contrib/credential/osxkeychain/git-credential-osxkeychain.c
+++ b/contrib/credential/osxkeychain/git-credential-osxkeychain.c
@@ -168,7 +168,7 @@ int main(int argc, const char **argv)
 		"usage: git credential-osxkeychain <get|store|erase>";
 
 	if (!argv[1])
-		die(usage);
+		die("%s", usage);
 
 	read_credential();
 


### PR DESCRIPTION
Running `make` in `contrib/credential/osxkeychain` currently shows the following warning:

`warning: format string is not a string literal (potentially insecure)`

This small change to treat the string as an argument fixes the issue.

Thanks,
Lessley

cc: gitster@pobox.com
cc: Derrick Stolee <derrickstolee@github.com>
cc: Glen Choo <chooglen@google.com>