### PR TITLE
ls-files: align format atoms with git ls-tree

### DIFF
--- a/Documentation/git-ls-files.txt
+++ b/Documentation/git-ls-files.txt
@@ -270,8 +270,14 @@ interpolated.  The following "fieldname" are understood:
 
 objectmode::
 	The mode of the file which is recorded in the index.
+objecttype::
+	The object type of the file which is recorded in the index.
 objectname::
 	The name of the file which is recorded in the index.
+objectsize[:padded]::
+	The object size of the file which is recorded in the index
+	("-" if the object is a `commit` or `tree`).
+	It also supports a padded format of size with "%(objectsize:padded)".
 stage::
 	The stage of the file which is recorded in the index.
 eolinfo:index::

--- a/t/t3013-ls-files-format.sh
+++ b/t/t3013-ls-files-format.sh
@@ -38,6 +38,41 @@ test_expect_success 'git ls-files --format objectname v.s. -s' '
 	test_cmp expect actual
 '
 
+test_expect_success 'git ls-files --format objecttype' '
+	git ls-files --format="%(objectname)" o1.txt o4.txt o6.txt >objectname &&
+	git cat-file --batch-check="%(objecttype)" >expect <objectname &&
+	git ls-files --format="%(objecttype)" o1.txt o4.txt o6.txt >actual &&
+	test_cmp expect actual
+'
+
+test_expect_success 'git ls-files --format objectsize' '
+	cat>expect <<-\EOF &&
+26
+29
+27
+26
+-
+26
+	EOF
+	git ls-files --format="%(objectsize)" >actual &&
+
+	test_cmp expect actual
+'
+
+test_expect_success 'git ls-files --format objectsize:padded' '
+	cat>expect <<-\EOF &&
+     26
+     29
+     27
+     26
+      -
+     26
+	EOF
+	git ls-files --format="%(objectsize:padded)" >actual &&
+
+	test_cmp expect actual
+'
+
 test_expect_success 'git ls-files --format v.s. --eol' '
 	git ls-files --eol >tmp &&
 	sed -e "s/	/ /g" -e "s/  */ /g" tmp >expect 2>err &&


### PR DESCRIPTION
Users sometimes want all format atoms of git ls-files --format to be
compatible with the format atoms of git ls-tree --format [1]. However, 
git ls-files --format lacks the %(objecttype) and %(objectsize),
%(objectsize:padded) atoms compared to git ls-tree --format, causing
incompatibility. Therefore, these atoms are added to the --format
of git ls-files to resolve the issue of incompatibility.

%(objecttype):  get the object type of the file which is recorded in the index.
%(objectsize):   get the object size of the file which is recorded in the index,
                           ("-" if the object is a `commit` or `tree`).
%(objectsize:padded): same as %(objectsize), but with a padded format.

v1:
add %(objecttype) and %(objectsize) atos to git ls-files --format.
v2:
1. squash two commit into one.
2. rewrite commit messages.


\[1\]: https://lore.kernel.org/git/21183ea9-84e2-fd89-eb9b-419556680c07@gnieh.org/T/#u

cc: Junio C Hamano <gitster@pobox.com>
cc: Ævar Arnfjörð Bjarmason <avarab@gmail.com>
cc: Martin Monperrus <martin.monperrus@gnieh.org>