### PR TITLE
Explicitly make CMake-based CI failures the responsibility of "Windows folks"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -132,7 +132,7 @@ jobs:
   vs-build:
     name: win+VS build
     needs: ci-config
-    if: needs.ci-config.outputs.enabled == 'yes'
+    if: github.event.repository.owner.login == 'git-for-windows' && needs.ci-config.outputs.enabled == 'yes'
     env:
       NO_PERL: 1
       GIT_CONFIG_PARAMETERS: "'user.name=CI' 'user.email=ci@git'"


### PR DESCRIPTION
Ævar and I have brain-stormed off-list what would be the best way to resolve the mounting frustration with CI failures that are caused by needing to mirror `Makefile` changes into the CMake-based build, a burden that the Git project never wanted to bear.

While he still wants to improve the CMake support (which will benefit Git for Windows), the main driver of trying to extend CMake support to Linux (which does not need it because `make` works very well there, indeed) was said frustration with CI failures.

A much quicker method to reduce that friction to close to nil is to simply disable the win+VS jobs, which is what this proposal is about. (Almost, at least, we still want to keep those job definitions and run them in Git for Windows' fork to ensure that CMake-based builds still work.)

A very welcome side effect is to reduce the CI build time again, which became alarmingly long as of recent, causing friction on its own.

Cc: avarab@gmail.com
Cc: phillip.wood@dunelm.org.uk
Cc: peff@peff.net
Cc: me@ttaylorr.com
Cc: phillip.wood123@gmail.com