### PR TITLE
merge-ort: clean up after failed merge

### DIFF
--- a/merge-ort.c
+++ b/merge-ort.c
@@ -3157,6 +3157,7 @@ void merge_switch_to_result(struct merge_options *opt,
 		if (checkout(opt, head, result->tree)) {
 			/* failure to function */
 			result->clean = -1;
+			merge_finalize(opt, result);
 			return;
 		}
 		trace2_region_leave("merge", "checkout", opt->repo);
@@ -3167,6 +3168,7 @@ void merge_switch_to_result(struct merge_options *opt,
 						    &opti->conflicted)) {
 			/* failure to function */
 			result->clean = -1;
+			merge_finalize(opt, result);
 			return;
 		}
 		trace2_region_leave("merge", "record_conflicted", opt->repo);

--- a/merge-ort.c
+++ b/merge-ort.c
@@ -3158,6 +3158,7 @@ void merge_switch_to_result(struct merge_options *opt,
 			/* failure to function */
 			result->clean = -1;
 			merge_finalize(opt, result);
+			trace2_region_leave("merge", "checkout", opt->repo);
 			return;
 		}
 		trace2_region_leave("merge", "checkout", opt->repo);
@@ -3169,6 +3170,8 @@ void merge_switch_to_result(struct merge_options *opt,
 			/* failure to function */
 			result->clean = -1;
 			merge_finalize(opt, result);
+			trace2_region_leave("merge", "record_conflicted",
+					    opt->repo);
 			return;
 		}
 		trace2_region_leave("merge", "record_conflicted", opt->repo);


### PR DESCRIPTION
I was investigating why `seen`'s CI runs fail, and came up with this fix.

Changes since v1:
- Rebased onto `en/merge-ort-perf`.
- Now we're not only cleaning up the merge data structure, but also leaving the Trace2 region when returning early from `merge_switch_to_result()`.

Cc: Elijah Newren <newren@gmail.com>