### PR TITLE
apply: make git apply respect core.fileMode settings

### DIFF
--- a/apply.c
+++ b/apply.c
@@ -3778,8 +3778,12 @@ static int check_preimage(struct apply_state *state,
 		return error_errno("%s", old_name);
 	}
 
-	if (!state->cached && !previous)
-		st_mode = ce_mode_from_stat(*ce, st->st_mode);
+	if (!state->cached && !previous) {
+		if (!trust_executable_bit)
+			st_mode = *ce ? (*ce)->ce_mode : patch->old_mode;
+		else
+			st_mode = ce_mode_from_stat(*ce, st->st_mode);
+	}
 
 	if (patch->is_new < 0)
 		patch->is_new = 0;

--- a/t/t4129-apply-samemode.sh
+++ b/t/t4129-apply-samemode.sh
@@ -101,4 +101,31 @@ test_expect_success POSIXPERM 'do not use core.sharedRepository for working tree
 	)
 '
 
+test_expect_success 'git apply respects core.fileMode' '
+	test_config core.fileMode false &&
+	echo true >script.sh &&
+	git add --chmod=+x script.sh &&
+	git ls-files -s script.sh > ls-files-output &&
+	test_grep "^100755" ls-files-output &&
+	test_tick && git commit -m "Add script" &&
+	git ls-tree -r HEAD script.sh > ls-tree-output &&
+	test_grep "^100755" ls-tree-output &&
+
+	echo true >>script.sh &&
+	test_tick && git commit -m "Modify script" script.sh &&
+	git format-patch -1 --stdout >patch &&
+	test_grep "^index.*100755$" patch &&
+
+	git switch -c branch HEAD^ &&
+	git apply --index patch 2>err &&
+	test_grep ! "has type 100644, expected 100755" err &&
+	git reset --hard &&
+
+	git apply patch 2>err &&
+	test_grep ! "has type 100644, expected 100755" err &&
+
+	git apply --cached patch 2>err &&
+	test_grep ! "has type 100644, expected 100755" err
+'
+
 test_done


### PR DESCRIPTION
Regarding this:

> I am wondering if we want to be more strict about hiding error
> return code from "git ls-files" and "git ls-tree" behind pipes
> like these.  Usually we encourage using a temporary file, e.g.,
>	...
>	git ls-files -s script.sh >ls-files-output &&
>	test_grep "^100755" ls-files-output &&
>	...

I have modified the patch so that the output of git ls-files and
git ls-tree are stored in a temporary file instead of being directly 
piped to grep but also noticed similar working in other test cases
in the same test file. For example, 

test_expect_success FILEMODE 'same mode (index only)' '
....
....
....
git ls-files -s file | grep "^100755"

and

test_expect_success FILEMODE 'mode update (index only)' '
...
...
...
git ls-files -s file | grep "^100755"

Would we want to modify these scripts as well so they follow the
same convention as above or is it okay to let them be as is?

cc: Torsten Bögershausen <tboegi@web.de>
cc: Johannes Schindelin <Johannes.Schindelin@gmx.de>