### PR TITLE
t3435: remove redundant test case

### DIFF
--- a/t/t3435-rebase-gpg-sign.sh
+++ b/t/t3435-rebase-gpg-sign.sh
@@ -64,14 +64,6 @@ test_rebase_gpg_sign ! true  -i --no-gpg-sign
 test_rebase_gpg_sign ! true  -i --gpg-sign --no-gpg-sign
 test_rebase_gpg_sign   false -i --no-gpg-sign --gpg-sign
 
-test_expect_failure 'rebase -p --no-gpg-sign override commit.gpgsign' '
-	test_when_finished "git clean -f" &&
-	git reset --hard merged &&
-	git config commit.gpgsign true &&
-	git rebase -p --no-gpg-sign --onto=one fork-point main &&
-	test_must_fail git verify-commit HEAD
-'
-
 test_expect_success 'rebase -r, merge strategy, --gpg-sign will sign commit' '
 	git reset --hard merged &&
 	test_unconfig commit.gpgsign &&


### PR DESCRIPTION
test_expect_failure was covering up an unexpected failure.

cc: Phillip Wood <phillip.wood123@gmail.com>