### PR TITLE
lib-httpd: extend module location auto-detection

### DIFF
--- a/t/lib-httpd.sh
+++ b/t/lib-httpd.sh
@@ -65,7 +65,8 @@ done
 for DEFAULT_HTTPD_MODULE_PATH in '/usr/libexec/apache2' \
 				 '/usr/lib/apache2/modules' \
 				 '/usr/lib64/httpd/modules' \
-				 '/usr/lib/httpd/modules'
+				 '/usr/lib/httpd/modules' \
+				 '/usr/libexec/httpd'
 do
 	if test -d "$DEFAULT_HTTPD_MODULE_PATH"
 	then


### PR DESCRIPTION
Make `httpd` tests work out-of-the-box on Void Linux.

cc: Jeff King <peff@peff.net>