### PR TITLE
Documentation/git-status: add missing line breaks

### DIFF
--- a/Documentation/git-status.txt
+++ b/Documentation/git-status.txt
@@ -245,10 +245,12 @@ U           U    unmerged, both modified
 ....
 
 Submodules have more state and instead report
+
 		M    the submodule has a different HEAD than
 		     recorded in the index
 		m    the submodule has modified content
 		?    the submodule has untracked files
+
 since modified content or untracked files in a submodule cannot be added
 via `git add` in the superproject to prepare a commit.
 


### PR DESCRIPTION
Most of the content in `git help status` is well formatted, as you can see here:
```
       In the following table, these three classes are shown in separate sections, and these characters are used for X and Y fields for the first two sections that show tracked paths:

       •   ' ' = unmodified

       •   M = modified

       •   T = file type changed (regular file, symbolic link or submodule)

       •   A = added

       •   D = deleted

       •   R = renamed

       •   C = copied (if config option status.renames is set to "copies")

       •   U = updated but unmerged

           X          Y     Meaning
           -------------------------------------------------
                    [AMD]   not updated
           M        [ MTD]  updated in index
           T        [ MTD]  type changed in index
           A        [ MTD]  added to index
           D                deleted from index
           R        [ MTD]  renamed in index
           C        [ MTD]  copied in index
           [MTARC]          index and work tree matches
           [ MTARC]    M    work tree changed since index
           [ MTARC]    T    type changed in work tree since index
           [ MTARC]    D    deleted in work tree
                       R    renamed in work tree
                       C    copied in work tree
           -------------------------------------------------
           D           D    unmerged, both deleted
           A           U    unmerged, added by us
           U           D    unmerged, deleted by them
           U           A    unmerged, added by them
           D           U    unmerged, deleted by us
           A           A    unmerged, both added
           U           U    unmerged, both modified
           -------------------------------------------------
           ?           ?    untracked
           !           !    ignored
           -------------------------------------------------

       Submodules have more state and instead report M the submodule has a different HEAD than recorded in the index m the submodule has modified content ? the submodule has untracked
       files since modified content or untracked files in a submodule cannot be added via git add in the superproject to prepare a commit.

       m and ? are applied recursively. For example if a nested submodule in a submodule contains an untracked file, this is reported as ? as well.

       If -b is used the short-format status is preceded by a line

           ## branchname tracking info
```

Except for the part:
```
       Submodules have more state and instead report M the submodule has a different HEAD than recorded in the index m the submodule has modified content ? the submodule has untracked
```

It appears that it wanted to be a table. With this patch, the html renders as:

```
Submodules have more state and instead report

M    the submodule has a different HEAD than
     recorded in the index
m    the submodule has modified content
?    the submodule has untracked files

since modified content or untracked files in a submodule cannot be added via git add in the superproject to prepare a commit.

m and ? are applied recursively. For example if a nested submodule in a submodule contains an untracked file, this is reported as ? as well.

If -b is used the short-format status is preceded by a line

## branchname tracking info
````