### PR TITLE
object-file: reprepare alternates when necessary

### DIFF
--- a/packfile.c
+++ b/packfile.c
@@ -1008,6 +1008,16 @@ void reprepare_packed_git(struct repository *r)
 	struct object_directory *odb;
 
 	obj_read_lock();
+
+	/*
+	 * Reprepare alt odbs, in case the alternates file was modified
+	 * during the course of this process. This only _adds_ odbs to
+	 * the linked list, so existing odbs will continue to exist for
+	 * the lifetime of the process.
+	 */
+	r->objects->loaded_alternates = 0;
+	prepare_alt_odb(r);
+
 	for (odb = r->objects->odb; odb; odb = odb->next)
 		odb_clear_loose_cache(odb);
 


### PR DESCRIPTION
This subtlety was notice by Michael Haggerty due to how alternates are used server-side at $DAYJOB. Moving pack-files from a repository to the alternate occasionally causes failures because processes that start before the alternate exists don't know how to find that alternate at run-time.

Update in v2
------------

* Instead of creating a new public reprepare_alt_odb() method, inline its implementation inside reprepare_packed_git().
* Update commit message to be explicit about behavior with alternates being removed from the alternates file or from disk.

Thanks,
- Stolee

cc: gitster@pobox.com
cc: me@ttaylorr.com
cc: Ævar Arnfjörð Bjarmason <avarab@gmail.com>
cc: Jeff King <peff@peff.net>
cc: Eric Wong <e@80x24.org>
cc: Jonathan Tan <jonathantanmy@google.com>