### PR TITLE
A couple of CI fixes regarding the built-in `add --patch` 

### DIFF
--- a/add-patch.c
+++ b/add-patch.c
@@ -1547,7 +1547,7 @@ soft_increment:
 			strbuf_remove(&s->answer, 0, 1);
 			strbuf_trim(&s->answer);
 			i = hunk_index - DISPLAY_HUNKS_LINES / 2;
-			if (i < file_diff->mode_change)
+			if (i < (int)file_diff->mode_change)
 				i = file_diff->mode_change;
 			while (s->answer.len == 0) {
 				i = display_hunks(s, file_diff, i);

--- a/t/t3701-add-interactive.sh
+++ b/t/t3701-add-interactive.sh
@@ -7,9 +7,9 @@ export GIT_TEST_DEFAULT_INITIAL_BRANCH_NAME
 . ./test-lib.sh
 . "$TEST_DIRECTORY"/lib-terminal.sh
 
-if ! test_have_prereq PERL
+if test_have_prereq !ADD_I_USE_BUILTIN,!PERL
 then
-	skip_all='skipping add -i tests, perl not available'
+	skip_all='skipping add -i (scripted) tests, perl not available'
 	test_done
 fi
 

--- a/t/t6132-pathspec-exclude.sh
+++ b/t/t6132-pathspec-exclude.sh
@@ -293,7 +293,11 @@ test_expect_success 'add with all negative' '
 	test_cmp expect actual
 '
 
-test_expect_success 'add -p with all negative' '
+test_lazy_prereq ADD_I_USE_BUILTIN_OR_PERL '
+	test_have_prereq ADD_I_USE_BUILTIN || test_have_prereq PERL
+'
+
+test_expect_success ADD_I_USE_BUILTIN_OR_PERL 'add -p with all negative' '
 	H=$(git rev-parse HEAD) &&
 	git reset --hard $H &&
 	git clean -f &&


### PR DESCRIPTION
This is an attempt to address the concern Junio raised in https://lore.kernel.org/git/xmqq7d3gm1bl.fsf@gitster.g/: originally motivated by a test suite failure when running Git's test suite in Visual Studio, this pulls out the signed vs unsigned fix whose implications are potentially much wider than Visual C.

While in that space, I spent the time (which took almost [as long as I expected](https://lore.kernel.org/git/nrr2312s-q256-61n7-2843-7r0s817rp432@tzk.qr/)) to craft a semantic patch to scrutinize Git's source code for similar issues (narrator's voice: there were no other instances, what did ya expect?).

To verify the fix, I then worked on a patch to exercise the built-in `git add -p` in the test suite even when `NO_PERL` is set, and while developing this patch and validating it, I got really puzzled that the `add -p` test case in `t6132` did not need to be guarded behind a `PERL` prereq. So this patch series also includes a fix for that.

The story arc that binds all of these patches together is that they all revolve around NO_PERL and CI issues that involve `git add --patch`.

Note: This patch series is based on `ds/github-actions-use-newer-ubuntu` (but probably applies cleanly even on `maint`) because I tried to develop a semantic patch to fix similar issues in the code base. However, I've since run into what [looks like a bug in Coccinelle](https://github.com/coccinelle/coccinelle/issues/284). My latest version of that semantic patch looks like this, but I stopped when running it on Git's source code triggered the bug for 66 of Git's `.c` files:

```diff
@@
type T = { unsigned int };
T:n b;
type S != { unsigned int, size_t };
S s;
binary operator o != { &&, || };
@@
-s o b
+s o (S)b

@@
type T = { unsigned int };
T:n b;
type S != { unsigned int, size_t };
S s;
binary operator o != { &&, || };
@@
-b o s
+(S)b o s
```

cc: Phillip Wood <phillip.wood123@gmail.com>
cc: Jeff King <peff@peff.net>