### PR TITLE
hashmap.h: fix minor typo

### DIFF
--- a/hashmap.h
+++ b/hashmap.h
@@ -270,7 +270,7 @@ void hashmap_clear_(struct hashmap *map, ssize_t offset);
 #define hashmap_clear(map) hashmap_clear_(map, -1)
 
 /*
- * Similar to hashmap_clear(), except that the table is no deallocated; it
+ * Similar to hashmap_clear(), except that the table is not deallocated; it
  * is merely zeroed out but left the same size as before.  If the hashmap
  * will be reused, this avoids the overhead of deallocating and
  * reallocating map->table.  As with hashmap_clear(), you may need to free


### PR DESCRIPTION
Hi folks ! I'm Siddharth from Google, I'm working on libification of Git, while going through the hashmap.h I found a minor typo in the documentation comment.

cc: Emily Shaffer [emilyshaffer@google.com](mailto:emilyshaffer@google.com)
cc: Jonathan Tan [jonathantanmy@google.com](mailto:jonathantanmy@google.com)
cc: Emily Shaffer <nasamuffin@google.com>