### PR TITLE
ls-files: fix black space in error message

### DIFF
--- a/builtin/ls-files.c
+++ b/builtin/ls-files.c
@@ -257,7 +257,7 @@ static size_t expand_show_index(struct strbuf *sb, const char *start,
 
 	end = strchr(start + 1, ')');
 	if (!end)
-		die(_("bad ls-files format: element '%s'"
+		die(_("bad ls-files format: element '%s' "
 		      "does not end in ')'"), start);
 
 	len = end - start + 1;


### PR DESCRIPTION
This patch want fix a little typo error in builtin/ls-files.c,
which pointed out by Jiang Xin in \[1\].


\[1\]: https://lore.kernel.org/git/CANYiYbFGSfg+iFV1ovhCSxW0YQSpemKUN-sS+F0BHee7KD5arA@mail.gmail.com/.

cc: Junio C Hamano gitster@pobox.com
cc: Jiang Xin <worldhello.net@gmail.com>