### PR TITLE
i18n: mark more bundle.c strings for translation

### DIFF
--- a/bundle.c
+++ b/bundle.c
@@ -271,10 +271,10 @@ int verify_bundle(struct repository *r,
 			list_refs(r, 0, NULL);
 		}
 
-		printf_ln("The bundle uses this hash algorithm: %s",
+		printf_ln(_("The bundle uses this hash algorithm: %s"),
 			  header->hash_algo->name);
 		if (header->filter.choice)
-			printf_ln("The bundle uses this filter: %s",
+			printf_ln(_("The bundle uses this filter: %s"),
 				  list_objects_filter_spec(&header->filter));
 	}
 cleanup:


### PR DESCRIPTION
I noticed that `git bundle` output contained some untranslated messages for `LC_ALL=fr_FR.UTF-8`; in order to add translations for these messages, they need to be marked for translation.