### PR TITLE
Shellcheck clean

### DIFF
--- a/templates/Makefile
+++ b/templates/Makefile
@@ -31,20 +31,17 @@ all: boilerplates.made custom
 
 bpsrc = $(filter-out %~,$(wildcard *--*))
 boilerplates.made : $(bpsrc)
-	$(QUIET)umask 022 && ls *--* 2>/dev/null | \
-	while read boilerplate; \
-	do \
+	$(QUIET)umask 022 && \
+	for boilerplate in *--*; do \
 		case "$$boilerplate" in *~) continue ;; esac && \
-		dst=`echo "$$boilerplate" | sed -e 's|^this|.|;s|--|/|g'` && \
-		dir=`expr "$$dst" : '\(.*\)/'` && \
-		mkdir -p blt/$$dir && \
-		case "$$boilerplate" in \
-		*--) continue;; \
-		esac && \
+		dst=$$(echo "$$boilerplate" | sed -e 's|^this|.|;s|--|/|g') && \
+		dir=$$(expr "$$dst" : '\(.*\)/') && \
+		mkdir -p blt/"$$dir" && \
+		case "$$boilerplate" in *--) continue;; esac && \
 		sed -e '1s|#!.*/sh|#!$(SHELL_PATH_SQ)|' \
 		    -e 's|@SHELL_PATH@|$(SHELL_PATH_SQ)|' \
-		    -e 's|@PERL_PATH@|$(PERL_PATH_SQ)|g' $$boilerplate > \
-			blt/$$dst && \
+		    -e 's|@PERL_PATH@|$(PERL_PATH_SQ)|g' "$$boilerplate" > \
+			blt/"$$dst" && \
 		if test -x "$$boilerplate"; then rx=rx; else rx=r; fi && \
 		chmod a+$$rx "blt/$$dst" || exit; \
 	done && \

--- a/templates/hooks--pre-commit.sample
+++ b/templates/hooks--pre-commit.sample
@@ -28,7 +28,7 @@ if [ "$allownonascii" != "true" ] &&
 	# Note that the use of brackets around a tr range is ok here, (it's
 	# even required, for portability to Solaris 10's /usr/bin/tr), since
 	# the square bracket bytes happen to fall in the designated range.
