### PR TITLE
fsmonitor: Handle differences between Windows named pipe functions

### DIFF
--- a/compat/fsmonitor/fsm-ipc-win32.c
+++ b/compat/fsmonitor/fsm-ipc-win32.c
@@ -1,9 +1,23 @@
+#include "cache.h"
 #include "config.h"
+#include "strbuf.h"
 #include "fsmonitor-ipc.h"
 
-const char *fsmonitor_ipc__get_path(struct repository *r) {
-	static char *ret;
-	if (!ret)
-		ret = git_pathdup("fsmonitor--daemon.ipc");
-	return ret;
+const char *fsmonitor_ipc__get_path(struct repository *r)
+{
+	static const char *ipc_path = NULL;
+	git_SHA_CTX sha1ctx;
+	struct strbuf pipe_name = STRBUF_INIT;
+	unsigned char hash[GIT_MAX_RAWSZ];
+
+	if (ipc_path)
+		return ipc_path;
+
+	git_SHA1_Init(&sha1ctx);
+	git_SHA1_Update(&sha1ctx, r->worktree, strlen(r->worktree));
+	git_SHA1_Final(hash, &sha1ctx);
+
+	strbuf_addf(&pipe_name, "git-fsmonitor-%s", hash_to_hex(hash));
+	ipc_path = strbuf_detach(&pipe_name, NULL);
+	return ipc_path;
 }

--- a/compat/simple-ipc/ipc-win32.c
+++ b/compat/simple-ipc/ipc-win32.c
@@ -17,27 +17,15 @@
 static int initialize_pipe_name(const char *path, wchar_t *wpath, size_t alloc)
 {
 	int off = 0;
-	struct strbuf realpath = STRBUF_INIT;
-
-	if (!strbuf_realpath(&realpath, path, 0))
-		return -1;
+	int ret = 0;
+	char *pipe_name = xstrdup(path);
 
 	off = swprintf(wpath, alloc, L"\\\\.\\pipe\\");
-	if (xutftowcs(wpath + off, realpath.buf, alloc - off) < 0)
-		return -1;
+	if (xutftowcs(wpath + off, basename(pipe_name), alloc - off) < 0)
+		ret = -1;
 
-	/* Handle drive prefix */
-	if (wpath[off] && wpath[off + 1] == L':') {
-		wpath[off + 1] = L'_';
-		off += 2;
-	}
-
-	for (; wpath[off]; off++)
-		if (wpath[off] == L'/')
-			wpath[off] = L'\\';
-
-	strbuf_release(&realpath);
-	return 0;
+	free(pipe_name);
+	return ret;
 }
 
 static enum ipc_active_state get_active_state(wchar_t *pipe_path)


### PR DESCRIPTION
CreateNamedPipeW is perfectly happy accepting pipe names with potential, embedded escape sequences (e.g. \b), however WaitNamedPipeW is not and incorrectly returns ERROR_FILE_NOT_FOUND when clearly a named pipe with the given name exists.

For example, this network repo path is problemmatic: \\batfs-sb29-cifs\vmgr\sbs29\mysandbox

In order to work around this issue, rather than using the path to the worktree directly as the name of the pipe, instead use the hash of the worktree path as the name of the pipe.
