### PR TITLE
t5583: fix shebang line

### DIFF
--- a/t/t5583-push-branches.sh
+++ b/t/t5583-push-branches.sh
@@ -1,4 +1,4 @@
-#!bin/sh
+#!/bin/sh
 
 test_description='check the consisitency of behavior of --all and --branches'
 


### PR DESCRIPTION
Applies on the top of tl/push-branches-is-an-alias-for-all.

Noticed yesterday when testing my header cleanups against next & seen.