### PR TITLE
ssh signing: return an error when signature cannot be read

### DIFF
--- a/gpg-interface.c
+++ b/gpg-interface.c
@@ -1043,12 +1043,11 @@ static int sign_buffer_ssh(struct strbuf *buffer, struct strbuf *signature,
 	strbuf_addbuf(&ssh_signature_filename, &buffer_file->filename);
 	strbuf_addstr(&ssh_signature_filename, ".sig");
 	if (strbuf_read_file(signature, ssh_signature_filename.buf, 0) < 0) {
-		error_errno(
+		ret = error_errno(
 			_("failed reading ssh signing data buffer from '%s'"),
 			ssh_signature_filename.buf);
+		goto out;
 	}
-	unlink_or_warn(ssh_signature_filename.buf);
-
 	/* Strip CR from the line endings, in case we are on Windows. */
 	remove_cr_after(signature, bottom);
 
@@ -1057,6 +1056,8 @@ out:
 		delete_tempfile(&key_file);
 	if (buffer_file)
 		delete_tempfile(&buffer_file);
+	if (ssh_signature_filename.len)
+		unlink_or_warn(ssh_signature_filename.buf);
 	strbuf_release(&signer_stderr);
 	strbuf_release(&ssh_signature_filename);
 	FREE_AND_NULL(ssh_signing_key_file);


### PR DESCRIPTION
Thanks to Junio for his comments. I've updated the patch to always use unlink_or_warn() to remove the signature file as it does not warn on missing files.

V1 cover letter

This patch is based on maint. In the longer term the code could be simplified by using pipes rather than tempfiles as we do for gpg. ssh-keygen has supported reading the data to be signed from stdin and writing the signature to stdout since it introduced signing.

Cc: Fabian Stelzer <fs@gigacodes.de>
Cc:
cc: Phillip Wood <phillip.wood123@gmail.com>