### PR TITLE
config: introduce an Operating System-specific `includeIf` condition

### DIFF
--- a/Documentation/config.txt
+++ b/Documentation/config.txt
@@ -186,6 +186,11 @@ As for the naming of this keyword, it is for forwards compatibiliy with
 a naming scheme that supports more variable-based include conditions,
 but currently Git only supports the exact keyword described above.
 
+`os`::
+	The data that follows this keyword is taken as the name of an
+	Operating System, e.g. `Linux` or `Windows`; If it matches the
+	current Operating System, the include condition is met.
+
 A few more notes on matching via `gitdir` and `gitdir/i`:
 
  * Symlinks in `$GIT_DIR` are not resolved before matching.

--- a/config.c
+++ b/config.c
@@ -394,6 +394,15 @@ static int include_by_remote_url(struct config_include_data *inc,
 					     inc->remote_urls);
 }
 
+static int include_by_os(const char *cond, size_t cond_len)
+{
+	struct utsname uname_info;
+
+	return !uname(&uname_info) &&
+		!strncasecmp(uname_info.sysname, cond, cond_len) &&
+		!uname_info.sysname[cond_len];
+}
+
 static int include_condition_is_true(struct config_include_data *inc,
 				     const char *cond, size_t cond_len)
 {
@@ -408,6 +417,8 @@ static int include_condition_is_true(struct config_include_data *inc,
 	else if (skip_prefix_mem(cond, cond_len, "hasconfig:remote.*.url:", &cond,
 				   &cond_len))
 		return include_by_remote_url(inc, cond, cond_len);
+	else if (skip_prefix_mem(cond, cond_len, "os:", &cond, &cond_len))
+		return include_by_os(cond, cond_len);
 
 	/* unknown conditionals are always false */
 	return 0;

--- a/t/t1309-early-config.sh
+++ b/t/t1309-early-config.sh
@@ -100,4 +100,20 @@ test_expect_success 'onbranch config outside of git repo' '
 	nongit git help
 '
 
+test_expect_success '[includeIf "os:..."]' '
+	test_config x.y 0 &&
+	echo "[x] y = z" >.git/xyz &&
+
+	if test_have_prereq MINGW
+	then
+		uname_s=Windows
+	else
+		uname_s="$(uname -s)"
+	fi &&
+	test_config "includeIf.os:not-$uname_s.path" xyz &&
+	test 0 = "$(git config x.y)" &&
+	test_config "includeIf.os:$uname_s.path" xyz &&
+	test z = "$(git config x.y)"
+'
+
 test_done


### PR DESCRIPTION
I was about to write up guidelines how to write this patch, but it turned out that it was much faster to write the patch instead.

Changes since v1:
- The documentation now avoids mentioning `uname -s` and clarifies what it means by offering examples.
- Replaced a double space in the test case with a single one.

cc: Ævar Arnfjörð Bjarmason <avarab@gmail.com>
cc: Phillip Wood <phillip.wood123@gmail.com>
cc: Jeff King <peff@peff.net>
cc: Philippe Blain <levraiphilippeblain@gmail.com>
cc: Philip Oakley <philipoakley@iee.email>
cc: Đoàn Trần Công Danh 
        <congdanhqx@gmail.com>

cc: Phillip Wood <phillip.wood123@gmail.com>
cc: Jeff King <peff@peff.net>
cc: Samuel Ferencik <sferencik@gmail.com>
cc: Felipe Contreras <felipe.contreras@gmail.com>
cc: Chris Torek <chris.torek@gmail.com>
cc: <rsbecker@nexbridge.com>