### PR TITLE
fsmonitor: handle differences between Windows named pipe functions

### DIFF
--- a/compat/simple-ipc/ipc-win32.c
+++ b/compat/simple-ipc/ipc-win32.c
@@ -19,13 +19,18 @@
 static int initialize_pipe_name(const char *path, wchar_t *wpath, size_t alloc)
 {
 	int off = 0;
+	int real_off = 0;
 	struct strbuf realpath = STRBUF_INIT;
 
 	if (!strbuf_realpath(&realpath, path, 0))
 		return -1;
 
+	/* UNC Path, skip leading slash */
+	if (realpath.buf[0] == '/' && realpath.buf[1] == '/')
+		real_off = 1;
+
 	off = swprintf(wpath, alloc, L"\\\\.\\pipe\\");
-	if (xutftowcs(wpath + off, realpath.buf, alloc - off) < 0)
+	if (xutftowcs(wpath + off, realpath.buf + real_off, alloc - off) < 0)
 		return -1;
 
 	/* Handle drive prefix */


### PR DESCRIPTION
The two functions involved with creating and checking for the existance of the local fsmonitor named pipe, CratedNamedPipeW and WaitNamedPipeW appear to handle names with leading slashes or backslashes a bit differently.

If a repo resolves to a remote file system with the UNC path of //some-server/some-dir/some-repo, CreateNamedPipeW accepts this name and creates this named pipe: \\.\pipe\some-server\some-dir\some-repo

However, when the same UNC path is passed to WaitNamedPipeW, it fails with ERROR_FILE_NOT_FOUND.

Skipping the leading slash for UNC paths works for both CreateNamedPipeW and WaitNamedPipeW. Resulting in a named pipe with the same name as above that WaitNamedPipeW is able to correctly find.

