### PR TITLE
Enhance credential helper protocol to include auth headers

### DIFF
--- a/Documentation/git-credential.txt
+++ b/Documentation/git-credential.txt
@@ -113,7 +113,13 @@ separated by an `=` (equals) sign, followed by a newline.
 The key may contain any bytes except `=`, newline, or NUL. The value may
 contain any bytes except newline or NUL.
 
-In both cases, all bytes are treated as-is (i.e., there is no quoting,
+Attributes with keys that end with C-style array brackets `[]` can have
+multiple values. Each instance of a multi-valued attribute forms an
+ordered list of values - the order of the repeated attributes defines
+the order of the values. An empty multi-valued attribute (`key[]=\n`)
+acts to clear any previous entries and reset the list.
+
+In all cases, all bytes are treated as-is (i.e., there is no quoting,
 and one cannot transmit a value with newline or NUL in it). The list of
 attributes is terminated by a blank line or end-of-file.
 
@@ -159,6 +165,17 @@ empty string.
 +
 Components which are missing from the URL (e.g., there is no
 username in the example above) will be left unset.
+
+`wwwauth[]`::
+
+	When an HTTP response is received by Git that includes one or more
+	'WWW-Authenticate' authentication headers, these will be passed by Git
+	to credential helpers.
++
+Each 'WWW-Authenticate' header value is passed as a multi-valued
+attribute 'wwwauth[]', where the order of the attributes is the same as
+they appear in the HTTP response. This attribute is 'one-way' from Git
+to pass additional information to credential helpers.
 
 Unrecognised attributes are silently discarded.
 

--- a/credential.c
+++ b/credential.c
@@ -22,6 +22,7 @@ void credential_clear(struct credential *c)
 	free(c->username);
 	free(c->password);
 	string_list_clear(&c->helpers, 0);
+	strvec_clear(&c->wwwauth_headers);
 
 	credential_init(c);
 }

--- a/credential.c
+++ b/credential.c
@@ -270,6 +270,9 @@ void credential_write(const struct credential *c, FILE *fp)
 	credential_write_item(fp, "path", c->path, 0);
 	credential_write_item(fp, "username", c->username, 0);
 	credential_write_item(fp, "password", c->password, 0);
