### PR TITLE
fsmonitor: handle differences between Windows named pipe functions

### DIFF
--- a/compat/simple-ipc/ipc-win32.c
+++ b/compat/simple-ipc/ipc-win32.c
@@ -19,13 +19,18 @@
 static int initialize_pipe_name(const char *path, wchar_t *wpath, size_t alloc)
 {
 	int off = 0;
+	int real_off = 0;
 	struct strbuf realpath = STRBUF_INIT;
 
 	if (!strbuf_realpath(&realpath, path, 0))
 		return -1;
 
+	/* UNC Path, skip leading slash */
+	if (realpath.buf[0] == '/' && realpath.buf[1] == '/')
+		real_off = 1;
+
 	off = swprintf(wpath, alloc, L"\\\\.\\pipe\\");
-	if (xutftowcs(wpath + off, realpath.buf, alloc - off) < 0)
+	if (xutftowcs(wpath + off, realpath.buf + real_off, alloc - off) < 0)
 		return -1;
 
 	/* Handle drive prefix */


### PR DESCRIPTION
CreateNamedPipeW is perfectly happy accepting pipe names with embedded escape charcters (e.g. \b), WaitNamedPipeW is not and incorrectly returns ERROR_FILE_NOT_FOUND when clearly a named pipe with the given name exists.

For example, this path is problemmatic:
\\batfs-sb29-cifs\vmgr\sbs29\my_git_repo

In order to work around this issue, rather than using the path to the worktree directly as the name of the pipe, instead use the hash of the worktree path.

cc: Johannes Schindelin <Johannes.Schindelin@gmx.de>
cc: Jeff Hostetler <git@jeffhostetler.com>