### PR TITLE
scalar: fix wrong shell hashbang

### DIFF
--- a/contrib/scalar/Makefile
+++ b/contrib/scalar/Makefile
@@ -8,6 +8,9 @@ include ../../config.mak.uname
 -include ../../config.mak.autogen
 -include ../../config.mak
 
+SHELL_PATH ?= $(SHELL)
+SHELL_PATH_SQ = $(subst ','\'',$(SHELL_PATH))
+
 TARGETS = scalar$(X) scalar.o
 GITLIBS = ../../common-main.o ../../libgit.a ../../xdiff/lib.a
 


### PR DESCRIPTION
The bin-wrappers/scalar seems like missing setting
$SHELL_PATH_SQ which lead to I can't execute
bin-wrappers/scalar correctly, which output error:

zsh: exec format error: scalar

(this bug will not turn out in bash)

The bin-wrappers/scalar begin with wrong hashbang "#!",
which cannot figure out by zsh. So this patch want to fix
this problem.

v1:
Setting $SHELL_PATH and $SHELL_PATH_SQ in scalar/Makefile.

cc: Junio C Hamano <gitster@pobox.com>
cc: Derrick Stolee <derrickstolee@github.com>
cc: Johannes Schindelin <johannes.schindelin@gmx.de>