### PR TITLE
scalar: show progress if stderr refer to a terminal

### DIFF
--- a/scalar.c
+++ b/scalar.c
@@ -404,7 +404,7 @@ void load_builtin_commands(const char *prefix, struct cmdnames *cmds)
 static int cmd_clone(int argc, const char **argv)
 {
 	const char *branch = NULL;
-	int full_clone = 0, single_branch = 0;
+	int full_clone = 0, single_branch = 0, show_progress = isatty(2);
 	struct option clone_options[] = {
 		OPT_STRING('b', "branch", &branch, N_("<branch>"),
 			   N_("branch to checkout after clone")),
@@ -499,7 +499,9 @@ static int cmd_clone(int argc, const char **argv)
 	if (set_recommended_config(0))
 		return error(_("could not configure '%s'"), dir);
 
-	if ((res = run_git("fetch", "--quiet", "origin", NULL))) {
+	if ((res = run_git("fetch", "--quiet",
+				show_progress ? "--progress" : "--no-progress",
+				"origin", NULL))) {
 		warning(_("partial clone failed; attempting full clone"));
 
 		if (set_config("remote.origin.promisor") ||
@@ -508,7 +510,9 @@ static int cmd_clone(int argc, const char **argv)
 			goto cleanup;
 		}
 
-		if ((res = run_git("fetch", "--quiet", "origin", NULL)))
+		if ((res = run_git("fetch", "--quiet",
+					show_progress ? "--progress" : "--no-progress",
+					"origin", NULL)))
 			goto cleanup;
 	}
 

--- a/t/t9211-scalar-clone.sh
+++ b/t/t9211-scalar-clone.sh
@@ -3,6 +3,7 @@
 test_description='test the `scalar clone` subcommand'
 
 . ./test-lib.sh
+. "${TEST_DIRECTORY}/lib-terminal.sh"
 
 GIT_TEST_MAINT_SCHEDULER="crontab:test-tool crontab cron.txt,launchctl:true,schtasks:true"
 export GIT_TEST_MAINT_SCHEDULER
@@ -145,6 +146,31 @@ test_expect_success '--no-single-branch clones all branches' '
 		grep "refs/remotes/origin/parallel" out
 	) &&
 
+	cleanup_clone $enlistment
+'
+
+test_expect_success TTY 'progress with tty' '
+	enlistment=progress1 &&
+
+	test_config -C to-clone uploadpack.allowfilter true &&
+	test_config -C to-clone uploadpack.allowanysha1inwant true &&
+
+	test_terminal env GIT_PROGRESS_DELAY=0 \
+		scalar clone "file://$(pwd)/to-clone" "$enlistment" 2>stderr &&
+	grep "Enumerating objects" stderr >actual &&
+	test_line_count = 2 actual &&
+	cleanup_clone $enlistment
+'
+
+test_expect_success TTY 'progress without tty' '
+	enlistment=progress2 &&
+
+	test_config -C to-clone uploadpack.allowfilter true &&
+	test_config -C to-clone uploadpack.allowanysha1inwant true &&
+
+	GIT_PROGRESS_DELAY=0 scalar clone "file://$(pwd)/to-clone" "$enlistment" 2>stderr &&
+	! grep "Enumerating objects" stderr &&
+	! grep "Updating files" stderr &&
 	cleanup_clone $enlistment
 '
 


### PR DESCRIPTION
When users use scalar to download a monorepo with a long commit
history (or the client and server network communication is very poor),
we often need to spend a long time in the fetch phase of scalar, some
users may want to check this progress bar To understand the progress
of fetch and how long they have to wait, so we should enable scalar to
display fetch progress.

v1.
add `[--verbose| -v]` to scalar clone.

v2.
1. remove `--verbose` option.
2. check if scalar stderr refer to terminal, if so, show progress.

v3.
1. fix some tests suggested by Derrick Stolee.

Note: output look like this:
```
$ scalar clone git@github.com:git/git.git
Initialized empty Git repository in /home/adl/test/git/src/.git/
remote: Enumerating objects: 208997, done.
remote: Counting objects: 100% (870/870), done.
remote: Compressing objects: 100% (870/870), done.
remote: Total 208991 (delta 0), reused 870 (delta 0), pack-reused 208121
remote: Enumerating objects: 470, done.
remote: Counting objects: 100% (418/418), done.
remote: Compressing objects: 100% (418/418), done.
remote: Total 470 (delta 1), reused 0 (delta 0), pack-reused 52
Receiving objects: 100% (470/470), 1.96 MiB | 1.64 MiB/s, done.
Resolving deltas: 100% (1/1), done.
Updating files: 100% (471/471), done.
branch 'master' set up to track 'origin/master'.
Switched to a new branch 'master'
Your branch is up to date with 'origin/master'.
```

"new branch", "new tag" output is a bit annoying, it would be
better to suppress them, but keep the progress.

cc: Junio C Hamano <gitster@pobox.com>
cc: Derrick Stolee <derrickstolee@github.com>
cc: Johannes Schindelin <johannes.schindelin@gmx.de>
cc: Victoria Dye <vdye@github.com>
cc: Taylor Blau <me@ttaylorr.com>