### PR TITLE
cmake(windows): fall back to user-wide Git if there is no system Git

### DIFF
--- a/contrib/buildsystems/CMakeLists.txt
+++ b/contrib/buildsystems/CMakeLists.txt
@@ -77,7 +77,7 @@ if(USE_VCPKG)
 	set(CMAKE_TOOLCHAIN_FILE ${VCPKG_DIR}/scripts/buildsystems/vcpkg.cmake CACHE STRING "Vcpkg toolchain file")
 endif()
 
-find_program(SH_EXE sh PATHS "C:/Program Files/Git/bin")
+find_program(SH_EXE sh PATHS "C:/Program Files/Git/bin" "$ENV{LOCALAPPDATA}/Programs/Git/bin")
 if(NOT SH_EXE)
 	message(FATAL_ERROR "sh: shell interpreter was not found in your path, please install one."
 			"On Windows, you can get it as part of 'Git for Windows' install at https://gitforwindows.org/")


### PR DESCRIPTION
On Windows, software is typically either installed into `C:\Program Files`, where all users can use it, or into a location inside the user's home directory, where only that particular user can use the software.

Git for Windows strongly encourages system-wide installations, but does not prevent user-wide installations.

When building Git via CMake, this matters because we rely on Git for Windows to provide the POSIX shell that is needed to run Git's generator scripts such as `generate-cmdlist.sh`. So far, we only found Git for Windows if it was installed system-wide, but with this here patch, we also find any user-wide installation.