### PR TITLE
git-gui: add support for filenames starting with tilde

### DIFF
--- a/git-gui/git-gui.sh
+++ b/git-gui/git-gui.sh
@@ -2273,6 +2273,7 @@ proc do_explore {} {
 # Open file relative to the working tree by the default associated app.
 proc do_file_open {file} {
 	global _gitworktree
+	if {[string index $file 0] eq {~}} {set file ./$file}
 	set explorer [get_explorer]
 	set full_file_path [file join $_gitworktree $file]
 	exec $explorer [file nativename $full_file_path] &

--- a/git-gui/lib/diff.tcl
+++ b/git-gui/lib/diff.tcl
@@ -190,6 +190,7 @@ proc show_other_diff {path w m cont_info} {
 		set max_sz 100000
 		set type unknown
 		if {[catch {
+				if {[string index $path 0] eq {~}} {set path ./$path}
 				set type [file type $path]
 				switch -- $type {
 				directory {

--- a/git-gui/lib/index.tcl
+++ b/git-gui/lib/index.tcl
@@ -617,7 +617,7 @@ proc delete_helper {path_list path_index deletion_errors batch_size \
 
 		set path [lindex $path_list $path_index]
 
-		set deletion_failed [catch {file delete -- $path} deletion_error]
+		set deletion_failed [catch {file delete -- ./$path} deletion_error]
 
 		if {$deletion_failed} {
 			lappend deletion_errors [list "$deletion_error"]


### PR DESCRIPTION
I've originally submitted this patch as a pull request to Pratyush's git-gui repository [1] on March 23rd, but that hasn't received any feedback in almost seven months, so I'm resubmitting it here, with an improved patch description.

[1] https://github.com/prati0100/git-gui/pull/96