+	for (size_t i = 0; i < c->wwwauth_headers.nr; i++)
+		credential_write_item(fp, "wwwauth[]", c->wwwauth_headers.v[i],
+				      0);
 }
 
 static int run_credential_helper(struct credential *c,

--- a/credential.h
+++ b/credential.h
@@ -2,6 +2,7 @@
 #define CREDENTIAL_H
 
 #include "string-list.h"
+#include "strvec.h"
 
 /**
  * The credentials API provides an abstracted way of gathering username and
@@ -115,6 +116,20 @@ struct credential {
 	 */
 	struct string_list helpers;
 
+	/**
+	 * A `strvec` of WWW-Authenticate header values. Each string
+	 * is the value of a WWW-Authenticate header in an HTTP response,
+	 * in the order they were received in the response.
+	 */
+	struct strvec wwwauth_headers;
+
+	/**
+	 * Internal use only. Keeps track of if we previously matched against a
+	 * WWW-Authenticate header line in order to re-fold future continuation
+	 * lines into one value.
+	 */
+	unsigned header_is_last_match:1;
+
 	unsigned approved:1,
 		 configured:1,
 		 quit:1,
@@ -130,6 +145,7 @@ struct credential {
 
 #define CREDENTIAL_INIT { \
 	.helpers = STRING_LIST_INIT_DUP, \
+	.wwwauth_headers = STRVEC_INIT, \
 }
 
 /* Initialize a credential structure, setting all fields to empty. */

--- a/git-compat-util.h
+++ b/git-compat-util.h
@@ -1266,6 +1266,25 @@ static inline int skip_iprefix(const char *str, const char *prefix,
 	return 0;
 }
 
+/*
+ * Like skip_prefix_mem, but compare case-insensitively. Note that the
+ * comparison is done via tolower(), so it is strictly ASCII (no multi-byte
+ * characters or locale-specific conversions).
+ */
+static inline int skip_iprefix_mem(const char *buf, size_t len,
+				   const char *prefix,
+				   const char **out, size_t *outlen)
+{
+	do {
+		if (!*prefix) {
+			*out = buf;
+			*outlen = len;
+			return 1;
+		}
+	} while (len-- > 0 && tolower(*buf++) == tolower(*prefix++));
+	return 0;
+}
+
 static inline int strtoul_ui(char const *s, int base, unsigned int *result)
 {
 	unsigned long ul;

--- a/http.c
+++ b/http.c
@@ -183,6 +183,115 @@ size_t fwrite_buffer(char *ptr, size_t eltsize, size_t nmemb, void *buffer_)
 	return nmemb;
 }
 
+/*
+ * A folded header continuation line starts with any number of spaces or
+ * horizontal tab characters (SP or HTAB) as per RFC 7230 section 3.2.
+ * It is not a continuation line if the line starts with any other character.
+ */
+static inline int is_hdr_continuation(const char *ptr, const size_t size)
+{
+	return size && (*ptr == ' ' || *ptr == '\t');
+}
+
+static size_t fwrite_wwwauth(char *ptr, size_t eltsize, size_t nmemb, void *p)
+{
+	size_t size = eltsize * nmemb;
+	struct strvec *values = &http_auth.wwwauth_headers;
+	struct strbuf buf = STRBUF_INIT;
+	const char *val;
+	size_t val_len;
+
+	/*
+	 * Header lines may not come NULL-terminated from libcurl so we must
+	 * limit all scans to the maximum length of the header line, or leverage
+	 * strbufs for all operations.
+	 *
+	 * In addition, it is possible that header values can be split over
+	 * multiple lines as per RFC 7230. 'Line folding' has been deprecated
+	 * but older servers may still emit them. A continuation header field
+	 * value is identified as starting with a space or horizontal tab.
+	 *
+	 * The formal definition of a header field as given in RFC 7230 is:
+	 *
+	 * header-field   = field-name ":" OWS field-value OWS
+	 *
+	 * field-name     = token
+	 * field-value    = *( field-content / obs-fold )
+	 * field-content  = field-vchar [ 1*( SP / HTAB ) field-vchar ]
+	 * field-vchar    = VCHAR / obs-text
+	 *
+	 * obs-fold       = CRLF 1*( SP / HTAB )
+	 *                ; obsolete line folding
+	 *                ; see Section 3.2.4
+	 */
+
+	/* Start of a new WWW-Authenticate header */
+	if (skip_iprefix_mem(ptr, size, "www-authenticate:", &val, &val_len)) {
+		strbuf_add(&buf, val, val_len);
+
+		/*
+		 * Strip the CRLF that should be present at the end of each
+		 * field as well as any trailing or leading whitespace from the
+		 * value.
+		 */
+		strbuf_trim(&buf);
+
+		strvec_push(values, buf.buf);
+		http_auth.header_is_last_match = 1;
+		goto exit;
+	}
+
+	/*
+	 * This line could be a continuation of the previously matched header
+	 * field. If this is the case then we should append this value to the
+	 * end of the previously consumed value.
+	 */
+	if (http_auth.header_is_last_match && is_hdr_continuation(ptr, size)) {
+		/*
+		 * Trim the CRLF and any leading or trailing from this line.
+		 */
+		strbuf_add(&buf, ptr, size);
+		strbuf_trim(&buf);
+
+		/*
+		 * At this point we should always have at least one existing
+		 * value, even if it is empty. Do not bother appending the new
+		 * value if this continuation header is itself empty.
+		 */
+		if (!values->nr) {
+			BUG("should have at least one existing header value");
+		} else if (buf.len) {
+			char *prev = xstrdup(values->v[values->nr - 1]);
+
+			/* Join two non-empty values with a single space. */
+			const char *const sp = *prev ? " " : "";
+
+			strvec_pop(values);
+			strvec_pushf(values, "%s%s%s", prev, sp, buf.buf);
+			free(prev);
+		}
+
+		goto exit;
+	}
+
+	/* Not a continuation of a previously matched auth header line. */
+	http_auth.header_is_last_match = 0;
+
+	/*
+	 * If this is a HTTP status line and not a header field, this signals
+	 * a different HTTP response. libcurl writes all the output of all
+	 * response headers of all responses, including redirects.
+	 * We only care about the last HTTP request response's headers so clear
+	 * the existing array.
+	 */
+	if (skip_iprefix_mem(ptr, size, "http/", &val, &val_len))
+		strvec_clear(values);
+
+exit:
+	strbuf_release(&buf);
+	return size;
+}
+
 size_t fwrite_null(char *ptr, size_t eltsize, size_t nmemb, void *strbuf)
 {
 	return nmemb;
@@ -1863,6 +1972,8 @@ static int http_request(const char *url,
 			curl_easy_setopt(slot->curl, CURLOPT_WRITEFUNCTION,
 					 fwrite_buffer);
 	}
+
+	curl_easy_setopt(slot->curl, CURLOPT_HEADERFUNCTION, fwrite_wwwauth);
 
 	accept_language = http_get_accept_language_header();
 

--- a/t/lib-httpd.sh
+++ b/t/lib-httpd.sh
@@ -137,6 +137,7 @@ prepare_httpd() {
 	install_script error-smart-http.sh
 	install_script error.sh
 	install_script apply-one-time-perl.sh
+	install_script nph-custom-auth.sh
 
 	ln -s "$LIB_HTTPD_MODULE_PATH" "$HTTPD_ROOT_PATH/modules"
 

--- a/t/lib-httpd/apache.conf
+++ b/t/lib-httpd/apache.conf
@@ -135,6 +135,11 @@ Alias /auth/dumb/ www/auth/dumb/
 	SetEnv GIT_HTTP_EXPORT_ALL
 	SetEnv GIT_PROTOCOL
 </LocationMatch>
+<LocationMatch /custom_auth/>
+	SetEnv GIT_EXEC_PATH ${GIT_EXEC_PATH}
+	SetEnv GIT_HTTP_EXPORT_ALL
+	CGIPassAuth on
+</LocationMatch>
 ScriptAlias /smart/incomplete_length/git-upload-pack incomplete-length-upload-pack-v2-http.sh/
 ScriptAlias /smart/incomplete_body/git-upload-pack incomplete-body-upload-pack-v2-http.sh/
 ScriptAlias /smart/no_report/git-receive-pack error-no-report.sh/
@@ -144,6 +149,7 @@ ScriptAlias /broken_smart/ broken-smart-http.sh/
 ScriptAlias /error_smart/ error-smart-http.sh/
 ScriptAlias /error/ error.sh/
 ScriptAliasMatch /one_time_perl/(.*) apply-one-time-perl.sh/$1
+ScriptAliasMatch /custom_auth/(.*) nph-custom-auth.sh/$1
 <Directory ${GIT_EXEC_PATH}>
 	Options FollowSymlinks
 </Directory>

--- a/t/lib-httpd/nph-custom-auth.sh
+++ b/t/lib-httpd/nph-custom-auth.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+VALID_CREDS_FILE=custom-auth.valid
+CHALLENGE_FILE=custom-auth.challenge
+
+#
+# If $VALID_CREDS_FILE exists in $HTTPD_ROOT_PATH, consider each line as a valid
+# credential for the current request. Each line in the file is considered a
+# valid HTTP Authorization header value. For example:
+#
+# Basic YWxpY2U6c2VjcmV0LXBhc3N3ZA==
+#
+# If $CHALLENGE_FILE exists in $HTTPD_ROOT_PATH, output the contents as headers
+# in a 401 response if no valid authentication credentials were included in the
+# request. For example:
+#
+# WWW-Authenticate: Bearer authorize_uri="id.example.com" p=1 q=0
+# WWW-Authenticate: Basic realm="example.com"
+#
+
+if test -n "$HTTP_AUTHORIZATION" && \
+	grep -Fqsx "${HTTP_AUTHORIZATION}" "$VALID_CREDS_FILE"
+then
+	# Note that although git-http-backend returns a status line, it
+	# does so using a CGI 'Status' header. Because this script is an
+	# No Parsed Headers (NPH) script, we must return a real HTTP
+	# status line.
+	# This is only a test script, so we don't bother to check for
+	# the actual status from git-http-backend and always return 200.
+	echo 'HTTP/1.1 200 OK'
+	exec "$GIT_EXEC_PATH"/git-http-backend
+fi
+
+echo 'HTTP/1.1 401 Authorization Required'
+if test -f "$CHALLENGE_FILE"
+then
+	cat "$CHALLENGE_FILE"
+fi
+echo

--- a/t/t5563-simple-http-auth.sh
+++ b/t/t5563-simple-http-auth.sh
@@ -1,0 +1,83 @@
+#!/bin/sh
+
+test_description='test http auth header and credential helper interop'
+
+. ./test-lib.sh
+. "$TEST_DIRECTORY"/lib-httpd.sh
+
+start_httpd
+
+test_expect_success 'setup_credential_helper' '
+	mkdir "$TRASH_DIRECTORY/bin" &&
+	PATH=$PATH:"$TRASH_DIRECTORY/bin" &&
+	export PATH &&
+
+	CREDENTIAL_HELPER="$TRASH_DIRECTORY/bin/git-credential-test-helper" &&
+	write_script "$CREDENTIAL_HELPER" <<-\EOF
+	cmd=$1
+	teefile=$cmd-query.cred
+	catfile=$cmd-reply.cred
+	sed -n -e "/^$/q" -e "p" >>$teefile
+	if test "$cmd" = "get"
+	then
+		cat $catfile
+	fi
+	EOF
+'
+
+set_credential_reply () {
+	cat >"$TRASH_DIRECTORY/$1-reply.cred"
+}
+
+expect_credential_query () {
+	cat >"$TRASH_DIRECTORY/$1-expect.cred" &&
+	test_cmp "$TRASH_DIRECTORY/$1-expect.cred" \
+		 "$TRASH_DIRECTORY/$1-query.cred"
+}
+
+per_test_cleanup () {
+	rm -f *.cred &&
+	rm -f "$HTTPD_ROOT_PATH"/custom-auth.valid \
+	      "$HTTPD_ROOT_PATH"/custom-auth.challenge
+}
+
+test_expect_success 'setup repository' '
+	test_commit foo &&
+	git init --bare "$HTTPD_DOCUMENT_ROOT_PATH/repo.git" &&
+	git push --mirror "$HTTPD_DOCUMENT_ROOT_PATH/repo.git"
+'
+
+test_expect_success 'access using basic auth' '
+	test_when_finished "per_test_cleanup" &&
+
+	set_credential_reply get <<-EOF &&
+	username=alice
+	password=secret-passwd
+	EOF
+
+	# Basic base64(alice:secret-passwd)
+	cat >"$HTTPD_ROOT_PATH/custom-auth.valid" <<-EOF &&
+	Basic YWxpY2U6c2VjcmV0LXBhc3N3ZA==
+	EOF
+
+	cat >"$HTTPD_ROOT_PATH/custom-auth.challenge" <<-EOF &&
+	WWW-Authenticate: Basic realm="example.com"
+	EOF
+
+	test_config_global credential.helper test-helper &&
+	git ls-remote "$HTTPD_URL/custom_auth/repo.git" &&
+
+	expect_credential_query get <<-EOF &&
+	protocol=http
+	host=$HTTPD_DEST
+	EOF
+
+	expect_credential_query store <<-EOF
+	protocol=http
+	host=$HTTPD_DEST
+	username=alice
+	password=secret-passwd
+	EOF
+'
+
+test_done

--- a/t/t5563-simple-http-auth.sh
+++ b/t/t5563-simple-http-auth.sh
@@ -70,6 +70,248 @@ test_expect_success 'access using basic auth' '
 	expect_credential_query get <<-EOF &&
 	protocol=http
 	host=$HTTPD_DEST
+	wwwauth[]=Basic realm="example.com"
+	EOF
+
+	expect_credential_query store <<-EOF
+	protocol=http
+	host=$HTTPD_DEST
+	username=alice
+	password=secret-passwd
+	EOF
+'
+
+test_expect_success 'access using basic auth invalid credentials' '
+	test_when_finished "per_test_cleanup" &&
+
+	set_credential_reply get <<-EOF &&
+	username=baduser
+	password=wrong-passwd
+	EOF
+
+	# Basic base64(alice:secret-passwd)
+	cat >"$HTTPD_ROOT_PATH/custom-auth.valid" <<-EOF &&
+	Basic YWxpY2U6c2VjcmV0LXBhc3N3ZA==
+	EOF
+
+	cat >"$HTTPD_ROOT_PATH/custom-auth.challenge" <<-EOF &&
+	WWW-Authenticate: Basic realm="example.com"
+	EOF
+
+	test_config_global credential.helper test-helper &&
+	test_must_fail git ls-remote "$HTTPD_URL/custom_auth/repo.git" &&
+
+	expect_credential_query get <<-EOF &&
+	protocol=http
+	host=$HTTPD_DEST
+	wwwauth[]=Basic realm="example.com"
+	EOF
+
+	expect_credential_query erase <<-EOF
+	protocol=http
+	host=$HTTPD_DEST
+	username=baduser
+	password=wrong-passwd
+	wwwauth[]=Basic realm="example.com"
+	EOF
+'
+
+test_expect_success 'access using basic auth with extra challenges' '
+	test_when_finished "per_test_cleanup" &&
+
+	set_credential_reply get <<-EOF &&
+	username=alice
+	password=secret-passwd
+	EOF
+
+	# Basic base64(alice:secret-passwd)
+	cat >"$HTTPD_ROOT_PATH/custom-auth.valid" <<-EOF &&
+	Basic YWxpY2U6c2VjcmV0LXBhc3N3ZA==
+	EOF
+
+	cat >"$HTTPD_ROOT_PATH/custom-auth.challenge" <<-EOF &&
+	WWW-Authenticate: FooBar param1="value1" param2="value2"
+	WWW-Authenticate: Bearer authorize_uri="id.example.com" p=1 q=0
+	WWW-Authenticate: Basic realm="example.com"
+	EOF
+
+	test_config_global credential.helper test-helper &&
+	git ls-remote "$HTTPD_URL/custom_auth/repo.git" &&
+
+	expect_credential_query get <<-EOF &&
+	protocol=http
+	host=$HTTPD_DEST
+	wwwauth[]=FooBar param1="value1" param2="value2"
+	wwwauth[]=Bearer authorize_uri="id.example.com" p=1 q=0
+	wwwauth[]=Basic realm="example.com"
+	EOF
+
+	expect_credential_query store <<-EOF
+	protocol=http
+	host=$HTTPD_DEST
+	username=alice
+	password=secret-passwd
+	EOF
+'
+
+test_expect_success 'access using basic auth mixed-case wwwauth header name' '
+	test_when_finished "per_test_cleanup" &&
+
+	set_credential_reply get <<-EOF &&
+	username=alice
+	password=secret-passwd
+	EOF
+
+	# Basic base64(alice:secret-passwd)
+	cat >"$HTTPD_ROOT_PATH/custom-auth.valid" <<-EOF &&
+	Basic YWxpY2U6c2VjcmV0LXBhc3N3ZA==
+	EOF
+
+	cat >"$HTTPD_ROOT_PATH/custom-auth.challenge" <<-EOF &&
+	www-authenticate: foobar param1="value1" param2="value2"
+	WWW-AUTHENTICATE: BEARER authorize_uri="id.example.com" p=1 q=0
+	WwW-aUtHeNtIcAtE: baSiC realm="example.com"
+	EOF
+
+	test_config_global credential.helper test-helper &&
+	git ls-remote "$HTTPD_URL/custom_auth/repo.git" &&
+
+	expect_credential_query get <<-EOF &&
+	protocol=http
+	host=$HTTPD_DEST
+	wwwauth[]=foobar param1="value1" param2="value2"
+	wwwauth[]=BEARER authorize_uri="id.example.com" p=1 q=0
+	wwwauth[]=baSiC realm="example.com"
+	EOF
+
+	expect_credential_query store <<-EOF
+	protocol=http
+	host=$HTTPD_DEST
+	username=alice
+	password=secret-passwd
+	EOF
+'
+
+test_expect_success 'access using basic auth with wwwauth header continuations' '
+	test_when_finished "per_test_cleanup" &&
+
+	set_credential_reply get <<-EOF &&
+	username=alice
+	password=secret-passwd
+	EOF
+
+	# Basic base64(alice:secret-passwd)
+	cat >"$HTTPD_ROOT_PATH/custom-auth.valid" <<-EOF &&
+	Basic YWxpY2U6c2VjcmV0LXBhc3N3ZA==
+	EOF
+
+	# Note that leading and trailing whitespace is important to correctly
+	# simulate a continuation/folded header.
+	cat >"$HTTPD_ROOT_PATH/custom-auth.challenge" <<-EOF &&
+	WWW-Authenticate: FooBar param1="value1"
+	 param2="value2"
+	WWW-Authenticate: Bearer authorize_uri="id.example.com"
+	 p=1
+	 q=0
+	WWW-Authenticate: Basic realm="example.com"
+	EOF
+
+	test_config_global credential.helper test-helper &&
+	git ls-remote "$HTTPD_URL/custom_auth/repo.git" &&
+
+	expect_credential_query get <<-EOF &&
+	protocol=http
+	host=$HTTPD_DEST
+	wwwauth[]=FooBar param1="value1" param2="value2"
+	wwwauth[]=Bearer authorize_uri="id.example.com" p=1 q=0
+	wwwauth[]=Basic realm="example.com"
+	EOF
+
+	expect_credential_query store <<-EOF
+	protocol=http
+	host=$HTTPD_DEST
+	username=alice
+	password=secret-passwd
+	EOF
+'
+
+test_expect_success 'access using basic auth with wwwauth header empty continuations' '
+	test_when_finished "per_test_cleanup" &&
+
+	set_credential_reply get <<-EOF &&
+	username=alice
+	password=secret-passwd
+	EOF
+
+	# Basic base64(alice:secret-passwd)
+	cat >"$HTTPD_ROOT_PATH/custom-auth.valid" <<-EOF &&
+	Basic YWxpY2U6c2VjcmV0LXBhc3N3ZA==
+	EOF
+
+	CHALLENGE="$HTTPD_ROOT_PATH/custom-auth.challenge" &&
+
+	# Note that leading and trailing whitespace is important to correctly
+	# simulate a continuation/folded header.
+	printf "">$CHALLENGE &&
+	printf "WWW-Authenticate: FooBar param1=\"value1\"\r\n" >$CHALLENGE &&
+	printf " \r\n" >>$CHALLENGE &&
+	printf " param2=\"value2\"\r\n" >>$CHALLENGE &&
+	printf "WWW-Authenticate: Bearer authorize_uri=\"id.example.com\"\r\n" >>$CHALLENGE &&
+	printf " p=1\r\n" >>$CHALLENGE &&
+	printf " \r\n" >>$CHALLENGE &&
+	printf " q=0\r\n" >>$CHALLENGE &&
+	printf "WWW-Authenticate: Basic realm=\"example.com\"\r\n" >>$CHALLENGE &&
+
+	test_config_global credential.helper test-helper &&
+	git ls-remote "$HTTPD_URL/custom_auth/repo.git" &&
+
+	expect_credential_query get <<-EOF &&
+	protocol=http
+	host=$HTTPD_DEST
+	wwwauth[]=FooBar param1="value1" param2="value2"
+	wwwauth[]=Bearer authorize_uri="id.example.com" p=1 q=0
+	wwwauth[]=Basic realm="example.com"
+	EOF
+
+	expect_credential_query store <<-EOF
+	protocol=http
+	host=$HTTPD_DEST
+	username=alice
+	password=secret-passwd
+	EOF
+'
+
+test_expect_success 'access using basic auth with wwwauth header mixed line-endings' '
+	test_when_finished "per_test_cleanup" &&
+
+	set_credential_reply get <<-EOF &&
+	username=alice
+	password=secret-passwd
+	EOF
+
+	# Basic base64(alice:secret-passwd)
+	cat >"$HTTPD_ROOT_PATH/custom-auth.valid" <<-EOF &&
+	Basic YWxpY2U6c2VjcmV0LXBhc3N3ZA==
+	EOF
+
+	CHALLENGE="$HTTPD_ROOT_PATH/custom-auth.challenge" &&
+
+	# Note that leading and trailing whitespace is important to correctly
+	# simulate a continuation/folded header.
+	printf "">$CHALLENGE &&
+	printf "WWW-Authenticate: FooBar param1=\"value1\"\r\n" >$CHALLENGE &&
+	printf " \r\n" >>$CHALLENGE &&
+	printf "\tparam2=\"value2\"\r\n" >>$CHALLENGE &&
+	printf "WWW-Authenticate: Basic realm=\"example.com\"" >>$CHALLENGE &&
+
+	test_config_global credential.helper test-helper &&
+	git ls-remote "$HTTPD_URL/custom_auth/repo.git" &&
+
+	expect_credential_query get <<-EOF &&
+	protocol=http
+	host=$HTTPD_DEST
+	wwwauth[]=FooBar param1="value1" param2="value2"
+	wwwauth[]=Basic realm="example.com"
 	EOF
 
 	expect_credential_query store <<-EOF


### PR DESCRIPTION
Following from my original RFC submission [0], this submission is considered
ready for full review. This patch series is now based on top of current `master`
(9c32cfb49c60fa8173b9666db02efe3b45a8522f) that includes my now separately
submitted patches [1] to fix up the other credential helpers' behaviour.

In this patch series I update the existing credential helper design in order to
allow for some new scenarios, and future evolution of auth methods that Git
hosts may wish to provide. I outline the background, summary of changes and some
challenges below.

Testing these new additions, I use a small CGI shell script that acts as a
frontend to `git-http-backend`; simple authentication is configurable by files.

Background
----------

Git uses a variety of protocols [2]: local, Smart HTTP, Dumb HTTP, SSH, and Git.
Here I focus on the Smart HTTP protocol, and attempt to enhance the
authentication capabilities of this protocol to address limitations (see below).

The Smart HTTP protocol in Git supports a few different types of HTTP
authentication - Basic and Digest (RFC 2617) [3], and Negotiate (RFC 2478) [4].
Git uses a extensible model where credential helpers can provide credentials for
protocols [5]. Several helpers support alternatives such as OAuth
authentication (RFC 6749) [6], but this is typically done as an extension.
For example, a helper might use basic auth and set the password to an OAuth
Bearer access token. Git uses standard input and output to communicate with
credential helpers.

After a HTTP 401 response, Git would call a credential helper with the following
over standard input:

```text
protocol=https
host=example.com

```

And then a credential helper would return over standard output:

```text
protocol=https
host=example.com
username=bob@id.example.com
password=<BEARER-TOKEN>

```

Git then the following request to the remote, including the standard HTTP
`Authorization` header (RFC 7235 Section 4.2) [7]:

```text
GET /info/refs?service=git-upload-pack HTTP/1.1
Host: git.example
Git-Protocol: version=2
Authorization: Basic base64(bob@id.example.com:<BEARER-TOKEN>)
```

Credential helpers are encouraged (see gitcredentials.txt) to return the minimum
information necessary.

Limitations
-----------

Because this credential model was built mostly for password based authentication
systems, it's somewhat limited. In particular:

1. To generate valid credentials, additional information about the request (or
   indeed the requestee and their device) may be required.
   For example, OAuth is based around scopes. A scope, like "git.read", might be
   required to read data from the remote. However, the remote cannot tell the
   credential helper what scope is required for this request.

2. This system is not fully extensible. Each time a new type of authentication
   (like OAuth Bearer) is invented, Git needs updates before credential
   helpers can take advantage of it (or leverage a new capability in libcurl).

Goals
-----

- As a user with multiple federated cloud identities:
  - Reach out to a remote and have my credential helper automatically prompt me
    for the correct identity.
  - Allow credential helpers to differentiate between different authorities or
    authentication/authorization challenge types, even from the same DNS
    hostname (and without needing to use `credential.useHttpPath`).
  - Leverage existing authentication systems built-in to many operating systems
    and devices to boost security and reduce reliance on passwords.

- As a Git host and/or cloud identity provider:
  - Enforce security policies (like requiring two-factor authentication)
    dynamically.
  - Allow integration with third party standard based identity providers in
    enterprises allowing customers to have a single plane of control for
    critical identities with access to source code.

Design Principles
-----------------

- Use the existing infrastructure. Git credential helpers are an already-working
  model.
- Follow widely-adopted time-proven open standards, avoid net new ideas in the
  authentication space.
- Minimize knowledge of authentication in Git; maintain modularity and
  extensibility.

Proposed Changes
----------------

1. Teach Git to read HTTP response headers, specifically the standard
   `WWW-Authenticate` (RFC 7235 Section 4.1) headers.

2. Teach Git to include extra information about HTTP responses that require
   authentication when calling credential helpers. Specifically the
   `WWW-Authenticate` header information.

   Because the extra information forms an ordered list, and the existing
   credential helper I/O format only provides for simple key=value pairs, we
   introduce a new convention for transmitting an ordered list of values.
   Key names that are suffixed with a C-style array syntax should have values
   considered to form an order list, i.e. `key[]=value`, where the order of the
   key=value pairs in the stream specifies the order.

   For the `WWW-Authenticate` header values we opt to use the key `wwwauth[]`.

Handling the WWW-Authenticate header in detail
----------------------------------------------

RFC 6750 [8] envisions that OAuth Bearer resource servers would give responses
that include `WWW-Authenticate` headers, for example:

```text
HTTP/1.1 401 Unauthorized
WWW-Authenticate: Bearer realm="login.example", scope="git.readwrite"
WWW-Authenticate: Basic realm="login.example"
```

Specifically, a `WWW-Authenticate` header consists of a scheme and arbitrary
attributes, depending on the scheme. This pattern enables generic OAuth or
OpenID Connect [9] authorities. Note that it is possible to have several
`WWW-Authenticate` challenges in a response.

First Git attempts to make a request, unauthenticated, which fails with a 401
response and includes `WWW-Authenticate` header(s).

Next, Git invokes a credential helper which may prompt the user. If the user
approves, a credential helper can generate a token (or any auth challenge
response) to be used for that request.

For example: with a remote that supports bearer tokens from an OpenID Connect
[9] authority, a credential helper can use OpenID Connect's Discovery [10] and
Dynamic Client Registration [11] to register a client and make a request with the
correct permissions to access the remote. In this manner, a user can be
dynamically sent to the right federated identity provider for a remote without
any up-front configuration or manual processes.

Following from the principle of keeping authentication knowledge in Git to a
minimum, we modify Git to add all `WWW-Authenticate` values to the credential
helper call.

Git sends over standard input:

```text
protocol=https
host=example.com
wwwauth[]=Bearer realm="login.example", scope="git.readwrite"
wwwauth[]=Basic realm="login.example"

```

A credential helper that understands the extra `wwwauth[n]` property can
decide on the "best" or correct authentication scheme, generate credentials for
the request, and interact with the user.

The credential helper would then return over standard output:

```text
protocol=https
host=example.com
path=foo.git
username=bob@identity.example
password=<BEARER-TOKEN>
```

Note that `WWW-Authenticate` supports multiple challenges, either in one header:

```text
HTTP/1.1 401 Unauthorized
WWW-Authenticate: Bearer realm="login.example", scope="git.readwrite", Basic realm="login.example"
```

or in multiple headers:

```text
HTTP/1.1 401 Unauthorized
WWW-Authenticate: Bearer realm="login.example", scope="git.readwrite"
WWW-Authenticate: Basic realm="login.example"
```

These have equivalent meaning (RFC 2616 Section 4.2 [12]). To simplify the
implementation, Git will not merge or split up any of these `WWW-Authenticate`
headers, and instead pass each header line as one credential helper property.
The credential helper is responsible for splitting, merging, and otherwise
parsing these header values.

An alternative option to sending the header fields individually would be to
merge the header values in to one `key=value` property, for example:

```text
...
wwwauth=Bearer realm="login.example", scope="git.readwrite", Basic realm="login.example"
```

Future work
-----------

In the future we can further expand the protocol to allow credential helpers
decide the best authentication scheme. Today credential helpers are still only
expected to return a username/password pair to Git, meaning the other
authentication schemes that may be offered still need challenge responses sent
via a `Basic` `Authorization` header. The changes outlined above still permit
helpers to select and configure an available authentication mode, but require
the remote for example to unpack a bearer token from a basic challenge.

More careful consideration is required in the handling of custom authentication
schemes which may not have a `username`, or may require arbitrary additional
request header values be set.

For example imagine a new "FooBar" authentication scheme that is surfaced in the
following response:

```text
HTTP/1.1 401 Unauthorized
WWW-Authenticate: FooBar realm="login.example", algs="ES256 PS256"
```

With support for arbitrary authentication schemes, Git would call credential
helpers with the following over standard input:

```text
protocol=https
host=example.com
wwwauth[]=FooBar realm="login.example", algs="ES256 PS256", nonce="abc123"

```

And then an enlightened credential helper could return over standard output:

```text
protocol=https
host=example.com
authtype=FooBar
username=bob@id.example.com
password=<FooBar credential>
header[]=X-FooBar: 12345
header[]=X-FooBar-Alt: ABCDEF
```

Git would be expected to attach this authorization header to the next request:

```text
GET /info/refs?service=git-upload-pack HTTP/1.1
Host: git.example
Git-Protocol: version=2
Authorization: FooBar <FooBar credential>
X-FooBar: 12345
X-FooBar-Alt: ABCDEF
```

Why not SSH?
------------

There's nothing wrong with SSH. However, Git's Smart HTTP transport is widely
used, often with OAuth Bearer tokens. Git's Smart HTTP transport sometimes
requires less client setup than SSH transport, and works in environments when
SSH ports may be blocked. As long as Git supports HTTP transport, it should
support common and popular HTTP authentication methods.

References
----------

- [0] [PATCH 0/8] [RFC] Enhance credential helper protocol to include auth headers
      https://lore.kernel.org/git/pull.1352.git.1663097156.gitgitgadget@gmail.com/

- [1] [PATCH 0/3] Correct credential helper discrepancies handling input
      https://lore.kernel.org/git/pull.1363.git.1663865974.gitgitgadget@gmail.com/

- [2] Git on the Server - The Protocols
      https://git-scm.com/book/en/v2/Git-on-the-Server-The-Protocols

- [3] HTTP Authentication: Basic and Digest Access Authentication
      https://datatracker.ietf.org/doc/html/rfc2617

- [4] The Simple and Protected GSS-API Negotiation Mechanism
      https://datatracker.ietf.org/doc/html/rfc2478

- [5] Git Credentials - Custom Helpers
      https://git-scm.com/docs/gitcredentials#_custom_helpers

- [6] The OAuth 2.0 Authorization Framework
      https://datatracker.ietf.org/doc/html/rfc6749

- [7] Hypertext Transfer Protocol (HTTP/1.1): Authentication
      https://datatracker.ietf.org/doc/html/rfc7235

- [8] The OAuth 2.0 Authorization Framework: Bearer Token Usage
      https://datatracker.ietf.org/doc/html/rfc6750

- [9] OpenID Connect Core 1.0
      https://openid.net/specs/openid-connect-core-1_0.html

- [10] OpenID Connect Discovery 1.0
       https://openid.net/specs/openid-connect-discovery-1_0.html

- [11] OpenID Connect Dynamic Client Registration 1.0
       https://openid.net/specs/openid-connect-registration-1_0.html

- [12] Hypertext Transfer Protocol (HTTP/1.1)
       https://datatracker.ietf.org/doc/html/rfc2616

Updates from RFC
----------------

* Submitted first three patches as separate submission:
  https://lore.kernel.org/git/pull.1363.git.1663865974.gitgitgadget@gmail.com/

* Various style fixes and updates to- and addition of comments.

* Drop the explicit integer index in new 'array' style credential helper
  attrbiutes ("key[n]=value" becomes just "key[]=value").

* Added test helper; a mini HTTP server, and several tests.

Updates in v3
-------------

* Split final patch that added the test-http-server in to several, easier
  to review patches.

* Updated wording in git-credential.txt to clarify which side of the credential
  helper protocol is sending/receiving the new wwwauth and authtype attributes.

Updates in v4
-------------

* Drop authentication scheme selection `authtype` attribute patches to greatly
  simplify the series; auth scheme selection is punted to a future series.
  This series still allows credential helpers to generate credentials and
  intelligently select correct identities for a given auth challenge.

Updates in v5
-------------

* Libify parts of daemon.c and share implementation with `test-http-server`.

* Clarify `test-http-server` Git request regex pattern and auth logic comments.

* Use `STD*_FILENO` in place of 'magic' file descriptor numbers.

* Use `strbuf_*` functions in continuation header parsing.

* Use configuration file to configure auth for `test-http-server` rather than
  command-line arguments. Add ability to specify arbitrary extra headers that
  is useful for testing 'malformed' server responses.

* Use `st_mult` over unchecked multiplication in http.c curl callback functions.

* Fix some documentation line break issues.

* Reorder some commits to bring in the tests and `test-http-server` helper first
  and, then the WWW-Authentication changes, alongside tests to cover.

* Expose previously static `strvec_push_nodup` function.

* Merge the two timeout args for `test-http-server` (`--timeout` and
  `--init-timeout`) that were a hang-over from the original daemon.c but are
  no longer required here.

* Be more careful around continuation headers where they may be empty strings.
  Add more tests to cover these header types.

* Include standard trace2 tracing calls at start of `test-http-server` helper.

Updates in v6
-------------

* Clarify the change to make logging optional in the `check_dead_children()`
  function during libification of `daemon.c`.

* Fix missing pointer dereference bugs identified in libification of child
  process handling functions for `daemon.c`.

* Add doc comments to child process handling function declarations in the
 `daemon-utils.h` header.

* Align function parameter names with variable names at callsites for libified
  daemon functions.

* Re-split out the `test-http-server` test helper commits in to smaller patches:
  error response handling, request parsing, `http-backend` pass-through, simple
  authentication, arbitrary header support.

* Call out auth configuration file format for `test-http-server` test helper and
  supported options in commit messages, as well as a test to exercise and
  demonstrate these options.

* Permit `auth.token` and `auth.challenge` to appear in any order; create the
  `struct auth_module` just-in-time as options for that scheme are read. This
  simplifies the configuration authoring of the `test-http-server` test helper.

* Update tests to use `auth.allowAnoymous` in the patch that introduces the new
  test helper option.

* Drop the `strvec_push_nodup()` commit and update the implementation of HTTP
  request header line folding to use `xstrdup` and `strvec_pop` and `_pushf`.

* Use `size_t` instead of `int` in `credential.c` when iterating over the
  `struct strvec` credential members. Also drop the not required `const` and
  cast from the `full_key` definition and `free`.

* Replace in-tree `test-credential-helper-reply.sh` test cred helper script with
  the `lib-credential-helper.sh` reusable 'lib' test script and shell functions
  to configure the helper behaviour.

* Leverage `sed` over the `while read $line` loop in the test credential helper
  script.

Updates in v7
-------------

* Address several whitespace and arg/param list alignment issues.

* Rethink the `test-http-helper` worker-mode error and result `enum` to be more
  simple and more informative to the nature of the error.

* Use `uintmax_t` to store the `Content-Length` of a request in the helper
  `test-http-server`. Maintain a bit flag to store if we received such a header.

* Return a "400 Bad Request" HTTP response if we fail to parse the request in
  the `test-http-server`.

* Add test case to cover request message parsing in `test-http-server`.

* Use `size_t` and `ALLOC_ARRAY` over `int` and `CALLOC_ARRAY` respectively in
  `get_auth_module`.

* Correctly free the split `strbuf`s created in the header parsing loop in
  `test-http-server`.

* Avoid needless comparison `> 0` for unsigned types.

* Always set optional outputs to `NULL` if not present in test helper config
  value handling.

* Remove an accidentally commented-out test cleanup line for one test case in
  t5556.

Updates in v8
-------------

* Drop custom HTTP test helper tool in favour of using a CGI shell script and
  Apache; avoiding the need to implement an HTTP server.

* Avoid allocations in header reading callback unless we have a header we care
  about; act on the char* from libcurl directly rather than create a strbuf for
  each header.

* Drop st_mult overflow guarding function in curl callback functions; we're not
  allocating memory based on the resulting value and just adds to potential
  confusion in the future.

Updates in v9
-------------

* Drop anoynmous auth tests as these cases are already covered by all other
  tests that perform HTTP interactions with a remote today.

* In the custom auth CGI script, avoid the empty-substitution in favour of
  testing explicitly for an empty string. Also simplify some other conditional
  expressions.

* Avoid an allocation on each wwwauth[] credential helper key-value pair write.

* Various style fixups.

Updates in v10
--------------

* Style fixups.

* Only consider space (SP ' ') and horizontal tab (HTAB '\t') when detecting
  a header continuation line, as per the latest RFC on the matter.

* Update references to old HTTP specs and formal grammars of header fields in
  comments.

* Rewording of commit messages to remove confusing comment about the case
  sensitivity of header field names - this is not relevant with the current
  iteration of the header parsing code. Also update the message around libcurl
  header support to clarify that physical header lines are returned, but not
  'logical' header lines.

* Reword `struct credential` member doc comment to clarify the purpose of
  `header_is_last_match` is for re-folding lines of the WWW-Authenticate header.

* Reintroduce helpful comments in tests to show the origin of the 'magic' base64
  basic auth value.

* Use `grep -F` to ensure we don't do regex matching; avoid interpreting special
  characters. Remove erronous insensitive comparison flag.

Updates in v11
--------------

* Delete custom-auth.valid and .challenge explicitly in test cleanup.

* Use `tolower` over `strncasecmp` in implementation of `skip_iprefix_mem`.

* Use `skip_iprefix_mem` to match "HTTP/" header lines.

cc: Derrick Stolee <derrickstolee@github.com>
cc: Lessley Dennington <lessleydennington@gmail.com>
cc: Matthew John Cheetham <mjcheetham@outlook.com>
cc: M Hickford <mirth.hickford@gmail.com>
cc: Jeff Hostetler <git@jeffhostetler.com>
cc: Glen Choo <chooglen@google.com>
cc: Victoria Dye <vdye@github.com>
cc: Ævar Arnfjörð Bjarmason <avarab@gmail.com>
cc: Jeff King <peff@peff.net>
cc: Johannes Schindelin <Johannes.Schindelin@gmx.de>