### PR TITLE
completion: commit: complete configured trailer tokens

### DIFF
--- a/contrib/completion/git-completion.bash
+++ b/contrib/completion/git-completion.bash
@@ -1677,6 +1677,11 @@ _git_clone ()
 
 __git_untracked_file_modes="all no normal"
 
+__git_trailer_tokens ()
+{
+	git config --name-only --get-regexp trailer.\*.key | awk -F. '{print $2}'
+}
+
 _git_commit ()
 {
 	case "$prev" in
@@ -1699,6 +1704,10 @@ _git_commit ()
 		;;
 	--untracked-files=*)
 		__gitcomp "$__git_untracked_file_modes" "" "${cur##--untracked-files=}"
+		return
+		;;
+	--trailer=*)
+		__gitcomp_nl "$(__git_trailer_tokens)" "" "${cur##--trailer=}" ":"
 		return
 		;;
 	--*)

--- a/contrib/completion/git-completion.bash
+++ b/contrib/completion/git-completion.bash
@@ -1679,7 +1679,7 @@ __git_untracked_file_modes="all no normal"
 
 __git_trailer_tokens ()
 {
-	git config --name-only --get-regexp trailer.\*.key | awk -F. '{print $2}'
+	__git config --name-only --get-regexp '^trailer\..*\.key$' | cut -d. -f 2- | rev | cut -d. -f2- | rev
 }
 
 _git_commit ()


### PR DESCRIPTION
v2: 
This series adds support for completing configured trailer tokens in 'git commit --trailer'.

Changes since v1:

- added all Martin's suggestions as an additional commit on top since pb/complete-commit-trailer is already in next.

CC: ZheNing Hu <adlternative@gmail.com>
cc: Martin Ågren <martin.agren@gmail.com>
cc: Philippe Blain <levraiphilippeblain@gmail.com>