### PR TITLE
diff, branch: allow "-" as a short-hand for "previous branch"

### DIFF
--- a/builtin/branch.c
+++ b/builtin/branch.c
@@ -241,6 +241,10 @@ static int delete_branches(int argc, const char **argv, int force, int kinds,
 			die(_("Couldn't look up commit object for HEAD"));
 	}
 
+	if ((argc == 1) && !strcmp(argv[0], "-")) {
+		argv[0] = "@{-1}";
+	}
+
 	for (i = 0; i < argc; i++, strbuf_reset(&bname)) {
 		char *target = NULL;
 		int flags = 0;


### PR DESCRIPTION
Align "diff" and "branch" with the intuitive use of "-" as a
short-hand for "@{-1}", like in "checkout" and "merge" commands.

$ git diff -           # short-hand for: "git diff @{-}"
$ git branch -d -      # short-hand for: "git branch -d @{-1}"
$ git branch -D -      # short-hand for: "git branch -D @{-1}"

Signed-off-by: Rubén Justo <rjusto@gmail.com>