### PR TITLE
fetch: choose a sensible default with --jobs=0 again

### DIFF
--- a/builtin/fetch.c
+++ b/builtin/fetch.c
@@ -2196,6 +2196,9 @@ int cmd_fetch(int argc, const char **argv, const char *prefix)
 	if (dry_run)
 		write_fetch_head = 0;
 
+	if (!max_jobs)
+		max_jobs = online_cpus();
+
 	if (!git_config_get_string_tmp("fetch.bundleuri", &bundle_uri) &&
 	    fetch_bundle_uri(the_repository, bundle_uri, NULL))
 		warning(_("failed to fetch bundles from '%s'"), bundle_uri);

--- a/t/t5514-fetch-multiple.sh
+++ b/t/t5514-fetch-multiple.sh
@@ -197,4 +197,9 @@ test_expect_success 'parallel' '
 	test_i18ngrep "could not fetch .two.*128" err
 '
 
+test_expect_success 'git fetch --multiple --jobs=0 picks a default' '
+	(cd test &&
+	 git fetch --multiple --jobs=0)
+'
+
 test_done


### PR DESCRIPTION
Prior to 51243f9 (run-command API: don't fall back on online_cpus(), 2022-10-12) `git fetch --multiple --jobs=0` would choose some default amount of jobs, similar to `git -c fetch.parallel=0 fetch --multiple`. While our documentation only ever promised that `fetch.parallel` would fall back to a "sensible default", it makes sense to do the same for `--jobs`. So fall back to online_cpus() and not BUG() out.

This was originally reported at https://lore.kernel.org/git/PSAP153MB03910458707331B64FA7460DCAA19@PSAP153MB0391.APCP153.PROD.OUTLOOK.COM/T/#u

cc: Drew Noakes <drnoakes@microsoft.com>
cc: Ævar Arnfjörð Bjarmason <avarab@gmail.com>