### PR TITLE
merge-tree: load default git config

### DIFF
--- a/builtin/merge-tree.c
+++ b/builtin/merge-tree.c
@@ -17,6 +17,7 @@
 #include "merge-blobs.h"
 #include "quote.h"
 #include "tree.h"
+#include "config.h"
 
 static int line_termination = '\n';
 
@@ -627,6 +628,8 @@ int cmd_merge_tree(int argc, const char **argv, const char *prefix)
 
 	if (argc != expected_remaining_argc)
 		usage_with_options(merge_tree_usage, mt_options);
+
+	git_config(git_default_config, NULL);
 
 	/* Do the relevant type of merge */
 	if (o.mode == MODE_REAL)

--- a/t/t4300-merge-tree.sh
+++ b/t/t4300-merge-tree.sh
@@ -334,4 +334,22 @@ test_expect_success 'turn tree to file' '
 	test_cmp expect actual
 '
 
+test_expect_success 'merge-tree respects core.useReplaceRefs=false' '
+	test_commit merge-to &&
+	test_commit valid base &&
+	git reset --hard HEAD^ &&
+	test_commit malicious base &&
+
+	test_when_finished "git replace -d $(git rev-parse valid^0)" &&
+	git replace valid^0 malicious^0 &&
+
+	tree=$(git -c core.useReplaceRefs=true merge-tree --write-tree merge-to valid) &&
+	merged=$(git cat-file -p $tree:base) &&
+	test malicious = $merged &&
+
+	tree=$(git -c core.useReplaceRefs=false merge-tree --write-tree merge-to valid) &&
+	merged=$(git cat-file -p $tree:base) &&
+	test valid = $merged
+'
+
 test_done


### PR DESCRIPTION
This patch was reviewed on the Git security list, but the impact seemed limited to Git forges using merge-ort to create merge commits. The forges represented on the list have deployed versions of this patch and thus are no longer vulnerable.

Thanks,
-Stolee

cc: gitster@pobox.com
cc: me@ttaylorr.com
cc: christian.couder@gmail.com
cc: Felipe Contreras <felipe.contreras@gmail.com>
cc: Elijah Newren <newren@gmail.com>