### PR TITLE
t0040: declare non-tab indentation to be okay in this script

### DIFF
--- a/t/.gitattributes
+++ b/t/.gitattributes
@@ -22,3 +22,4 @@ t[0-9][0-9][0-9][0-9]/* -whitespace
 /t7500/* eol=lf
 /t8005/*.txt eol=lf
 /t9*/*.dump eol=lf
+/t0040*.sh whitespace=-indent-with-non-tab


### PR DESCRIPTION
When preparing Git for Windows v2.42.0-rc0, I ran into this issue: the Pull Request's `check-whitespace` run failed. Let's prevent having future contributors from also running into this type of issue when modifying t0040.

cc: Taylor Blau <me@ttaylorr.com>