### PR TITLE
fetch: download bundles once, even with --all

### DIFF
--- a/builtin/fetch.c
+++ b/builtin/fetch.c
@@ -1955,7 +1955,12 @@ static int fetch_multiple(struct string_list *list, int max_children)
 			return errcode;
 	}
 
-	strvec_pushl(&argv, "fetch", "--append", "--no-auto-gc",
+	/*
+	 * Cancel out the fetch.bundleURI config when running subprocesses,
+	 * to avoid fetching from the same bundle list multiple times.
+	 */
+	strvec_pushl(&argv, "-c", "fetch.bundleURI=",
+		     "fetch", "--append", "--no-auto-gc",
 		     "--no-write-commit-graph", NULL);
 	add_options_to_argv(&argv);
 

--- a/bundle-uri.c
+++ b/bundle-uri.c
@@ -792,6 +792,15 @@ int fetch_bundle_uri(struct repository *r, const char *uri,
 
 	init_bundle_list(&list);
 
+	/*
+	 * Do not fetch a NULL or empty bundle URI. An empty bundle URI
+	 * could signal that a configured bundle URI has been disabled.
+	 */
+	if (!uri || !*uri) {
+		result = 0;
+		goto cleanup;
+	}
+
 	/* If a bundle is added to this global list, then it is required. */
 	list.mode = BUNDLE_MODE_ALL;
 


### PR DESCRIPTION
I noticed this in local testing where I had set up a bundle server for my Git repo, but wrote the wrong port number so I saw multiple warning messages during a `git fetch --all` run.

Thanks,
-Stolee

cc: vdye@github.com
cc: gitster@pobox.com
cc: Jeff King <peff@peff.net>