### PR TITLE
Allow scalar to succeed despite maintenance failures

### DIFF
--- a/Documentation/scalar.txt
+++ b/Documentation/scalar.txt
@@ -8,7 +8,8 @@ scalar - A tool for managing large Git repositories
 SYNOPSIS
 --------
 [verse]
-scalar clone [--single-branch] [--branch <main-branch>] [--full-clone] <url> [<enlistment>]
+scalar clone [--single-branch] [--branch <main-branch>] [--full-clone]
+	     [--[no-]src] <url> [<enlistment>]
 scalar list
 scalar register [<enlistment>]
 scalar unregister [<enlistment>]
@@ -79,6 +80,15 @@ Further fetches into the resulting repository will only update the
 remote-tracking branch for the branch this option was used for the initial
 cloning. If the HEAD at the remote did not point at any branch when
 `--single-branch` clone was made, no remote-tracking branch is created.
+
+--[no-]src::
+	Indicate explicitly whether `scalar clone` should add a `src`
+	directory within the target enlistment. This is enabled by default
+	in order to create space for sibling directories to contain
+	repository artifacts such as build outputs or imported packages;
+	keeping such files out of the `src` directory improves Git's
+	performance when interacting with worktree files. Use `--no-src`
+	to opt out of creating this directory.
 
 --[no-]full-clone::
 	A sparse-checkout is initialized by default. This behavior can be

--- a/scalar.c
+++ b/scalar.c
@@ -262,7 +262,7 @@ static int register_dir(void)
 		return error(_("could not set recommended config"));
 
 	if (toggle_maintenance(1))
