### PR TITLE
[Newbie] tests: Remove space after file redirection operator for cat commands

### DIFF
--- a/t/t1300-config.sh
+++ b/t/t1300-config.sh
@@ -15,7 +15,7 @@ test_expect_success 'clear default config' '
 	rm -f .git/config
 '
 
-cat > expect << EOF
+cat >expect << EOF
 [section]
 	penguin = little blue
 EOF
@@ -24,7 +24,7 @@ test_expect_success 'initial' '
 	test_cmp expect .git/config
 '
 
-cat > expect << EOF
+cat >expect << EOF
 [section]
 	penguin = little blue
 	Movie = BadPhysics
@@ -34,7 +34,7 @@ test_expect_success 'mixed case' '
 	test_cmp expect .git/config
 '
 
-cat > expect << EOF
+cat >expect << EOF
 [section]
 	penguin = little blue
 	Movie = BadPhysics
@@ -46,7 +46,7 @@ test_expect_success 'similar section' '
 	test_cmp expect .git/config
 '
 
-cat > expect << EOF
+cat >expect << EOF
 [section]
 	penguin = little blue
 	Movie = BadPhysics
@@ -67,7 +67,7 @@ test_expect_success 'replace with non-match (actually matching)' '
 	git config section.penguin "very blue" !kingpin
 '
 
-cat > expect << EOF
+cat >expect << EOF
 [section]
 	penguin = very blue
 	Movie = BadPhysics
@@ -111,7 +111,7 @@ test_expect_success 'unset with cont. lines' '
 	git config --unset beta.baz
 '
 
-cat > expect <<\EOF
+cat >expect <<\EOF
 [alpha]
 bar = foo
 [beta]
@@ -138,7 +138,7 @@ test_expect_success 'multiple unset' '
 	git config --unset-all beta.haha
 '
 
-cat > expect << EOF
+cat >expect << EOF
 [beta] ; silly comment # another comment
 noIndent= sillyValue ; 'nother silly comment
 
@@ -164,7 +164,7 @@ test_expect_success '--replace-all' '
 	git config --replace-all beta.haha gamma
 '
 
-cat > expect << EOF
+cat >expect << EOF
 [beta] ; silly comment # another comment
 noIndent= sillyValue ; 'nother silly comment
 
@@ -178,7 +178,7 @@ test_expect_success 'all replaced' '
 	test_cmp expect .git/config
 '
 
-cat > expect << EOF
+cat >expect << EOF
 [beta] ; silly comment # another comment
 noIndent= sillyValue ; 'nother silly comment
 
@@ -192,7 +192,7 @@ test_expect_success 'really mean test' '
 	test_cmp expect .git/config
 '
 
-cat > expect << EOF
+cat >expect << EOF
 [beta] ; silly comment # another comment
 noIndent= sillyValue ; 'nother silly comment
 
@@ -211,7 +211,7 @@ test_expect_success 'get value' '
 	test_cmp_config alpha beta.haha
 '
 
-cat > expect << EOF
+cat >expect << EOF
 [beta] ; silly comment # another comment
 noIndent= sillyValue ; 'nother silly comment
 
@@ -225,7 +225,7 @@ test_expect_success 'unset' '
 	test_cmp expect .git/config
 '
 
-cat > expect << EOF
+cat >expect << EOF
 [beta] ; silly comment # another comment
 noIndent= sillyValue ; 'nother silly comment
 
@@ -261,7 +261,7 @@ test_expect_success 'multi-valued get-all returns all' '
 	test_cmp expect actual
 '
 
-cat > expect << EOF
+cat >expect << EOF
 [beta] ; silly comment # another comment
 noIndent= sillyValue ; 'nother silly comment
 
@@ -284,7 +284,7 @@ test_expect_success 'invalid unset' '
 	test_must_fail git config --unset somesection.nonewline
 '
 
-cat > expect << EOF
+cat >expect << EOF
 [beta] ; silly comment # another comment
 noIndent= sillyValue ; 'nother silly comment
 
@@ -307,7 +307,7 @@ test_expect_success 'hierarchical section' '
 	git config Version.1.2.3eX.Alpha beta
 '
 
-cat > expect << EOF
+cat >expect << EOF
 [beta] ; silly comment # another comment
 noIndent= sillyValue ; 'nother silly comment
 
@@ -325,7 +325,7 @@ test_expect_success 'hierarchical section value' '
 	test_cmp expect .git/config
 '
 
-cat > expect << EOF
+cat >expect << EOF
 beta.noindent=sillyValue
 nextsection.nonewline=wow2 for me
 123456.a123=987
@@ -341,7 +341,7 @@ test_expect_success '--list without repo produces empty output' '
 	test_must_be_empty output
 '
 
-cat > expect << EOF
+cat >expect << EOF
 beta.noindent
 nextsection.nonewline
 123456.a123
@@ -353,7 +353,7 @@ test_expect_success '--name-only --list' '
 	test_cmp expect output
 '
 
-cat > expect << EOF
+cat >expect << EOF
 beta.noindent sillyValue
 nextsection.nonewline wow2 for me
 EOF
