### PR TITLE
Trailer cleanups toward libification

### DIFF
--- a/Documentation/git-interpret-trailers.txt
+++ b/Documentation/git-interpret-trailers.txt
@@ -114,7 +114,7 @@ OPTIONS
 	Specify where all new trailers will be added.  A setting
 	provided with '--where' overrides all configuration variables
 	and applies to all '--trailer' options until the next occurrence of
-	'--where' or '--no-where'. Possible values are `after`, `before`,
+	'--where' or '--no-where'. Possible placements are `after`, `before`,
 	`end` or `start`.
 
 --if-exists <action>::

--- a/Documentation/git-interpret-trailers.txt
+++ b/Documentation/git-interpret-trailers.txt
@@ -114,8 +114,10 @@ OPTIONS
 	Specify where all new trailers will be added.  A setting
 	provided with '--where' overrides all configuration variables
 	and applies to all '--trailer' options until the next occurrence of
-	'--where' or '--no-where'. Possible placements are `after`, `before`,
-	`end` or `start`.
+	'--where' or '--no-where'. Upon encountering '--no-where', clear the
+	effect of any previous use of '--where', such that the relevant configuration
+	variables are no longer overridden. Possible placements are `after`,
+	`before`, `end` or `start`.
 
 --if-exists <action>::
 --no-if-exists::
@@ -123,7 +125,9 @@ OPTIONS
 	least one trailer with the same <token> in the input.  A setting
 	provided with '--if-exists' overrides all configuration variables
 	and applies to all '--trailer' options until the next occurrence of
-	'--if-exists' or '--no-if-exists'. Possible actions are `addIfDifferent`,
+	'--if-exists' or '--no-if-exists'. Upon encountering '--no-if-exists, clear the
+	effect of any previous use of '--if-exists, such that the relevant configuration
+	variables are no longer overridden. Possible actions are `addIfDifferent`,
 	`addIfDifferentNeighbor`, `add`, `replace` and `doNothing`.
 
 --if-missing <action>::
@@ -132,7 +136,9 @@ OPTIONS
 	trailer with the same <token> in the input.  A setting
 	provided with '--if-missing' overrides all configuration variables
 	and applies to all '--trailer' options until the next occurrence of
-	'--if-missing' or '--no-if-missing'. Possible actions are `doNothing`
+	'--if-missing' or '--no-if-missing'. Upon encountering '--no-if-missing,
+	clear the effect of any previous use of '--if-missing, such that the relevant
+	configuration variables are no longer overridden. Possible actions are `doNothing`
 	or `add`.
 
 --only-trailers::

--- a/builtin/interpret-trailers.c
+++ b/builtin/interpret-trailers.c
@@ -109,7 +109,7 @@ int cmd_interpret_trailers(int argc, const char **argv, const char *prefix)
 		OPT_BOOL(0, "unfold", &opts.unfold, N_("join whitespace-continued values")),
 		OPT_CALLBACK_F(0, "parse", &opts, NULL, N_("set parsing options"),
 			PARSE_OPT_NOARG | PARSE_OPT_NONEG, parse_opt_parse),
-		OPT_BOOL(0, "no-divider", &opts.no_divider, N_("do not treat --- specially")),
+		OPT_BOOL(0, "no-divider", &opts.no_divider, N_("do not treat \"---\" as the end of input")),
 		OPT_CALLBACK(0, "trailer", &trailers, N_("trailer"),
 				N_("trailer(s) to add"), option_parse_trailer),
 		OPT_END()

--- a/builtin/interpret-trailers.c
+++ b/builtin/interpret-trailers.c
@@ -97,7 +97,7 @@ int cmd_interpret_trailers(int argc, const char **argv, const char *prefix)
 		OPT_BOOL(0, "in-place", &opts.in_place, N_("edit files in place")),
 		OPT_BOOL(0, "trim-empty", &opts.trim_empty, N_("trim empty trailers")),
 
