### PR TITLE
ci: fix the FreeBSD build

### DIFF
--- a/bulk-checkin.c
+++ b/bulk-checkin.c
@@ -340,6 +340,8 @@ void fsync_loose_object_bulk_checkin(int fd, const char *filename)
 	 */
 	if (!bulk_fsync_objdir ||
 	    git_fsync(fd, FSYNC_WRITEOUT_ONLY) < 0) {
+		if (errno == ENOSYS)
+			warning(_("core.fsyncMethod = batch is unsupported on this platform"));
 		fsync_or_die(fd, filename);
 	}
 }

--- a/t/t5351-unpack-large-objects.sh
+++ b/t/t5351-unpack-large-objects.sh
@@ -93,7 +93,7 @@ test_expect_success 'do not unpack existing large objects' '
 
 	# The destination came up with the exact same pack...
 	DEST_PACK=$(echo dest.git/objects/pack/pack-*.pack) &&
-	test_cmp pack-$PACK.pack $DEST_PACK &&
+	cmp pack-$PACK.pack $DEST_PACK &&
 
 	# ...and wrote no loose objects
 	test_stdout_line_count = 0 find dest.git/objects -type f ! -name "pack-*"

--- a/t/t5351-unpack-large-objects.sh
+++ b/t/t5351-unpack-large-objects.sh
@@ -70,9 +70,15 @@ test_expect_success 'unpack big object in stream (core.fsyncmethod=batch)' '
 	GIT_TRACE2_EVENT="$(pwd)/trace2.txt" \
 	GIT_TEST_FSYNC=true \
 		git -C dest.git $BATCH_CONFIGURATION unpack-objects <pack-$PACK.pack &&
-	check_fsync_events trace2.txt <<-\EOF &&
+	if grep "core.fsyncMethod = batch is unsupported" trace2.txt
+	then
+		flush_count=7
+	else
+		flush_count=1
+	fi &&
+	check_fsync_events trace2.txt <<-EOF &&
 	"key":"fsync/writeout-only","value":"6"
-	"key":"fsync/hardware-flush","value":"1"
+	"key":"fsync/hardware-flush","value":"$flush_count"
 	EOF
 
 	test_dir_is_empty dest.git/objects/pack &&


### PR DESCRIPTION
Since 3a251bac0d1a (trace2: only include "fsync" events if we git_fsync(), 2022-07-18), the FreeBSD builds are failing in t5351.6. See https://cirrus-ci.com/task/4577761405698048 for an example. The run at https://cirrus-ci.com/task/6004115347079168 shows that this patch fixes the bug.

While verifying the fix on Windows, I noticed a recent, rather terrible performance regression: t5351 all of a sudden takes [almost half an hour](https://github.com/git/git/runs/7398490747?check_suite_focus=true#step:5:171) to run on Windows. I found a fix, and it now passes [in less than half a minute](https://github.com/gitgitgadget/git/runs/7578071365?check_suite_focus=true#step:5:125) again.

cc: Derrick Stolee <derrickstolee@github.com>
cc: Carlo Marcelo Arenas Belón <carenas@gmail.com>
cc: "brian m. carlson" <sandals@crustytoothpaste.net>