@@ -363,7 +363,7 @@ test_expect_success '--get-regexp' '
 	test_cmp expect output
 '
 
-cat > expect << EOF
+cat >expect << EOF
 beta.noindent
 nextsection.nonewline
 EOF
@@ -373,7 +373,7 @@ test_expect_success '--name-only --get-regexp' '
 	test_cmp expect output
 '
 
-cat > expect << EOF
+cat >expect << EOF
 wow2 for me
 wow4 for you
 EOF
@@ -444,7 +444,7 @@ cat > .git/config << EOF
 	c = d
 EOF
 
-cat > expect << EOF
+cat >expect << EOF
 [a.b]
 	c = d
 [a]
@@ -456,7 +456,7 @@ test_expect_success 'new section is partial match of another' '
 	test_cmp expect .git/config
 '
 
-cat > expect << EOF
+cat >expect << EOF
 [a.b]
 	c = d
 [a]
@@ -477,12 +477,12 @@ test_expect_success 'alternative --file (non-existing file should fail)' '
 	test_must_fail git config --file non-existing-config test.xyzzy
 '
 
-cat > other-config << EOF
+cat >other-config << EOF
 [ein]
 	bahn = strasse
 EOF
 
-cat > expect << EOF
+cat >expect << EOF
 ein.bahn=strasse
 EOF
 
@@ -514,7 +514,7 @@ test_expect_success 'refer config from subdirectory' '
 	test_cmp_config -C x strasse --file=../other-config --get ein.bahn
 '
 
-cat > expect << EOF
+cat >expect << EOF
 [ein]
 	bahn = strasse
 [anwohner]
@@ -541,7 +541,7 @@ test_expect_success 'rename section' '
 	git config --rename-section branch.eins branch.zwei
 '
 
-cat > expect << EOF
+cat >expect << EOF
 # Hallo
 	#Bello
 [branch "zwei"]
@@ -569,7 +569,7 @@ test_expect_success 'rename another section' '
 	git config --rename-section branch."1 234 blabl/a" branch.drei
 '
 
-cat > expect << EOF
+cat >expect << EOF
 # Hallo
 	#Bello
 [branch "zwei"]
@@ -592,7 +592,7 @@ test_expect_success 'rename a section with a var on the same line' '
 	git config --rename-section branch.vier branch.zwei
 '
 
-cat > expect << EOF
+cat >expect << EOF
 # Hallo
 	#Bello
 [branch "zwei"]
@@ -625,7 +625,7 @@ test_expect_success 'remove section' '
 	git config --remove-section branch.zwei
 '
 
-cat > expect << EOF
+cat >expect << EOF
 # Hallo
 	#Bello
 [branch "drei"]
@@ -636,7 +636,7 @@ test_expect_success 'section was removed properly' '
 	test_cmp expect .git/config
 '
 
-cat > expect << EOF
+cat >expect << EOF
 [gitcvs]
 	enabled = true
 	dbname = %Ggitcvs2.%a.%m.sqlite
@@ -694,7 +694,7 @@ test_expect_success 'invalid stdin config' '
 	test_i18ngrep "bad config line 1 in standard input" output
 '
 
-cat > expect << EOF
+cat >expect << EOF
 true
 false
 true
@@ -732,7 +732,7 @@ test_expect_success 'invalid bool (set)' '
 
 	test_must_fail git config --bool bool.nobool foobar'
 
-cat > expect <<\EOF
+cat >expect <<\EOF
 [bool]
 	true1 = true
 	true2 = true
@@ -757,7 +757,7 @@ test_expect_success 'set --bool' '
 	git config --bool bool.false4 FALSE &&
 	test_cmp expect .git/config'
 
-cat > expect <<\EOF
+cat >expect <<\EOF
 [int]
 	val1 = 1
 	val2 = -1
@@ -942,7 +942,7 @@ test_expect_success 'set --type=color barfs on non-color' '
 	test_i18ngrep "cannot parse color" error
 '
 
-cat > expect << EOF
+cat >expect << EOF
 [quote]
 	leading = " test"
 	ending = "test "
@@ -975,7 +975,7 @@ inued
 inued"
 EOF
 
-cat > expect <<\EOF
+cat >expect <<\EOF
 section.continued=continued
 section.noncont=not continued
 section.quotecont=cont;inued
@@ -995,7 +995,7 @@ cat > .git/config <<\EOF
 	val5
 EOF
 
-cat > expect <<\EOF
+cat >expect <<\EOF
 section.sub=section.val1
 foo=barQsection.sub=section.val2
 foo

--- a/t/t1502-rev-parse-parseopt.sh
+++ b/t/t1502-rev-parse-parseopt.sh
@@ -180,7 +180,7 @@ END_EXPECT
 '
 
 test_expect_success 'setup expect.1' "
-	cat > expect <<EOF
+	cat >expect <<EOF
 set -- --foo --bar 'ham' -b --aswitch -- 'arg'
 EOF
 "
@@ -196,7 +196,7 @@ test_expect_success 'test --parseopt with mixed options and arguments' '
 '
 
 test_expect_success 'setup expect.2' "
