### PR TITLE
Git.pm: add semicolon after catch statement

### DIFF
--- a/perl/Git.pm
+++ b/perl/Git.pm
@@ -217,7 +217,7 @@ sub repository {
 			} catch Git::Error::Command with {
 				# Mimic git-rev-parse --git-dir error message:
 				throw Error::Simple("fatal: Not a git repository: $dir");
-			}
+			};
 
 			$opts{Repository} = Cwd::abs_path($dir);
 		}


### PR DESCRIPTION
When looking into a bug about Git.pm's handling of unsafe repositories [1],
I found the immediate cause of the error, which this patch fixes. This
patch doesn't do anything about the actual problem (Git.pm happily
continues to work in unsafe repositories), but it at least fixes the
runtime error.

[1] https://lore.kernel.org/git/20221011182607.f1113fff-9333-427d-ba45-741a78fa6040@korelogic.com/