### PR TITLE
trace2: always use O_APPEND when creating log files

### DIFF
--- a/trace2/tr2_dst.c
+++ b/trace2/tr2_dst.c
@@ -101,7 +101,7 @@ static int tr2_dst_too_many_files(struct tr2_dst *dst, const char *tgt_prefix)
 
 	if (file_count >= tr2env_max_files) {
 		dst->too_many_files = 1;
-		dst->fd = open(sentinel_path.buf, O_WRONLY | O_CREAT | O_EXCL, 0666);
+		dst->fd = open(sentinel_path.buf, O_WRONLY | O_APPEND | O_CREAT | O_EXCL, 0666);
 		ret = -1;
 		goto cleanup;
 	}
@@ -138,7 +138,7 @@ static int tr2_dst_try_auto_path(struct tr2_dst *dst, const char *tgt_prefix)
 				strbuf_addf(&path, ".%d", attempt_count);
 			}
 
-			dst->fd = open(path.buf, O_WRONLY | O_CREAT | O_EXCL, 0666);
+			dst->fd = open(path.buf, O_WRONLY | O_APPEND | O_CREAT | O_EXCL, 0666);
 			if (dst->fd != -1)
 				break;
 		}


### PR DESCRIPTION
Always use O_APPEND when creating trace2 log files on disk.

Log files should always be opened with O_APPEND so that each write() does an atomic lseek() to the end of the file before writing the new content.  This ensures that concurrent writes to the same log file from concurrent processes will be coordinated and not overwrite each other.

In the original trace2 code [1] we only supported logging to explicitly named log files (with a pathname set in config or an environment variable) so it was common for multiple processes to be writing to the same log file.  That code path did use the O_APPEND option.

In [2], trace2 was extended to allow the config/env variable to point to a directory and a pathname was generated within that directory. Files created this way did not have the O_APPEND bit set. In [3], the too-many-files code was added and to create a sentinel log file.  This did not use the O_APPEND bit either.

Granted, the new calls in [2,3] do use the O_EXCL, so they will fail if they don't create a new log file, so this process will not overwrite messages of existing processes.  But O_EXCL does not protect from later processes that start logging using the log file by name (as in [1]).

[1] ee4512ed48 (trace2: create new combined trace facility, 2019-02-22) 
[2] a4d3a283db (trace2: write to directory targets, 2019-03-21) 
[3] 87db61a436 (trace2: write discard message to sentinel files, 2019-10-04)

NEEDSWORK: I've confirmed this behavior in the debugger, but I'm not sure it warrants a very difficult to set up and racy test.  Basically, I set logging to a directory and stopped Git in the debugger after tracing had started.  Then in another window, run Git with tracing set explicitly to the full path of that new logfile.  Then let the debugger instance complete.  This was easiest to see when one process was using the _PERF target and one was using the _EVENT target.  The resulting log file would be a jumble of both formats.

Signed-off-by: Jeff Hostetler <jeffhostetler@github.com>
