### PR TITLE
packfile: delete .idx files before .pack files

### DIFF
--- a/packfile.c
+++ b/packfile.c
@@ -381,7 +381,7 @@ void close_object_store(struct raw_object_store *o)
 
 void unlink_pack_path(const char *pack_name, int force_delete)
 {
-	static const char *exts[] = {".pack", ".idx", ".rev", ".keep", ".bitmap", ".promisor", ".mtimes"};
+	static const char *exts[] = {".idx", ".pack", ".rev", ".keep", ".bitmap", ".promisor", ".mtimes"};
 	int i;
 	struct strbuf buf = STRBUF_INIT;
 	size_t plen;


### PR DESCRIPTION
I'm going to submit an RFC soon [1] that approaches this issue from another angle, but this should be a straightforward fix to avoid the problematic "an .idx exists without its .pack" case that has been seen in the wild.

[1] https://github.com/gitgitgadget/git/pull/1546

Thanks,
-Stolee

cc: gitster@pobox.com
cc: me@ttaylorr.com
cc: vdye@github.com