### PR TITLE
diagnose.c: refactor to safely use 'd_type'

### DIFF
--- a/t/t0092-diagnose.sh
+++ b/t/t0092-diagnose.sh
@@ -28,12 +28,23 @@ test_expect_success UNZIP 'creates diagnostics zip archive' '
 	! "$GIT_UNZIP" -l "$zip_path" | grep ".git/"
 '
 
+test_expect_success UNZIP 'counts loose objects' '
+	test_commit A &&
+
+	# After committing, should have non-zero loose objects
+	git diagnose -o test-count -s 1 >out &&
+	zip_path=test-count/git-diagnostics-1.zip &&
+	"$GIT_UNZIP" -p "$zip_path" objects-local.txt >out &&
+	grep "^Total: [1-9][0-9]* loose objects" out
+'
+
 test_expect_success UNZIP '--mode=stats excludes .git dir contents' '
 	test_when_finished rm -rf report &&
 
 	git diagnose -o report -s test --mode=stats >out &&
 
 	# Includes pack quantity/size info
+	zip_path=report/git-diagnostics-test.zip &&
 	"$GIT_UNZIP" -p "$zip_path" packs-local.txt >out &&
 	grep ".git/objects" out &&
 
@@ -47,6 +58,7 @@ test_expect_success UNZIP '--mode=all includes .git dir contents' '
 	git diagnose -o report -s test --mode=all >out &&
 
 	# Includes pack quantity/size info
+	zip_path=report/git-diagnostics-test.zip &&
 	"$GIT_UNZIP" -p "$zip_path" packs-local.txt >out &&
 	grep ".git/objects" out &&
 


### PR DESCRIPTION
This fixes the compilation error reported by Randall in [1], which happens because 'd_type' doesn't exist in the 'dirent' struct on all platforms. 

The implementation of new-'get_dtype()' shares some code with 'resolve_dtype()' (and its previous incarnations as old-'get_dtype()') but, to keep this fix down to a single patch, I didn't refactor the bits of shared logic into a common location. I'm happy to do that if it would be a valuable addition to this fix, but I wanted to start small and avoid the churn of a refactor if it *isn't* something people want here.

Thanks!
- Victoria

[1] https://lore.kernel.org/git/011001d8ca20$bc4d81f0$34e885d0$@nexbridge.com/

CC: rsbecker@nexbridge.com
CC: gitster@pobox.com