### PR TITLE
ci: upgrade to using macos-13

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -276,11 +276,11 @@ jobs:
             pool: ubuntu-20.04
           - jobname: osx-clang
             cc: clang
-            pool: macos-12
+            pool: macos-13
           - jobname: osx-gcc
             cc: gcc
-            cc_package: gcc-9
-            pool: macos-12
+            cc_package: gcc-13
+            pool: macos-13
           - jobname: linux-gcc-default
             cc: gcc
             pool: ubuntu-latest

--- a/ci/lib.sh
+++ b/ci/lib.sh
@@ -253,11 +253,9 @@ ubuntu-*)
 	export PATH="$GIT_LFS_PATH:$P4_PATH:$PATH"
 	;;
 macos-*)
-	if [ "$jobname" = osx-gcc ]
+	MAKEFLAGS="$MAKEFLAGS PYTHON_PATH=$(which python3)"
+	if [ "$jobname" != osx-gcc ]
 	then
-		MAKEFLAGS="$MAKEFLAGS PYTHON_PATH=$(which python3)"
-	else
-		MAKEFLAGS="$MAKEFLAGS PYTHON_PATH=$(which python2)"
 		MAKEFLAGS="$MAKEFLAGS APPLE_COMMON_CRYPTO_SHA1=Yes"
 	fi
 	;;


### PR DESCRIPTION
[GitHub announced in April that the `macos-13` pool is available](https://github.blog/changelog/2023-04-24-github-actions-macos-13-is-now-available/), so let's switch. This might also stave off CI failures we experience over in GitGitGadget (e.g. [here](https://github.com/gitgitgadget/git/actions/runs/6729366919/job/18290134547#step:3:56)) and in Git for Windows (e.g. [here](https://github.com/git-for-windows/git/actions/runs/6708618181/job/18252834721#step:3:57)) where occasionally `macos-12-xl` runners seem to be co-opted to cope with `macos-12` workload (and the former don't have Python2 in their `PATH`).