### PR TITLE
check-docs: fix 'diagnose' and 'version'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,6 +181,7 @@
 /git-verify-commit
 /git-verify-pack
 /git-verify-tag
+/git-version
 /git-web--browse
 /git-whatchanged
 /git-worktree

--- a/Makefile
+++ b/Makefile
@@ -818,6 +818,7 @@ BUILT_INS += git-show$X
 BUILT_INS += git-stage$X
 BUILT_INS += git-status$X
 BUILT_INS += git-switch$X
+BUILT_INS += git-version$X
 BUILT_INS += git-whatchanged$X
 
 # what 'all' will build but not install in gitexecdir

--- a/command-list.txt
+++ b/command-list.txt
@@ -91,6 +91,7 @@ git-cvsimport                           foreignscminterface
 git-cvsserver                           foreignscminterface
 git-daemon                              synchingrepositories
 git-describe                            mainporcelain
+git-diagnose                            ancillaryinterrogators
 git-diff                                mainporcelain           info
 git-diff-files                          plumbinginterrogators
 git-diff-index                          plumbinginterrogators

--- a/command-list.txt
+++ b/command-list.txt
@@ -199,6 +199,7 @@ git-var                                 plumbinginterrogators
 git-verify-commit                       ancillaryinterrogators
 git-verify-pack                         plumbinginterrogators
 git-verify-tag                          ancillaryinterrogators
+git-version                             ancillaryinterrogators
 git-whatchanged                         ancillaryinterrogators          complete
 git-worktree                            mainporcelain
 git-write-tree                          plumbingmanipulators


### PR DESCRIPTION
While locally verifying an unrelated documentation change, I noticed that the 'check-docs' target displayed two warnings on the 'master' branch:

```
no link: git-diagnose
removed but documented: git-version
```

The first message was due to the introduction of 'git diagnose' [1] not including a corresponding update to 'command-list.txt'; the latter was due to 'git-version' not being built as a standalone builtin executable. This series corrects both, adding 'git-diagnose' and 'git-version' as "ancilliaryinterrogators" to 'command-list.txt' and building a 'git-version' executable.

A possible future improvement to avoid this sort of thing could be to have 'check-docs' exit with an error if it encounters any issues (rather than printing a warning that's easily lost in build logs). For now, though, this series is restricted to fixing what's currently broken for ease of review and minimal risk.

Maintainer's note: if this would be too much of a disruption to include in v2.38 last-minute, I'm happy deferring it to the next release cycle. Alternatively, the series could be split, aiming to review & merge the first patch in this release cycle (since the 'git diagnose' error was introduced in this version) and leave the second the next cycle.

Thanks!
- Victoria

[1] https://lore.kernel.org/git/pull.1310.v4.git.1660335019.gitgitgadget@gmail.com/

CC: gitster@pobox.com
CC: avarab@gmail.com