### PR TITLE
[PATCH] mv: handle lstat() failure correctly

### DIFF
--- a/builtin/mv.c
+++ b/builtin/mv.c
@@ -184,7 +184,7 @@ int cmd_mv(int argc, const char **argv, const char *prefix)
 	int src_dir_nr = 0, src_dir_alloc = 0;
 	struct strbuf a_src_dir = STRBUF_INIT;
 	enum update_mode *modes, dst_mode = 0;
-	struct stat st;
+	struct stat st, dest_st;
 	struct string_list src_for_dst = STRING_LIST_INIT_NODUP;
 	struct lock_file lock_file = LOCK_INIT;
 	struct cache_entry *ce;
@@ -304,7 +304,7 @@ int cmd_mv(int argc, const char **argv, const char *prefix)
 			goto act_on_entry;
 		}
 		if (S_ISDIR(st.st_mode)
-		    && lstat(dst, &st) == 0) {
+		    && lstat(dst, &dest_st) == 0) {
 			bad = _("cannot move directory over file");
 			goto act_on_entry;
 		}

--- a/t/t7001-mv.sh
+++ b/t/t7001-mv.sh
@@ -174,6 +174,13 @@ test_expect_success 'do not move directory over existing directory' '
 	test_must_fail git mv path2 path0
 '
 
+test_expect_success 'rename directory to non-existing directory' '
+	mkdir dir-a &&
+	>dir-a/f &&
+	git add dir-a &&
+	git mv dir-a non-existing-dir
+'
+
 test_expect_success 'move into "."' '
 	git mv path1/path2/ .
 '


### PR DESCRIPTION
When moving a directory onto another with `git mv` various checks are
performed. One of of these validates that the destination is not existing.

When calling `lstat` on the destination path and it fails as the path
doesn't exist, some environments seem to overwrite the passed  in
`stat` memory nonetheless (I observed this issue on debian 12 of x86_64,
running on OrbStack on ARM, emulated with Rosetta).

This would affect the code that followed as it would still acccess a now
modified `st` structure, which now seems to contain uninitialized memory.
`S_ISDIR(st_dir_mode)` would then typically return false causing the code
to run into a bad case.

The fix avoids overwriting the existing `st` structure, providing an
alternative that exists only for that purpose.

Note that this patch minimizes complexity instead of stack-frame size.
---

It's worth pointing out that the test demonstrates this case only if one happens to execute it in one of the environments that happen to have an `lstat` that writes into `stat` even on error. Thus it already worked for me on MacOS, even without the patch applied, which matches my observation that a certain script works there but doesn't work on the VM.

Even though the patch now minimizes size, I can imagine one might instead want to rather copy `st.st_mode` to protect only the relevant field from being affected by potential rewrites of `st` later on.

Changes since v1:
- replaced previous title with recommendation by Junio C Hermano
- improved formatting of commit message and renamed `gix` to `git`. Let's call that a typo
- apply Junio C Hermano's suggestions to test-case 
- I refrained from changing the error message as this would mean all translations need adjustment (and I don't know how this is tracked then)

I also want to apologise for the possibly terrible formatting and the repetition - it feels strange but is what gitgadget seems to suggests.
Further, it's my honour to submit a patch to `git` and interact with the maintainers, it's like meeting my idols!

cc: Torsten Bögershausen <tboegi@web.de>