### PR TITLE
docs(git-bundle): fix two typos

### DIFF
--- a/Documentation/git-bundle.txt
+++ b/Documentation/git-bundle.txt
@@ -28,10 +28,10 @@ to another.
 
 Git commands that fetch or otherwise "read" via protocols such as
 `ssh://` and `https://` can also operate on bundle files. It is
-possible linkgit:git-clone[1] a new repository from a bundle, to use
+possible to linkgit:git-clone[1] a new repository from a bundle, to use
 linkgit:git-fetch[1] to fetch from one, and to list the references
 contained within it with linkgit:git-ls-remote[1]. There's no
-corresponding "write" support, i.e.a 'git push' into a bundle is not
+corresponding "write" support, i.e., a 'git push' into a bundle is not
 supported.
 
 See the "EXAMPLES" section below for examples of how to use bundles.


### PR DESCRIPTION
Add missing word "to" and fix some run-on punctuation in the
third paragraph of the documentation file for `git-bundle`.

Signed-off-by: Michael Hucka <mhucka@caltech.edu>