### PR TITLE
unpack-trees: fix sparse directory recursion check

### DIFF
--- a/t/t1092-sparse-checkout-compatibility.sh
+++ b/t/t1092-sparse-checkout-compatibility.sh
@@ -380,6 +380,15 @@ test_expect_success 'checkout with modified sparse directory' '
 	test_all_match git checkout base
 '
 
+test_expect_success 'checkout orphan then non-orphan' '
+	init_repos &&
+
+	test_all_match git checkout --orphan test-orphan &&
+	test_all_match git status --porcelain=v2 &&
+	test_all_match git checkout base &&
+	test_all_match git status --porcelain=v2
+'
+
 test_expect_success 'add outside sparse cone' '
 	init_repos &&
 

--- a/unpack-trees.c
+++ b/unpack-trees.c
@@ -1423,7 +1423,7 @@ static void debug_unpack_callback(int n,
  * from the tree walk at the given traverse_info.
  */
 static int is_sparse_directory_entry(struct cache_entry *ce,
-				     struct name_entry *name,
+				     const struct name_entry *name,
 				     struct traverse_info *info)
 {
 	if (!ce || !name || !S_ISSPARSEDIR(ce->ce_mode))
@@ -1562,7 +1562,7 @@ static int unpack_callback(int n, unsigned long mask, unsigned long dirmask, str
 			}
 		}
 
-		if (!is_sparse_directory_entry(src[0], names, info) &&
+		if (!is_sparse_directory_entry(src[0], p, info) &&
 		    !is_new_sparse_dir &&
 		    traverse_trees_recursive(n, dirmask, mask & ~dirmask,
 						    names, info) < 0) {


### PR DESCRIPTION
This issue was found when the updates from v2.37.3 introduced a test failure in a downstream test suite. 

The issue stems from the fact that, before v2.37.3, 'unpack_callback()' could previously "assume" that 'names[0]' was non-empty if a cache entry was unpacked as a sparse index. When b15207b8cf (unpack-trees: unpack new trees as sparse directories, 2022-08-08)) was introduced, it invalidated that assumption by allowing sparse directories to be unpacked based on the contents of other 'names' entries, rather than unnecessarily recursing into them and unpacking files individually. As a result, certain scenarios could cause a sparse directory to be unpacked then *also* recursively unpacked via 'traverse_trees_recursive()', creating duplicate index entries.

CC: shaoxuan.yuan02@gmail.com
CC: gitster@pobox.com
CC: derrickstolee@github.com
cc: Johannes Schindelin <Johannes.Schindelin@gmx.de>