### PR TITLE
ci: use a newer `github-script` version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,14 +37,14 @@ jobs:
           echo "::set-output name=enabled::$enabled"
       - name: skip if the commit or tree was already tested
         id: skip-if-redundant
-        uses: actions/github-script@v3
+        uses: actions/github-script@v6
         if: steps.check-ref.outputs.enabled == 'yes'
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             try {
               // Figure out workflow ID, commit and tree
-              const { data: run } = await github.actions.getWorkflowRun({
+              const { data: run } = await github.rest.actions.getWorkflowRun({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 run_id: context.runId,
@@ -54,7 +54,7 @@ jobs:
               const tree_id = run.head_commit.tree_id;
 
               // See whether there is a successful run for that commit or tree
-              const { data: runs } = await github.actions.listWorkflowRuns({
+              const { data: runs } = await github.rest.actions.listWorkflowRuns({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 per_page: 500,


### PR DESCRIPTION
I had a look at the CI run of `seen` a couple of weeks ago and saw not only quite a number of failures but also quite a number of warnings.

This patch addresses a few of them, including the ones [about using the deprecated `::set-output::` workflow command](https://github.com/gitgitgadget/git/actions/runs/3412982102/jobs/5679166059#step:4:46).

Similar warnings will be addressed by `od/ci-use-checkout-v3-when-applicable`.

cc: Taylor Blau <me@ttaylorr.com>