### PR TITLE
[RFC] repack: only repack .packs that exist

### DIFF
--- a/builtin/repack.c
+++ b/builtin/repack.c
@@ -123,6 +123,9 @@ static void collect_pack_filenames(struct string_list *fname_nonkept_list,
 		strbuf_add(&buf, e->d_name, len);
 		strbuf_addstr(&buf, ".pack");
 
+		if (!file_exists(mkpath("%s/%s", packdir, buf.buf)))
+			continue;
+
 		for (i = 0; i < extra_keep->nr; i++)
 			if (!fspathcmp(buf.buf, extra_keep->items[i].string))
 				break;

--- a/t/t7700-repack.sh
+++ b/t/t7700-repack.sh
@@ -239,11 +239,45 @@ test_expect_success 'repack --keep-pack' '
 			mv "$from" "$to" || return 1
 		done &&
 
+		# A .idx file without a .pack should not stop us from
+		# repacking what we can.
+		touch .git/objects/pack/pack-does-not-exist.idx &&
+
 		git repack --cruft -d --keep-pack $P1 --keep-pack $P4 &&
 
 		ls .git/objects/pack/*.pack >newer-counts &&
 		test_cmp new-counts newer-counts &&
 		git fsck
+	)
+'
+
+test_expect_success 'repacking fails when missing .pack actually means missing objects' '
+	test_create_repo idx-without-pack &&
+	(
+		cd idx-without-pack &&
+
+		# Avoid producing difference packs to delta/base choices
+		git config pack.window 0 &&
+		P1=$(commit_and_pack 1) &&
+		P2=$(commit_and_pack 2) &&
+		P3=$(commit_and_pack 3) &&
+		P4=$(commit_and_pack 4) &&
+		ls .git/objects/pack/*.pack >old-counts &&
+		test_line_count = 4 old-counts &&
+
+		# Remove one .pack file
+		rm .git/objects/pack/$P2 &&
+
+		ls .git/objects/pack >before-pack-dir &&
+
+		test_must_fail git fsck &&
+		test_must_fail git repack --cruft -d 2>err &&
+		grep "bad object" err &&
+
+		# Before failing, the repack did not modify the
+		# pack directory.
+		ls .git/objects/pack >after-pack-dir &&
+		test_cmp before-pack-dir after-pack-dir
 	)
 '
 


### PR DESCRIPTION
This is based on tb/collect-pack-filenames-fix.

This is an RFC since there is some internal disagreement as to whether this is a safe scenario to "ignore" during a repack.

I'm of the opinion that blocking on the case where there are no missing objects is unnecessary noise, and matches our behavior before the change to scan for '.idx' files.

I'm submitting this to the list to gather more opinions about the safety and/or necessity of this change before moving forward with a full review.

This is related to the deletion of .packs before .idx files that I submitted as [1]

[1] https://lore.kernel.org/git/pull.1547.git.1687287675248.gitgitgadget@gmail.com

Thanks,
-Stolee

cc: gitster@pobox.com
cc: me@ttaylorr.com
cc: Jeff King <peff@peff.net>