### PR TITLE
t5563: prevent "ambiguous redirect"

### DIFF
--- a/t/t5563-simple-http-auth.sh
+++ b/t/t5563-simple-http-auth.sh
@@ -252,15 +252,14 @@ test_expect_success 'access using basic auth with wwwauth header empty continuat
 
 	# Note that leading and trailing whitespace is important to correctly
 	# simulate a continuation/folded header.
-	printf "">$CHALLENGE &&
-	printf "WWW-Authenticate: FooBar param1=\"value1\"\r\n" >$CHALLENGE &&
-	printf " \r\n" >>$CHALLENGE &&
-	printf " param2=\"value2\"\r\n" >>$CHALLENGE &&
-	printf "WWW-Authenticate: Bearer authorize_uri=\"id.example.com\"\r\n" >>$CHALLENGE &&
-	printf " p=1\r\n" >>$CHALLENGE &&
-	printf " \r\n" >>$CHALLENGE &&
-	printf " q=0\r\n" >>$CHALLENGE &&
-	printf "WWW-Authenticate: Basic realm=\"example.com\"\r\n" >>$CHALLENGE &&
+	printf "WWW-Authenticate: FooBar param1=\"value1\"\r\n" >"$CHALLENGE" &&
+	printf " \r\n" >>"$CHALLENGE" &&
+	printf " param2=\"value2\"\r\n" >>"$CHALLENGE" &&
+	printf "WWW-Authenticate: Bearer authorize_uri=\"id.example.com\"\r\n" >>"$CHALLENGE" &&
+	printf " p=1\r\n" >>"$CHALLENGE" &&
+	printf " \r\n" >>"$CHALLENGE" &&
+	printf " q=0\r\n" >>"$CHALLENGE" &&
+	printf "WWW-Authenticate: Basic realm=\"example.com\"\r\n" >>"$CHALLENGE" &&
 
 	test_config_global credential.helper test-helper &&
 	git ls-remote "$HTTPD_URL/custom_auth/repo.git" &&
@@ -298,11 +297,10 @@ test_expect_success 'access using basic auth with wwwauth header mixed line-endi
 
 	# Note that leading and trailing whitespace is important to correctly
 	# simulate a continuation/folded header.
-	printf "">$CHALLENGE &&
-	printf "WWW-Authenticate: FooBar param1=\"value1\"\r\n" >$CHALLENGE &&
-	printf " \r\n" >>$CHALLENGE &&
-	printf "\tparam2=\"value2\"\r\n" >>$CHALLENGE &&
-	printf "WWW-Authenticate: Basic realm=\"example.com\"" >>$CHALLENGE &&
+	printf "WWW-Authenticate: FooBar param1=\"value1\"\r\n" >"$CHALLENGE" &&
+	printf " \r\n" >>"$CHALLENGE" &&
+	printf "\tparam2=\"value2\"\r\n" >>"$CHALLENGE" &&
+	printf "WWW-Authenticate: Basic realm=\"example.com\"" >>"$CHALLENGE" &&
 
 	test_config_global credential.helper test-helper &&
 	git ls-remote "$HTTPD_URL/custom_auth/repo.git" &&


### PR DESCRIPTION
I ran into this issue while running the tests with `TEST_SHELL_PATH=/bin/bash`.

Cc: Matthew John Cheetham <mjcheetham@outlook.com>