-		return error(_("could not turn on maintenance"));
+		warning(_("could not turn on maintenance"));
 
 	if (have_fsmonitor_support() && start_fsmonitor_daemon()) {
 		return error(_("could not start the FSMonitor daemon"));

--- a/scalar.c
+++ b/scalar.c
@@ -406,6 +406,7 @@ static int cmd_clone(int argc, const char **argv)
 {
 	const char *branch = NULL;
 	int full_clone = 0, single_branch = 0, show_progress = isatty(2);
+	int src_dir = 1;
 	struct option clone_options[] = {
 		OPT_STRING('b', "branch", &branch, N_("<branch>"),
 			   N_("branch to checkout after clone")),
@@ -414,6 +415,8 @@ static int cmd_clone(int argc, const char **argv)
 		OPT_BOOL(0, "single-branch", &single_branch,
 			 N_("only download metadata for the branch that will "
 			    "be checked out")),
+		OPT_BOOL(0, "src", &src_dir,
+			 N_("toggle creating a 'src' directory")),
 		OPT_END(),
 	};
 	const char * const clone_usage[] = {
@@ -453,7 +456,10 @@ static int cmd_clone(int argc, const char **argv)
 	if (is_directory(enlistment))
 		die(_("directory '%s' exists already"), enlistment);
 
-	dir = xstrfmt("%s/src", enlistment);
+	if (src_dir)
+		dir = xstrfmt("%s/src", enlistment);
+	else
+		dir = xstrdup(enlistment);
 
 	strbuf_reset(&buf);
 	if (branch)

--- a/t/t9210-scalar.sh
+++ b/t/t9210-scalar.sh
@@ -104,6 +104,16 @@ test_expect_success FSMONITOR_DAEMON 'scalar register starts fsmon daemon' '
 	test_cmp_config -C test/src true core.fsmonitor
 '
 
+test_expect_success 'scalar register fails when background maintenance fails' '
+	git init register-repo &&
+	(
+		GIT_TEST_MAINT_SCHEDULER="crontab:false,launchctl:false,schtasks:false" &&
+		export GIT_TEST_MAINT_SCHEDULER &&
+		test_must_fail scalar register register-repo 2>err &&
+		grep "could not turn on maintenance" err
+	)
+'
+
 test_expect_success 'scalar unregister' '
 	git init vanish/src &&
 	scalar register vanish/src &&

--- a/t/t9210-scalar.sh
+++ b/t/t9210-scalar.sh
@@ -104,14 +104,11 @@ test_expect_success FSMONITOR_DAEMON 'scalar register starts fsmon daemon' '
 	test_cmp_config -C test/src true core.fsmonitor
 '
 
-test_expect_success 'scalar register fails when background maintenance fails' '
+test_expect_success 'scalar register warns when background maintenance fails' '
 	git init register-repo &&
-	(
-		GIT_TEST_MAINT_SCHEDULER="crontab:false,launchctl:false,schtasks:false" &&
-		export GIT_TEST_MAINT_SCHEDULER &&
-		test_must_fail scalar register register-repo 2>err &&
-		grep "could not turn on maintenance" err
-	)
+	GIT_TEST_MAINT_SCHEDULER="crontab:false,launchctl:false,schtasks:false" \
+		scalar register register-repo 2>err &&
+	grep "could not turn on maintenance" err
 '
 
 test_expect_success 'scalar unregister' '

--- a/t/t9211-scalar-clone.sh
+++ b/t/t9211-scalar-clone.sh
@@ -174,4 +174,13 @@ test_expect_success 'progress without tty' '
 	cleanup_clone $enlistment
 '
 
+test_expect_success 'scalar clone fails when background maintenance fails' '
+	(
+		GIT_TEST_MAINT_SCHEDULER="crontab:false,launchctl:false,schtasks:false" &&
+		export GIT_TEST_MAINT_SCHEDULER &&
+		test_must_fail scalar clone "file://$(pwd)/to-clone" maint-fail 2>err &&
+		grep "could not turn on maintenance" err
+	)
+'
+
 test_done

--- a/t/t9211-scalar-clone.sh
+++ b/t/t9211-scalar-clone.sh
@@ -180,4 +180,12 @@ test_expect_success 'scalar clone fails when background maintenance fails' '
 	grep "could not turn on maintenance" err
 '
 
+test_expect_success '`scalar clone --no-src`' '
+	scalar clone --src "file://$(pwd)/to-clone" with-src &&
+	scalar clone --no-src "file://$(pwd)/to-clone" without-src &&
+
+	test_path_is_dir with-src/src &&
+	test_path_is_missing without-src/src
+'
+
 test_done

--- a/t/t9211-scalar-clone.sh
+++ b/t/t9211-scalar-clone.sh
@@ -175,12 +175,9 @@ test_expect_success 'progress without tty' '
 '
 
 test_expect_success 'scalar clone fails when background maintenance fails' '
-	(
-		GIT_TEST_MAINT_SCHEDULER="crontab:false,launchctl:false,schtasks:false" &&
-		export GIT_TEST_MAINT_SCHEDULER &&
-		test_must_fail scalar clone "file://$(pwd)/to-clone" maint-fail 2>err &&
-		grep "could not turn on maintenance" err
-	)
+	GIT_TEST_MAINT_SCHEDULER="crontab:false,launchctl:false,schtasks:false" \
+		scalar clone "file://$(pwd)/to-clone" maint-fail 2>err &&
+	grep "could not turn on maintenance" err
 '
 
 test_done

--- a/t/test-lib-functions.sh
+++ b/t/test-lib-functions.sh
@@ -1016,7 +1016,7 @@ test_must_fail_acceptable () {
 	fi
 
 	case "$1" in
-	git|__git*|test-tool|test_terminal)
+	git|__git*|scalar|test-tool|test_terminal)
 		return 0
 		;;
 	*)


### PR DESCRIPTION
At $DAYJOB we received a report of issues with `scalar clone` and `scalar register` in a protected environment. Specifically, they couldn't run `crontab` or `systemctl`, which causes `git maintenance start` to fail. That failure was percolating through `scalar clone` and `scalar register`, even though the rest of their repository was properly set up.

Document these hard failures with test cases, then make them be soft warnings instead.

While we are here, add a new `--no-src` option to allow users to customize their directory structure. This is based on a change we took in microsoft/git in the 2.38.0 cycle based on some internal feedback.

Updates in v2
-------------

* In Patch 2, the tests are slightly modified to use a sub-shell. In one of the CI builds, I caught an error due to the test linter complaining about the environment variable going through the shell function. Using a sub-shell solves the linter problem with equivalent behavior. This has some effects on the range-diff in patch 3.
* The `--no-src` change is new to this series, present in patch 4.

Thanks,
* Stolee

cc: vdye@github.com
cc: gitster@pobox.com