### PR TITLE
apply: improve error messages when reading patch

### DIFF
--- a/apply.c
+++ b/apply.c
@@ -410,9 +410,10 @@ static void say_patch_name(FILE *output, const char *fmt, struct patch *patch)
 
 static int read_patch_file(struct strbuf *sb, int fd)
 {
-	if (strbuf_read(sb, fd, 0) < 0 || sb->len >= MAX_APPLY_SIZE)
-		return error_errno("git apply: failed to read");
-
+	if (strbuf_read(sb, fd, 0) < 0)
+		return error_errno(_("failed to read patch"));
+	else if (sb->len >= MAX_APPLY_SIZE)
+		return error(_("patch too large"));
 	/*
 	 * Make sure that we have some slop in the buffer
 	 * so that we can do speculative "memcmp" etc, and

--- a/t/t4141-apply-too-large.sh
+++ b/t/t4141-apply-too-large.sh
@@ -17,7 +17,7 @@ test_expect_success EXPENSIVE 'git apply rejects patches that are too large' '
 		EOF
 		test-tool genzeros
 	} | test_copy_bytes $sz | test_must_fail git apply 2>err &&
-	grep "git apply: failed to read" err
+	grep "patch too large" err
 '
 
 test_done


### PR DESCRIPTION
I haven't changed it but I found the test a bit confusing as it superficially looks like it is generating a valid patch that is too large, but it isn't actually a valid patch because the changed line is lacking a leading '+' and a trailing '\n'. As we are checking for the  error message that does not matter but it might be clearer to just do

	sz=$((1024 * 1024 * 1023)) &&
	test-tool genzeros $sz | test_must_fail git apply &&
	grep "patch too large" err

if we don't care about the patch being valid. Alternatively we could create a valid patch with

	sz=$((1024 * 1024 * 1023)) &&
	{
		cat <<-\EOF &&
		diff --git a/file b/file
		new file mode 100644
		--- /dev/null
		+++ b/file
		@@ -0,0 +1 @@
		EOF
		printf "+%${sz}s\n" x
	} | test_must_fail git apply 2>err &&
	grep "patch too large" err

Cc: Taylor Blau <me@ttaylorr.com>