-	cat > expect <<EOF
+	cat >expect <<EOF
 set -- --foo -- 'arg' '--bar=ham'
 EOF
 "
@@ -212,7 +212,7 @@ test_expect_success 'test --parseopt --stop-at-non-option' '
 '
 
 test_expect_success 'setup expect.3' "
-	cat > expect <<EOF
+	cat >expect <<EOF
 set -- --foo -- '--' 'arg' '--bar=ham'
 EOF
 "
@@ -234,7 +234,7 @@ test_expect_success 'test --parseopt --keep-dashdash --stop-at-non-option with -
 '
 
 test_expect_success 'setup expect.5' "
-	cat > expect <<EOF
+	cat >expect <<EOF
 set -- --foo -- 'arg' '--spam=ham'
 EOF
 "
@@ -245,7 +245,7 @@ test_expect_success 'test --parseopt --keep-dashdash --stop-at-non-option withou
 '
 
 test_expect_success 'setup expect.6' "
-	cat > expect <<EOF
+	cat >expect <<EOF
 set -- --foo --bar='z' --baz -C'Z' --data='A' -- 'arg'
 EOF
 "
@@ -256,7 +256,7 @@ test_expect_success 'test --parseopt --stuck-long' '
 '
 
 test_expect_success 'setup expect.7' "
-	cat > expect <<EOF
+	cat >expect <<EOF
 set -- --data='' -C --baz -- 'arg'
 EOF
 "
@@ -267,7 +267,7 @@ test_expect_success 'test --parseopt --stuck-long and empty optional argument' '
 '
 
 test_expect_success 'setup expect.8' "
-	cat > expect <<EOF
+	cat >expect <<EOF
 set -- --data --baz -- 'arg'
 EOF
 "

--- a/t/t3001-ls-files-others-exclude.sh
+++ b/t/t3001-ls-files-others-exclude.sh
@@ -108,7 +108,7 @@ test_expect_success 'restore gitignore' '
 	rm .git/index
 '
 
-cat > excludes-file <<\EOF
+cat >excludes-file <<\EOF
 *.[1-8]
 e*
 \#*
@@ -118,7 +118,7 @@ git config core.excludesFile excludes-file
 
 git -c status.displayCommentPrefix=true status | grep "^#	" > output
 
-cat > expect << EOF
+cat >expect << EOF
 #	.gitignore
 #	a.6
 #	one/

--- a/t/t3306-notes-prune.sh
+++ b/t/t3306-notes-prune.sh
@@ -29,7 +29,7 @@ test_expect_success 'setup: create a few commits with notes' '
 	git notes add -m "Note #3"
 '
 
-cat > expect <<END_OF_LOG
+cat >expect <<END_OF_LOG
 commit $third
 Author: A U Thor <author@example.com>
 Date:   Thu Apr 7 15:15:13 2005 -0700

--- a/t/t3412-rebase-root.sh
+++ b/t/t3412-rebase-root.sh
@@ -36,7 +36,7 @@ test_expect_success 'setup pre-rebase hook' '
 	echo "$1,$2" >.git/PRE-REBASE-INPUT
 	EOF
 '
-cat > expect <<EOF
+cat >expect <<EOF
 4
 3
 2
@@ -95,7 +95,7 @@ test_expect_success 'set up merge history' '
 	git merge side
 '
 
-cat > expect-side <<'EOF'
+cat >expect-side <<'EOF'
 commit work6 work6~1 work6^2
 Merge branch 'side' into other
 commit work6^2 work6~2
@@ -119,7 +119,7 @@ test_expect_success 'set up second root and merge' '
 	git merge --allow-unrelated-histories third
 '
 
-cat > expect-third <<'EOF'
+cat >expect-third <<'EOF'
 commit work7 work7~1 work7^2
 Merge branch 'third' into other
 commit work7^2 work7~4
@@ -180,7 +180,7 @@ test_expect_success 'fix the conflict' '
 	git add B
 '
 
-cat > expect-conflict <<EOF
+cat >expect-conflict <<EOF
 6
 5
 4

--- a/t/t3702-add-edit.sh
+++ b/t/t3702-add-edit.sh
@@ -9,7 +9,7 @@ TEST_PASSES_SANITIZE_LEAK=true
 . ./test-lib.sh
 
 
-cat > file << EOF
+cat >file << EOF
 LO, praise of the prowess of people-kings
 of spear-armed Danes, in days long sped,
 we have heard, and what honor the athelings won!
@@ -23,7 +23,7 @@ who house by the whale-path, heard his mandate,
 gave him gifts:  a good king he!
 EOF
 
-cat > second-part << EOF
+cat >second-part << EOF
 To him an heir was afterward born,
 a son in his halls, whom heaven sent
 to favor the folk, feeling their woe
@@ -40,7 +40,7 @@ test_expect_success 'setup' '
 
 '
 
-cat > expected-patch << EOF
+cat >expected-patch << EOF
 diff --git a/file b/file
 --- a/file
 +++ b/file
@@ -64,7 +64,7 @@ diff --git a/file b/file
 +the Wielder of Wonder, with world's renown.
 EOF
 
