### PR TITLE
merge-ort: fix calling merge_finalize() with no intermediate merge

### DIFF
--- a/merge-ort.c
+++ b/merge-ort.c
@@ -4718,14 +4718,14 @@ void merge_switch_to_result(struct merge_options *opt,
 void merge_finalize(struct merge_options *opt,
 		    struct merge_result *result)
 {
-	struct merge_options_internal *opti = result->priv;
-
 	if (opt->renormalize)
 		git_attr_set_direction(GIT_ATTR_CHECKIN);
 	assert(opt->priv == NULL);
 
-	clear_or_reinit_internal_opts(opti, 0);
-	FREE_AND_NULL(opti);
+	if (result->priv) {
+		clear_or_reinit_internal_opts(result->priv, 0);
+		FREE_AND_NULL(result->priv);
+	}
 }
 
 /*** Function Grouping: helper functions for merge_incore_*() ***/


### PR DESCRIPTION
Changes since v1:
  - Moved code into an if-block instead of returning early, as suggested by Stolee.

See https://lore.kernel.org/git/CABPp-BHCdjOutYqdMO1NbYKNA0BgkXRgwUEKK=MX0kXM-5G_DQ@mail.gmail.com/

cc: Derrick Stolee <derrickstolee@github.com>
cc: Elijah Newren <newren@gmail.com>