-		OPT_CALLBACK(0, "where", NULL, N_("action"),
+		OPT_CALLBACK(0, "where", NULL, N_("placement"),
 			     N_("where to place the new trailer"), option_parse_where),
 		OPT_CALLBACK(0, "if-exists", NULL, N_("action"),
 			     N_("action if trailer already exists"), option_parse_if_exists),

--- a/t/t7513-interpret-trailers.sh
+++ b/t/t7513-interpret-trailers.sh
@@ -812,6 +812,53 @@ test_expect_success 'using "--where after" with "--no-where"' '
 	test_cmp expected actual
 '
 
+# Check whether using "--no-where" cancels out only the "--where after", such
+# that we still use the configuration in trailer.where (which is different from
+# the hardcoded default (in WHERE_END) assuming the absence of .gitconfig).
+# Here, the "start" setting of trailer.where is respected, so the new "Acked-by"
+# and "Bug" trailers are placed at the beginning, and not at the end which is
+# the harcoded default.
+test_expect_success 'using "--where after" with "--no-where" defaults to configuration' '
+	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.bug.key "Bug #" &&
+	test_config trailer.separators ":=#" &&
+	test_config trailer.where "start" &&
+	cat complex_message_body >expected &&
+	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
+		Bug #42
+		Acked-by= Peff
+		Fixes: Z
+		Acked-by= Z
+		Reviewed-by: Z
+		Signed-off-by: Z
+	EOF
+	git interpret-trailers --where after --no-where --trailer "ack: Peff" \
+		--trailer "bug: 42" complex_message >actual &&
+	test_cmp expected actual
+'
+
+# The "--where after" will only get respected for the trailer that came
+# immediately after it. For the next trailer (Bug #42), we default to using the
+# hardcoded WHERE_END because we don't have any "trailer.where" or
+# "trailer.bug.where" configured.
+test_expect_success 'using "--no-where" defaults to harcoded default if nothing configured' '
+	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.bug.key "Bug #" &&
+	test_config trailer.separators ":=#" &&
+	cat complex_message_body >expected &&
+	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
+		Fixes: Z
+		Acked-by= Z
+		Acked-by= Peff
+		Reviewed-by: Z
+		Signed-off-by: Z
+		Bug #42
+	EOF
+	git interpret-trailers --where after --trailer "ack: Peff" --no-where \
+		--trailer "bug: 42" complex_message >actual &&
+	test_cmp expected actual
+'
+
 test_expect_success 'using "where = after"' '
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.ack.where "after" &&
@@ -1176,6 +1223,56 @@ test_expect_success 'overriding configuration with "--if-exists replace"' '
 	test_cmp expected actual
 '
 
+# "trailer.ifexists" is set to "doNothing", so using "--no-if-exists" defaults
+# to this "doNothing" behavior. So the "Fixes: 53" trailer does not get added.
+test_expect_success 'using "--if-exists replace" with "--no-if-exists" defaults to configuration' '
+	test_config trailer.ifexists "doNothing" &&
+	cat complex_message_body >expected &&
+	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
+		Fixes: Z
+		Acked-by: Z
+		Reviewed-by: Z
+		Signed-off-by: Z
+	EOF
+	git interpret-trailers --if-exists replace --no-if-exists --trailer "Fixes: 53" \
+		<complex_message >actual &&
+	test_cmp expected actual
+'
+
+# No "ifexists" configuration is set, so using "--no-if-exists" makes it default
+# to addIfDifferentNeighbor. Because we do have a different neighbor "Fixes: 53"
+# (because it got added by overriding with "--if-exists replace" earlier in the
+# arguments list), we add "Signed-off-by: addme".
+test_expect_success 'using "--no-if-exists" defaults to hardcoded default if nothing configured' '
+	cat complex_message_body >expected &&
+	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
+		Acked-by: Z
+		Reviewed-by: Z
+		Signed-off-by: Z
+		Fixes: 53
+		Signed-off-by: addme
+	EOF
+	git interpret-trailers --if-exists replace --trailer "Fixes: 53" --no-if-exists \
+		--trailer "Signed-off-by: addme" <complex_message >actual &&
+	test_cmp expected actual
+'
+
+# The second "Fixes: 53" trailer is discarded, because the "--no-if-exists" here
+# makes us default to addIfDifferentNeighbor, and we already added the "Fixes:
+# 53" trailer earlier in the argument list.
+test_expect_success 'using "--no-if-exists" defaults to hardcoded default if nothing configured (no addition)' '
+	cat complex_message_body >expected &&
+	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
+		Acked-by: Z
+		Reviewed-by: Z
+		Signed-off-by: Z
+		Fixes: 53
+	EOF
+	git interpret-trailers --if-exists replace --trailer "Fixes: 53" --no-if-exists \
+		--trailer "Fixes: 53" <complex_message >actual &&
+	test_cmp expected actual
+'
+
 test_expect_success 'using "ifExists = replace"' '
 	test_config trailer.fix.key "Fixes: " &&
 	test_config trailer.fix.ifExists "replace" &&
@@ -1422,6 +1519,39 @@ test_expect_success 'using "ifMissing = doNothing"' '
 		--trailer "cc=Linus" --trailer "ack: Junio" \
 		--trailer "fix=22" --trailer "bug: 42" --trailer "ack: Peff" \
 		<complex_message >actual &&
+	test_cmp expected actual
+'
+
+# Ignore the "IgnoredTrailer" because of "--if-missing doNothing", but also
+# ignore the "StillIgnoredTrailer" because we set "trailer.ifMissing" to
+# "doNothing" in configuration.
+test_expect_success 'using "--no-if-missing" defaults to configuration' '
+	test_config trailer.ifMissing "doNothing" &&
+	cat complex_message_body >expected &&
+	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
+			Fixes: Z
+			Acked-by: Z
+			Reviewed-by: Z
+			Signed-off-by: Z
+	EOF
+	git interpret-trailers --if-missing doNothing --trailer "IgnoredTrailer: ignoreme" --no-if-missing \
+			--trailer "StillIgnoredTrailer: ignoreme" <complex_message >actual &&
+	test_cmp expected actual
+'
+
+# Add the "AddedTrailer" because the "--no-if-missing" clears the "--if-missing
+# doNothing" from earlier in the argument list.
+test_expect_success 'using "--no-if-missing" defaults to hardcoded default if nothing configured' '
+	cat complex_message_body >expected &&
+	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
+			Fixes: Z
+			Acked-by: Z
+			Reviewed-by: Z
+			Signed-off-by: Z
+			AddedTrailer: addme
+	EOF
+	git interpret-trailers --if-missing doNothing --trailer "IgnoredTrailer: ignoreme" --no-if-missing \
+			--trailer "AddedTrailer: addme" <complex_message >actual &&
 	test_cmp expected actual
 '
 

--- a/t/t7513-interpret-trailers.sh
+++ b/t/t7513-interpret-trailers.sh
@@ -1289,13 +1289,13 @@ test_expect_success 'the default is "ifMissing = add"' '
 '
 
 test_expect_success 'overriding configuration with "--if-missing doNothing"' '
-	git config trailer.ifmissing "add" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.ack.where "after" &&
 	test_config trailer.fix.key "Fixes: " &&
 	test_config trailer.fix.ifExists "doNothing" &&
 	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.ifexists "addIfDifferent" &&
+	test_config trailer.ifmissing "add" &&
 	test_config trailer.separators ":=" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1315,12 +1315,12 @@ test_expect_success 'overriding configuration with "--if-missing doNothing"' '
 '
 
 test_expect_success 'when default "ifMissing" is "doNothing"' '
-	git config trailer.ifmissing "doNothing" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.ack.where "after" &&
 	test_config trailer.fix.ifExists "doNothing" &&
 	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.ifexists "addIfDifferent" &&
+	test_config trailer.ifmissing "doNothing" &&
 	test_config trailer.separators ":=" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1335,8 +1335,7 @@ test_expect_success 'when default "ifMissing" is "doNothing"' '
 		--trailer "cc=Linus" --trailer "ack: Junio" \
 		--trailer "fix=22" --trailer "bug: 42" --trailer "ack: Peff" \
 		<complex_message >actual &&
-	test_cmp expected actual &&
-	git config trailer.ifmissing "add"
+	test_cmp expected actual
 '
 
 test_expect_success 'using "ifMissing = add" with "where = end"' '

--- a/t/t7513-interpret-trailers.sh
+++ b/t/t7513-interpret-trailers.sh
@@ -1259,11 +1259,11 @@ test_expect_success 'using "ifExists = doNothing"' '
 '
 
 test_expect_success 'the default is "ifMissing = add"' '
-	git config trailer.cc.key "Cc: " &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.ack.where "after" &&
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
+	test_config trailer.cc.key "Cc: " &&
 	test_config trailer.cc.where "before" &&
 	test_config trailer.fix.key "Fixes: " &&
 	test_config trailer.fix.ifExists "doNothing" &&
@@ -1340,12 +1340,12 @@ test_expect_success 'when default "ifMissing" is "doNothing"' '
 '
 
 test_expect_success 'using "ifMissing = add" with "where = end"' '
-	git config trailer.cc.key "Cc: " &&
 	git config trailer.cc.ifMissing "add" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.ack.where "after" &&
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
+	test_config trailer.cc.key "Cc: " &&
 	test_config trailer.cc.where "end" &&
 	test_config trailer.fix.ifExists "doNothing" &&
 	test_config trailer.review.key "Reviewed-by:" &&
@@ -1370,12 +1370,12 @@ test_expect_success 'using "ifMissing = add" with "where = end"' '
 '
 
 test_expect_success 'using "ifMissing = add" with "where = before"' '
-	git config trailer.cc.key "Cc: " &&
 	git config trailer.cc.ifMissing "add" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.ack.where "after" &&
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
+	test_config trailer.cc.key "Cc: " &&
 	test_config trailer.cc.where "before" &&
 	test_config trailer.fix.ifExists "doNothing" &&
 	test_config trailer.review.key "Reviewed-by:" &&

--- a/t/t7513-interpret-trailers.sh
+++ b/t/t7513-interpret-trailers.sh
@@ -1533,9 +1533,9 @@ test_expect_success 'setup a commit' '
 '
 
 test_expect_success 'cmd takes precedence over command' '
-	git config trailer.fix.command "git log -1 --oneline --format=\"%h (%s)\" \
-		--abbrev-commit --abbrev=14 \$ARG" &&
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.fix.command "git log -1 --oneline --format=\"%h (%s)\" \
+		--abbrev-commit --abbrev=14 \$ARG" &&
 	test_config trailer.fix.cmd "test -n \"\$1\" && git log -1 --oneline --format=\"%h (%aN)\" \
 	--abbrev-commit --abbrev=14 \"\$1\" || true" &&
 	test_config trailer.fix.key "Fixes: " &&
@@ -1561,8 +1561,8 @@ test_expect_success 'cmd takes precedence over command' '
 '
 
 test_expect_success 'with command using $ARG' '
-	git config trailer.fix.command "git log -1 --oneline --format=\"%h (%s)\" --abbrev-commit --abbrev=14 \$ARG" &&
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.fix.command "git log -1 --oneline --format=\"%h (%s)\" --abbrev-commit --abbrev=14 \$ARG" &&
 	test_config trailer.fix.key "Fixes: " &&
 	test_config trailer.fix.ifExists "replace" &&
 	test_config trailer.fix.where "after" &&
@@ -1586,8 +1586,8 @@ test_expect_success 'with command using $ARG' '
 '
 
 test_expect_success 'with failing command using $ARG' '
-	git config trailer.fix.command "false \$ARG" &&
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.fix.command "false \$ARG" &&
 	test_config trailer.fix.key "Fixes: " &&
 	test_config trailer.fix.ifExists "replace" &&
 	test_config trailer.fix.where "after" &&
@@ -1610,7 +1610,6 @@ test_expect_success 'with failing command using $ARG' '
 '
 
 test_expect_success 'with empty tokens' '
-	git config --unset trailer.fix.command &&
 	test_config trailer.sign.command "echo \"\$GIT_AUTHOR_NAME <\$GIT_AUTHOR_EMAIL>\"" &&
 	test_config trailer.sign.key "Signed-off-by: " &&
 	test_config trailer.ifexists "addIfDifferent" &&

--- a/t/t7513-interpret-trailers.sh
+++ b/t/t7513-interpret-trailers.sh
@@ -1459,11 +1459,11 @@ test_expect_success 'default "where" is now "after"' '
 '
 
 test_expect_success 'with simple command' '
-	git config trailer.sign.key "Signed-off-by: " &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.fix.ifExists "doNothing" &&
 	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.sign.command "echo \"A U Thor <author@example.com>\"" &&
+	test_config trailer.sign.key "Signed-off-by: " &&
 	test_config trailer.sign.ifExists "addIfDifferentNeighbor" &&
 	test_config trailer.sign.where "after" &&
 	test_config trailer.ifexists "addIfDifferent" &&
@@ -1486,6 +1486,7 @@ test_expect_success 'with command using committer information' '
 	test_config trailer.fix.ifExists "doNothing" &&
 	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.sign.command "echo \"\$GIT_COMMITTER_NAME <\$GIT_COMMITTER_EMAIL>\"" &&
+	test_config trailer.sign.key "Signed-off-by: " &&
 	test_config trailer.sign.ifExists "addIfDifferent" &&
 	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=" &&
@@ -1503,11 +1504,11 @@ test_expect_success 'with command using committer information' '
 '
 
 test_expect_success 'with command using author information' '
-	git config trailer.sign.key "Signed-off-by: " &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.fix.ifExists "doNothing" &&
 	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.sign.command "echo \"\$GIT_AUTHOR_NAME <\$GIT_AUTHOR_EMAIL>\"" &&
+	test_config trailer.sign.key "Signed-off-by: " &&
 	test_config trailer.sign.ifExists "addIfDifferentNeighbor" &&
 	test_config trailer.sign.where "after" &&
 	test_config trailer.ifexists "addIfDifferent" &&
@@ -1543,6 +1544,7 @@ test_expect_success 'cmd takes precedence over command' '
 	test_config trailer.fix.where "after" &&
 	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.sign.command "echo \"\$GIT_AUTHOR_NAME <\$GIT_AUTHOR_EMAIL>\"" &&
+	test_config trailer.sign.key "Signed-off-by: " &&
 	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=" &&
 	FIXED=$(git log -1 --oneline --format="%h (%aN)" --abbrev-commit --abbrev=14 HEAD) &&
@@ -1567,6 +1569,7 @@ test_expect_success 'with command using $ARG' '
 	test_config trailer.fix.where "after" &&
 	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.sign.command "echo \"\$GIT_AUTHOR_NAME <\$GIT_AUTHOR_EMAIL>\"" &&
+	test_config trailer.sign.key "Signed-off-by: " &&
 	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=" &&
 	FIXED=$(git log -1 --oneline --format="%h (%s)" --abbrev-commit --abbrev=14 HEAD) &&
@@ -1591,6 +1594,7 @@ test_expect_success 'with failing command using $ARG' '
 	test_config trailer.fix.where "after" &&
 	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.sign.command "echo \"\$GIT_AUTHOR_NAME <\$GIT_AUTHOR_EMAIL>\"" &&
+	test_config trailer.sign.key "Signed-off-by: " &&
 	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=" &&
 	cat complex_message_body >expected &&
@@ -1609,6 +1613,7 @@ test_expect_success 'with failing command using $ARG' '
 test_expect_success 'with empty tokens' '
 	git config --unset trailer.fix.command &&
 	test_config trailer.sign.command "echo \"\$GIT_AUTHOR_NAME <\$GIT_AUTHOR_EMAIL>\"" &&
+	test_config trailer.sign.key "Signed-off-by: " &&
 	test_config trailer.ifexists "addIfDifferent" &&
 	cat >expected <<-EOF &&
 
@@ -1620,7 +1625,6 @@ test_expect_success 'with empty tokens' '
 '
 
 test_expect_success 'with command but no key' '
-	git config --unset trailer.sign.key &&
 	test_config trailer.sign.command "echo \"\$GIT_AUTHOR_NAME <\$GIT_AUTHOR_EMAIL>\"" &&
 	test_config trailer.ifexists "addIfDifferent" &&
 	cat >expected <<-EOF &&

--- a/t/t7513-interpret-trailers.sh
+++ b/t/t7513-interpret-trailers.sh
@@ -1462,10 +1462,10 @@ test_expect_success 'with simple command' '
 	git config trailer.sign.key "Signed-off-by: " &&
 	git config trailer.sign.where "after" &&
 	git config trailer.sign.ifExists "addIfDifferentNeighbor" &&
-	git config trailer.sign.command "echo \"A U Thor <author@example.com>\"" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.fix.ifExists "doNothing" &&
 	test_config trailer.review.key "Reviewed-by:" &&
+	test_config trailer.sign.command "echo \"A U Thor <author@example.com>\"" &&
 	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=" &&
 	cat complex_message_body >expected &&
@@ -1483,10 +1483,10 @@ test_expect_success 'with simple command' '
 
 test_expect_success 'with command using committer information' '
 	git config trailer.sign.ifExists "addIfDifferent" &&
-	git config trailer.sign.command "echo \"\$GIT_COMMITTER_NAME <\$GIT_COMMITTER_EMAIL>\"" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.fix.ifExists "doNothing" &&
 	test_config trailer.review.key "Reviewed-by:" &&
+	test_config trailer.sign.command "echo \"\$GIT_COMMITTER_NAME <\$GIT_COMMITTER_EMAIL>\"" &&
 	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=" &&
 	cat complex_message_body >expected &&
@@ -1506,10 +1506,10 @@ test_expect_success 'with command using author information' '
 	git config trailer.sign.key "Signed-off-by: " &&
 	git config trailer.sign.where "after" &&
 	git config trailer.sign.ifExists "addIfDifferentNeighbor" &&
-	git config trailer.sign.command "echo \"\$GIT_AUTHOR_NAME <\$GIT_AUTHOR_EMAIL>\"" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.fix.ifExists "doNothing" &&
 	test_config trailer.review.key "Reviewed-by:" &&
+	test_config trailer.sign.command "echo \"\$GIT_AUTHOR_NAME <\$GIT_AUTHOR_EMAIL>\"" &&
 	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=" &&
 	cat complex_message_body >expected &&
@@ -1542,6 +1542,7 @@ test_expect_success 'cmd takes precedence over command' '
 	test_config trailer.fix.ifExists "replace" &&
 	test_config trailer.fix.where "after" &&
 	test_config trailer.review.key "Reviewed-by:" &&
+	test_config trailer.sign.command "echo \"\$GIT_AUTHOR_NAME <\$GIT_AUTHOR_EMAIL>\"" &&
 	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=" &&
 	FIXED=$(git log -1 --oneline --format="%h (%aN)" --abbrev-commit --abbrev=14 HEAD) &&
@@ -1565,6 +1566,7 @@ test_expect_success 'with command using $ARG' '
 	test_config trailer.fix.ifExists "replace" &&
 	test_config trailer.fix.where "after" &&
 	test_config trailer.review.key "Reviewed-by:" &&
+	test_config trailer.sign.command "echo \"\$GIT_AUTHOR_NAME <\$GIT_AUTHOR_EMAIL>\"" &&
 	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=" &&
 	FIXED=$(git log -1 --oneline --format="%h (%s)" --abbrev-commit --abbrev=14 HEAD) &&
@@ -1588,6 +1590,7 @@ test_expect_success 'with failing command using $ARG' '
 	test_config trailer.fix.ifExists "replace" &&
 	test_config trailer.fix.where "after" &&
 	test_config trailer.review.key "Reviewed-by:" &&
+	test_config trailer.sign.command "echo \"\$GIT_AUTHOR_NAME <\$GIT_AUTHOR_EMAIL>\"" &&
 	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=" &&
 	cat complex_message_body >expected &&
@@ -1605,6 +1608,7 @@ test_expect_success 'with failing command using $ARG' '
 
 test_expect_success 'with empty tokens' '
 	git config --unset trailer.fix.command &&
+	test_config trailer.sign.command "echo \"\$GIT_AUTHOR_NAME <\$GIT_AUTHOR_EMAIL>\"" &&
 	test_config trailer.ifexists "addIfDifferent" &&
 	cat >expected <<-EOF &&
 
@@ -1617,6 +1621,7 @@ test_expect_success 'with empty tokens' '
 
 test_expect_success 'with command but no key' '
 	git config --unset trailer.sign.key &&
+	test_config trailer.sign.command "echo \"\$GIT_AUTHOR_NAME <\$GIT_AUTHOR_EMAIL>\"" &&
 	test_config trailer.ifexists "addIfDifferent" &&
 	cat >expected <<-EOF &&
 
@@ -1629,6 +1634,7 @@ test_expect_success 'with command but no key' '
 
 test_expect_success 'with no command and no key' '
 	test_config trailer.review.where "before" &&
+	test_config trailer.sign.command "echo \"\$GIT_AUTHOR_NAME <\$GIT_AUTHOR_EMAIL>\"" &&
 	test_config trailer.ifexists "addIfDifferent" &&
 	cat >expected <<-EOF &&
 
@@ -1642,6 +1648,7 @@ test_expect_success 'with no command and no key' '
 
 test_expect_success 'with cut line' '
 	test_config trailer.review.where "before" &&
+	test_config trailer.sign.command "echo \"\$GIT_AUTHOR_NAME <\$GIT_AUTHOR_EMAIL>\"" &&
 	cat >expected <<-\EOF &&
 		my subject
 
@@ -1659,8 +1666,8 @@ test_expect_success 'with cut line' '
 '
 
 test_expect_success 'only trailers' '
+	test_config trailer.sign.command "echo config-value" &&
 	test_config trailer.ifexists "addIfDifferent" &&
-	git config trailer.sign.command "echo config-value" &&
 	cat >expected <<-\EOF &&
 		existing: existing-value
 		sign: config-value
@@ -1679,7 +1686,7 @@ test_expect_success 'only trailers' '
 '
 
 test_expect_success 'only-trailers omits non-trailer in middle of block' '
-	git config trailer.sign.command "echo config-value" &&
+	test_config trailer.sign.command "echo config-value" &&
 	cat >expected <<-\EOF &&
 		Signed-off-by: nobody <nobody@nowhere>
 		Signed-off-by: somebody <somebody@somewhere>
@@ -1699,7 +1706,7 @@ test_expect_success 'only-trailers omits non-trailer in middle of block' '
 '
 
 test_expect_success 'only input' '
-	git config trailer.sign.command "echo config-value" &&
+	test_config trailer.sign.command "echo config-value" &&
 	cat >expected <<-\EOF &&
 		existing: existing-value
 	EOF

--- a/t/t7513-interpret-trailers.sh
+++ b/t/t7513-interpret-trailers.sh
@@ -834,7 +834,7 @@ test_expect_success 'using "where = after"' '
 
 test_expect_success 'using "where = end"' '
 	git config trailer.review.key "Reviewed-by" &&
-	git config trailer.review.where "end" &&
+	test_config trailer.review.where "end" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.ack.where "after" &&
 	test_config trailer.separators ":=" &&
@@ -856,7 +856,7 @@ test_expect_success 'using "where = end"' '
 
 test_expect_success 'using "where = start"' '
 	git config trailer.review.key "Reviewed-by" &&
-	git config trailer.review.where "start" &&
+	test_config trailer.review.where "start" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.ack.where "after" &&
 	test_config trailer.separators ":=" &&
@@ -878,7 +878,7 @@ test_expect_success 'using "where = start"' '
 
 test_expect_success 'using "where = before" for a token in the middle of the message' '
 	git config trailer.review.key "Reviewed-by:" &&
-	git config trailer.review.where "before" &&
+	test_config trailer.review.where "before" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.ack.where "after" &&
 	test_config trailer.bug.key "Bug #" &&
@@ -923,6 +923,7 @@ test_expect_success 'the default is "ifExists = addIfDifferentNeighbor"' '
 	test_config trailer.ack.where "after" &&
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
+	test_config trailer.review.where "before" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1143,6 +1144,7 @@ test_expect_success 'overriding configuration with "--if-exists replace"' '
 	test_config trailer.ack.where "after" &&
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
+	test_config trailer.review.where "before" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1556,6 +1558,7 @@ test_expect_success 'with command but no key' '
 
 test_expect_success 'with no command and no key' '
 	git config --unset trailer.review.key &&
+	test_config trailer.review.where "before" &&
 	cat >expected <<-EOF &&
 
 		review: Junio
@@ -1567,6 +1570,7 @@ test_expect_success 'with no command and no key' '
 '
 
 test_expect_success 'with cut line' '
+	test_config trailer.review.where "before" &&
 	cat >expected <<-\EOF &&
 		my subject
 

--- a/t/t7513-interpret-trailers.sh
+++ b/t/t7513-interpret-trailers.sh
@@ -1153,7 +1153,7 @@ test_expect_success 'using "ifExists = add" with "where = after"' '
 '
 
 test_expect_success 'overriding configuration with "--if-exists replace"' '
-	git config trailer.fix.key "Fixes: " &&
+	test_config trailer.fix.key "Fixes: " &&
 	git config trailer.fix.ifExists "add" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.ack.where "after" &&
@@ -1177,7 +1177,7 @@ test_expect_success 'overriding configuration with "--if-exists replace"' '
 '
 
 test_expect_success 'using "ifExists = replace"' '
-	git config trailer.fix.key "Fixes: " &&
+	test_config trailer.fix.key "Fixes: " &&
 	git config trailer.fix.ifExists "replace" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.ack.where "after" &&
@@ -1209,6 +1209,7 @@ test_expect_success 'using "ifExists = replace" with "where = after"' '
 	test_config trailer.ack.where "after" &&
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
+	test_config trailer.fix.key "Fixes: " &&
 	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=#" &&
@@ -1235,6 +1236,7 @@ test_expect_success 'using "ifExists = doNothing"' '
 	test_config trailer.ack.where "after" &&
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
+	test_config trailer.fix.key "Fixes: " &&
 	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=#" &&
@@ -1262,6 +1264,7 @@ test_expect_success 'the default is "ifMissing = add"' '
 	test_config trailer.ack.where "after" &&
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
+	test_config trailer.fix.key "Fixes: " &&
 	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=#" &&
@@ -1287,6 +1290,7 @@ test_expect_success 'overriding configuration with "--if-missing doNothing"' '
 	git config trailer.ifmissing "add" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.ack.where "after" &&
+	test_config trailer.fix.key "Fixes: " &&
 	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=" &&
@@ -1525,6 +1529,7 @@ test_expect_success 'cmd takes precedence over command' '
 	git config trailer.fix.command "git log -1 --oneline --format=\"%h (%s)\" \
 		--abbrev-commit --abbrev=14 \$ARG" &&
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.fix.key "Fixes: " &&
 	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=" &&
@@ -1546,6 +1551,7 @@ test_expect_success 'with command using $ARG' '
 	git config trailer.fix.ifExists "replace" &&
 	git config trailer.fix.command "git log -1 --oneline --format=\"%h (%s)\" --abbrev-commit --abbrev=14 \$ARG" &&
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.fix.key "Fixes: " &&
 	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=" &&
@@ -1567,6 +1573,7 @@ test_expect_success 'with failing command using $ARG' '
 	git config trailer.fix.ifExists "replace" &&
 	git config trailer.fix.command "false \$ARG" &&
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.fix.key "Fixes: " &&
 	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=" &&

--- a/t/t7513-interpret-trailers.sh
+++ b/t/t7513-interpret-trailers.sh
@@ -792,7 +792,7 @@ test_expect_success 'overriding configuration with "--where after"' '
 	test_cmp expected actual
 '
 
-test_expect_success 'using "where = before" with "--no-where"' '
+test_expect_success 'using "--where after" with "--no-where"' '
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.ack.where "before" &&
 	test_config trailer.bug.key "Bug #" &&

--- a/t/t7513-interpret-trailers.sh
+++ b/t/t7513-interpret-trailers.sh
@@ -1204,13 +1204,13 @@ test_expect_success 'using "ifExists = replace"' '
 '
 
 test_expect_success 'using "ifExists = replace" with "where = after"' '
-	git config trailer.fix.where "after" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.ack.where "after" &&
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
 	test_config trailer.fix.key "Fixes: " &&
 	test_config trailer.fix.ifExists "replace" &&
+	test_config trailer.fix.where "after" &&
 	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=#" &&
@@ -1541,6 +1541,7 @@ test_expect_success 'cmd takes precedence over command' '
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.fix.key "Fixes: " &&
 	test_config trailer.fix.ifExists "replace" &&
+	test_config trailer.fix.where "after" &&
 	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=" &&
@@ -1563,6 +1564,7 @@ test_expect_success 'with command using $ARG' '
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.fix.key "Fixes: " &&
 	test_config trailer.fix.ifExists "replace" &&
+	test_config trailer.fix.where "after" &&
 	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=" &&
@@ -1585,6 +1587,7 @@ test_expect_success 'with failing command using $ARG' '
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.fix.key "Fixes: " &&
 	test_config trailer.fix.ifExists "replace" &&
+	test_config trailer.fix.where "after" &&
 	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=" &&

--- a/t/t7513-interpret-trailers.sh
+++ b/t/t7513-interpret-trailers.sh
@@ -833,7 +833,7 @@ test_expect_success 'using "where = after"' '
 '
 
 test_expect_success 'using "where = end"' '
-	git config trailer.review.key "Reviewed-by" &&
+	test_config trailer.review.key "Reviewed-by" &&
 	test_config trailer.review.where "end" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.ack.where "after" &&
@@ -855,7 +855,7 @@ test_expect_success 'using "where = end"' '
 '
 
 test_expect_success 'using "where = start"' '
-	git config trailer.review.key "Reviewed-by" &&
+	test_config trailer.review.key "Reviewed-by" &&
 	test_config trailer.review.where "start" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.ack.where "after" &&
@@ -877,7 +877,7 @@ test_expect_success 'using "where = start"' '
 '
 
 test_expect_success 'using "where = before" for a token in the middle of the message' '
-	git config trailer.review.key "Reviewed-by:" &&
+	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.review.where "before" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.ack.where "after" &&
@@ -904,6 +904,7 @@ test_expect_success 'using "where = before" and --trim-empty' '
 	test_config trailer.ack.where "after" &&
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
+	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	cat >>expected <<-\EOF &&
@@ -923,6 +924,7 @@ test_expect_success 'the default is "ifExists = addIfDifferentNeighbor"' '
 	test_config trailer.ack.where "after" &&
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
+	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.review.where "before" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
@@ -948,6 +950,7 @@ test_expect_success 'default "ifExists" is now "addIfDifferent"' '
 	test_config trailer.ack.where "after" &&
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
+	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -971,6 +974,7 @@ test_expect_success 'using "ifExists = addIfDifferent" with "where = end"' '
 	test_config trailer.ack.where "end" &&
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
+	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -993,6 +997,7 @@ test_expect_success 'using "ifExists = addIfDifferent" with "where = before"' '
 	test_config trailer.ack.where "before" &&
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
+	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1015,6 +1020,7 @@ test_expect_success 'using "ifExists = addIfDifferentNeighbor" with "where = end
 	test_config trailer.ack.where "end" &&
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
+	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1042,6 +1048,7 @@ test_expect_success 'using "ifExists = addIfDifferentNeighbor"  with "where = af
 	test_config trailer.ack.where "after" &&
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
+	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1088,6 +1095,7 @@ test_expect_success 'using "ifExists = add" with "where = end"' '
 	test_config trailer.ack.where "end" &&
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
+	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1117,6 +1125,7 @@ test_expect_success 'using "ifExists = add" with "where = after"' '
 	test_config trailer.ack.where "after" &&
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
+	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1144,6 +1153,7 @@ test_expect_success 'overriding configuration with "--if-exists replace"' '
 	test_config trailer.ack.where "after" &&
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
+	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.review.where "before" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
@@ -1167,6 +1177,7 @@ test_expect_success 'using "ifExists = replace"' '
 	test_config trailer.ack.where "after" &&
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
+	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1191,6 +1202,7 @@ test_expect_success 'using "ifExists = replace" with "where = after"' '
 	test_config trailer.ack.where "after" &&
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
+	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1215,6 +1227,7 @@ test_expect_success 'using "ifExists = doNothing"' '
 	test_config trailer.ack.where "after" &&
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
+	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1240,6 +1253,7 @@ test_expect_success 'the default is "ifMissing = add"' '
 	test_config trailer.ack.where "after" &&
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
+	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1263,6 +1277,7 @@ test_expect_success 'overriding configuration with "--if-missing doNothing"' '
 	git config trailer.ifmissing "add" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.ack.where "after" &&
+	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.separators ":=" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1285,6 +1300,7 @@ test_expect_success 'when default "ifMissing" is "doNothing"' '
 	git config trailer.ifmissing "doNothing" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.ack.where "after" &&
+	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.separators ":=" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1311,6 +1327,7 @@ test_expect_success 'using "ifMissing = add" with "where = end"' '
 	test_config trailer.ack.where "after" &&
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
+	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1338,6 +1355,7 @@ test_expect_success 'using "ifMissing = add" with "where = before"' '
 	test_config trailer.ack.where "after" &&
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
+	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1363,6 +1381,7 @@ test_expect_success 'using "ifMissing = doNothing"' '
 	test_config trailer.ack.where "after" &&
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
+	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1387,6 +1406,7 @@ test_expect_success 'default "where" is now "after"' '
 	test_config trailer.ack.where "after" &&
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
+	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1416,6 +1436,7 @@ test_expect_success 'with simple command' '
 	git config trailer.sign.ifExists "addIfDifferentNeighbor" &&
 	git config trailer.sign.command "echo \"A U Thor <author@example.com>\"" &&
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.separators ":=" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1434,6 +1455,7 @@ test_expect_success 'with command using committer information' '
 	git config trailer.sign.ifExists "addIfDifferent" &&
 	git config trailer.sign.command "echo \"\$GIT_COMMITTER_NAME <\$GIT_COMMITTER_EMAIL>\"" &&
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.separators ":=" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1454,6 +1476,7 @@ test_expect_success 'with command using author information' '
 	git config trailer.sign.ifExists "addIfDifferentNeighbor" &&
 	git config trailer.sign.command "echo \"\$GIT_AUTHOR_NAME <\$GIT_AUTHOR_EMAIL>\"" &&
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.separators ":=" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1482,6 +1505,7 @@ test_expect_success 'cmd takes precedence over command' '
 	git config trailer.fix.command "git log -1 --oneline --format=\"%h (%s)\" \
 		--abbrev-commit --abbrev=14 \$ARG" &&
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.separators ":=" &&
 	FIXED=$(git log -1 --oneline --format="%h (%aN)" --abbrev-commit --abbrev=14 HEAD) &&
 	cat complex_message_body >expected2 &&
@@ -1501,6 +1525,7 @@ test_expect_success 'with command using $ARG' '
 	git config trailer.fix.ifExists "replace" &&
 	git config trailer.fix.command "git log -1 --oneline --format=\"%h (%s)\" --abbrev-commit --abbrev=14 \$ARG" &&
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.separators ":=" &&
 	FIXED=$(git log -1 --oneline --format="%h (%s)" --abbrev-commit --abbrev=14 HEAD) &&
 	cat complex_message_body >expected &&
@@ -1520,6 +1545,7 @@ test_expect_success 'with failing command using $ARG' '
 	git config trailer.fix.ifExists "replace" &&
 	git config trailer.fix.command "false \$ARG" &&
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.separators ":=" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-EOF &&
@@ -1557,7 +1583,6 @@ test_expect_success 'with command but no key' '
 '
 
 test_expect_success 'with no command and no key' '
-	git config --unset trailer.review.key &&
 	test_config trailer.review.where "before" &&
 	cat >expected <<-EOF &&
 

--- a/t/t7513-interpret-trailers.sh
+++ b/t/t7513-interpret-trailers.sh
@@ -760,7 +760,7 @@ test_expect_success 'using "where = before"' '
 	test_config trailer.separators ":=#" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.bug.key "Bug #" &&
-	git config trailer.bug.where "before" &&
+	test_config trailer.bug.where "before" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
 		Bug #42
@@ -795,6 +795,7 @@ test_expect_success 'overriding configuration with "--where after"' '
 test_expect_success 'using "where = before" with "--no-where"' '
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.bug.key "Bug #" &&
+	test_config trailer.bug.where "before" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -814,6 +815,7 @@ test_expect_success 'using "where = after"' '
 	git config trailer.ack.where "after" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.bug.key "Bug #" &&
+	test_config trailer.bug.where "before" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -876,6 +878,7 @@ test_expect_success 'using "where = before" for a token in the middle of the mes
 	git config trailer.review.where "before" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.bug.key "Bug #" &&
+	test_config trailer.bug.where "before" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -895,6 +898,7 @@ test_expect_success 'using "where = before" for a token in the middle of the mes
 test_expect_success 'using "where = before" and --trim-empty' '
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.bug.key "Bug #" &&
+	test_config trailer.bug.where "before" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	cat >>expected <<-\EOF &&
@@ -912,6 +916,7 @@ test_expect_success 'using "where = before" and --trim-empty' '
 test_expect_success 'the default is "ifExists = addIfDifferentNeighbor"' '
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.bug.key "Bug #" &&
+	test_config trailer.bug.where "before" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -934,6 +939,7 @@ test_expect_success 'default "ifExists" is now "addIfDifferent"' '
 	git config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.bug.key "Bug #" &&
+	test_config trailer.bug.where "before" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -956,6 +962,7 @@ test_expect_success 'using "ifExists = addIfDifferent" with "where = end"' '
 	git config trailer.ack.where "end" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.bug.key "Bug #" &&
+	test_config trailer.bug.where "before" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -977,6 +984,7 @@ test_expect_success 'using "ifExists = addIfDifferent" with "where = before"' '
 	git config trailer.ack.where "before" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.bug.key "Bug #" &&
+	test_config trailer.bug.where "before" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -998,6 +1006,7 @@ test_expect_success 'using "ifExists = addIfDifferentNeighbor" with "where = end
 	git config trailer.ack.where "end" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.bug.key "Bug #" &&
+	test_config trailer.bug.where "before" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1024,6 +1033,7 @@ test_expect_success 'using "ifExists = addIfDifferentNeighbor"  with "where = af
 	git config trailer.ack.where "after" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.bug.key "Bug #" &&
+	test_config trailer.bug.where "before" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1048,6 +1058,7 @@ test_expect_success 'using "ifExists = addIfDifferentNeighbor" and --trim-empty'
 	git config trailer.ack.ifExists "addIfDifferentNeighbor" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.bug.key "Bug #" &&
+	test_config trailer.bug.where "before" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	cat >>expected <<-\EOF &&
@@ -1068,6 +1079,7 @@ test_expect_success 'using "ifExists = add" with "where = end"' '
 	git config trailer.ack.where "end" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.bug.key "Bug #" &&
+	test_config trailer.bug.where "before" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1096,6 +1108,7 @@ test_expect_success 'using "ifExists = add" with "where = after"' '
 	git config trailer.ack.where "after" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.bug.key "Bug #" &&
+	test_config trailer.bug.where "before" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1121,6 +1134,7 @@ test_expect_success 'overriding configuration with "--if-exists replace"' '
 	git config trailer.fix.ifExists "add" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.bug.key "Bug #" &&
+	test_config trailer.bug.where "before" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1141,6 +1155,7 @@ test_expect_success 'using "ifExists = replace"' '
 	git config trailer.fix.ifExists "replace" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.bug.key "Bug #" &&
+	test_config trailer.bug.where "before" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1163,6 +1178,7 @@ test_expect_success 'using "ifExists = replace" with "where = after"' '
 	git config trailer.fix.where "after" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.bug.key "Bug #" &&
+	test_config trailer.bug.where "before" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1185,6 +1201,7 @@ test_expect_success 'using "ifExists = doNothing"' '
 	git config trailer.fix.ifExists "doNothing" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.bug.key "Bug #" &&
+	test_config trailer.bug.where "before" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1208,6 +1225,7 @@ test_expect_success 'the default is "ifMissing = add"' '
 	git config trailer.cc.where "before" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.bug.key "Bug #" &&
+	test_config trailer.bug.where "before" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1275,6 +1293,7 @@ test_expect_success 'using "ifMissing = add" with "where = end"' '
 	git config trailer.cc.ifMissing "add" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.bug.key "Bug #" &&
+	test_config trailer.bug.where "before" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1300,6 +1319,7 @@ test_expect_success 'using "ifMissing = add" with "where = before"' '
 	git config trailer.cc.ifMissing "add" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.bug.key "Bug #" &&
+	test_config trailer.bug.where "before" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1323,6 +1343,7 @@ test_expect_success 'using "ifMissing = doNothing"' '
 	git config trailer.cc.ifMissing "doNothing" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.bug.key "Bug #" &&
+	test_config trailer.bug.where "before" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1346,6 +1367,7 @@ test_expect_success 'default "where" is now "after"' '
 	git config --unset trailer.ack.where &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.bug.key "Bug #" &&
+	test_config trailer.bug.where "before" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&

--- a/t/t7513-interpret-trailers.sh
+++ b/t/t7513-interpret-trailers.sh
@@ -1461,11 +1461,11 @@ test_expect_success 'default "where" is now "after"' '
 test_expect_success 'with simple command' '
 	git config trailer.sign.key "Signed-off-by: " &&
 	git config trailer.sign.where "after" &&
-	git config trailer.sign.ifExists "addIfDifferentNeighbor" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.fix.ifExists "doNothing" &&
 	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.sign.command "echo \"A U Thor <author@example.com>\"" &&
+	test_config trailer.sign.ifExists "addIfDifferentNeighbor" &&
 	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=" &&
 	cat complex_message_body >expected &&
@@ -1482,11 +1482,11 @@ test_expect_success 'with simple command' '
 '
 
 test_expect_success 'with command using committer information' '
-	git config trailer.sign.ifExists "addIfDifferent" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.fix.ifExists "doNothing" &&
 	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.sign.command "echo \"\$GIT_COMMITTER_NAME <\$GIT_COMMITTER_EMAIL>\"" &&
+	test_config trailer.sign.ifExists "addIfDifferent" &&
 	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=" &&
 	cat complex_message_body >expected &&
@@ -1505,11 +1505,11 @@ test_expect_success 'with command using committer information' '
 test_expect_success 'with command using author information' '
 	git config trailer.sign.key "Signed-off-by: " &&
 	git config trailer.sign.where "after" &&
-	git config trailer.sign.ifExists "addIfDifferentNeighbor" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.fix.ifExists "doNothing" &&
 	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.sign.command "echo \"\$GIT_AUTHOR_NAME <\$GIT_AUTHOR_EMAIL>\"" &&
+	test_config trailer.sign.ifExists "addIfDifferentNeighbor" &&
 	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=" &&
 	cat complex_message_body >expected &&

--- a/t/t7513-interpret-trailers.sh
+++ b/t/t7513-interpret-trailers.sh
@@ -1154,7 +1154,7 @@ test_expect_success 'using "ifExists = add" with "where = after"' '
 
 test_expect_success 'overriding configuration with "--if-exists replace"' '
 	test_config trailer.fix.key "Fixes: " &&
-	git config trailer.fix.ifExists "add" &&
+	test_config trailer.fix.ifExists "add" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.ack.where "after" &&
 	test_config trailer.bug.key "Bug #" &&
@@ -1178,7 +1178,7 @@ test_expect_success 'overriding configuration with "--if-exists replace"' '
 
 test_expect_success 'using "ifExists = replace"' '
 	test_config trailer.fix.key "Fixes: " &&
-	git config trailer.fix.ifExists "replace" &&
+	test_config trailer.fix.ifExists "replace" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.ack.where "after" &&
 	test_config trailer.bug.key "Bug #" &&
@@ -1210,6 +1210,7 @@ test_expect_success 'using "ifExists = replace" with "where = after"' '
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
 	test_config trailer.fix.key "Fixes: " &&
+	test_config trailer.fix.ifExists "replace" &&
 	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=#" &&
@@ -1231,7 +1232,7 @@ test_expect_success 'using "ifExists = replace" with "where = after"' '
 '
 
 test_expect_success 'using "ifExists = doNothing"' '
-	git config trailer.fix.ifExists "doNothing" &&
+	test_config trailer.fix.ifExists "doNothing" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.ack.where "after" &&
 	test_config trailer.bug.key "Bug #" &&
@@ -1265,6 +1266,7 @@ test_expect_success 'the default is "ifMissing = add"' '
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
 	test_config trailer.fix.key "Fixes: " &&
+	test_config trailer.fix.ifExists "doNothing" &&
 	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=#" &&
@@ -1291,6 +1293,7 @@ test_expect_success 'overriding configuration with "--if-missing doNothing"' '
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.ack.where "after" &&
 	test_config trailer.fix.key "Fixes: " &&
+	test_config trailer.fix.ifExists "doNothing" &&
 	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=" &&
@@ -1315,6 +1318,7 @@ test_expect_success 'when default "ifMissing" is "doNothing"' '
 	git config trailer.ifmissing "doNothing" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.ack.where "after" &&
+	test_config trailer.fix.ifExists "doNothing" &&
 	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=" &&
@@ -1343,6 +1347,7 @@ test_expect_success 'using "ifMissing = add" with "where = end"' '
 	test_config trailer.ack.where "after" &&
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
+	test_config trailer.fix.ifExists "doNothing" &&
 	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=#" &&
@@ -1372,6 +1377,7 @@ test_expect_success 'using "ifMissing = add" with "where = before"' '
 	test_config trailer.ack.where "after" &&
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
+	test_config trailer.fix.ifExists "doNothing" &&
 	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=#" &&
@@ -1399,6 +1405,7 @@ test_expect_success 'using "ifMissing = doNothing"' '
 	test_config trailer.ack.where "after" &&
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
+	test_config trailer.fix.ifExists "doNothing" &&
 	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=#" &&
@@ -1426,6 +1433,7 @@ test_expect_success 'default "where" is now "after"' '
 	test_config trailer.ack.where "after" &&
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
+	test_config trailer.fix.ifExists "doNothing" &&
 	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=#" &&
@@ -1457,6 +1465,7 @@ test_expect_success 'with simple command' '
 	git config trailer.sign.ifExists "addIfDifferentNeighbor" &&
 	git config trailer.sign.command "echo \"A U Thor <author@example.com>\"" &&
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.fix.ifExists "doNothing" &&
 	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=" &&
@@ -1477,6 +1486,7 @@ test_expect_success 'with command using committer information' '
 	git config trailer.sign.ifExists "addIfDifferent" &&
 	git config trailer.sign.command "echo \"\$GIT_COMMITTER_NAME <\$GIT_COMMITTER_EMAIL>\"" &&
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.fix.ifExists "doNothing" &&
 	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=" &&
@@ -1499,6 +1509,7 @@ test_expect_success 'with command using author information' '
 	git config trailer.sign.ifExists "addIfDifferentNeighbor" &&
 	git config trailer.sign.command "echo \"\$GIT_AUTHOR_NAME <\$GIT_AUTHOR_EMAIL>\"" &&
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.fix.ifExists "doNothing" &&
 	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=" &&
@@ -1523,13 +1534,13 @@ test_expect_success 'setup a commit' '
 
 test_expect_success 'cmd takes precedence over command' '
 	test_when_finished "git config --unset trailer.fix.cmd" &&
-	git config trailer.fix.ifExists "replace" &&
 	git config trailer.fix.cmd "test -n \"\$1\" && git log -1 --oneline --format=\"%h (%aN)\" \
 	--abbrev-commit --abbrev=14 \"\$1\" || true" &&
 	git config trailer.fix.command "git log -1 --oneline --format=\"%h (%s)\" \
 		--abbrev-commit --abbrev=14 \$ARG" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.fix.key "Fixes: " &&
+	test_config trailer.fix.ifExists "replace" &&
 	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=" &&
@@ -1548,10 +1559,10 @@ test_expect_success 'cmd takes precedence over command' '
 '
 
 test_expect_success 'with command using $ARG' '
-	git config trailer.fix.ifExists "replace" &&
 	git config trailer.fix.command "git log -1 --oneline --format=\"%h (%s)\" --abbrev-commit --abbrev=14 \$ARG" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.fix.key "Fixes: " &&
+	test_config trailer.fix.ifExists "replace" &&
 	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=" &&
@@ -1570,10 +1581,10 @@ test_expect_success 'with command using $ARG' '
 '
 
 test_expect_success 'with failing command using $ARG' '
-	git config trailer.fix.ifExists "replace" &&
 	git config trailer.fix.command "false \$ARG" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.fix.key "Fixes: " &&
+	test_config trailer.fix.ifExists "replace" &&
 	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=" &&

--- a/t/t7513-interpret-trailers.sh
+++ b/t/t7513-interpret-trailers.sh
@@ -1460,12 +1460,12 @@ test_expect_success 'default "where" is now "after"' '
 
 test_expect_success 'with simple command' '
 	git config trailer.sign.key "Signed-off-by: " &&
-	git config trailer.sign.where "after" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.fix.ifExists "doNothing" &&
 	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.sign.command "echo \"A U Thor <author@example.com>\"" &&
 	test_config trailer.sign.ifExists "addIfDifferentNeighbor" &&
+	test_config trailer.sign.where "after" &&
 	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=" &&
 	cat complex_message_body >expected &&
@@ -1504,12 +1504,12 @@ test_expect_success 'with command using committer information' '
 
 test_expect_success 'with command using author information' '
 	git config trailer.sign.key "Signed-off-by: " &&
-	git config trailer.sign.where "after" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.fix.ifExists "doNothing" &&
 	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.sign.command "echo \"\$GIT_AUTHOR_NAME <\$GIT_AUTHOR_EMAIL>\"" &&
 	test_config trailer.sign.ifExists "addIfDifferentNeighbor" &&
+	test_config trailer.sign.where "after" &&
 	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=" &&
 	cat complex_message_body >expected &&

--- a/t/t7513-interpret-trailers.sh
+++ b/t/t7513-interpret-trailers.sh
@@ -945,7 +945,7 @@ test_expect_success 'the default is "ifExists = addIfDifferentNeighbor"' '
 '
 
 test_expect_success 'default "ifExists" is now "addIfDifferent"' '
-	git config trailer.ifexists "addIfDifferent" &&
+	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.ack.where "after" &&
 	test_config trailer.bug.key "Bug #" &&
@@ -975,6 +975,7 @@ test_expect_success 'using "ifExists = addIfDifferent" with "where = end"' '
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
 	test_config trailer.review.key "Reviewed-by:" &&
+	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -998,6 +999,7 @@ test_expect_success 'using "ifExists = addIfDifferent" with "where = before"' '
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
 	test_config trailer.review.key "Reviewed-by:" &&
+	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1021,6 +1023,7 @@ test_expect_success 'using "ifExists = addIfDifferentNeighbor" with "where = end
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
 	test_config trailer.review.key "Reviewed-by:" &&
+	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1049,6 +1052,7 @@ test_expect_success 'using "ifExists = addIfDifferentNeighbor"  with "where = af
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
 	test_config trailer.review.key "Reviewed-by:" &&
+	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1096,6 +1100,7 @@ test_expect_success 'using "ifExists = add" with "where = end"' '
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
 	test_config trailer.review.key "Reviewed-by:" &&
+	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1126,6 +1131,7 @@ test_expect_success 'using "ifExists = add" with "where = after"' '
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
 	test_config trailer.review.key "Reviewed-by:" &&
+	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1178,6 +1184,7 @@ test_expect_success 'using "ifExists = replace"' '
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
 	test_config trailer.review.key "Reviewed-by:" &&
+	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1203,6 +1210,7 @@ test_expect_success 'using "ifExists = replace" with "where = after"' '
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
 	test_config trailer.review.key "Reviewed-by:" &&
+	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1228,6 +1236,7 @@ test_expect_success 'using "ifExists = doNothing"' '
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
 	test_config trailer.review.key "Reviewed-by:" &&
+	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1254,6 +1263,7 @@ test_expect_success 'the default is "ifMissing = add"' '
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
 	test_config trailer.review.key "Reviewed-by:" &&
+	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1278,6 +1288,7 @@ test_expect_success 'overriding configuration with "--if-missing doNothing"' '
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.ack.where "after" &&
 	test_config trailer.review.key "Reviewed-by:" &&
+	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1301,6 +1312,7 @@ test_expect_success 'when default "ifMissing" is "doNothing"' '
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.ack.where "after" &&
 	test_config trailer.review.key "Reviewed-by:" &&
+	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1328,6 +1340,7 @@ test_expect_success 'using "ifMissing = add" with "where = end"' '
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
 	test_config trailer.review.key "Reviewed-by:" &&
+	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1356,6 +1369,7 @@ test_expect_success 'using "ifMissing = add" with "where = before"' '
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
 	test_config trailer.review.key "Reviewed-by:" &&
+	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1382,6 +1396,7 @@ test_expect_success 'using "ifMissing = doNothing"' '
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
 	test_config trailer.review.key "Reviewed-by:" &&
+	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1407,6 +1422,7 @@ test_expect_success 'default "where" is now "after"' '
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
 	test_config trailer.review.key "Reviewed-by:" &&
+	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1437,6 +1453,7 @@ test_expect_success 'with simple command' '
 	git config trailer.sign.command "echo \"A U Thor <author@example.com>\"" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.review.key "Reviewed-by:" &&
+	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1456,6 +1473,7 @@ test_expect_success 'with command using committer information' '
 	git config trailer.sign.command "echo \"\$GIT_COMMITTER_NAME <\$GIT_COMMITTER_EMAIL>\"" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.review.key "Reviewed-by:" &&
+	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1477,6 +1495,7 @@ test_expect_success 'with command using author information' '
 	git config trailer.sign.command "echo \"\$GIT_AUTHOR_NAME <\$GIT_AUTHOR_EMAIL>\"" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.review.key "Reviewed-by:" &&
+	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1506,6 +1525,7 @@ test_expect_success 'cmd takes precedence over command' '
 		--abbrev-commit --abbrev=14 \$ARG" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.review.key "Reviewed-by:" &&
+	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=" &&
 	FIXED=$(git log -1 --oneline --format="%h (%aN)" --abbrev-commit --abbrev=14 HEAD) &&
 	cat complex_message_body >expected2 &&
@@ -1526,6 +1546,7 @@ test_expect_success 'with command using $ARG' '
 	git config trailer.fix.command "git log -1 --oneline --format=\"%h (%s)\" --abbrev-commit --abbrev=14 \$ARG" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.review.key "Reviewed-by:" &&
+	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=" &&
 	FIXED=$(git log -1 --oneline --format="%h (%s)" --abbrev-commit --abbrev=14 HEAD) &&
 	cat complex_message_body >expected &&
@@ -1546,6 +1567,7 @@ test_expect_success 'with failing command using $ARG' '
 	git config trailer.fix.command "false \$ARG" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.review.key "Reviewed-by:" &&
+	test_config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.separators ":=" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-EOF &&
@@ -1562,6 +1584,7 @@ test_expect_success 'with failing command using $ARG' '
 
 test_expect_success 'with empty tokens' '
 	git config --unset trailer.fix.command &&
+	test_config trailer.ifexists "addIfDifferent" &&
 	cat >expected <<-EOF &&
 
 		Signed-off-by: A U Thor <author@example.com>
@@ -1573,6 +1596,7 @@ test_expect_success 'with empty tokens' '
 
 test_expect_success 'with command but no key' '
 	git config --unset trailer.sign.key &&
+	test_config trailer.ifexists "addIfDifferent" &&
 	cat >expected <<-EOF &&
 
 		sign: A U Thor <author@example.com>
@@ -1584,6 +1608,7 @@ test_expect_success 'with command but no key' '
 
 test_expect_success 'with no command and no key' '
 	test_config trailer.review.where "before" &&
+	test_config trailer.ifexists "addIfDifferent" &&
 	cat >expected <<-EOF &&
 
 		review: Junio
@@ -1613,6 +1638,7 @@ test_expect_success 'with cut line' '
 '
 
 test_expect_success 'only trailers' '
+	test_config trailer.ifexists "addIfDifferent" &&
 	git config trailer.sign.command "echo config-value" &&
 	cat >expected <<-\EOF &&
 		existing: existing-value

--- a/t/t7513-interpret-trailers.sh
+++ b/t/t7513-interpret-trailers.sh
@@ -969,7 +969,7 @@ test_expect_success 'default "ifExists" is now "addIfDifferent"' '
 '
 
 test_expect_success 'using "ifExists = addIfDifferent" with "where = end"' '
-	git config trailer.ack.ifExists "addIfDifferent" &&
+	test_config trailer.ack.ifExists "addIfDifferent" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.ack.where "end" &&
 	test_config trailer.bug.key "Bug #" &&
@@ -993,7 +993,7 @@ test_expect_success 'using "ifExists = addIfDifferent" with "where = end"' '
 '
 
 test_expect_success 'using "ifExists = addIfDifferent" with "where = before"' '
-	git config trailer.ack.ifExists "addIfDifferent" &&
+	test_config trailer.ack.ifExists "addIfDifferent" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.ack.where "before" &&
 	test_config trailer.bug.key "Bug #" &&
@@ -1017,7 +1017,7 @@ test_expect_success 'using "ifExists = addIfDifferent" with "where = before"' '
 '
 
 test_expect_success 'using "ifExists = addIfDifferentNeighbor" with "where = end"' '
-	git config trailer.ack.ifExists "addIfDifferentNeighbor" &&
+	test_config trailer.ack.ifExists "addIfDifferentNeighbor" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.ack.where "end" &&
 	test_config trailer.bug.key "Bug #" &&
@@ -1046,7 +1046,7 @@ test_expect_success 'using "ifExists = addIfDifferentNeighbor" with "where = end
 '
 
 test_expect_success 'using "ifExists = addIfDifferentNeighbor"  with "where = after"' '
-	git config trailer.ack.ifExists "addIfDifferentNeighbor" &&
+	test_config trailer.ack.ifExists "addIfDifferentNeighbor" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.ack.where "after" &&
 	test_config trailer.bug.key "Bug #" &&
@@ -1074,7 +1074,7 @@ test_expect_success 'using "ifExists = addIfDifferentNeighbor"  with "where = af
 '
 
 test_expect_success 'using "ifExists = addIfDifferentNeighbor" and --trim-empty' '
-	git config trailer.ack.ifExists "addIfDifferentNeighbor" &&
+	test_config trailer.ack.ifExists "addIfDifferentNeighbor" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
@@ -1094,7 +1094,7 @@ test_expect_success 'using "ifExists = addIfDifferentNeighbor" and --trim-empty'
 '
 
 test_expect_success 'using "ifExists = add" with "where = end"' '
-	git config trailer.ack.ifExists "add" &&
+	test_config trailer.ack.ifExists "add" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.ack.where "end" &&
 	test_config trailer.bug.key "Bug #" &&
@@ -1125,7 +1125,7 @@ test_expect_success 'using "ifExists = add" with "where = end"' '
 '
 
 test_expect_success 'using "ifExists = add" with "where = after"' '
-	git config trailer.ack.ifExists "add" &&
+	test_config trailer.ack.ifExists "add" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.ack.where "after" &&
 	test_config trailer.bug.key "Bug #" &&
@@ -1417,6 +1417,7 @@ test_expect_success 'using "ifMissing = doNothing"' '
 
 test_expect_success 'default "where" is now "after"' '
 	git config trailer.where "after" &&
+	test_config trailer.ack.ifExists "add" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.ack.where "after" &&
 	test_config trailer.bug.key "Bug #" &&

--- a/t/t7513-interpret-trailers.sh
+++ b/t/t7513-interpret-trailers.sh
@@ -1339,12 +1339,12 @@ test_expect_success 'when default "ifMissing" is "doNothing"' '
 '
 
 test_expect_success 'using "ifMissing = add" with "where = end"' '
-	git config trailer.cc.ifMissing "add" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.ack.where "after" &&
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
 	test_config trailer.cc.key "Cc: " &&
+	test_config trailer.cc.ifMissing "add" &&
 	test_config trailer.cc.where "end" &&
 	test_config trailer.fix.ifExists "doNothing" &&
 	test_config trailer.review.key "Reviewed-by:" &&
@@ -1369,12 +1369,12 @@ test_expect_success 'using "ifMissing = add" with "where = end"' '
 '
 
 test_expect_success 'using "ifMissing = add" with "where = before"' '
-	git config trailer.cc.ifMissing "add" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.ack.where "after" &&
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
 	test_config trailer.cc.key "Cc: " &&
+	test_config trailer.cc.ifMissing "add" &&
 	test_config trailer.cc.where "before" &&
 	test_config trailer.fix.ifExists "doNothing" &&
 	test_config trailer.review.key "Reviewed-by:" &&
@@ -1399,11 +1399,11 @@ test_expect_success 'using "ifMissing = add" with "where = before"' '
 '
 
 test_expect_success 'using "ifMissing = doNothing"' '
-	git config trailer.cc.ifMissing "doNothing" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.ack.where "after" &&
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
+	test_config trailer.cc.ifMissing "doNothing" &&
 	test_config trailer.fix.ifExists "doNothing" &&
 	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.ifexists "addIfDifferent" &&

--- a/t/t7513-interpret-trailers.sh
+++ b/t/t7513-interpret-trailers.sh
@@ -778,7 +778,7 @@ test_expect_success 'using "where = before"' '
 test_expect_success 'overriding configuration with "--where after"' '
 	test_config trailer.separators ":=" &&
 	test_config trailer.ack.key "Acked-by= " &&
-	git config trailer.ack.where "before" &&
+	test_config trailer.ack.where "before" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
 		Fixes: Z
@@ -794,6 +794,7 @@ test_expect_success 'overriding configuration with "--where after"' '
 
 test_expect_success 'using "where = before" with "--no-where"' '
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.ack.where "before" &&
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
 	test_config trailer.separators ":=#" &&
@@ -812,8 +813,8 @@ test_expect_success 'using "where = before" with "--no-where"' '
 '
 
 test_expect_success 'using "where = after"' '
-	git config trailer.ack.where "after" &&
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.ack.where "after" &&
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
 	test_config trailer.separators ":=#" &&
@@ -835,6 +836,7 @@ test_expect_success 'using "where = end"' '
 	git config trailer.review.key "Reviewed-by" &&
 	git config trailer.review.where "end" &&
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.ack.where "after" &&
 	test_config trailer.separators ":=" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -856,6 +858,7 @@ test_expect_success 'using "where = start"' '
 	git config trailer.review.key "Reviewed-by" &&
 	git config trailer.review.where "start" &&
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.ack.where "after" &&
 	test_config trailer.separators ":=" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -877,6 +880,7 @@ test_expect_success 'using "where = before" for a token in the middle of the mes
 	git config trailer.review.key "Reviewed-by:" &&
 	git config trailer.review.where "before" &&
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.ack.where "after" &&
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
 	test_config trailer.separators ":=#" &&
@@ -897,6 +901,7 @@ test_expect_success 'using "where = before" for a token in the middle of the mes
 
 test_expect_success 'using "where = before" and --trim-empty' '
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.ack.where "after" &&
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
 	test_config trailer.separators ":=#" &&
@@ -915,6 +920,7 @@ test_expect_success 'using "where = before" and --trim-empty' '
 
 test_expect_success 'the default is "ifExists = addIfDifferentNeighbor"' '
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.ack.where "after" &&
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
 	test_config trailer.separators ":=#" &&
@@ -938,6 +944,7 @@ test_expect_success 'the default is "ifExists = addIfDifferentNeighbor"' '
 test_expect_success 'default "ifExists" is now "addIfDifferent"' '
 	git config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.ack.where "after" &&
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
 	test_config trailer.separators ":=#" &&
@@ -959,8 +966,8 @@ test_expect_success 'default "ifExists" is now "addIfDifferent"' '
 
 test_expect_success 'using "ifExists = addIfDifferent" with "where = end"' '
 	git config trailer.ack.ifExists "addIfDifferent" &&
-	git config trailer.ack.where "end" &&
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.ack.where "end" &&
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
 	test_config trailer.separators ":=#" &&
@@ -981,8 +988,8 @@ test_expect_success 'using "ifExists = addIfDifferent" with "where = end"' '
 
 test_expect_success 'using "ifExists = addIfDifferent" with "where = before"' '
 	git config trailer.ack.ifExists "addIfDifferent" &&
-	git config trailer.ack.where "before" &&
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.ack.where "before" &&
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
 	test_config trailer.separators ":=#" &&
@@ -1003,8 +1010,8 @@ test_expect_success 'using "ifExists = addIfDifferent" with "where = before"' '
 
 test_expect_success 'using "ifExists = addIfDifferentNeighbor" with "where = end"' '
 	git config trailer.ack.ifExists "addIfDifferentNeighbor" &&
-	git config trailer.ack.where "end" &&
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.ack.where "end" &&
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
 	test_config trailer.separators ":=#" &&
@@ -1030,8 +1037,8 @@ test_expect_success 'using "ifExists = addIfDifferentNeighbor" with "where = end
 
 test_expect_success 'using "ifExists = addIfDifferentNeighbor"  with "where = after"' '
 	git config trailer.ack.ifExists "addIfDifferentNeighbor" &&
-	git config trailer.ack.where "after" &&
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.ack.where "after" &&
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
 	test_config trailer.separators ":=#" &&
@@ -1076,8 +1083,8 @@ test_expect_success 'using "ifExists = addIfDifferentNeighbor" and --trim-empty'
 
 test_expect_success 'using "ifExists = add" with "where = end"' '
 	git config trailer.ack.ifExists "add" &&
-	git config trailer.ack.where "end" &&
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.ack.where "end" &&
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
 	test_config trailer.separators ":=#" &&
@@ -1105,8 +1112,8 @@ test_expect_success 'using "ifExists = add" with "where = end"' '
 
 test_expect_success 'using "ifExists = add" with "where = after"' '
 	git config trailer.ack.ifExists "add" &&
-	git config trailer.ack.where "after" &&
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.ack.where "after" &&
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
 	test_config trailer.separators ":=#" &&
@@ -1133,6 +1140,7 @@ test_expect_success 'overriding configuration with "--if-exists replace"' '
 	git config trailer.fix.key "Fixes: " &&
 	git config trailer.fix.ifExists "add" &&
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.ack.where "after" &&
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
 	test_config trailer.separators ":=#" &&
@@ -1154,6 +1162,7 @@ test_expect_success 'using "ifExists = replace"' '
 	git config trailer.fix.key "Fixes: " &&
 	git config trailer.fix.ifExists "replace" &&
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.ack.where "after" &&
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
 	test_config trailer.separators ":=#" &&
@@ -1177,6 +1186,7 @@ test_expect_success 'using "ifExists = replace"' '
 test_expect_success 'using "ifExists = replace" with "where = after"' '
 	git config trailer.fix.where "after" &&
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.ack.where "after" &&
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
 	test_config trailer.separators ":=#" &&
@@ -1200,6 +1210,7 @@ test_expect_success 'using "ifExists = replace" with "where = after"' '
 test_expect_success 'using "ifExists = doNothing"' '
 	git config trailer.fix.ifExists "doNothing" &&
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.ack.where "after" &&
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
 	test_config trailer.separators ":=#" &&
@@ -1224,6 +1235,7 @@ test_expect_success 'the default is "ifMissing = add"' '
 	git config trailer.cc.key "Cc: " &&
 	git config trailer.cc.where "before" &&
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.ack.where "after" &&
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
 	test_config trailer.separators ":=#" &&
@@ -1248,6 +1260,7 @@ test_expect_success 'the default is "ifMissing = add"' '
 test_expect_success 'overriding configuration with "--if-missing doNothing"' '
 	git config trailer.ifmissing "add" &&
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.ack.where "after" &&
 	test_config trailer.separators ":=" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1269,6 +1282,7 @@ test_expect_success 'overriding configuration with "--if-missing doNothing"' '
 test_expect_success 'when default "ifMissing" is "doNothing"' '
 	git config trailer.ifmissing "doNothing" &&
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.ack.where "after" &&
 	test_config trailer.separators ":=" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1292,6 +1306,7 @@ test_expect_success 'using "ifMissing = add" with "where = end"' '
 	git config trailer.cc.where "end" &&
 	git config trailer.cc.ifMissing "add" &&
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.ack.where "after" &&
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
 	test_config trailer.separators ":=#" &&
@@ -1318,6 +1333,7 @@ test_expect_success 'using "ifMissing = add" with "where = before"' '
 	git config trailer.cc.where "before" &&
 	git config trailer.cc.ifMissing "add" &&
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.ack.where "after" &&
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
 	test_config trailer.separators ":=#" &&
@@ -1342,6 +1358,7 @@ test_expect_success 'using "ifMissing = add" with "where = before"' '
 test_expect_success 'using "ifMissing = doNothing"' '
 	git config trailer.cc.ifMissing "doNothing" &&
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.ack.where "after" &&
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
 	test_config trailer.separators ":=#" &&
@@ -1364,8 +1381,8 @@ test_expect_success 'using "ifMissing = doNothing"' '
 
 test_expect_success 'default "where" is now "after"' '
 	git config trailer.where "after" &&
-	git config --unset trailer.ack.where &&
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.ack.where "after" &&
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
 	test_config trailer.separators ":=#" &&

--- a/t/t7513-interpret-trailers.sh
+++ b/t/t7513-interpret-trailers.sh
@@ -489,7 +489,7 @@ test_expect_success 'multiline field treated as atomic for neighbor check' '
 '
 
 test_expect_success 'with config setup' '
-	git config trailer.ack.key "Acked-by: " &&
+	test_config trailer.ack.key "Acked-by: " &&
 	cat >expected <<-\EOF &&
 
 		Acked-by: Peff
@@ -504,7 +504,7 @@ test_expect_success 'with config setup' '
 
 test_expect_success 'with config setup and ":=" as separators' '
 	test_config trailer.separators ":=" &&
-	git config trailer.ack.key "Acked-by= " &&
+	test_config trailer.ack.key "Acked-by= " &&
 	cat >expected <<-\EOF &&
 
 		Acked-by= Peff
@@ -583,6 +583,7 @@ test_expect_success 'with basic patch' '
 
 test_expect_success 'with commit complex message as argument' '
 	test_config trailer.separators ":=" &&
+	test_config trailer.ack.key "Acked-by= " &&
 	cat complex_message_body complex_message_trailers >complex_message &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -597,6 +598,7 @@ test_expect_success 'with commit complex message as argument' '
 
 test_expect_success 'with 2 files arguments' '
 	test_config trailer.separators ":=" &&
+	test_config trailer.ack.key "Acked-by= " &&
 	cat basic_message >>expected &&
 	echo >>expected &&
 	cat basic_patch >>expected &&
@@ -681,6 +683,7 @@ test_expect_success 'with message that has an old style conflict block' '
 
 test_expect_success 'with commit complex message and trailer args' '
 	test_config trailer.separators ":=#" &&
+	test_config trailer.ack.key "Acked-by= " &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
 		Fixes: Z
@@ -697,6 +700,7 @@ test_expect_success 'with commit complex message and trailer args' '
 
 test_expect_success 'with complex patch, args and --trim-empty' '
 	test_config trailer.separators ":=#" &&
+	test_config trailer.ack.key "Acked-by= " &&
 	cat complex_message >complex_patch &&
 	cat basic_patch >>complex_patch &&
 	cat complex_message_body >expected &&
@@ -752,6 +756,7 @@ test_expect_success POSIXPERM,SANITY "in-place editing doesn't clobber original 
 
 test_expect_success 'using "where = before"' '
 	test_config trailer.separators ":=#" &&
+	test_config trailer.ack.key "Acked-by= " &&
 	git config trailer.bug.where "before" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -769,6 +774,7 @@ test_expect_success 'using "where = before"' '
 
 test_expect_success 'overriding configuration with "--where after"' '
 	test_config trailer.separators ":=" &&
+	test_config trailer.ack.key "Acked-by= " &&
 	git config trailer.ack.where "before" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -784,6 +790,7 @@ test_expect_success 'overriding configuration with "--where after"' '
 '
 
 test_expect_success 'using "where = before" with "--no-where"' '
+	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -801,6 +808,7 @@ test_expect_success 'using "where = before" with "--no-where"' '
 
 test_expect_success 'using "where = after"' '
 	git config trailer.ack.where "after" &&
+	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -819,6 +827,7 @@ test_expect_success 'using "where = after"' '
 test_expect_success 'using "where = end"' '
 	git config trailer.review.key "Reviewed-by" &&
 	git config trailer.review.where "end" &&
+	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.separators ":=" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -839,6 +848,7 @@ test_expect_success 'using "where = end"' '
 test_expect_success 'using "where = start"' '
 	git config trailer.review.key "Reviewed-by" &&
 	git config trailer.review.where "start" &&
+	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.separators ":=" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -859,6 +869,7 @@ test_expect_success 'using "where = start"' '
 test_expect_success 'using "where = before" for a token in the middle of the message' '
 	git config trailer.review.key "Reviewed-by:" &&
 	git config trailer.review.where "before" &&
+	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -876,6 +887,7 @@ test_expect_success 'using "where = before" for a token in the middle of the mes
 '
 
 test_expect_success 'using "where = before" and --trim-empty' '
+	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	cat >>expected <<-\EOF &&
@@ -891,6 +903,7 @@ test_expect_success 'using "where = before" and --trim-empty' '
 '
 
 test_expect_success 'the default is "ifExists = addIfDifferentNeighbor"' '
+	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -911,6 +924,7 @@ test_expect_success 'the default is "ifExists = addIfDifferentNeighbor"' '
 
 test_expect_success 'default "ifExists" is now "addIfDifferent"' '
 	git config trailer.ifexists "addIfDifferent" &&
+	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -931,6 +945,7 @@ test_expect_success 'default "ifExists" is now "addIfDifferent"' '
 test_expect_success 'using "ifExists = addIfDifferent" with "where = end"' '
 	git config trailer.ack.ifExists "addIfDifferent" &&
 	git config trailer.ack.where "end" &&
+	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -950,6 +965,7 @@ test_expect_success 'using "ifExists = addIfDifferent" with "where = end"' '
 test_expect_success 'using "ifExists = addIfDifferent" with "where = before"' '
 	git config trailer.ack.ifExists "addIfDifferent" &&
 	git config trailer.ack.where "before" &&
+	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -969,6 +985,7 @@ test_expect_success 'using "ifExists = addIfDifferent" with "where = before"' '
 test_expect_success 'using "ifExists = addIfDifferentNeighbor" with "where = end"' '
 	git config trailer.ack.ifExists "addIfDifferentNeighbor" &&
 	git config trailer.ack.where "end" &&
+	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -993,6 +1010,7 @@ test_expect_success 'using "ifExists = addIfDifferentNeighbor" with "where = end
 test_expect_success 'using "ifExists = addIfDifferentNeighbor"  with "where = after"' '
 	git config trailer.ack.ifExists "addIfDifferentNeighbor" &&
 	git config trailer.ack.where "after" &&
+	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1015,6 +1033,7 @@ test_expect_success 'using "ifExists = addIfDifferentNeighbor"  with "where = af
 
 test_expect_success 'using "ifExists = addIfDifferentNeighbor" and --trim-empty' '
 	git config trailer.ack.ifExists "addIfDifferentNeighbor" &&
+	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	cat >>expected <<-\EOF &&
@@ -1033,6 +1052,7 @@ test_expect_success 'using "ifExists = addIfDifferentNeighbor" and --trim-empty'
 test_expect_success 'using "ifExists = add" with "where = end"' '
 	git config trailer.ack.ifExists "add" &&
 	git config trailer.ack.where "end" &&
+	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1059,6 +1079,7 @@ test_expect_success 'using "ifExists = add" with "where = end"' '
 test_expect_success 'using "ifExists = add" with "where = after"' '
 	git config trailer.ack.ifExists "add" &&
 	git config trailer.ack.where "after" &&
+	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1082,6 +1103,7 @@ test_expect_success 'using "ifExists = add" with "where = after"' '
 test_expect_success 'overriding configuration with "--if-exists replace"' '
 	git config trailer.fix.key "Fixes: " &&
 	git config trailer.fix.ifExists "add" &&
+	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1100,6 +1122,7 @@ test_expect_success 'overriding configuration with "--if-exists replace"' '
 test_expect_success 'using "ifExists = replace"' '
 	git config trailer.fix.key "Fixes: " &&
 	git config trailer.fix.ifExists "replace" &&
+	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1120,6 +1143,7 @@ test_expect_success 'using "ifExists = replace"' '
 
 test_expect_success 'using "ifExists = replace" with "where = after"' '
 	git config trailer.fix.where "after" &&
+	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1140,6 +1164,7 @@ test_expect_success 'using "ifExists = replace" with "where = after"' '
 
 test_expect_success 'using "ifExists = doNothing"' '
 	git config trailer.fix.ifExists "doNothing" &&
+	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1161,6 +1186,7 @@ test_expect_success 'using "ifExists = doNothing"' '
 test_expect_success 'the default is "ifMissing = add"' '
 	git config trailer.cc.key "Cc: " &&
 	git config trailer.cc.where "before" &&
+	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1182,6 +1208,7 @@ test_expect_success 'the default is "ifMissing = add"' '
 
 test_expect_success 'overriding configuration with "--if-missing doNothing"' '
 	git config trailer.ifmissing "add" &&
+	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.separators ":=" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1202,6 +1229,7 @@ test_expect_success 'overriding configuration with "--if-missing doNothing"' '
 
 test_expect_success 'when default "ifMissing" is "doNothing"' '
 	git config trailer.ifmissing "doNothing" &&
+	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.separators ":=" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1224,6 +1252,7 @@ test_expect_success 'using "ifMissing = add" with "where = end"' '
 	git config trailer.cc.key "Cc: " &&
 	git config trailer.cc.where "end" &&
 	git config trailer.cc.ifMissing "add" &&
+	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1247,6 +1276,7 @@ test_expect_success 'using "ifMissing = add" with "where = before"' '
 	git config trailer.cc.key "Cc: " &&
 	git config trailer.cc.where "before" &&
 	git config trailer.cc.ifMissing "add" &&
+	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1268,6 +1298,7 @@ test_expect_success 'using "ifMissing = add" with "where = before"' '
 
 test_expect_success 'using "ifMissing = doNothing"' '
 	git config trailer.cc.ifMissing "doNothing" &&
+	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1289,6 +1320,7 @@ test_expect_success 'using "ifMissing = doNothing"' '
 test_expect_success 'default "where" is now "after"' '
 	git config trailer.where "after" &&
 	git config --unset trailer.ack.where &&
+	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1317,6 +1349,7 @@ test_expect_success 'with simple command' '
 	git config trailer.sign.where "after" &&
 	git config trailer.sign.ifExists "addIfDifferentNeighbor" &&
 	git config trailer.sign.command "echo \"A U Thor <author@example.com>\"" &&
+	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.separators ":=" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1334,6 +1367,7 @@ test_expect_success 'with simple command' '
 test_expect_success 'with command using committer information' '
 	git config trailer.sign.ifExists "addIfDifferent" &&
 	git config trailer.sign.command "echo \"\$GIT_COMMITTER_NAME <\$GIT_COMMITTER_EMAIL>\"" &&
+	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.separators ":=" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1353,6 +1387,7 @@ test_expect_success 'with command using author information' '
 	git config trailer.sign.where "after" &&
 	git config trailer.sign.ifExists "addIfDifferentNeighbor" &&
 	git config trailer.sign.command "echo \"\$GIT_AUTHOR_NAME <\$GIT_AUTHOR_EMAIL>\"" &&
+	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.separators ":=" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1380,6 +1415,7 @@ test_expect_success 'cmd takes precedence over command' '
 	--abbrev-commit --abbrev=14 \"\$1\" || true" &&
 	git config trailer.fix.command "git log -1 --oneline --format=\"%h (%s)\" \
 		--abbrev-commit --abbrev=14 \$ARG" &&
+	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.separators ":=" &&
 	FIXED=$(git log -1 --oneline --format="%h (%aN)" --abbrev-commit --abbrev=14 HEAD) &&
 	cat complex_message_body >expected2 &&
@@ -1398,6 +1434,7 @@ test_expect_success 'cmd takes precedence over command' '
 test_expect_success 'with command using $ARG' '
 	git config trailer.fix.ifExists "replace" &&
 	git config trailer.fix.command "git log -1 --oneline --format=\"%h (%s)\" --abbrev-commit --abbrev=14 \$ARG" &&
+	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.separators ":=" &&
 	FIXED=$(git log -1 --oneline --format="%h (%s)" --abbrev-commit --abbrev=14 HEAD) &&
 	cat complex_message_body >expected &&
@@ -1416,6 +1453,7 @@ test_expect_success 'with command using $ARG' '
 test_expect_success 'with failing command using $ARG' '
 	git config trailer.fix.ifExists "replace" &&
 	git config trailer.fix.command "false \$ARG" &&
+	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.separators ":=" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-EOF &&

--- a/t/t7513-interpret-trailers.sh
+++ b/t/t7513-interpret-trailers.sh
@@ -1533,12 +1533,11 @@ test_expect_success 'setup a commit' '
 '
 
 test_expect_success 'cmd takes precedence over command' '
-	test_when_finished "git config --unset trailer.fix.cmd" &&
-	git config trailer.fix.cmd "test -n \"\$1\" && git log -1 --oneline --format=\"%h (%aN)\" \
-	--abbrev-commit --abbrev=14 \"\$1\" || true" &&
 	git config trailer.fix.command "git log -1 --oneline --format=\"%h (%s)\" \
 		--abbrev-commit --abbrev=14 \$ARG" &&
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.fix.cmd "test -n \"\$1\" && git log -1 --oneline --format=\"%h (%aN)\" \
+	--abbrev-commit --abbrev=14 \"\$1\" || true" &&
 	test_config trailer.fix.key "Fixes: " &&
 	test_config trailer.fix.ifExists "replace" &&
 	test_config trailer.fix.where "after" &&

--- a/t/t7513-interpret-trailers.sh
+++ b/t/t7513-interpret-trailers.sh
@@ -555,7 +555,7 @@ test_expect_success 'with "%" as separators and a message with trailers' '
 
 test_expect_success 'with config setup and ":=#" as separators' '
 	test_config trailer.separators ":=#" &&
-	git config trailer.bug.key "Bug #" &&
+	test_config trailer.bug.key "Bug #" &&
 	cat >expected <<-\EOF &&
 
 		Bug #42
@@ -684,6 +684,7 @@ test_expect_success 'with message that has an old style conflict block' '
 test_expect_success 'with commit complex message and trailer args' '
 	test_config trailer.separators ":=#" &&
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.bug.key "Bug #" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
 		Fixes: Z
@@ -701,6 +702,7 @@ test_expect_success 'with commit complex message and trailer args' '
 test_expect_success 'with complex patch, args and --trim-empty' '
 	test_config trailer.separators ":=#" &&
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.bug.key "Bug #" &&
 	cat complex_message >complex_patch &&
 	cat basic_patch >>complex_patch &&
 	cat complex_message_body >expected &&
@@ -757,6 +759,7 @@ test_expect_success POSIXPERM,SANITY "in-place editing doesn't clobber original 
 test_expect_success 'using "where = before"' '
 	test_config trailer.separators ":=#" &&
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.bug.key "Bug #" &&
 	git config trailer.bug.where "before" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -791,6 +794,7 @@ test_expect_success 'overriding configuration with "--where after"' '
 
 test_expect_success 'using "where = before" with "--no-where"' '
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -809,6 +813,7 @@ test_expect_success 'using "where = before" with "--no-where"' '
 test_expect_success 'using "where = after"' '
 	git config trailer.ack.where "after" &&
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -870,6 +875,7 @@ test_expect_success 'using "where = before" for a token in the middle of the mes
 	git config trailer.review.key "Reviewed-by:" &&
 	git config trailer.review.where "before" &&
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -888,6 +894,7 @@ test_expect_success 'using "where = before" for a token in the middle of the mes
 
 test_expect_success 'using "where = before" and --trim-empty' '
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	cat >>expected <<-\EOF &&
@@ -904,6 +911,7 @@ test_expect_success 'using "where = before" and --trim-empty' '
 
 test_expect_success 'the default is "ifExists = addIfDifferentNeighbor"' '
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -925,6 +933,7 @@ test_expect_success 'the default is "ifExists = addIfDifferentNeighbor"' '
 test_expect_success 'default "ifExists" is now "addIfDifferent"' '
 	git config trailer.ifexists "addIfDifferent" &&
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -946,6 +955,7 @@ test_expect_success 'using "ifExists = addIfDifferent" with "where = end"' '
 	git config trailer.ack.ifExists "addIfDifferent" &&
 	git config trailer.ack.where "end" &&
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -966,6 +976,7 @@ test_expect_success 'using "ifExists = addIfDifferent" with "where = before"' '
 	git config trailer.ack.ifExists "addIfDifferent" &&
 	git config trailer.ack.where "before" &&
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -986,6 +997,7 @@ test_expect_success 'using "ifExists = addIfDifferentNeighbor" with "where = end
 	git config trailer.ack.ifExists "addIfDifferentNeighbor" &&
 	git config trailer.ack.where "end" &&
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1011,6 +1023,7 @@ test_expect_success 'using "ifExists = addIfDifferentNeighbor"  with "where = af
 	git config trailer.ack.ifExists "addIfDifferentNeighbor" &&
 	git config trailer.ack.where "after" &&
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1034,6 +1047,7 @@ test_expect_success 'using "ifExists = addIfDifferentNeighbor"  with "where = af
 test_expect_success 'using "ifExists = addIfDifferentNeighbor" and --trim-empty' '
 	git config trailer.ack.ifExists "addIfDifferentNeighbor" &&
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	cat >>expected <<-\EOF &&
@@ -1053,6 +1067,7 @@ test_expect_success 'using "ifExists = add" with "where = end"' '
 	git config trailer.ack.ifExists "add" &&
 	git config trailer.ack.where "end" &&
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1080,6 +1095,7 @@ test_expect_success 'using "ifExists = add" with "where = after"' '
 	git config trailer.ack.ifExists "add" &&
 	git config trailer.ack.where "after" &&
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1104,6 +1120,7 @@ test_expect_success 'overriding configuration with "--if-exists replace"' '
 	git config trailer.fix.key "Fixes: " &&
 	git config trailer.fix.ifExists "add" &&
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1123,6 +1140,7 @@ test_expect_success 'using "ifExists = replace"' '
 	git config trailer.fix.key "Fixes: " &&
 	git config trailer.fix.ifExists "replace" &&
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1144,6 +1162,7 @@ test_expect_success 'using "ifExists = replace"' '
 test_expect_success 'using "ifExists = replace" with "where = after"' '
 	git config trailer.fix.where "after" &&
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1165,6 +1184,7 @@ test_expect_success 'using "ifExists = replace" with "where = after"' '
 test_expect_success 'using "ifExists = doNothing"' '
 	git config trailer.fix.ifExists "doNothing" &&
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1187,6 +1207,7 @@ test_expect_success 'the default is "ifMissing = add"' '
 	git config trailer.cc.key "Cc: " &&
 	git config trailer.cc.where "before" &&
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1253,6 +1274,7 @@ test_expect_success 'using "ifMissing = add" with "where = end"' '
 	git config trailer.cc.where "end" &&
 	git config trailer.cc.ifMissing "add" &&
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1277,6 +1299,7 @@ test_expect_success 'using "ifMissing = add" with "where = before"' '
 	git config trailer.cc.where "before" &&
 	git config trailer.cc.ifMissing "add" &&
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1299,6 +1322,7 @@ test_expect_success 'using "ifMissing = add" with "where = before"' '
 test_expect_success 'using "ifMissing = doNothing"' '
 	git config trailer.cc.ifMissing "doNothing" &&
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -1321,6 +1345,7 @@ test_expect_success 'default "where" is now "after"' '
 	git config trailer.where "after" &&
 	git config --unset trailer.ack.where &&
 	test_config trailer.ack.key "Acked-by= " &&
+	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&

--- a/t/t7513-interpret-trailers.sh
+++ b/t/t7513-interpret-trailers.sh
@@ -1260,11 +1260,11 @@ test_expect_success 'using "ifExists = doNothing"' '
 
 test_expect_success 'the default is "ifMissing = add"' '
 	git config trailer.cc.key "Cc: " &&
-	git config trailer.cc.where "before" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.ack.where "after" &&
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
+	test_config trailer.cc.where "before" &&
 	test_config trailer.fix.key "Fixes: " &&
 	test_config trailer.fix.ifExists "doNothing" &&
 	test_config trailer.review.key "Reviewed-by:" &&
@@ -1341,12 +1341,12 @@ test_expect_success 'when default "ifMissing" is "doNothing"' '
 
 test_expect_success 'using "ifMissing = add" with "where = end"' '
 	git config trailer.cc.key "Cc: " &&
-	git config trailer.cc.where "end" &&
 	git config trailer.cc.ifMissing "add" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.ack.where "after" &&
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
+	test_config trailer.cc.where "end" &&
 	test_config trailer.fix.ifExists "doNothing" &&
 	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.ifexists "addIfDifferent" &&
@@ -1371,12 +1371,12 @@ test_expect_success 'using "ifMissing = add" with "where = end"' '
 
 test_expect_success 'using "ifMissing = add" with "where = before"' '
 	git config trailer.cc.key "Cc: " &&
-	git config trailer.cc.where "before" &&
 	git config trailer.cc.ifMissing "add" &&
 	test_config trailer.ack.key "Acked-by= " &&
 	test_config trailer.ack.where "after" &&
 	test_config trailer.bug.key "Bug #" &&
 	test_config trailer.bug.where "before" &&
+	test_config trailer.cc.where "before" &&
 	test_config trailer.fix.ifExists "doNothing" &&
 	test_config trailer.review.key "Reviewed-by:" &&
 	test_config trailer.ifexists "addIfDifferent" &&

--- a/t/t7513-interpret-trailers.sh
+++ b/t/t7513-interpret-trailers.sh
@@ -503,7 +503,7 @@ test_expect_success 'with config setup' '
 '
 
 test_expect_success 'with config setup and ":=" as separators' '
-	git config trailer.separators ":=" &&
+	test_config trailer.separators ":=" &&
 	git config trailer.ack.key "Acked-by= " &&
 	cat >expected <<-\EOF &&
 
@@ -518,7 +518,7 @@ test_expect_success 'with config setup and ":=" as separators' '
 '
 
 test_expect_success 'with config setup and "%" as separators' '
-	git config trailer.separators "%" &&
+	test_config trailer.separators "%" &&
 	cat >expected <<-\EOF &&
 
 		bug% 42
@@ -532,6 +532,7 @@ test_expect_success 'with config setup and "%" as separators' '
 '
 
 test_expect_success 'with "%" as separators and a message with trailers' '
+	test_config trailer.separators "%" &&
 	cat >special_message <<-\EOF &&
 		Special Message
 
@@ -553,7 +554,7 @@ test_expect_success 'with "%" as separators and a message with trailers' '
 '
 
 test_expect_success 'with config setup and ":=#" as separators' '
-	git config trailer.separators ":=#" &&
+	test_config trailer.separators ":=#" &&
 	git config trailer.bug.key "Bug #" &&
 	cat >expected <<-\EOF &&
 
@@ -581,6 +582,7 @@ test_expect_success 'with basic patch' '
 '
 
 test_expect_success 'with commit complex message as argument' '
+	test_config trailer.separators ":=" &&
 	cat complex_message_body complex_message_trailers >complex_message &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -594,6 +596,7 @@ test_expect_success 'with commit complex message as argument' '
 '
 
 test_expect_success 'with 2 files arguments' '
+	test_config trailer.separators ":=" &&
 	cat basic_message >>expected &&
 	echo >>expected &&
 	cat basic_patch >>expected &&
@@ -677,6 +680,7 @@ test_expect_success 'with message that has an old style conflict block' '
 '
 
 test_expect_success 'with commit complex message and trailer args' '
+	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
 		Fixes: Z
@@ -692,6 +696,7 @@ test_expect_success 'with commit complex message and trailer args' '
 '
 
 test_expect_success 'with complex patch, args and --trim-empty' '
+	test_config trailer.separators ":=#" &&
 	cat complex_message >complex_patch &&
 	cat basic_patch >>complex_patch &&
 	cat complex_message_body >expected &&
@@ -746,6 +751,7 @@ test_expect_success POSIXPERM,SANITY "in-place editing doesn't clobber original 
 '
 
 test_expect_success 'using "where = before"' '
+	test_config trailer.separators ":=#" &&
 	git config trailer.bug.where "before" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -762,6 +768,7 @@ test_expect_success 'using "where = before"' '
 '
 
 test_expect_success 'overriding configuration with "--where after"' '
+	test_config trailer.separators ":=" &&
 	git config trailer.ack.where "before" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
@@ -777,6 +784,7 @@ test_expect_success 'overriding configuration with "--where after"' '
 '
 
 test_expect_success 'using "where = before" with "--no-where"' '
+	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
 		Bug #42
@@ -793,6 +801,7 @@ test_expect_success 'using "where = before" with "--no-where"' '
 
 test_expect_success 'using "where = after"' '
 	git config trailer.ack.where "after" &&
+	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
 		Bug #42
@@ -810,6 +819,7 @@ test_expect_success 'using "where = after"' '
 test_expect_success 'using "where = end"' '
 	git config trailer.review.key "Reviewed-by" &&
 	git config trailer.review.where "end" &&
+	test_config trailer.separators ":=" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
 		Fixes: Z
@@ -829,6 +839,7 @@ test_expect_success 'using "where = end"' '
 test_expect_success 'using "where = start"' '
 	git config trailer.review.key "Reviewed-by" &&
 	git config trailer.review.where "start" &&
+	test_config trailer.separators ":=" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
 		Reviewed-by: Johannes
@@ -848,6 +859,7 @@ test_expect_success 'using "where = start"' '
 test_expect_success 'using "where = before" for a token in the middle of the message' '
 	git config trailer.review.key "Reviewed-by:" &&
 	git config trailer.review.where "before" &&
+	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
 		Bug #42
@@ -864,6 +876,7 @@ test_expect_success 'using "where = before" for a token in the middle of the mes
 '
 
 test_expect_success 'using "where = before" and --trim-empty' '
+	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	cat >>expected <<-\EOF &&
 		Bug #46
@@ -878,6 +891,7 @@ test_expect_success 'using "where = before" and --trim-empty' '
 '
 
 test_expect_success 'the default is "ifExists = addIfDifferentNeighbor"' '
+	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
 		Bug #42
@@ -897,6 +911,7 @@ test_expect_success 'the default is "ifExists = addIfDifferentNeighbor"' '
 
 test_expect_success 'default "ifExists" is now "addIfDifferent"' '
 	git config trailer.ifexists "addIfDifferent" &&
+	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
 		Bug #42
@@ -916,6 +931,7 @@ test_expect_success 'default "ifExists" is now "addIfDifferent"' '
 test_expect_success 'using "ifExists = addIfDifferent" with "where = end"' '
 	git config trailer.ack.ifExists "addIfDifferent" &&
 	git config trailer.ack.where "end" &&
+	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
 		Bug #42
@@ -934,6 +950,7 @@ test_expect_success 'using "ifExists = addIfDifferent" with "where = end"' '
 test_expect_success 'using "ifExists = addIfDifferent" with "where = before"' '
 	git config trailer.ack.ifExists "addIfDifferent" &&
 	git config trailer.ack.where "before" &&
+	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
 		Bug #42
@@ -952,6 +969,7 @@ test_expect_success 'using "ifExists = addIfDifferent" with "where = before"' '
 test_expect_success 'using "ifExists = addIfDifferentNeighbor" with "where = end"' '
 	git config trailer.ack.ifExists "addIfDifferentNeighbor" &&
 	git config trailer.ack.where "end" &&
+	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
 		Bug #42
@@ -975,6 +993,7 @@ test_expect_success 'using "ifExists = addIfDifferentNeighbor" with "where = end
 test_expect_success 'using "ifExists = addIfDifferentNeighbor"  with "where = after"' '
 	git config trailer.ack.ifExists "addIfDifferentNeighbor" &&
 	git config trailer.ack.where "after" &&
+	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
 		Bug #42
@@ -996,6 +1015,7 @@ test_expect_success 'using "ifExists = addIfDifferentNeighbor"  with "where = af
 
 test_expect_success 'using "ifExists = addIfDifferentNeighbor" and --trim-empty' '
 	git config trailer.ack.ifExists "addIfDifferentNeighbor" &&
+	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	cat >>expected <<-\EOF &&
 		Bug #42
@@ -1013,6 +1033,7 @@ test_expect_success 'using "ifExists = addIfDifferentNeighbor" and --trim-empty'
 test_expect_success 'using "ifExists = add" with "where = end"' '
 	git config trailer.ack.ifExists "add" &&
 	git config trailer.ack.where "end" &&
+	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
 		Bug #42
@@ -1038,6 +1059,7 @@ test_expect_success 'using "ifExists = add" with "where = end"' '
 test_expect_success 'using "ifExists = add" with "where = after"' '
 	git config trailer.ack.ifExists "add" &&
 	git config trailer.ack.where "after" &&
+	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
 		Bug #42
@@ -1060,6 +1082,7 @@ test_expect_success 'using "ifExists = add" with "where = after"' '
 test_expect_success 'overriding configuration with "--if-exists replace"' '
 	git config trailer.fix.key "Fixes: " &&
 	git config trailer.fix.ifExists "add" &&
+	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
 		Bug #42
@@ -1077,6 +1100,7 @@ test_expect_success 'overriding configuration with "--if-exists replace"' '
 test_expect_success 'using "ifExists = replace"' '
 	git config trailer.fix.key "Fixes: " &&
 	git config trailer.fix.ifExists "replace" &&
+	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
 		Bug #42
@@ -1096,6 +1120,7 @@ test_expect_success 'using "ifExists = replace"' '
 
 test_expect_success 'using "ifExists = replace" with "where = after"' '
 	git config trailer.fix.where "after" &&
+	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
 		Bug #42
@@ -1115,6 +1140,7 @@ test_expect_success 'using "ifExists = replace" with "where = after"' '
 
 test_expect_success 'using "ifExists = doNothing"' '
 	git config trailer.fix.ifExists "doNothing" &&
+	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
 		Bug #42
@@ -1135,6 +1161,7 @@ test_expect_success 'using "ifExists = doNothing"' '
 test_expect_success 'the default is "ifMissing = add"' '
 	git config trailer.cc.key "Cc: " &&
 	git config trailer.cc.where "before" &&
+	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
 		Bug #42
@@ -1155,6 +1182,7 @@ test_expect_success 'the default is "ifMissing = add"' '
 
 test_expect_success 'overriding configuration with "--if-missing doNothing"' '
 	git config trailer.ifmissing "add" &&
+	test_config trailer.separators ":=" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
 		Fixes: Z
@@ -1174,6 +1202,7 @@ test_expect_success 'overriding configuration with "--if-missing doNothing"' '
 
 test_expect_success 'when default "ifMissing" is "doNothing"' '
 	git config trailer.ifmissing "doNothing" &&
+	test_config trailer.separators ":=" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
 		Fixes: Z
@@ -1195,6 +1224,7 @@ test_expect_success 'using "ifMissing = add" with "where = end"' '
 	git config trailer.cc.key "Cc: " &&
 	git config trailer.cc.where "end" &&
 	git config trailer.cc.ifMissing "add" &&
+	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
 		Bug #42
@@ -1217,6 +1247,7 @@ test_expect_success 'using "ifMissing = add" with "where = before"' '
 	git config trailer.cc.key "Cc: " &&
 	git config trailer.cc.where "before" &&
 	git config trailer.cc.ifMissing "add" &&
+	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
 		Cc: Linus
@@ -1237,6 +1268,7 @@ test_expect_success 'using "ifMissing = add" with "where = before"' '
 
 test_expect_success 'using "ifMissing = doNothing"' '
 	git config trailer.cc.ifMissing "doNothing" &&
+	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
 		Bug #42
@@ -1257,6 +1289,7 @@ test_expect_success 'using "ifMissing = doNothing"' '
 test_expect_success 'default "where" is now "after"' '
 	git config trailer.where "after" &&
 	git config --unset trailer.ack.where &&
+	test_config trailer.separators ":=#" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
 		Bug #42
@@ -1284,6 +1317,7 @@ test_expect_success 'with simple command' '
 	git config trailer.sign.where "after" &&
 	git config trailer.sign.ifExists "addIfDifferentNeighbor" &&
 	git config trailer.sign.command "echo \"A U Thor <author@example.com>\"" &&
+	test_config trailer.separators ":=" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
 		Fixes: Z
@@ -1300,6 +1334,7 @@ test_expect_success 'with simple command' '
 test_expect_success 'with command using committer information' '
 	git config trailer.sign.ifExists "addIfDifferent" &&
 	git config trailer.sign.command "echo \"\$GIT_COMMITTER_NAME <\$GIT_COMMITTER_EMAIL>\"" &&
+	test_config trailer.separators ":=" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
 		Fixes: Z
@@ -1318,6 +1353,7 @@ test_expect_success 'with command using author information' '
 	git config trailer.sign.where "after" &&
 	git config trailer.sign.ifExists "addIfDifferentNeighbor" &&
 	git config trailer.sign.command "echo \"\$GIT_AUTHOR_NAME <\$GIT_AUTHOR_EMAIL>\"" &&
+	test_config trailer.separators ":=" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-\EOF &&
 		Fixes: Z
@@ -1344,6 +1380,7 @@ test_expect_success 'cmd takes precedence over command' '
 	--abbrev-commit --abbrev=14 \"\$1\" || true" &&
 	git config trailer.fix.command "git log -1 --oneline --format=\"%h (%s)\" \
 		--abbrev-commit --abbrev=14 \$ARG" &&
+	test_config trailer.separators ":=" &&
 	FIXED=$(git log -1 --oneline --format="%h (%aN)" --abbrev-commit --abbrev=14 HEAD) &&
 	cat complex_message_body >expected2 &&
 	sed -e "s/ Z\$/ /" >>expected2 <<-EOF &&
@@ -1361,6 +1398,7 @@ test_expect_success 'cmd takes precedence over command' '
 test_expect_success 'with command using $ARG' '
 	git config trailer.fix.ifExists "replace" &&
 	git config trailer.fix.command "git log -1 --oneline --format=\"%h (%s)\" --abbrev-commit --abbrev=14 \$ARG" &&
+	test_config trailer.separators ":=" &&
 	FIXED=$(git log -1 --oneline --format="%h (%s)" --abbrev-commit --abbrev=14 HEAD) &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-EOF &&
@@ -1378,6 +1416,7 @@ test_expect_success 'with command using $ARG' '
 test_expect_success 'with failing command using $ARG' '
 	git config trailer.fix.ifExists "replace" &&
 	git config trailer.fix.command "false \$ARG" &&
+	test_config trailer.separators ":=" &&
 	cat complex_message_body >expected &&
 	sed -e "s/ Z\$/ /" >>expected <<-EOF &&
 		Fixes: Z

--- a/trailer.c
+++ b/trailer.c
@@ -964,28 +964,23 @@ static void unfold_value(struct strbuf *val)
 	strbuf_release(&out);
 }
 