-cat > patch << EOF
+cat >patch << EOF
 diff --git a/file b/file
 index b9834b5..ef6e94c 100644
 --- a/file
@@ -79,7 +79,7 @@ index b9834b5..ef6e94c 100644
  for he waxed under welkin, in wealth he throve,
 EOF
 
-cat > expected << EOF
+cat >expected << EOF
 diff --git a/file b/file
 --- a/file
 +++ b/file

--- a/t/t4012-diff-binary.sh
+++ b/t/t4012-diff-binary.sh
@@ -25,7 +25,7 @@ test_expect_success 'prepare repository' '
 	cat b b >d
 '
 
-cat > expected <<\EOF
+cat >expected <<\EOF
  a |    2 +-
  b |  Bin
  c |    2 +-

--- a/t/t4043-diff-rename-binary.sh
+++ b/t/t4043-diff-rename-binary.sh
@@ -22,7 +22,7 @@ test_expect_success 'move the files into a "sub" directory' '
 	git commit -m "Moved to sub/"
 '
 
-cat > expected <<\EOF
+cat >expected <<\EOF
 -	-	bar => sub/bar
 0	0	foo => sub/foo
 

--- a/t/t4107-apply-ignore-whitespace.sh
+++ b/t/t4107-apply-ignore-whitespace.sh
@@ -11,7 +11,7 @@ test_description='git-apply --ignore-whitespace.
 # This primes main.c file that indents without using HT at all.
 # Various patches with HT and other spaces are attempted in the test.
 
-cat > patch1.patch <<\EOF
+cat >patch1.patch <<\EOF
 diff --git a/main.c b/main.c
 new file mode 100644
 --- /dev/null

--- a/t/t4128-apply-root.sh
+++ b/t/t4128-apply-root.sh
@@ -15,7 +15,7 @@ test_expect_success 'setup' '
 
 '
 
-cat > patch << EOF
+cat >patch << EOF
 diff a/bla/blub/dir/file b/bla/blub/dir/file
 --- a/bla/blub/dir/file
 +++ b/bla/blub/dir/file
@@ -44,7 +44,7 @@ test_expect_success 'apply --directory -p (2) ' '
 
 '
 
-cat > patch << EOF
+cat >patch << EOF
 diff --git a/newfile b/newfile
 new file mode 100644
 index 0000000..d95f3ad
@@ -63,7 +63,7 @@ test_expect_success 'apply --directory (new file)' '
 	test_cmp expect some/sub/dir/newfile
 '
 
-cat > patch << EOF
+cat >patch << EOF
 diff --git a/c/newfile2 b/c/newfile2
 new file mode 100644
 index 0000000..d95f3ad
@@ -82,7 +82,7 @@ test_expect_success 'apply --directory -p (new file)' '
 	test_cmp expect some/sub/dir/newfile2
 '
 
-cat > patch << EOF
+cat >patch << EOF
 diff --git a/delfile b/delfile
 deleted file mode 100644
 index d95f3ad..0000000
@@ -101,7 +101,7 @@ test_expect_success 'apply --directory (delete file)' '
 	! grep delfile out
 '
 
-cat > patch << 'EOF'
+cat >patch << 'EOF'
 diff --git "a/qu\157tefile" "b/qu\157tefile"
 new file mode 100644
 index 0000000..d95f3ad

--- a/t/t4133-apply-filenames.sh
+++ b/t/t4133-apply-filenames.sh
@@ -10,7 +10,7 @@ TEST_PASSES_SANITIZE_LEAK=true
 . ./test-lib.sh
 
 test_expect_success setup '
-	cat > bad1.patch <<EOF &&
+	cat >bad1.patch <<EOF &&
 diff --git a/f b/f
 new file mode 100644
 index 0000000..d00491f
@@ -19,7 +19,7 @@ index 0000000..d00491f
 @@ -0,0 +1 @@
 +1
 EOF
-	cat > bad2.patch <<EOF
+	cat >bad2.patch <<EOF
 diff --git a/f b/f
 deleted file mode 100644
 index d00491f..0000000

--- a/t/t4134-apply-submodule.sh
+++ b/t/t4134-apply-submodule.sh
@@ -10,7 +10,7 @@ TEST_PASSES_SANITIZE_LEAK=true
 . ./test-lib.sh
 
 test_expect_success setup '
-	cat > create-sm.patch <<EOF &&
+	cat >create-sm.patch <<EOF &&
 diff --git a/dir/sm b/dir/sm
 new file mode 160000
 index 0000000..0123456
@@ -19,7 +19,7 @@ index 0000000..0123456
 @@ -0,0 +1 @@
 +Subproject commit $(test_oid numeric)
 EOF
-	cat > remove-sm.patch <<EOF
+	cat >remove-sm.patch <<EOF
 diff --git a/dir/sm b/dir/sm
 deleted file mode 160000
 index 0123456..0000000

--- a/t/t4202-log.sh
+++ b/t/t4202-log.sh
@@ -73,7 +73,7 @@ test_expect_success 'format' '
 	test_cmp expect actual
 '
 
-cat > expect << EOF
+cat >expect << EOF
  This is
   the sixth
   commit.
