### PR TITLE
trailer: allow whitespace in tokens

### DIFF
--- a/t/t7513-interpret-trailers.sh
+++ b/t/t7513-interpret-trailers.sh
@@ -1560,4 +1560,16 @@ test_expect_success 'suppress --- handling' '
 	test_cmp expected actual
 '
 
+test_expect_success 'whitespace in token' '
+	echo "real trailer: just right" >expected &&
+
+	git interpret-trailers --parse >actual <<-\EOF &&
+	subject
+
+	real trailer: just right
+	EOF
+
+	test_cmp expected actual
+'
+
 test_done

--- a/trailer.c
+++ b/trailer.c
@@ -608,11 +608,10 @@ static int token_matches_item(const char *tok, struct arg_item *item, size_t tok
 }
 
 /*
- * If the given line is of the form
- * "<token><optional whitespace><separator>..." or "<separator>...", return the
- * location of the separator. Otherwise, return -1.  The optional whitespace
- * is allowed there primarily to allow things like "Bug #43" where <token> is
- * "Bug" and <separator> is "#".
+ * If the given line is of the form "<token><separator>..." or
+ * "<separator>...", return the location of the separator. Otherwise, return
+ * -1.  Whitespace is allowed within the token primarily to allow things like
+ * "Bug #43" where <token> is "Bug" and <separator> is "#".
  *
  * The separator-starts-line case (in which this function returns 0) is
  * distinguished from the non-well-formed-line case (in which this function
@@ -620,15 +619,13 @@ static int token_matches_item(const char *tok, struct arg_item *item, size_t tok
  */
 static ssize_t find_separator(const char *line, const char *separators)
 {
-	int whitespace_found = 0;
 	const char *c;
 	for (c = line; *c; c++) {
 		if (strchr(separators, *c))
 			return c - line;
-		if (!whitespace_found && (isalnum(*c) || *c == '-'))
-			continue;
-		if (c != line && (*c == ' ' || *c == '\t')) {
-			whitespace_found = 1;
+		if (isalnum(*c) ||
+		    *c == '-' ||
+		    (c != line && (*c == ' ' || *c == '\t'))) {
 			continue;
 		}
 		break;


### PR DESCRIPTION
Since e4319562bc (trailer: be stricter in parsing separators, 2016-11-02), there has been a disagreement between the implementation and the documentation, which states:

> There can also be whitespaces inside the token and the value.

Resolve that inconsistency by once again allowing any whitespace within the token.

Signed-off-by: Sam Sneddon <gsnedders@apple.com>
