### PR TITLE
ci: avoid running the test suite _twice_

### DIFF
--- a/ci/lib.sh
+++ b/ci/lib.sh
@@ -281,7 +281,7 @@ else
 fi
 
 MAKEFLAGS="$MAKEFLAGS --jobs=$JOBS"
-GIT_PROVE_OPTS="--timer --jobs $JOBS --state=failed,slow,save"
+GIT_PROVE_OPTS="--timer --jobs $JOBS"
 
 GIT_TEST_OPTS="$GIT_TEST_OPTS --verbose-log -x"
 case "$CI_OS_NAME" in


### PR DESCRIPTION
[This](https://github.com/git/git/actions/runs/6845537889/job/18614840166) is an example of a `osx-*` job that times out. [Here](https://github.com/git/git/actions/runs/6845537889/job/18614840166#step:4:839), it is running `t0013`, and [here](https://github.com/git/git/actions/runs/6845537889/job/18614840166#step:4:2765), it is run again (in the middle of the entire test suite, as part of `make unit-tests`).

While this tries to fix a bug uncovered by `js/doc-unit-tests`, to avoid merge conflicts, this is based on `ps/ci-gitlab`.

Changes since v1:
- Reworded the commit message, specifically avoiding a reference to a patch that has not been upstreamed from Git for Windows yet.

cc: Jeff King <peff@peff.net>
cc: Josh Steadmon <steadmon@google.com>