@@ -94,7 +94,7 @@ test_expect_success 'format %w(,1,2)' '
 	test_cmp expect actual
 '
 
-cat > expect << EOF
+cat >expect << EOF
 $(git rev-parse --short :/sixth  ) sixth
 $(git rev-parse --short :/fifth  ) fifth
 $(git rev-parse --short :/fourth ) fourth
@@ -196,7 +196,7 @@ test_expect_success 'git config log.follow is overridden by --no-follow' '
 
 # Note that these commits are intentionally listed out of order.
 last_three="$(git rev-parse :/fourth :/sixth :/fifth)"
-cat > expect << EOF
+cat >expect << EOF
 $(git rev-parse --short :/sixth ) sixth
 $(git rev-parse --short :/fifth ) fifth
 $(git rev-parse --short :/fourth) fourth
@@ -211,7 +211,7 @@ test_expect_success 'git log --no-walk=sorted <commits> sorts by commit time' '
 	test_cmp expect actual
 '
 
-cat > expect << EOF
+cat >expect << EOF
 === $(git rev-parse --short :/sixth ) sixth
 === $(git rev-parse --short :/fifth ) fifth
 === $(git rev-parse --short :/fourth) fourth
@@ -221,7 +221,7 @@ test_expect_success 'git log --line-prefix="=== " --no-walk <commits> sorts by c
 	test_cmp expect actual
 '
 
-cat > expect << EOF
+cat >expect << EOF
 $(git rev-parse --short :/fourth) fourth
 $(git rev-parse --short :/sixth ) sixth
 $(git rev-parse --short :/fifth ) fifth
@@ -258,7 +258,7 @@ do
 	'
 done
 
-cat > expect << EOF
+cat >expect << EOF
 second
 initial
 EOF
@@ -545,7 +545,7 @@ test_expect_success '-c color.grep.matchSelected log --grep' '
 	test_cmp expect actual
 '
 
-cat > expect <<EOF
+cat >expect <<EOF
 * Second
 * sixth
 * fifth
@@ -559,7 +559,7 @@ test_expect_success 'simple log --graph' '
 	test_cmp_graph
 '
 
-cat > expect <<EOF
+cat >expect <<EOF
 123 * Second
 123 * sixth
 123 * fifth
@@ -581,7 +581,7 @@ test_expect_success 'set up merge history' '
 	git merge side
 '
 
-cat > expect <<\EOF
+cat >expect <<\EOF
 *   Merge branch 'side'
 |\
 | * side-2
@@ -600,7 +600,7 @@ test_expect_success 'log --graph with merge' '
 	test_cmp_graph --date-order
 '
 
-cat > expect <<\EOF
+cat >expect <<\EOF
 | | | *   Merge branch 'side'
 | | | |\
 | | | | * side-2
@@ -619,7 +619,7 @@ test_expect_success 'log --graph --line-prefix="| | | " with merge' '
 	test_cmp_graph --line-prefix="| | | " --date-order
 '
 
-cat > expect.colors <<\EOF
+cat >expect.colors <<\EOF
 *   Merge branch 'side'
 <BLUE>|<RESET><CYAN>\<RESET>
 <BLUE>|<RESET> * side-2
@@ -649,7 +649,7 @@ test_expect_success 'diff-tree --graph' '
 	grep "one" actual
 '
 
-cat > expect <<\EOF
+cat >expect <<\EOF
 *   commit main
 |\  Merge: A B
 | | Author: A U Thor <author@example.com>
@@ -733,7 +733,7 @@ test_expect_success 'set up more tangled history' '
 	git merge reach
 '
 
-cat > expect <<\EOF
+cat >expect <<\EOF
 *   Merge tag 'reach'
 |\
 | \

--- a/t/t5514-fetch-multiple.sh
+++ b/t/t5514-fetch-multiple.sh
@@ -34,7 +34,7 @@ test_expect_success setup '
 	git clone one test
 '
 
-cat > test/expect << EOF
+cat >test/expect << EOF
   one/main
   one/side
   origin/HEAD -> origin/main
@@ -76,7 +76,7 @@ test_expect_success 'git fetch --all does not allow non-option arguments' '
 	 test_must_fail git fetch --all origin main)
 '
 
-cat > expect << EOF
+cat >expect << EOF
   origin/HEAD -> origin/main
   origin/main
   origin/side
@@ -94,7 +94,7 @@ test_expect_success 'git fetch --multiple (but only one remote)' '
 	 test_cmp ../expect output)
 '
 
-cat > expect << EOF
+cat >expect << EOF
   one/main
   one/side
   two/another
@@ -135,7 +135,7 @@ test_expect_success 'git fetch --all (skipFetchAll)' '
 	 test_cmp ../expect output)
 '
 
-cat > expect << EOF
+cat >expect << EOF
   one/main
   one/side
   three/another

--- a/t/t6030-bisect-porcelain.sh
+++ b/t/t6030-bisect-porcelain.sh
@@ -848,7 +848,7 @@ test_expect_success 'broken branch creation' '
 '
 
 echo "" > expected.ok
