### PR TITLE
strvec: drop unnecessary include of hex.h

### DIFF
--- a/strvec.c
+++ b/strvec.c
@@ -1,6 +1,5 @@
 #include "git-compat-util.h"
 #include "strvec.h"
-#include "hex.h"
 #include "strbuf.h"
 
 const char *empty_strvec[] = { NULL };


### PR DESCRIPTION
In 41771fa435 (cache.h: remove dependence on hex.h; make other files include it explicitly, 2023-02-24) we added this as part of a larger mechanical refactor. But strvec doesn't actually depend on hex.h, so remove it.

cc: Jonathan Tan jonathantanmy@google.com
cc: Calvin Wan calvinwan@google.com
