### PR TITLE
Correct credential helper discrepancies handling input

### DIFF
--- a/contrib/credential/netrc/git-credential-netrc.perl
+++ b/contrib/credential/netrc/git-credential-netrc.perl
@@ -356,7 +356,10 @@ sub read_credential_data_from_stdin {
 		next unless m/^([^=]+)=(.+)/;
 
 		my ($token, $value) = ($1, $2);
-		die "Unknown search token $token" unless exists $q{$token};
+
+		# skip any unknown tokens
+		next unless exists $q{$token};
+
 		$q{$token} = $value;
 		log_debug("We were given search token $token and value $value");
 	}

--- a/contrib/credential/osxkeychain/git-credential-osxkeychain.c
+++ b/contrib/credential/osxkeychain/git-credential-osxkeychain.c
@@ -159,6 +159,11 @@ static void read_credential(void)
 			username = xstrdup(v);
 		else if (!strcmp(buf, "password"))
 			password = xstrdup(v);
+		/*
+		 * Ignore other lines; we don't know what they mean, but
+		 * this future-proofs us when later versions of git do
+		 * learn new lines, and the helpers are updated to match.
+		 */
 	}
 }
 

--- a/contrib/credential/wincred/git-credential-wincred.c
+++ b/contrib/credential/wincred/git-credential-wincred.c
@@ -278,8 +278,11 @@ static void read_credential(void)
 			wusername = utf8_to_utf16_dup(v);
 		} else if (!strcmp(buf, "password"))
 			password = utf8_to_utf16_dup(v);
-		else
-			die("unrecognized input");
+		/*
+		 * Ignore other lines; we don't know what they mean, but
+		 * this future-proofs us when later versions of git do
+		 * learn new lines, and the helpers are updated to match.
+		 */
 	}
 }
 


### PR DESCRIPTION
Whilst working in the credential helper and auth space I happened to notice
that the behaviour of some of the credential helpers in contrib/credential/ is
not consistent.

Specifically both the git-credential-wincred and git-credential-netrc helpers
`die` when they receive unknown credential property keys, which is contrary to
the behaviour of all the other in-tree helpers including: git-credential-cache,
-store, -libsecret, -gnome-keyring, -osxkeychain.

Also update the git-credential-osxkeychain helper to include a comment making
it's behaviour explicit in ignoring unknown keys, as per other helpers.

cc: derrickstolee@github.com
cc: mjcheetham@outlook.com
cc: Jeff King <peff@peff.net>