### PR TITLE
[RFC] extensions: add refFormat extension

### DIFF
--- a/Documentation/config/extensions.txt
+++ b/Documentation/config/extensions.txt
@@ -7,6 +7,31 @@ Note that this setting should only be set by linkgit:git-init[1] or
 linkgit:git-clone[1].  Trying to change it after initialization will not
 work and will produce hard-to-diagnose issues.
 
+extensions.refFormat::
+	Specify the reference storage mechanisms used by the repoitory as a
+	multi-valued list. The acceptable values are `files` and `packed`.
+	If not specified, the list of `files` and `packed` is assumed. It
+	is an error to specify this key unless `core.repositoryFormatVersion`
+	is 1.
++
+As new ref formats are added, Git commands may modify this list before and
+after upgrading the on-disk reference storage files. The specific values
+indicate the existence of different layers:
++
+* `files`: When present, references may be stored as "loose" reference files
+  in the `$GIT_DIR/refs/` directory. The name of the reference corresponds
+  to the filename after `$GIT_DIR` and the file contains an object ID as
+  a hexadecimal string. If a loose reference file exists, then its value
+  takes precedence over all other formats.
++
+* `packed`: When present, references may be stored as a group in a
+  `packed-refs` file in its version 1 format. When grouped with `"files"`
+  or provided on its own, this file is located at `$GIT_DIR/packed-refs`.
+  This file contains a list of distinct reference names, paired with their
+  object IDs. When combined with `files`, the `packed` format will only be
+  used to group multiple loose object files upon request via the
+  `git pack-refs` command or via the `pack-refs` maintenance task.
+
 extensions.worktreeConfig::
 	If enabled, then worktrees will load config settings from the
 	`$GIT_DIR/config.worktree` file in addition to the

--- a/setup.c
+++ b/setup.c
@@ -577,6 +577,11 @@ static enum extension_result handle_extension(const char *var,
 				     "extensions.objectformat", value);
 		data->hash_algo = format;
 		return EXTENSION_OK;
+	} else if (!strcmp(ext, "refformat")) {
+		if (strcmp(value, "files") && strcmp(value, "packed"))
+			return error(_("invalid value for '%s': '%s'"),
+				     "extensions.refformat", value);
+		return EXTENSION_OK;
 	}
 	return EXTENSION_UNKNOWN;
 }


### PR DESCRIPTION
I've been doing some explorations into ways to speed up Git's ref backends using smaller updates than a full replacement with something completely new, such as reftable. The thing that I found staring me in the face was that we cannot add new ref formats very easily, and we haven't even agreed on the way we would want to describe the ref format(s) using extensions.

Even something as simple as creating a more compact version of packed-refs has no clear direction without specifying first how to describe the ref backend via an extension.

So here is my RFC to start a discussion on this. The message includes a note about whether `"files"` and `"packed"` should exist separately, and I think there are more options here that I haven't thought about.

One alternative of course is to only allow a single value, but have that single value describe multiple ref backends, say `"files:reftable"` would be a representation that loose refs and reftables are coexisting. To me, this kind of option just seems like different style for the same idea except it requires extra steps.

I do think it interesting that the documented plan for reftable does not allow for a mix of loose refs with reftable as a replacement for the packed backend. That seems like an interesting direction to pursue, since modifying the tests that check the packed backend to be aware of reftable seems like a smaller lift than updating every test that cares about ref storage. The "upgrade" scenario also seems valuable to users who do not want to start over from scratch.

Of course, this implementation only presents a way for Git to recognize the extension and assure that the value(s) are what Git understands. There is no connection to the rest of Git's behavior. That would come later, but I think there is value in committing to an extension model now.

Thanks,
- Stolee

cc: gitster@pobox.com
cc: peff@peff.net
cc: me@ttaylorr.com
cc: hanwen@google.com