### PR TITLE
Fix two rebase bugs related to `total_nr`

### DIFF
--- a/sequencer.c
+++ b/sequencer.c
@@ -4202,7 +4202,7 @@ void todo_list_filter_update_refs(struct repository *r,
 		if (!is_null_oid(&rec->after))
 			continue;
 
-		for (j = 0; !found && j < todo_list->total_nr; j++) {
+		for (j = 0; !found && j < todo_list->nr; j++) {
 			struct todo_item *item = &todo_list->items[j];
 			const char *arg = todo_list->buf.buf + item->arg_offset;
 
@@ -4232,7 +4232,7 @@ void todo_list_filter_update_refs(struct repository *r,
 	 * For each todo_item, check if its ref is in the update_refs list.
 	 * If not, then add it as an un-updated ref.
 	 */
-	for (i = 0; i < todo_list->total_nr; i++) {
+	for (i = 0; i < todo_list->nr; i++) {
 		struct todo_item *item = &todo_list->items[i];
 		const char *arg = todo_list->buf.buf + item->arg_offset;
 		int j, found = 0;

--- a/sequencer.c
+++ b/sequencer.c
@@ -2453,7 +2453,6 @@ void todo_list_release(struct todo_list *todo_list)
 static struct todo_item *append_new_todo(struct todo_list *todo_list)
 {
 	ALLOC_GROW(todo_list->items, todo_list->nr + 1, todo_list->alloc);
-	todo_list->total_nr++;
 	return todo_list->items + todo_list->nr++;
 }
 
@@ -2609,7 +2608,7 @@ int todo_list_parse_insn_buffer(struct repository *r, char *buf,
 	char *p = buf, *next_p;
 	int i, res = 0, fixup_okay = file_exists(rebase_path_done());
 
-	todo_list->current = todo_list->nr = 0;
+	todo_list->current = todo_list->nr = todo_list->total_nr = 0;
 
 	for (i = 1; *p; i++, p = next_p) {
 		char *eol = strchrnul(p, '\n');
@@ -2629,6 +2628,9 @@ int todo_list_parse_insn_buffer(struct repository *r, char *buf,
 			item->arg_len = (int)(eol - p);
 			item->commit = NULL;
 		}
+
+		if (item->command != TODO_COMMENT)
+			todo_list->total_nr++;
 
 		if (fixup_okay)
 			; /* do nothing */
@@ -6092,7 +6094,8 @@ int complete_action(struct repository *r, struct replay_opts *opts, unsigned fla
 	todo_list_to_strbuf(r, &new_todo, &buf2, -1, 0);
 	strbuf_swap(&new_todo.buf, &buf2);
 	strbuf_release(&buf2);
-	new_todo.total_nr -= new_todo.nr;
+	/* Nothing is done yet, and we're reparsing, so let's reset the count */
+	new_todo.total_nr = 0;
 	if (todo_list_parse_insn_buffer(r, new_todo.buf.buf, &new_todo) < 0)
 		BUG("invalid todo list after expanding IDs:\n%s",
 		    new_todo.buf.buf);

--- a/t/t3430-rebase-merges.sh
+++ b/t/t3430-rebase-merges.sh
@@ -517,4 +517,12 @@ test_expect_success '--rebase-merges with message matched with onto label' '
 	EOF
 '
 
+test_expect_success 'progress shows the correct total' '
+	git checkout -b progress H &&
+	git rebase --rebase-merges --force-rebase --verbose A 2> err &&
+	# Expecting "Rebasing (N/14)" here, no bogus total number
+	grep "^Rebasing.*/14.$" err >progress &&
+	test_line_count = 14 progress
+'
+
 test_done


### PR DESCRIPTION
I recently picked up work where I regularly rebase large branch thickets consisting of thousands of commits. During those rebases, I could not fail to notice that the progress initially showed a total number around 2,100, when the actual number of commands was more like 1,850. And indeed, when resuming the rebase after being interrupted due to a `break` command or due to a merge conflict, the progress showed the correct number!

So I set out to fix this, stumbling over an incorrect use of `total_nr` in the `--update-refs` code, so I fixed that, too.

Note: These patches apply cleanly on top of `ds/rebase-update-ref` as well as on top of the current `main` branch.

Changes since v1:

- Clarified the pattern expected by the test case in the progress output, as suggested by Junio.
- Simplified the code as suggested by Phillipp, based on the insight that `complete_action()` (naming is _hard_!) is only called at the very beginning of a rebase, and therefore there cannot be any already-done commands in the todo list.

Cc: Derrick Stolee <derrickstolee@github.com>
cc: Phillip Wood <phillip.wood123@gmail.com>