### PR TITLE
packfile.h: fix a typo

### DIFF
--- a/packfile.h
+++ b/packfile.h
@@ -54,7 +54,7 @@ const char *pack_basename(struct packed_git *p);
 struct packed_git *parse_pack_index(unsigned char *sha1, const char *idx_path);
 
 typedef void each_file_in_pack_dir_fn(const char *full_path, size_t full_path_len,
-				      const char *file_pach, void *data);
+				      const char *file_name, void *data);
 void for_each_file_in_pack_dir(const char *objdir,
 			       each_file_in_pack_dir_fn fn,
 			       void *data);


### PR DESCRIPTION
I stumbled over this typo yesterday. Nothing about this patch is urgent, of course, it can easily wait until v2.43.0 is released.