### PR TITLE
t/perf: fix broken tests

### DIFF
--- a/t/perf/p0004-lazy-init-name-hash.sh
+++ b/t/perf/p0004-lazy-init-name-hash.sh
@@ -49,7 +49,7 @@ test_perf "single-threaded, $desc" "
 	test-tool lazy-init-name-hash --single --count=$count
 "
 
-test_perf REPO_BIG_ENOUGH_FOR_MULTI "multi-threaded, $desc" "
+test_perf "multi-threaded, $desc" --prereq REPO_BIG_ENOUGH_FOR_MULTI "
 	test-tool lazy-init-name-hash --multi --count=$count
 "
 

--- a/t/perf/p0006-read-tree-checkout.sh
+++ b/t/perf/p0006-read-tree-checkout.sh
@@ -46,7 +46,7 @@ test_expect_success "setup repo" '
 '
 
 test_perf "read-tree br_base br_ballast ($nr_files)" '
-	git read-tree -m br_base br_ballast -n
+	git read-tree -n -m br_base br_ballast
 '
 
 test_perf "switch between br_base br_ballast ($nr_files)" '


### PR DESCRIPTION
This series fixes two performance tests (p0004 & p0006) with syntax issues preventing them from running properly. Since these are pretty straightforward syntax bugs, the fixes don't seem to change the intended behavior of the tests.

Thanks!
- Victoria