-cat > expected.missing-tree.default <<EOF
+cat >expected.missing-tree.default <<EOF
 fatal: unable to read tree $deleted
 EOF
 
@@ -934,7 +934,7 @@ test_expect_success 'bisect: demonstrate identification of damage boundary' "
 	git bisect reset
 "
 
-cat > expected.bisect-log <<EOF
+cat >expected.bisect-log <<EOF
 # bad: [$HASH4] Add <4: Ciao for now> into <hello>.
 # good: [$HASH2] Add <2: A new day for git> into <hello>.
 git bisect start '$HASH4' '$HASH2'
@@ -952,7 +952,7 @@ test_expect_success 'bisect log: successful result' '
 	git bisect reset
 '
 
-cat > expected.bisect-skip-log <<EOF
+cat >expected.bisect-skip-log <<EOF
 # bad: [$HASH4] Add <4: Ciao for now> into <hello>.
 # good: [$HASH2] Add <2: A new day for git> into <hello>.
 git bisect start '$HASH4' '$HASH2'

--- a/t/t7004-tag.sh
+++ b/t/t7004-tag.sh
@@ -1497,7 +1497,7 @@ hash3=$(git rev-parse HEAD)
 
 # simple linear checks of --continue
 
-cat > expected <<EOF
+cat >expected <<EOF
 v0.2.1
 v1.0
 v1.0.1
@@ -1537,7 +1537,7 @@ test_expect_success 'checking that first commit is in all tags (relative)' "
 	test_must_be_empty actual
 "
 
-cat > expected <<EOF
+cat >expected <<EOF
 v2.0
 EOF
 
@@ -1546,7 +1546,7 @@ test_expect_success 'checking that second commit only has one tag' "
 	test_cmp expected actual
 "
 
-cat > expected <<EOF
+cat >expected <<EOF
 v0.2.1
 v1.0
 v1.0.1
@@ -1563,7 +1563,7 @@ test_expect_success 'checking that third commit has no tags' "
 	test_must_be_empty actual
 "
 
-cat > expected <<EOF
+cat >expected <<EOF
 v0.2.1
 v1.0
 v1.0.1
@@ -1588,7 +1588,7 @@ test_expect_success 'creating simple branch' '
 
 hash4=$(git rev-parse HEAD)
 
-cat > expected <<EOF
+cat >expected <<EOF
 v3.0
 EOF
 
@@ -1597,7 +1597,7 @@ test_expect_success 'checking that branch head only has one tag' "
 	test_cmp expected actual
 "
 
-cat > expected <<EOF
+cat >expected <<EOF
 v0.2.1
 v1.0
 v1.0.1
@@ -1615,7 +1615,7 @@ test_expect_success 'merging original branch into this branch' '
         git tag v4.0
 '
 
-cat > expected <<EOF
+cat >expected <<EOF
 v4.0
 EOF
 
@@ -1624,7 +1624,7 @@ test_expect_success 'checking that original branch head has one tag now' "
 	test_cmp expected actual
 "
 
-cat > expected <<EOF
+cat >expected <<EOF
 v0.2.1
 v1.0
 v1.0.1
@@ -1638,7 +1638,7 @@ test_expect_success 'checking that original branch head with --no-contains lists
 	test_cmp expected actual
 "
 
-cat > expected <<EOF
+cat >expected <<EOF
 v0.2.1
 v1.0
 v1.0.1

--- a/t/t7402-submodule-rebase.sh
+++ b/t/t7402-submodule-rebase.sh
@@ -48,7 +48,7 @@ test_expect_success 'rebase with a dirty submodule' '
 
 '
 
-cat > fake-editor.sh << \EOF
+cat >fake-editor.sh << \EOF
 #!/bin/sh
 echo $EDITOR_TEXT
 EOF

--- a/t/t7407-submodule-foreach.sh
+++ b/t/t7407-submodule-foreach.sh
@@ -65,7 +65,7 @@ sub3sha1=$(cd super/sub3 && git rev-parse HEAD)
 
 pwd=$(pwd)
 
-cat > expect <<EOF
+cat >expect <<EOF
 Entering 'sub1'
 $pwd/clone-foo1-sub1-$sub1sha1
 Entering 'sub3'
@@ -168,7 +168,7 @@ test_expect_success 'use "foreach --recursive" to checkout all submodules' '
 	)
 '
 
-cat > expect <<EOF
+cat >expect <<EOF
 Entering 'nested1'
 Entering 'nested1/nested2'
 Entering 'nested1/nested2/nested3'
@@ -186,7 +186,7 @@ test_expect_success 'test messages from "foreach --recursive"' '
 	test_cmp expect actual
 '
 
-cat > expect <<EOF
+cat >expect <<EOF
 Entering '../nested1'
 Entering '../nested1/nested2'
 Entering '../nested1/nested2/nested3'
@@ -238,7 +238,7 @@ test_expect_success 'test "submodule foreach --recursive" from subdirectory' '
 	test_cmp expect actual
 '
 
-cat > expect <<EOF
+cat >expect <<EOF
 nested1-nested1
 nested2-nested2
 nested3-nested3
