### PR TITLE
doc/git-bisect: clarify `git bisect run` syntax

### DIFF
--- a/Documentation/git-bisect.txt
+++ b/Documentation/git-bisect.txt
@@ -26,7 +26,7 @@ on the subcommand:
  git bisect (visualize|view)
  git bisect replay <logfile>
  git bisect log
- git bisect run <cmd>...
+ git bisect run <cmd> [<arg>...]
  git bisect help
 
 This command uses a binary search algorithm to find which commit in


### PR DESCRIPTION
I saw someone in IRC wondering about the syntax for `git bisect run` for a command with arguments, and found that its short description at the beginning of the manpage is not very clear (although it gets clarified later when it is properly described).
It describes the syntax as `git bisect run <cmd>...` which is a bit confusing; it should say `git bisect run <cmd> [<arg>...]`, otherwise it somehow looks like you have to "enter one or more commands", and that each command is a single argument.