### PR TITLE
fuzz: add new oss-fuzz fuzzer for date.c / date.h

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -750,6 +750,7 @@ SCRIPTS = $(SCRIPT_SH_GEN) \
 ETAGS_TARGET = TAGS
 
 FUZZ_OBJS += oss-fuzz/fuzz-commit-graph.o
+FUZZ_OBJS += oss-fuzz/fuzz-date.o
 FUZZ_OBJS += oss-fuzz/fuzz-pack-headers.o
 FUZZ_OBJS += oss-fuzz/fuzz-pack-idx.o
 .PHONY: fuzz-objs

--- a/oss-fuzz/.gitignore
+++ b/oss-fuzz/.gitignore
@@ -1,3 +1,4 @@
 fuzz-commit-graph
+fuzz-date
 fuzz-pack-headers
 fuzz-pack-idx

--- a/oss-fuzz/fuzz-date.c
+++ b/oss-fuzz/fuzz-date.c
@@ -1,0 +1,49 @@
+#include "git-compat-util.h"
+#include "date.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+	int local;
+	int num;
+	char *str;
+	int16_t tz;
+	timestamp_t ts;
+	enum date_mode_type dmtype;
+	struct date_mode *dm;
+
+	if (size <= 4)
+		/*
+		 * we use the first byte to fuzz dmtype and the
+		 * second byte to fuzz local, then the next two
+		 * bytes to fuzz tz offset. The remainder
+		 * (at least one byte) is fed as input to
+		 * approxidate_careful().
+		 */
+		return 0;
+
+	local = !!(*data++ & 0x10);
+	num = *data++ % DATE_UNIX;
+	if (num >= DATE_STRFTIME)
+		num++;
+	dmtype = (enum date_mode_type)num;
+	size -= 2;
+
+	tz = *data++;
+	tz = (tz << 8) | *data++;
+	size -= 2;
+
+	str = xmemdupz(data, size);
+
+	ts = approxidate_careful(str, &num);
+	free(str);
+
+	dm = date_mode_from_type(dmtype);
+	dm->local = local;
+	show_date(ts, (int)tz, dm);
+
+	date_mode_release(dm);
+
+	return 0;
+}


### PR DESCRIPTION
This patch is aimed to add a new oss-fuzz fuzzer to the oss-fuzz directory for fuzzing date.c / date.h in the base directory.

The .gitignore of the oss-fuzz directory and the Makefile have been modified to accommodate the new fuzzer fuzz-date.c.

Fixed the objects order in .gitignore and Makefiles and fixed some of the logic and formatting for the fuzz-date.c fuzzer in v2.

Fixed the creation and memory allocation of the fuzzing str in v3. Also fixed the tz type and sign-extended the data before passing to the tz variable.

Fixed the tz variable allocations and some of the bytes used for fuzzing variables in v4.

Comment: 
Yes, indeed. It is quite annoying to have that twice. 
Yes, the tz should be considered as attacker controllable and thus negative values should be considered. But it is tricky to fuzz it because the date.c::gm_time_t() will call die() if the value is invalid and that exit the fuzzer directly. OSS-Fuzz may consider it as an issue (or bug) because the fuzzer exit "unexpectedly". I agree that if we consider the tz as "attacker controllable, we should include negative values, but since it will cause the fuzzer exit, I am not sure if it is the right approach from the fuzzing perspective. Also, it is something that date.c already take care of with the conditional checking, thus it may also be worth to do some checking and exclude some invalid values before calling date.c::show_date() but this may result in copying some conditional checking code from date.c.

Additional comment for v4:
Thanks for the suggestion. Yes, that maybe the easier approach. Since the new logic is only using 2 bytes for the int16_t tz, thus the local and dmtype variable could use separate bytes to increase "randomness".

Thanks for taking the time to contribute to Git! Please be advised that the
Git community does not use github.com for their contributions. Instead, we use
a mailing list (git@vger.kernel.org) for code submissions, code reviews, and
bug reports. Nevertheless, you can use GitGitGadget (https://gitgitgadget.github.io/)
to conveniently send your Pull Requests commits to our mailing list.

Please read the "guidelines for contributing" linked above!

cc: Jeff King <peff@peff.net>