@@ -285,7 +285,7 @@ sub3sha1=$(cd clone3/sub3 && git rev-parse HEAD)
 sub1sha1_short=$(cd clone3/sub1 && git rev-parse --short HEAD)
 sub2sha1_short=$(cd clone3/sub2 && git rev-parse --short HEAD)
 
-cat > expect <<EOF
+cat >expect <<EOF
  $nested1sha1 nested1 (heads/main)
  $nested2sha1 nested1/nested2 (heads/main)
  $nested3sha1 nested1/nested2/nested3 (heads/main)
@@ -303,7 +303,7 @@ test_expect_success 'test "status --recursive"' '
 	test_cmp expect actual
 '
 
-cat > expect <<EOF
+cat >expect <<EOF
  $nested1sha1 nested1 (heads/main)
 +$nested2sha1 nested1/nested2 (file2~1)
  $nested3sha1 nested1/nested2/nested3 (heads/main)
@@ -324,7 +324,7 @@ test_expect_success 'ensure "status --cached --recursive" preserves the --cached
 
 nested2sha1=$(git -C clone3/nested1/nested2 rev-parse HEAD)
 
-cat > expect <<EOF
+cat >expect <<EOF
  $nested1sha1 ../nested1 (heads/main)
 +$nested2sha1 ../nested1/nested2 (file2)
  $nested3sha1 ../nested1/nested2/nested3 (heads/main)

--- a/t/t7500-commit-template-squash-signoff.sh
+++ b/t/t7500-commit-template-squash-signoff.sh
@@ -168,7 +168,7 @@ test_expect_success 'using alternate GIT_INDEX_FILE (2)' '
 	cmp .git/index saved-index >/dev/null
 '
 
-cat > expect << EOF
+cat >expect << EOF
 zort
 
 Signed-off-by: C O Mitter <committer@example.com>

--- a/t/t7504-commit-msg-hook.sh
+++ b/t/t7504-commit-msg-hook.sh
@@ -17,7 +17,7 @@ test_expect_success 'with no hook' '
 '
 
 # set up fake editor for interactive editing
-cat > fake-editor <<'EOF'
+cat >fake-editor <<'EOF'
 #!/bin/sh
 cp FAKE_MSG "$1"
 exit 0
@@ -289,7 +289,7 @@ test_expect_failure 'merge --continue remembers --no-verify' '
 '
 
 # set up fake editor to replace `pick` by `reword`
-cat > reword-editor <<'EOF'
+cat >reword-editor <<'EOF'
 #!/bin/sh
 mv "$1" "$1".bup &&
 sed 's/^pick/reword/' <"$1".bup >"$1"

--- a/t/t7508-status.sh
+++ b/t/t7508-status.sh
@@ -1112,7 +1112,7 @@ new_head=$(cd sm && git rev-parse --short=7 --verify HEAD)
 touch .gitmodules
 
 test_expect_success '--ignore-submodules=untracked suppresses submodules with untracked content' '
-	cat > expect << EOF &&
+	cat >expect << EOF &&
 On branch main
 Your branch and '\''upstream'\'' have diverged,
 and have 2 and 2 different commits each, respectively.
@@ -1221,7 +1221,7 @@ test_expect_success '.git/config ignore=dirty suppresses submodules with modifie
 '
 
 test_expect_success "--ignore-submodules=untracked doesn't suppress submodules with modified content" '
-	cat > expect << EOF &&
+	cat >expect << EOF &&
 On branch main
 Your branch and '\''upstream'\'' have diverged,
 and have 2 and 2 different commits each, respectively.
@@ -1278,7 +1278,7 @@ test_expect_success ".git/config ignore=untracked doesn't suppress submodules wi
 head2=$(cd sm && git commit -q -m "2nd commit" foo && git rev-parse --short=7 --verify HEAD)
 
 test_expect_success "--ignore-submodules=untracked doesn't suppress submodule summary" '
-	cat > expect << EOF &&
+	cat >expect << EOF &&
 On branch main
 Your branch and '\''upstream'\'' have diverged,
 and have 2 and 2 different commits each, respectively.
@@ -1359,7 +1359,7 @@ test_expect_success ".git/config ignore=dirty doesn't suppress submodule summary
 	git config -f .gitmodules  --remove-section submodule.subname
 '
 
-cat > expect << EOF
+cat >expect << EOF
 ; On branch main
 ; Your branch and 'upstream' have diverged,
 ; and have 2 and 2 different commits each, respectively.
@@ -1407,7 +1407,7 @@ test_expect_success "status (core.commentchar with two chars with submodule summ
 '
 
 test_expect_success "--ignore-submodules=all suppresses submodule summary" '
-	cat > expect << EOF &&
+	cat >expect << EOF &&
 On branch main
 Your branch and '\''upstream'\'' have diverged,
 and have 2 and 2 different commits each, respectively.
@@ -1433,7 +1433,7 @@ EOF
 '
 
 test_expect_success '.gitmodules ignore=all suppresses unstaged submodule summary' '
-	cat > expect << EOF &&
+	cat >expect << EOF &&
 On branch main
 Your branch and '\''upstream'\'' have diverged,
 and have 2 and 2 different commits each, respectively.

