### PR TITLE
[For 2.38.0] pack-bitmap: remove trace2 region from hot path

### DIFF
--- a/pack-bitmap.c
+++ b/pack-bitmap.c
@@ -830,10 +830,9 @@ struct ewah_bitmap *bitmap_for_commit(struct bitmap_index *bitmap_git,
 		if (!bitmap_git->table_lookup)
 			return NULL;
 
-		trace2_region_enter("pack-bitmap", "reading_lookup_table", the_repository);
+		/* this is a fairly hot codepath - no trace2_region please */
 		/* NEEDSWORK: cache misses aren't recorded */
 		bitmap = lazy_bitmap_for_commit(bitmap_git, commit);
-		trace2_region_leave("pack-bitmap", "reading_lookup_table", the_repository);
 		if (!bitmap)
 			return NULL;
 		return lookup_stored_bitmap(bitmap);

--- a/t/t5310-pack-bitmaps.sh
+++ b/t/t5310-pack-bitmaps.sh
@@ -455,13 +455,6 @@ test_expect_success 'verify writing bitmap lookup table when enabled' '
 	grep "\"label\":\"writing_lookup_table\"" trace2
 '
 
-test_expect_success 'lookup table is actually used to traverse objects' '
-	git repack -adb &&
-	GIT_TRACE2_EVENT="$(pwd)/trace3" \
-		git rev-list --use-bitmap-index --count --all &&
-	grep "\"label\":\"reading_lookup_table\"" trace3
-'
-
 test_expect_success 'truncated bitmap fails gracefully (lookup table)' '
 	test_config pack.writebitmaphashcache false &&
 	git repack -adb &&


### PR DESCRIPTION
I noticed this while trying to backport the Abhradeep's lookup table work into GitHub's fork. Something went wrong in that process, causing this region to significantly slow down. It turns out that slow down does not reproduce on current 'master', which is good. I must have missed something while I was backporting.

Regardless, the use of trace2_region_enter() here should be removed or replaced. For the sake of 2.38.0, this simple removal is safe enough. However, to really dig into what was happening I had to construct a rebase [2] of Jeff's trace2 stopwatch work, then apply changes on top [3] that could replace this region with trace2_timer_*() methods.

[2] https://github.com/git/git/compare/master...derrickstolee:trace2-stopwatch
[3] https://github.com/derrickstolee/git/compare/trace2-stopwatch...bitmap-trace2

As a separate discussion, it might be worth revisiting that stopwatch work so we have it available as a tool when doing these kinds of investigations.

Updates in v2
-------------

* I removed the test that was checking for trace2 regions. In [3], I played around with using trace2_counter() to replace that check, so we could reinstate the test without the performance drop from using repeated trace2_region() calls.
* I squashed in Junio's comment change.
* I changed the exit code from passing the exact return value from the config API. Instead, use die() to fail in these cases, which should present a more helpful error message.

Thanks,
-Stolee

cc: gitster@pobox.com
cc: git@jeffhostetler.com
cc: me@ttaylorr.com
cc: chakrabortyabhradeep79@gmail.com
cc: Ævar Arnfjörð Bjarmason <avarab@gmail.com>