### PR TITLE
t4053: avoid race when killing background processes

### DIFF
--- a/t/t4053-diff-no-index.sh
+++ b/t/t4053-diff-no-index.sh
@@ -248,11 +248,11 @@ test_expect_success PIPE,SYMLINKS 'diff --no-index reads from pipes' '
 	{
 		(test_write_lines a b c >old) &
 	} &&
-	test_when_finished "! kill $!" &&
+	test_when_finished "kill $! || :" &&
 	{
 		(test_write_lines a x c >new) &
 	} &&
-	test_when_finished "! kill $!" &&
+	test_when_finished "kill $! || :" &&
 
 	cat >expect <<-EOF &&
 	diff --git a/old b/new-link


### PR DESCRIPTION
Thanks to Peff for reporting this.
Junio - this fixes a regression introduced in the current cycle. It is fairly minor though so I'm not sure if you want to pick it up now or wait until 2.42.0 is out.

Cc: Jeff King <peff@peff.net>
Cc: Junio C Hamano <gitster@pobox.com>
cc: Phillip Wood <phillip.wood123@gmail.com>