--- a/t/t9101-git-svn-props.sh
+++ b/t/t9101-git-svn-props.sh
@@ -126,7 +126,7 @@ b_ne_cr="$(git hash-object ne_cr)"
 test_expect_success 'CRLF + $Id$' "test '$a_cr' = '$b_cr'"
 test_expect_success 'CRLF + $Id$ (no newline)' "test '$a_ne_cr' = '$b_ne_cr'"
 
-cat > show-ignore.expect <<\EOF
+cat >show-ignore.expect <<\EOF
 
 # /
 /no-such-file*

--- a/t/t9108-git-svn-glob.sh
+++ b/t/t9108-git-svn-glob.sh
@@ -3,7 +3,7 @@
 test_description='git svn globbing refspecs'
 . ./lib-git-svn.sh
 
-cat > expect.end <<EOF
+cat >expect.end <<EOF
 the end
 hi
 start a new branch

--- a/t/t9109-git-svn-multi-glob.sh
+++ b/t/t9109-git-svn-multi-glob.sh
@@ -3,7 +3,7 @@
 test_description='git svn globbing refspecs'
 . ./lib-git-svn.sh
 
-cat > expect.end <<EOF
+cat >expect.end <<EOF
 the end
 hi
 start a new branch
@@ -87,7 +87,7 @@ test_expect_success 'test left-hand-side only globbing' '
 	cut -d" " -f2- actual >output.two &&
 	test_cmp expect.two output.two
 	'
-cat > expect.four <<EOF
+cat >expect.four <<EOF
 adios
 adding more
 Changed 2 in v2/start

--- a/t/t9112-git-svn-md5less-file.sh
+++ b/t/t9112-git-svn-md5less-file.sh
@@ -9,7 +9,7 @@ test_description='test that git handles an svn repository with missing md5sums'
 # calculate one if you had put Text-Content-Length: 0).  This showed
 # up in a repository created with cvs2svn.
 
-cat > dumpfile.svn <<EOF
+cat >dumpfile.svn <<EOF
 SVN-fs-dump-format-version: 1
 
 Revision-number: 1

--- a/t/t9130-git-svn-authors-file.sh
+++ b/t/t9130-git-svn-authors-file.sh
@@ -7,7 +7,7 @@ test_description='git svn authors file tests'
 
 . ./lib-git-svn.sh
 
-cat > svn-authors <<EOF
+cat >svn-authors <<EOF
 aa = AAAAAAA AAAAAAA <aa@example.com>
 bb = BBBBBBB BBBBBBB <bb@example.com>
 EOF

--- a/t/t9350-fast-export.sh
+++ b/t/t9350-fast-export.sh
@@ -219,7 +219,7 @@ test_expect_success 'import/export-marks' '
 
 '
 
-cat > signed-tag-import << EOF
+cat >signed-tag-import << EOF
 tag sign-your-name
 from $(git rev-parse HEAD)
 tagger C O Mitter <committer@example.com> 1112911993 -0700
@@ -365,7 +365,7 @@ test_expect_success 'fast-export | fast-import when main is tagged' '
 
 '
 
-cat > tag-content << EOF
+cat >tag-content << EOF
 object $(git rev-parse HEAD)
 type commit
 tag rosten
@@ -403,7 +403,7 @@ test_expect_success 'setup for limiting exports by PATH' '
 	)
 '
 
-cat > limit-by-paths/expected << EOF
+cat >limit-by-paths/expected << EOF
 blob
 mark :1
 data 3
@@ -461,7 +461,7 @@ test_expect_success 'rewrite tag predating pathspecs to nothing' '
 	)
 '
 
-cat > limit-by-paths/expected << EOF
+cat >limit-by-paths/expected << EOF
 blob
 mark :1
 data 4
@@ -649,7 +649,7 @@ test_expect_success 'test bidirectionality' '
 	git fast-import --export-marks=marks-cur --import-marks-if-exists=marks-cur
 '
 
-cat > expected << EOF
+cat >expected << EOF
 blob
 mark :13
 data 5
@@ -679,7 +679,7 @@ test_expect_success 'avoid uninteresting refs' '
 	test_cmp expected actual
 '
 
-cat > expected << EOF
+cat >expected << EOF
 reset refs/heads/main
 from :14
 


### PR DESCRIPTION
Hi, this is my first contribution to the git project.

This patch removes white-space after the ">" operator in several
instances of the "cat" command in test scripts, in order to comply with
the convention that there should be no white-space after redirect
operators. [1]

I found instances to replace using the regex /cat > (?=[a-zA-Z])/ and
replaced the matches with "cat >".

This patch is passing the CI pipelines. [2]

[1] https://lore.kernel.org/git/CAPig+cQpUu2UO-+jWn1nTaDykWnxwuEitzVB7PnW2SS_b7V8Hg@mail.gmail.com
[2] https://github.com/agrawal-d/git/actions/runs/4224680452

Aside: In emails, should I wrap lines after 72 or 80 characters?

Thanks,
Divyanshu

CC: Eric Sunshine <sunshine@sunshineco.com>