### PR TITLE
Documentation: Increase example cache timeout to 1 hour

### DIFF
--- a/Documentation/git-credential-cache.txt
+++ b/Documentation/git-credential-cache.txt
@@ -69,10 +69,10 @@ $ git push http://example.com/repo.git
 ------------------------------------
 
 You can provide options via the credential.helper configuration
-variable (this example drops the cache time to 5 minutes):
+variable (this example increases the cache time to 1 hour):
 
 -------------------------------------------------------
-$ git config credential.helper 'cache --timeout=300'
+$ git config credential.helper 'cache --timeout=3600'
 -------------------------------------------------------
 
 GIT


### PR DESCRIPTION
Previously, the example *decreased* the cache timeout compared to the
default, nudging users to make cache less usable.

Instead, nudge users to make cache more usable. Currently many users
choose store over cache for usability. See
https://lore.kernel.org/git/Y2p4rhiOphuOM0VQ@coredump.intra.peff.net/

The default timeout remains 15 minutes. A stronger nudge would
be to increase that.

Signed-off-by: M Hickford <mirth.hickford@gmail.com>

CC: Jeff King <peff@peff.net>
cc: Taylor Blau <me@ttaylorr.com>