### PR TITLE
bugreport: fix erroneous user editor

### DIFF
--- a/builtin/bugreport.c
+++ b/builtin/bugreport.c
@@ -6,6 +6,7 @@
 #include "hook.h"
 #include "hook-list.h"
 #include "diagnose.h"
+#include "config.h"
 
 
 static void get_system_info(struct strbuf *sys_info)
@@ -121,6 +122,8 @@ int cmd_bugreport(int argc, const char **argv, const char *prefix)
 
 	argc = parse_options(argc, argv, prefix, bugreport_options,
 			     bugreport_usage, 0);
+
+	git_config(git_default_config, NULL);
 
 	/* Prepare the path to put the result */
 	prefixed_filename = prefix_filename(prefix,


### PR DESCRIPTION
This patch attempts to fix the issue of the user's editor in bugreport not being called correctly. See https://lore.kernel.org/git/PR2P264MB0799BA146D27303A72B3EF69F4869@PR2P264MB0799.FRAP264.PROD.OUTLOOK.COM/

v1. read git config in git bugreport.

cc: Emily Shaffer <emilyshaffer@google.com>
cc: Junio C Hamano <gitster@pobox.com>
cc: Coirier, Emmanuel <Emmanuel.Coirier@caissedesdepots.fr>