### PR TITLE
ci: update 'static-analysis' to Ubuntu 22.04

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -309,7 +309,7 @@ jobs:
     if: needs.ci-config.outputs.enabled == 'yes'
     env:
       jobname: StaticAnalysis
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
     - run: ci/install-dependencies.sh


### PR DESCRIPTION
I noticed this while preparing my bundle URIs series. See an example cancellation at [1]

[1] https://github.com/gitgitgadget/git/runs/7954913465?check_suite_focus=true 

I initially asked about this [2]. Thanks to Matthias Aßhauer for pointing out that 22.04 has Coccinelle available [3].

[2] https://lore.kernel.org/git/eb8779bc-fc41-f601-05f2-024e6bf3f316@github.com/
[3] https://github.com/gitgitgadget/git/pull/1334#issuecomment-1223597655

Thanks,
* Stolee

cc: Johannes Schindelin <Johannes.Schindelin@gmx.de>
cc: Ævar Arnfjörð Bjarmason <avarab@gmail.com>
cc: Jeff King <peff@peff.net>