### PR TITLE
fsmonitor--daemon: on macOS support symlink

### DIFF
--- a/compat/fsmonitor/fsm-listen-darwin.c
+++ b/compat/fsmonitor/fsm-listen-darwin.c
@@ -336,7 +336,7 @@ static void fsevent_callback(ConstFSEventStreamRef streamRef,
 			 * know how much to invalidate/refresh.
 			 */
 
-			if (event_flags[k] & kFSEventStreamEventFlagItemIsFile) {
+			if (event_flags[k] & (kFSEventStreamEventFlagItemIsFile | kFSEventStreamEventFlagItemIsSymlink)) {
 				const char *rel = path_k +
 					state->path_worktree_watch.len + 1;
 


### PR DESCRIPTION
Resolves a problem where symbolic links were not showing up in diff when created or modified.
(on macOS with git config core.fsmonitor=true)

cc: Taylor Blau <me@ttaylorr.com>
cc: Jeff Hostetler <git@jeffhostetler.com>