### PR TITLE
[RFC] push: allow delete one level ref 

### DIFF
--- a/builtin/receive-pack.c
+++ b/builtin/receive-pack.c
@@ -1463,7 +1463,9 @@ static const char *update(struct command *cmd, struct shallow_info *si)
 		find_shared_symref(worktrees, "HEAD", name);
 
 	/* only refs/... are allowed */
-	if (!starts_with(name, "refs/") || check_refname_format(name + 5, 0)) {
+	if (!starts_with(name, "refs/") ||
+	    check_refname_format(name + 5, is_null_oid(new_oid) ?
+				 REFNAME_ALLOW_ONELEVEL : 0)) {
 		rp_error("refusing to update funny ref '%s' remotely", name);
 		ret = "funny refname";
 		goto out;

--- a/builtin/receive-pack.c
+++ b/builtin/receive-pack.c
@@ -1464,7 +1464,7 @@ static const char *update(struct command *cmd, struct shallow_info *si)
 
 	/* only refs/... are allowed */
 	if (!starts_with(name, "refs/") || check_refname_format(name + 5, 0)) {
-		rp_error("refusing to create funny ref '%s' remotely", name);
+		rp_error("refusing to update funny ref '%s' remotely", name);
 		ret = "funny refname";
 		goto out;
 	}

--- a/connect.c
+++ b/connect.c
@@ -30,7 +30,8 @@ static int check_ref(const char *name, unsigned int flags)
 		return 0;
 
 	/* REF_NORMAL means that we don't want the magic fake tag refs */
-	if ((flags & REF_NORMAL) && check_refname_format(name, 0))
+	if ((flags & REF_NORMAL) && check_refname_format(name,
+							 REFNAME_ALLOW_ONELEVEL))
 		return 0;
 
 	/* REF_HEADS means that we want regular branch heads */

--- a/t/t5516-fetch-push.sh
+++ b/t/t5516-fetch-push.sh
@@ -401,6 +401,11 @@ test_expect_success 'push with ambiguity' '
 
 '
 
+test_expect_success 'push with onelevel ref' '
+	mk_test testrepo heads/main &&
+	test_must_fail git push testrepo HEAD:refs/onelevel
+'
+
 test_expect_success 'push with colon-less refspec (1)' '
 
 	mk_test testrepo heads/frotz tags/frotz &&
@@ -896,6 +901,13 @@ test_expect_success 'push --delete refuses src:dest refspecs' '
 test_expect_success 'push --delete refuses empty string' '
 	mk_test testrepo heads/master &&
 	test_must_fail git push testrepo --delete ""
+'
+
+test_expect_success 'push --delete onelevel refspecs' '
+	mk_test testrepo heads/main &&
+	git -C testrepo update-ref refs/onelevel refs/heads/main &&
+	git push testrepo --delete refs/onelevel &&
+	test_must_fail git -C testrepo rev-parse --verify refs/onelevel
 '
 
 test_expect_success 'warn on push to HEAD of non-bare repository' '


### PR DESCRIPTION
This might be an odd request: allow git push to delete
one level refs like "ref/foo".

Some users on my side often push "refs/for/master"
to the remote for code review, but due to a user's typo,
"refs/master" is pushed to the remote.

Pushing a one level ref like "refs/foo" should not have been
successful, but since my server side directly updated the ref
during the proc-receive-hook phase of git receive-pack,
"refs/foo" was mistakenly left at on the server.

But for some reasons, users cannot delete this special branch
through "git push -d".

First, I executed git update-ref --stdin inside my proc-receive-hook
to delete the branch. As a result, update-ref reported an error:
"cannot lock ref 'refs/foo': reference already exists".

So I tried GIT_TRACKET_PACKET to debug and found that git push
did not seem to pass the correct ref old-oid, which is why update-ref
reported an error.

```
"18:13:41.214872 pkt-line.c:80           packet: receive-pack< 0000000000000000000000000000000000000000 0000000000000000000000000000000000000000 refs/foo\0 report-status-v2 side-band-64k object-format=sha1 agent=git/2.39.0.227.g262c45b6a1"
```

Tracing it back, the check_ref() in the git push link didn't record
the old-oid for the remote "refs/foo".

At the same time, the server update() process will reject the one
level ref by default and return a "funny refname" error.

It is worth mentioning that since I deleted the branch, the error
message returned here is "refusing to create funny ref 'refs/foo'
remotely", which is also worth fixing.

So this patch series do:

v1.
1. fix funny refname error message from "create" to "update".
2. let server allow delete one level ref.
3. let client pass correct one level ref old-oid.

v2.
1. fix code style.

v3.
1. clarify in the docs why single-level refs are allowed to be
deleted but not created/updated.

v4.
1. move the testing part of the first patch to the second patch.

cc: Ævar Arnfjörð Bjarmason <avarab@gmail.com>
cc: Junio C Hamano <gitster@pobox.com>
cc: Derrick Stolee <derrickstolee@github.com>
cc: Elijah Newren <newren@gmail.com>
cc: Michael Haggerty <mhagger@alum.mit.edu>
cc: Christian Couder <christian.couder@gmail.com>
cc: Jeff King <peff@peff.net>