-	test $(git diff --cached --name-only --diff-filter=A -z $against |
+	test $(git diff --cached --name-only --diff-filter=A -z "$against" |
 	  LC_ALL=C tr -d '[ -~]\0' | wc -c) != 0
 then
 	cat <<\EOF
@@ -46,4 +46,4 @@ EOF
 fi
 
 # If there are whitespace errors, print the offending file names and fail.
-exec git diff-index --check --cached $against --
+exec git diff-index --check --cached "$against" --

--- a/templates/hooks--pre-rebase.sample
+++ b/templates/hooks--pre-rebase.sample
@@ -21,7 +21,7 @@ if test "$#" = 2
 then
 	topic="refs/heads/$2"
 else
-	topic=`git symbolic-ref HEAD` ||
+	topic=$(git symbolic-ref HEAD) ||
 	exit 0 ;# we do not interrupt rebasing detached HEAD
 fi
 
@@ -43,7 +43,7 @@ git show-ref -q "$topic" || {
 }
 
 # Is topic fully merged to master?
-not_in_master=`git rev-list --pretty=oneline ^master "$topic"`
+not_in_master=$(git rev-list --pretty=oneline ^master "$topic")
 if test -z "$not_in_master"
 then
 	echo >&2 "$topic is fully merged to master; better remove it."
@@ -51,11 +51,11 @@ then
 fi
 
 # Is topic ever merged to next?  If so you should not be rebasing it.
-only_next_1=`git rev-list ^master "^$topic" ${publish} | sort`
-only_next_2=`git rev-list ^master           ${publish} | sort`
+only_next_1=$(git rev-list ^master "^$topic" ${publish} | sort)
+only_next_2=$(git rev-list ^master           ${publish} | sort)
 if test "$only_next_1" = "$only_next_2"
 then
-	not_in_topic=`git rev-list "^$topic" master`
+	not_in_topic=$(git rev-list "^$topic" master)
 	if test -z "$not_in_topic"
 	then
 		echo >&2 "$topic is already up to date with master"
@@ -64,7 +64,7 @@ then
 		exit 0
 	fi
 else
-	not_in_next=`git rev-list --pretty=oneline ^${publish} "$topic"`
+	not_in_next=$(git rev-list --pretty=oneline ^${publish} "$topic")
 	@PERL_PATH@ -e '
 		my $topic = $ARGV[0];
 		my $msg = "* $topic has commits already merged to public branch:\n";

--- a/templates/hooks--pre-rebase.sample
+++ b/templates/hooks--pre-rebase.sample
@@ -88,7 +88,7 @@ else
 	exit 1
 fi
 
-<<\DOC_END
+:<<\DOC_END
 
 This sample hook safeguards topic branches that have been
 published from being rewound.

--- a/templates/hooks--push-to-checkout.sample
+++ b/templates/hooks--push-to-checkout.sample
@@ -67,7 +67,7 @@ else
 	head=$(git hash-object -t tree --stdin </dev/null)
 fi
 
-if ! git diff-index --quiet --cached --ignore-submodules $head --
+if ! git diff-index --quiet --cached --ignore-submodules "$head" --
 then
 	die "Working directory has staged changes"
 fi

--- a/templates/hooks--update.sample
+++ b/templates/hooks--update.sample
@@ -37,7 +37,7 @@ if [ -z "$GIT_DIR" ]; then
 	exit 1
 fi
 
-if [ -z "$refname" -o -z "$oldrev" -o -z "$newrev" ]; then
+if [ -z "$refname" ] || [ -z "$oldrev" ] || [ -z "$newrev" ]; then
 	echo "usage: $0 <ref> <oldrev> <newrev>" >&2
 	exit 1
 fi
@@ -95,7 +95,7 @@ case "$refname","$newrev_type" in
 		;;
 	refs/heads/*,commit)
 		# branch
-		if [ "$oldrev" = "$zero" -a "$denycreatebranch" = "true" ]; then
+		if [ "$oldrev" = "$zero" ] && [ "$denycreatebranch" = "true" ]; then
 			echo "*** Creating a branch is not allowed in this repository" >&2
 			exit 1
 		fi

--- a/templates/hooks--update.sample
+++ b/templates/hooks--update.sample
@@ -64,7 +64,7 @@ zero=$(git hash-object --stdin </dev/null | tr '[0-9a-f]' '0')
 if [ "$newrev" = "$zero" ]; then
 	newrev_type=delete
 else
-	newrev_type=$(git cat-file -t $newrev)
+	newrev_type=$(git cat-file -t "$newrev")
 fi
 
 case "$refname","$newrev_type" in
@@ -86,7 +86,7 @@ case "$refname","$newrev_type" in
 		;;
 	refs/tags/*,tag)
 		# annotated tag
-		if [ "$allowmodifytag" != "true" ] && git rev-parse $refname > /dev/null 2>&1
+		if [ "$allowmodifytag" != "true" ] && git rev-parse "$refname" > /dev/null 2>&1
 		then
 			echo "*** Tag '$refname' already exists." >&2
 			echo "*** Modifying a tag is not allowed in this repository." >&2


### PR DESCRIPTION
Fix most shellcheck warnings in templates/*.sample

The shellcheck tool https://www.shellcheck.net/ warns against many shell programming errors.

The templates are meant as boilerplate for hooks, so it makes sense for them to avoid various shell programming antipatterns, portability problems, and inefficiencies. Shell scripts are frequently written by practitioners who are inexperienced with the language and just want to get the job done; we should make it as easy as possible for them to avoid common shell programming pitfalls, and teach them good practices when we can.