### PR TITLE
var: add GIT_SEQUENCE_EDITOR variable

### DIFF
--- a/Documentation/git-var.txt
+++ b/Documentation/git-var.txt
@@ -50,6 +50,14 @@ ifdef::git-default-editor[]
     The build you are using chose '{git-default-editor}' as the default.
 endif::git-default-editor[]
 
+GIT_SEQUENCE_EDITOR::
+    Text editor used to edit the 'todo' file while running `git rebase
+    -i`. Like `GIT_EDITOR`, the value is meant to be interpreted by
+    the shell when it is used. The order of preference is the
+    `$GIT_SEQUENCE_EDITOR` environment variable, then
+    `sequence.editor` configuration, and then the value of `git var
+    GIT_EDITOR`.
+
 GIT_PAGER::
     Text viewer for use by Git commands (e.g., 'less').  The value
     is meant to be interpreted by the shell.  The order of preference

--- a/builtin/var.c
+++ b/builtin/var.c
@@ -14,6 +14,11 @@ static const char *editor(int flag)
 	return git_editor();
 }
 
+static const char *sequence_editor(int flag)
+{
+	return git_sequence_editor();
+}
+
 static const char *pager(int flag)
 {
 	const char *pgm = git_pager(1);
@@ -36,6 +41,7 @@ static struct git_var git_vars[] = {
 	{ "GIT_COMMITTER_IDENT", git_committer_info },
 	{ "GIT_AUTHOR_IDENT",   git_author_info },
 	{ "GIT_EDITOR", editor },
+	{ "GIT_SEQUENCE_EDITOR", sequence_editor },
 	{ "GIT_PAGER", pager },
 	{ "GIT_DEFAULT_BRANCH", default_branch },
 	{ "", NULL },

--- a/t/t0007-git-var.sh
+++ b/t/t0007-git-var.sh
@@ -109,6 +109,44 @@ test_expect_success 'get GIT_EDITOR with configuration and environment variable 
 	)
 '
 
+test_expect_success 'get GIT_SEQUENCE_EDITOR without configuration' '
+	(
+		sane_unset GIT_SEQUENCE_EDITOR &&
+		git var GIT_EDITOR >expect &&
+		git var GIT_SEQUENCE_EDITOR >actual &&
+		test_cmp expect actual
+	)
+'
+
+test_expect_success 'get GIT_SEQUENCE_EDITOR with configuration' '
+	test_config sequence.editor foo &&
+	(
+		sane_unset GIT_SEQUENCE_EDITOR &&
+		echo foo >expect &&
+		git var GIT_SEQUENCE_EDITOR >actual &&
+		test_cmp expect actual
+	)
+'
+
+test_expect_success 'get GIT_SEQUENCE_EDITOR with environment variable' '
+	(
+		sane_unset GIT_SEQUENCE_EDITOR &&
+		echo bar >expect &&
+		GIT_SEQUENCE_EDITOR=bar git var GIT_SEQUENCE_EDITOR >actual &&
+		test_cmp expect actual
+	)
+'
+
+test_expect_success 'get GIT_SEQUENCE_EDITOR with configuration and environment variable' '
+	test_config sequence.editor foo &&
+	(
+		sane_unset GIT_SEQUENCE_EDITOR &&
+		echo bar >expect &&
+		GIT_SEQUENCE_EDITOR=bar git var GIT_SEQUENCE_EDITOR >actual &&
+		test_cmp expect actual
+	)
+'
+
 # For git var -l, we check only a representative variable;
 # testing the whole output would make our test too brittle with
 # respect to unrelated changes in the test suite's environment.


### PR DESCRIPTION
In my case, I'm overriding the sequence editor in `git rebase -i` to do some pre-processing on the todo file, but I'd still like to open up the editor for further manipulation/verification of the todo steps. Just using `GIT_EDITOR` here will clobber folks' expectations that their custom-built sequence editor pops up (e.g. VSCode or Git Cola).

Changes since v1:
- rebased on current main
- following new, simplified patterns from my previous pull-request merged in d8184580

cc: Sean Allred <allred.sean@gmail.com>