### PR TITLE
diff: introduce --restrict option

### DIFF
--- a/Documentation/diff-options.txt
+++ b/Documentation/diff-options.txt
@@ -631,6 +631,10 @@ Also, these upper-case letters can be downcased to exclude.  E.g.
 Note that not all diffs can feature all types. For instance, copied and
 renamed entries cannot appear if detection for those types is disabled.
 
+--restrict::
+	Restrict the diff filespec in the sparse-checkout cone(s).
+	See linkgit:git-sparse-checkout[1] for more details.
+
 -S<string>::
 	Look for differences that change the number of occurrences of
 	the specified string (i.e. addition/deletion) in a file.

--- a/diff.h
+++ b/diff.h
@@ -396,6 +396,7 @@ struct diff_options {
 	struct repository *repo;
 	struct option *parseopts;
 	struct strmap *additional_path_headers;
+	struct pattern_list *sparse_checkout_patterns;
 
 	int no_free;
 };

--- a/t/t1092-sparse-checkout-compatibility.sh
+++ b/t/t1092-sparse-checkout-compatibility.sh
@@ -504,6 +504,36 @@ test_expect_success 'diff --cached' '
 	test_all_match git diff --cached
 '
 
+test_expect_success 'diff --restrict' '
+	init_repos &&
+
+	test_all_match mkdir modules &&
+	test_all_match touch modules/a &&
+	test_all_match touch deep/b &&
+	test_all_match git rm deep/a &&
+	test_all_match git add --sparse modules deep &&
+	run_on_all git diff --restrict --staged --stat &&
+	cat >expect <<-EOF &&
+	 deep/a | 1 -
+	 deep/b | 0
+	 2 files changed, 1 deletion(-)
+	EOF
+	test_cmp expect sparse-checkout-out &&
+	cat >expect <<-EOF &&
+	 deep/a | 1 -
+	 deep/b | 0
+	 2 files changed, 1 deletion(-)
+	EOF
+	test_cmp expect sparse-index-out &&
+	cat >expect <<-EOF &&
+	 deep/a    | 1 -
+	 deep/b    | 0
+	 modules/a | 0
+	 3 files changed, 1 deletion(-)
+	EOF
+	test_cmp expect full-checkout-out
+'
+
 # NEEDSWORK: sparse-checkout behaves differently from full-checkout when
 # running this test with 'df-conflict-2' after 'df-conflict-1'.
 test_expect_success 'diff with renames and conflicts' '


### PR DESCRIPTION
In `[1]`, we discovered that users working on different sparse-checkout cone(s)
may download unnecessary blobs from each other's cone(s) in collaboration.
And Junio in `[2]` suggected that maybe we can restrict some git command's
filespec in sparse-checkout cone(s) to elegantly solve this problem above.

So this patch is attempt to do this thing on git diff:

v1
1. add --restrict option to git diff, which restrict diff filespec in sparse-checkout cone(s).

`[1]`: https://lore.kernel.org/git/CAOLTT8SHo66kGbvWr=+LQ9UVd1NHgqGGEYK2qq6==QgRCgLZqQ@mail.gmail.com/
`[2]`: https://lore.kernel.org/git/xmqqzgeqw0sy.fsf@gitster.g/

cc: Christian Couder <christian.couder@gmail.com>
cc: Ævar Arnfjörð Bjarmason <avarab@gmail.com>
cc: Jeff King <peff@peff.net>
cc: Junio C Hamano <gitster@pobox.com>
cc: Derrick Stolee <derrickstolee@github.com>
cc: Johannes Schindelin <johannes.schindelin@gmx.de>
cc: Victoria Dye <vdye@github.com>
cc: Elijah Newren <newren@gmail.com>