-static size_t process_input_file(FILE *outfile,
-				 const char *str,
-				 struct list_head *head,
-				 const struct process_trailer_options *opts)
+/*
+ * Parse trailers in "str" and populate the "head" linked list structure.
+ */
+static void parse_trailers(struct trailer_info *info,
+			     const char *str,
+			     struct list_head *head,
+			     const struct process_trailer_options *opts)
 {
-	struct trailer_info info;
 	struct strbuf tok = STRBUF_INIT;
 	struct strbuf val = STRBUF_INIT;
 	size_t i;
 
-	trailer_info_get(&info, str, opts);
+	trailer_info_get(info, str, opts);
 
-	/* Print lines before the trailers as is */
-	if (!opts->only_trailers)
-		fwrite(str, 1, info.trailer_start - str, outfile);
-
-	if (!opts->only_trailers && !info.blank_line_before_trailer)
-		fprintf(outfile, "\n");
-
-	for (i = 0; i < info.trailer_nr; i++) {
+	for (i = 0; i < info->trailer_nr; i++) {
 		int separator_pos;
-		char *trailer = info.trailers[i];
+		char *trailer = info->trailers[i];
 		if (trailer[0] == comment_line_char)
 			continue;
 		separator_pos = find_separator(trailer, separators);
@@ -1006,9 +1001,7 @@ static size_t process_input_file(FILE *outfile,
 		}
 	}
 
-	trailer_info_release(&info);
-
-	return info.trailer_end - str;
+	trailer_info_release(info);
 }
 
 static void free_all(struct list_head *head)
@@ -1057,6 +1050,7 @@ void process_trailers(const char *file,
 {
 	LIST_HEAD(head);
 	struct strbuf sb = STRBUF_INIT;
+	struct trailer_info info;
 	size_t trailer_end;
 	FILE *outfile = stdout;
 
@@ -1067,8 +1061,16 @@ void process_trailers(const char *file,
 	if (opts->in_place)
 		outfile = create_in_place_tempfile(file);
 
+	parse_trailers(&info, sb.buf, &head, opts);
+	trailer_end = info.trailer_end - sb.buf;
+
 	/* Print the lines before the trailers */
-	trailer_end = process_input_file(outfile, sb.buf, &head, opts);
+	if (!opts->only_trailers)
+		fwrite(sb.buf, 1, info.trailer_start - sb.buf, outfile);
+
+	if (!opts->only_trailers && !info.blank_line_before_trailer)
+		fprintf(outfile, "\n");
+
 
 	if (!opts->only_input) {
 		LIST_HEAD(arg_head);

--- a/trailer.c
+++ b/trailer.c
@@ -1223,20 +1223,22 @@ void format_trailers_from_commit(struct strbuf *out, const char *msg,
 	trailer_info_release(&info);
 }
 
+#define private __private_to_trailer_c__do_not_use
+
 void trailer_iterator_init(struct trailer_iterator *iter, const char *msg)
 {
 	struct process_trailer_options opts = PROCESS_TRAILER_OPTIONS_INIT;
 	strbuf_init(&iter->key, 0);
 	strbuf_init(&iter->val, 0);
 	opts.no_divider = 1;
-	trailer_info_get(&iter->info, msg, &opts);
-	iter->cur = 0;
+	trailer_info_get(&iter->private.info, msg, &opts);
+	iter->private.cur = 0;
 }
 
 int trailer_iterator_advance(struct trailer_iterator *iter)
 {
-	while (iter->cur < iter->info.trailer_nr) {
-		char *trailer = iter->info.trailers[iter->cur++];
+	while (iter->private.cur < iter->private.info.trailer_nr) {
+		char *trailer = iter->private.info.trailers[iter->private.cur++];
 		int separator_pos = find_separator(trailer, separators);
 
 		if (separator_pos < 1)
@@ -1254,7 +1256,7 @@ int trailer_iterator_advance(struct trailer_iterator *iter)
 
 void trailer_iterator_release(struct trailer_iterator *iter)
 {
-	trailer_info_release(&iter->info);
+	trailer_info_release(&iter->private.info);
 	strbuf_release(&iter->val);
 	strbuf_release(&iter->key);
 }

--- a/trailer.c
+++ b/trailer.c
@@ -388,7 +388,7 @@ static void process_trailers_lists(struct list_head *head,
 int trailer_set_where(enum trailer_where *item, const char *value)
 {
 	if (!value)
-		*item = WHERE_DEFAULT;
+		*item = WHERE_CONFIG;
 	else if (!strcasecmp("after", value))
 		*item = WHERE_AFTER;
 	else if (!strcasecmp("before", value))
@@ -405,7 +405,7 @@ int trailer_set_where(enum trailer_where *item, const char *value)
 int trailer_set_if_exists(enum trailer_if_exists *item, const char *value)
 {
 	if (!value)
-		*item = EXISTS_DEFAULT;
+		*item = EXISTS_CONFIG;
 	else if (!strcasecmp("addIfDifferent", value))
 		*item = EXISTS_ADD_IF_DIFFERENT;
 	else if (!strcasecmp("addIfDifferentNeighbor", value))
@@ -424,7 +424,7 @@ int trailer_set_if_exists(enum trailer_if_exists *item, const char *value)
 int trailer_set_if_missing(enum trailer_if_missing *item, const char *value)
 {
 	if (!value)
-		*item = MISSING_DEFAULT;
+		*item = MISSING_CONFIG;
 	else if (!strcasecmp("doNothing", value))
 		*item = MISSING_DO_NOTHING;
 	else if (!strcasecmp("add", value))
@@ -586,7 +586,10 @@ static void ensure_configured(void)
 	if (configured)
 		return;
 
-	/* Default config must be setup first */
+	/*
+	 * Default config must be setup first. These defaults are used if there
+	 * are no "trailer.*" or "trailer.<token>.*" options configured.
+	 */
 	default_conf_info.where = WHERE_END;
 	default_conf_info.if_exists = EXISTS_ADD_IF_DIFFERENT_NEIGHBOR;
 	default_conf_info.if_missing = MISSING_ADD;
@@ -701,11 +704,11 @@ static void add_arg_item(struct list_head *arg_head, char *tok, char *val,
 	new_item->value = val;
 	duplicate_conf(&new_item->conf, conf);
 	if (new_trailer_item) {
-		if (new_trailer_item->where != WHERE_DEFAULT)
+		if (new_trailer_item->where != WHERE_CONFIG)
 			new_item->conf.where = new_trailer_item->where;
-		if (new_trailer_item->if_exists != EXISTS_DEFAULT)
+		if (new_trailer_item->if_exists != EXISTS_CONFIG)
 			new_item->conf.if_exists = new_trailer_item->if_exists;
-		if (new_trailer_item->if_missing != MISSING_DEFAULT)
+		if (new_trailer_item->if_missing != MISSING_CONFIG)
 			new_item->conf.if_missing = new_trailer_item->if_missing;
 	}
 	list_add_tail(&new_item->list, arg_head);

--- a/trailer.c
+++ b/trailer.c
@@ -810,14 +810,14 @@ static ssize_t last_line(const char *buf, size_t len)
  * Return the position of the start of the patch or the length of str if there
  * is no patch in the message.
  */
-static size_t find_patch_start(const char *str)
+static size_t find_patch_start(const char *str, int no_divider)
 {
 	const char *s;
 
 	for (s = str; *s; s = next_line(s)) {
 		const char *v;
 
-		if (skip_prefix(s, "---", &v) && isspace(*v))
+		if (!no_divider && skip_prefix(s, "---", &v) && isspace(*v))
 			return s - str;
 	}
 
@@ -1102,11 +1102,7 @@ void trailer_info_get(struct trailer_info *info, const char *str,
 
 	ensure_configured();
 
-	if (opts->no_divider)
-		patch_start = strlen(str);
-	else
-		patch_start = find_patch_start(str);
-
+	patch_start = find_patch_start(str, opts->no_divider);
 	trailer_end = find_trailer_end(str, patch_start);
 	trailer_start = find_trailer_start(str, trailer_end);
 

--- a/trailer.c
+++ b/trailer.c
@@ -714,10 +714,25 @@ static void add_arg_item(struct list_head *arg_head, char *tok, char *val,
 	list_add_tail(&new_item->list, arg_head);
 }
 
-static void process_command_line_args(struct list_head *arg_head,
-				      struct list_head *new_trailer_head)
+static void parse_trailers_from_config(struct list_head *config_head)
 {
 	struct arg_item *item;
+	struct list_head *pos;
+
+	/* Add an arg item for each configured trailer with a command */
+	list_for_each(pos, &conf_head) {
+		item = list_entry(pos, struct arg_item, list);
+		if (item->conf.command)
+			add_arg_item(config_head,
+				     xstrdup(token_from_item(item, NULL)),
+				     xstrdup(""),
+				     &item->conf, NULL);
+	}
+}
+
+static void parse_trailers_from_command_line_args(struct list_head *arg_head,
+						  struct list_head *new_trailer_head)
+{
 	struct strbuf tok = STRBUF_INIT;
 	struct strbuf val = STRBUF_INIT;
 	const struct conf_info *conf;
@@ -728,16 +743,6 @@ static void process_command_line_args(struct list_head *arg_head,
 	 * separators that are defined).
 	 */
 	char *cl_separators = xstrfmt("=%s", separators);
-
-	/* Add an arg item for each configured trailer with a command */
-	list_for_each(pos, &conf_head) {
-		item = list_entry(pos, struct arg_item, list);
-		if (item->conf.command)
-			add_arg_item(arg_head,
-				     xstrdup(token_from_item(item, NULL)),
-				     xstrdup(""),
-				     &item->conf, NULL);
-	}
 
 	/* Add an arg item for each trailer on the command line */
 	list_for_each(pos, new_trailer_head) {
@@ -1073,8 +1078,11 @@ void process_trailers(const char *file,
 
 
 	if (!opts->only_input) {
+		LIST_HEAD(config_head);
 		LIST_HEAD(arg_head);
-		process_command_line_args(&arg_head, new_trailer_head);
+		parse_trailers_from_config(&config_head);
+		parse_trailers_from_command_line_args(&arg_head, new_trailer_head);
+		list_splice(&config_head, &arg_head);
 		process_trailers_lists(&head, &arg_head);
 	}
 

--- a/trailer.h
+++ b/trailer.h
@@ -5,14 +5,14 @@
 #include "strbuf.h"
 
 enum trailer_where {
-	WHERE_DEFAULT,
+	WHERE_CONFIG,
 	WHERE_END,
 	WHERE_AFTER,
 	WHERE_BEFORE,
 	WHERE_START
 };
 enum trailer_if_exists {
-	EXISTS_DEFAULT,
+	EXISTS_CONFIG,
 	EXISTS_ADD_IF_DIFFERENT_NEIGHBOR,
 	EXISTS_ADD_IF_DIFFERENT,
 	EXISTS_ADD,
@@ -20,7 +20,7 @@ enum trailer_if_exists {
 	EXISTS_DO_NOTHING
 };
 enum trailer_if_missing {
-	MISSING_DEFAULT,
+	MISSING_CONFIG,
 	MISSING_ADD,
 	MISSING_DO_NOTHING
 };

--- a/trailer.h
+++ b/trailer.h
@@ -119,8 +119,10 @@ struct trailer_iterator {
 	struct strbuf val;
 
 	/* private */
-	struct trailer_info info;
-	size_t cur;
+	struct {
+		struct trailer_info info;
+		size_t cur;
+	} __private_to_trailer_c__do_not_use;
 };
 
 /*


### PR DESCRIPTION
These patches were created while digging into the trailer code to better understand how it works, in preparation for making the trailer.{c,h} files as small as possible to make them available as a library for external users. These patches do not add or change any features. Instead, their goal is to make the code easier to understand for new contributors (like myself), while making various cleanups and improvements along the way. In short, my hope is that with such cleanups, we are better positioned to make larger changes (such as the broader libification effort, such as in "Introduce Git Standard Library" [1]).

Most of the patches in this series are titled "trailer: test: track state explicitly (...)", which are cleanups in the tests where we used 'git config' in a test case without cleaning up that state for the next test. This makes the tests self-contained, making it easier to add new tests (such as in "trailer: add tests to check defaulting behavior with --no-* flags"). These test cleanups exposed lots of cases where the test cases are mutating more configuration state than is necessary to test the specific behavior in the test; however such extraneous configurations were not cleaned up to make these patches easier to review (again, we are not changing any behavior and we are also not changing what the test cases themselves purport to do).

The last 5 patches (28-32) are refactors to make the code a little more flexible in preparation for future continued libification efforts. These 5 patches are not really necessary now per se (they are refactors, not really fixes), but I've included them because I didn't want to wait on them. Patch 32 in particular was inspired by [2].

[1] https://lore.kernel.org/git/20230627195251.1973421-1-calvinwan@google.com/
[2] https://lore.kernel.org/git/pull.1149.git.1677143700.gitgitgadget@gmail.com/