### PR TITLE
pack-objects: introduce --exclude-delta=<pattern> option

### DIFF
--- a/Documentation/git-pack-objects.txt
+++ b/Documentation/git-pack-objects.txt
@@ -13,7 +13,7 @@ SYNOPSIS
 	[--no-reuse-delta] [--delta-base-offset] [--non-empty]
 	[--local] [--incremental] [--window=<n>] [--depth=<n>]
 	[--revs [--unpacked | --all]] [--keep-pack=<pack-name>]
-	[--cruft] [--cruft-expiration=<time>]
+	[--cruft] [--cruft-expiration=<time>] [--exclude-delta=<file>]
 	[--stdout [--filter=<filter-spec>] | <base-name>]
 	[--shallow] [--keep-true-parents] [--[no-]sparse] < <object-list>
 
@@ -220,6 +220,10 @@ depth is 4095.
 	This sometimes results in a slightly suboptimal pack.
 	This flag tells the command not to reuse existing deltas
 	but compute them from scratch.
+
+--exclude-delta=<pattern>::
+	Delta compression will not be attempted for blobs for paths
+	matching pattern. See linkgit:gitignore[5] for pattern details.
 
 --no-reuse-object::
 	This flag tells the command not to reuse existing object data at all,


### PR DESCRIPTION
While analyzing some repositories using `git filter-repo -analyze`,
I noticed that many huge binaries in the repositories were
delta-compressed without much reduction in size.

$ cat .git/filter-repo/analysis/path-all-sizes.txt | more
=== All paths by reverse accumulated size ===
Format: unpacked size, packed size, date deleted, path name
    23816778   23765921 2022-08-22 managed/src/universal/ybc/ybc-1.0.0-b1-linux-x86_64.tar.gz
    22504398   22445676 2022-08-22 managed/src/universal/ybc/ybc-1.0.0-b1-el8-aarch64.tar.gz
    11726471    6424233 2022-08-09 managed/yba-installer/yba-installer_linux_amd64
   294644800    5794201 <present>  src/yb/master/catalog_manager.cc
     2912780    2872186 <present>  docs/static/images/yp/tables-view-ycql.png
     2992192    2634232 <present>  docs/static/images/yb-cloud/cloud-clusters-backups.png
     2757095    2501915 <present>  docs/static/images/deploy/aws/aws-cf-configure-options.png
...

The current solution to avoid delta compression is not very
suitable for git servers. First, files that exceed the
big_file_threshold are not delta compressed, but the above
analysis indicates that many big binary files do not exceed
the the big_file_threshold (default to 512MB). Second, there
is not .gitattrbutes to disable delta compression for them, we
also don't really can let repo administrators add it manually.

But we can also see that the large files in these repositories often
have some common characteristics: they end in ".tar.gz"or “.png".
So perhaps we can take advantage of this feature and disable delta
compression on the server for some common type binary files.

This is currently implemented by command line parameters 
`--exclude-delta=<pattern>`. But maybe we can also try passing
it through git config.

[1]: https://gitlab.com/gitlab-org/gitaly/-/issues/1853

cc: Christian Couder <christian.couder@gmail.com>
cc: Ævar Arnfjörð Bjarmason <avarab@gmail.com>
cc: Junio C Hamano <gitster@pobox.com>
cc: Derrick Stolee <derrickstolee@github.com>
cc: Johannes Schindelin <johannes.schindelin@gmx.de>
cc: Elijah Newren <newren@gmail.com>
cc: James Ramsay <james@jramsay.com.au>