### PR TITLE
replay: fix failed assertion when directory renames are turned off

### DIFF
--- a/merge-ort.c
+++ b/merge-ort.c
@@ -3292,6 +3292,13 @@ static int collect_renames(struct merge_options *opt,
 			continue;
 		}
 
+		if (opt->detect_directory_renames == MERGE_DIRECTORY_RENAMES_NONE &&
+		    p->status == 'R') {
+			possibly_cache_new_pair(renames, p, side_index, NULL);
+			pool_diff_free_filepair(&opt->priv->pool, p);
+			continue;
+		}
+
 		new_path = check_for_directory_rename(opt, p->two->path,
 						      side_index,
 						      dir_renames_for_side,

--- a/t/t3650-replay-basics.sh
+++ b/t/t3650-replay-basics.sh
@@ -195,4 +195,26 @@ test_expect_success 'using replay on bare repo to rebase multiple divergent bran
 	done
 '
 
+test_expect_success 'merge.directoryRenames=false' '
+	# create a test case that stress-tests the rename caching
+	git switch -c rename-onto &&
+
+	mkdir -p to-rename &&
+	test_commit to-rename/move &&
+
+	mkdir -p renamed-directory &&
+	git mv to-rename/move* renamed-directory/ &&
+	test_tick &&
+	git commit -m renamed-directory &&
+
+	git switch -c rename-from HEAD^ &&
+	test_commit to-rename/add-a-file &&
+	echo modified >to-rename/add-a-file.t &&
+	test_tick &&
+	git commit -m modified to-rename/add-a-file.t &&
+
+	git -c merge.directoryRenames=false replay \
+		--onto rename-onto rename-onto..rename-from
+'
+
 test_done


### PR DESCRIPTION
@newren maybe I can ask you to look over this first, before I send it off to the Git mailing list? I am almost 100% certain that this work-around is not only heavy-handed but also incorrect. There's got to be a better way to handle this situation. After all, the rename detection cache was designed by you _specifically_ to accelerate long-running rebases.

I also suspect that the underlying bug has little to do with `merge.directoryRenames=false` even if it might very well be a lot easier to trigger using that flag.

Here are the details:

There is a bug in the way renames are cached that rears its head when directory renames are turned off.

This patch comes with a demonstration of this bug which will fail with the following message unless the rename cache is explicitly reset in `merge_check_renames_reusable()` when `merge.directoryRenames=false`:

	merge-ort.c:2909: process_renames: Assertion `newinfo && !newinfo->merged.clean' failed.
	Aborted

It is quite a curious bug: the same test case will succeed, without any assertion, if instead run with `merge.directoryRenames=true`.

Further, the assertion does not manifest while replaying the first commit, it manifests while replaying the _second_ commit of the commit range. But it does _not_ manifest when the second commit is replayed individually.

This would indicate that there is an incomplete rename cache left-over from the first replayed commit which is being reused for the second commit, and if directory rename detection is enabled, the missing paths are somehow regenerated.

This will be a fun, intense hunt.

However, to use my time efficiently, I will first verify that the band-aid works to simply throw away the rename cache when running with directory rename detection turned off, and if it works, will run with it for the time being in order to unblock the ongoing experiment to replace libgit2-based PR rebases with `git replay`-based ones.