### PR TITLE
Use 'Everything up to date.' instead of 'Everything up-to-date'

### DIFF
--- a/builtin/send-pack.c
+++ b/builtin/send-pack.c
@@ -338,7 +338,7 @@ int cmd_send_pack(int argc, const char **argv, const char *prefix)
 	}
 
 	if (!ret && !transport_refs_pushed(remote_refs))
-		fprintf(stderr, "Everything up-to-date\n");
+		fprintf(stderr, "Everything up to date.\n");
 
 	return ret;
 }

--- a/transport.c
+++ b/transport.c
@@ -1416,7 +1416,7 @@ int transport_push(struct repository *r,
 	if (porcelain && !push_ret)
 		puts("Done");
 	else if (!quiet && !ret && !transport_refs_pushed(remote_refs))
-		fprintf(stderr, "Everything up-to-date\n");
+		fprintf(stderr, "Everything up to date.\n");
 
 done:
 	free_refs(local_refs);


### PR DESCRIPTION
There are two hard-coded
`fprintf(stderr, "Everything up-to-date\n")`
which I have changed to
`fprintf(stderr, "Everything up to date.\n")`
since most other strings used localised versions of `up to date.`

Before (stupidly inconsistent):
```
$ git pull
Already up to date.
$ git push
Everything up-to-date
```
After (consistent):
```
$ git pull
Already up to date.
$ git push
Everything up to date.
```
Signed-off-by: Jay Berry <jb2170@selfadjointoperator.com>

cc: Ævar Arnfjörð Bjarmason <avarab@gmail.com>
cc: Paul Smith <paul@mad-scientist.net>
cc: Johannes Schindelin <Johannes.Schindelin@gmx.de>