### PR TITLE
git bisect visualize: find gitk on Windows again

### DIFF
--- a/Documentation/git-bisect.txt
+++ b/Documentation/git-bisect.txt
@@ -204,9 +204,14 @@ as an alternative to `visualize`):
 $ git bisect visualize
 ------------
 
-If the `DISPLAY` environment variable is not set, 'git log' is used
-instead.  You can also give command-line options such as `-p` and
-`--stat`.
+Git detects a graphical environment through various environment variables:
+`DISPLAY`, which is set in X Window System environments on Unix systems.
+`SESSIONNAME`, which is set under Cygwin in interactive desktop sessions.
+`MSYSTEM`, which is set under Msys2 and Git for Windows.
+`SECURITYSESSIONID`, which may be set on macOS in interactive desktop sessions.
+
+If none of these environment variables are set, 'git log' is used instead.
+You can also give command-line options such as `-p` and `--stat`.
 
 ------------
 $ git bisect visualize --stat

--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -1347,6 +1347,11 @@ static char *path_lookup(const char *cmd, int exe_only)
 	return prog;
 }
 
+char *mingw_locate_in_PATH(const char *cmd)
+{
+	return path_lookup(cmd, 0);
+}
+
 static const wchar_t *wcschrnul(const wchar_t *s, wchar_t c)
 {
 	while (*s && *s != c)

--- a/compat/mingw.h
+++ b/compat/mingw.h
@@ -175,6 +175,9 @@ pid_t waitpid(pid_t pid, int *status, int options);
 #define kill mingw_kill
 int mingw_kill(pid_t pid, int sig);
 
+#define locate_in_PATH mingw_locate_in_PATH
+char *mingw_locate_in_PATH(const char *cmd);
+
 #ifndef NO_OPENSSL
 #include <openssl/ssl.h>
 static inline int mingw_SSL_set_fd(SSL *ssl, int fd)

--- a/run-command.c
+++ b/run-command.c
@@ -170,6 +170,7 @@ int is_executable(const char *name)
 	return st.st_mode & S_IXUSR;
 }
 
+#ifndef locate_in_PATH
 /*
  * Search $PATH for a command.  This emulates the path search that
  * execvp would perform, without actually executing the command so it
@@ -218,6 +219,7 @@ static char *locate_in_PATH(const char *file)
 	strbuf_release(&buf);
 	return NULL;
 }
+#endif
 
 int exists_in_PATH(const char *command)
 {


### PR DESCRIPTION
Louis Strous reported a regression in `git bisect visualize` on Windows[1] that caused
`git bisect visualize` to use `git log` instead of `gitk` unless explicitly called as 
`git bisect visualize gitk`. It was introduced during the conversion of `git bisect visualize` to a builtin.

This patch series fixes that regression.

Changes since v2:
* reworded docs based on Junios and Erics feedback.

Changes since v1:
* simplified patches 1 and 2 based on Junios feedback.
* expanded the new wording in the documentation to clarify which variables users might encounter

[1] https://lore.kernel.org/git/VI1PR10MB2462F7B52FF2E3F59AFE94A7F500A@VI1PR10MB2462.EURPRD10.PROD.OUTLOOK.COM/

cc: Louis Strous <Louis.Strous@intellimagic.com>
cc: Pranit Bauva <pranit.bauva@gmail.com>
cc: Johannes Schindelin <Johannes.Schindelin@gmx.de>
cc: Denton Liu <liu.denton@gmail.com>
cc: Tanushree Tumane <tanushreetumane@gmail.com>
cc: Jeff Hostetler <jeffhost@microsoft.com>
cc: Miriam Rubio <mirucam@gmail.com>
cc: Junio C Hamano <gitster@pobox.com>
cc: Eric Sunshine <sunshine@sunshineco.com>