### PR TITLE
Fixups for cw/submodule-merge-messages

### DIFF
--- a/merge-ort.c
+++ b/merge-ort.c
@@ -1767,7 +1767,7 @@ static int merge_submodule(struct merge_options *opt,
 	int i;
 	int search = !opt->priv->call_depth;
 	int sub_not_initialized = 1;
-	int sub_flag = -1;
+	int sub_flag = CONFLICT_SUBMODULE_FAILED_TO_MERGE;
 
 	/* store fallback answer in result in case we fail */
 	oidcpy(result, opt->priv->call_depth ? o : a);

--- a/merge-ort.c
+++ b/merge-ort.c
@@ -4490,21 +4490,17 @@ static void print_submodule_conflict_suggestion(struct string_list *csub) {
 	if (!csub->nr)
 		return;
 
-	/*
-	 * NEEDSWORK: The steps to resolve these errors deserve a more
-	 * detailed explanation than what is currently printed below.
-	 */
-	for_each_string_list_item(item, csub) {
-		struct conflicted_submodule_item *util = item->util;
-
-		if (util->flag == CONFLICT_SUBMODULE_NOT_INITIALIZED ||
-			util->flag == CONFLICT_SUBMODULE_HISTORY_NOT_AVAILABLE)
-			return;
-	}
-
 	strbuf_add_separated_string_list(&subs, " ", csub);
 	for_each_string_list_item(item, csub) {
 		struct conflicted_submodule_item *util = item->util;
+
+		/*
+		 * NEEDSWORK: The steps to resolve these errors deserve a more
+		 * detailed explanation than what is currently printed below.
+		 */
+		if (util->flag == CONFLICT_SUBMODULE_NOT_INITIALIZED ||
+		    util->flag == CONFLICT_SUBMODULE_HISTORY_NOT_AVAILABLE)
+			continue;
 
 		/*
 		 * TRANSLATORS: This is a line of advice to resolve a merge


### PR DESCRIPTION
This series fixes a few issues I noted in cw/submodule-merge-messages (which merged to next a few days ago).  Sorry for not responding before that topic merged to next; I caught Covid near the end of my vacation and it took me out for a while.  So here are a few patches on top instead.

Changes since v1:
  - rebased directly on top of Calvin's patch, allowing Junio's patch in cw/submodule-merge-messages to be dropped.

Changes since v2:
  - changed the second patch to instead initialize sub_flag to CONFLICT_SUBMODULE_FAILED_TO_MERGE, as suggested by Junio.  (thanks!)

cc: Calvin Wan <calvinwan@google.com>
cc: Elijah Newren <newren@gmail.com>