### PR TITLE
ci(linux-asan-ubsan): let's save some time

### DIFF
--- a/ci/lib.sh
+++ b/ci/lib.sh
@@ -280,6 +280,8 @@ linux-leaks)
 	;;
 linux-asan-ubsan)
 	export SANITIZE=address,undefined
+	export NO_SVN_TESTS=LetsSaveSomeTime
+	MAKEFLAGS="$MAKEFLAGS NO_PYTHON=YepBecauseP4FlakesTooOften"
 	;;
 esac
 


### PR DESCRIPTION
I often look at failed CI runs, and the `linux-asan-ubsan` job comes up frequently, and painfully (because it takes such a long time that re-running is often less desirable than getting the CI runs to pass).

This commit is an attempt to reduce the pain and suffering stemming from this particular job, simply by deciding that the benefit of running the Python/Subversion-related tests in that job is far outweighed by its cost.

This commit not only reduces the number of `git-p4` flakes in `linux-asan-ubsan` to 0, it also seems to shave off about 10 minutes runtime, comparing https://github.com/gitgitgadget/git/actions/runs/5929602548/job/16077585391 to https://github.com/gitgitgadget/git/actions/runs/6010305446/job/16301473243?pr=1578 (which is not quite scientific due to the lack of a controlled environment, but it's the best we got for now). Together, those benefits form a strong incentive for me to get this merged.

This patch is based on `maint`.

Changes since v1:
- Made the rationale clearer (it is not Python that flakes, but Perforce).
- Touched up the commit message.

cc: Jeff King <peff@peff.net>