### PR TITLE
ci: deal better with hanging tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -149,13 +149,19 @@ jobs:
       run: tar xf artifacts.tar.gz && tar xf tracked.tar.gz
     - uses: git-for-windows/setup-git-for-windows-sdk@v1
     - name: test
+      id: test
       shell: bash
+      timeout-minutes: 20
       run: . /etc/profile && ci/run-test-slice.sh ${{matrix.nr}} 10
+    - name: handle timed-out tests
+      if: failure() && steps.test.outcome == 'failure' && env.FAILED_TEST_ARTIFACTS == ''
+      shell: bash
+      run: . /etc/profile && . ci/lib.sh && { handle_failed_tests || test $? = 1; }
     - name: print test failures
       if: failure() && env.FAILED_TEST_ARTIFACTS != ''
       shell: bash
       run: ci/print-test-failures.sh
-    - name: Upload failed tests' directories
+    - name: Upload failed/timed-out tests' directories
       if: failure() && env.FAILED_TEST_ARTIFACTS != ''
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -117,7 +117,7 @@ jobs:
     - name: build
       shell: bash
       env:
-        HOME: ${{runner.workspace}}
+        HOME: ${{ github.workspace }}
         NO_PERL: 1
       run: . /etc/profile && ci/make-test-artifacts.sh artifacts
     - name: zip up tracked files

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -250,7 +250,7 @@ jobs:
       if: failure() && env.FAILED_TEST_ARTIFACTS != ''
       uses: actions/upload-artifact@v3
       with:
-        name: failed-tests-windows
+        name: failed-tests-vs
         path: ${{env.FAILED_TEST_ARTIFACTS}}
   regular:
     name: ${{matrix.vector.jobname}} (${{matrix.vector.pool}})

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -244,15 +244,21 @@ jobs:
       shell: bash
       run: tar xf artifacts.tar.gz && tar xf tracked.tar.gz
     - name: test
+      id: test
       shell: bash
+      timeout-minutes: 20
       env:
         NO_SVN_TESTS: 1
       run: . /etc/profile && ci/run-test-slice.sh ${{matrix.nr}} 10
+    - name: handle timed-out tests
+      if: failure() && steps.test.outcome == 'failure' && env.FAILED_TEST_ARTIFACTS == ''
+      shell: bash
+      run: . /etc/profile && . ci/lib.sh && { handle_failed_tests || test $? = 1; }
     - name: print test failures
       if: failure() && env.FAILED_TEST_ARTIFACTS != ''
       shell: bash
       run: ci/print-test-failures.sh
-    - name: Upload failed tests' directories
+    - name: Upload failed/timed-out tests' directories
       if: failure() && env.FAILED_TEST_ARTIFACTS != ''
       uses: actions/upload-artifact@v3
       with:
@@ -306,10 +312,15 @@ jobs:
     - uses: actions/checkout@v3
     - run: ci/install-dependencies.sh
     - run: ci/run-build-and-tests.sh
+      id: test
+      timeout-minutes: ${{ (matrix.vector.jobname == 'linux-asan-ubsan' || startsWith(matrix.vector.pool, 'macos')) && 60 || 20 }}
+    - name: handle timed-out tests
+      if: failure() && steps.test.outcome == 'failure' && env.FAILED_TEST_ARTIFACTS == ''
+      run: . /etc/profile && . ci/lib.sh && { handle_failed_tests || test $? = 1; }
     - name: print test failures
       if: failure() && env.FAILED_TEST_ARTIFACTS != ''
       run: ci/print-test-failures.sh
-    - name: Upload failed tests' directories
+    - name: Upload failed/timed-out tests' directories
       if: failure() && env.FAILED_TEST_ARTIFACTS != ''
       uses: actions/upload-artifact@v3
       with:
@@ -343,10 +354,15 @@ jobs:
       if: matrix.vector.jobname == 'linux32'
     - run: ci/install-docker-dependencies.sh
     - run: ci/run-build-and-tests.sh
+      id: test
+      timeout-minutes: 20
+    - name: handle timed-out tests
+      if: failure() && steps.test.outcome == 'failure' && env.FAILED_TEST_ARTIFACTS == ''
+      run: . /etc/profile && . ci/lib.sh && { handle_failed_tests || test $? = 1; }
     - name: print test failures
       if: failure() && env.FAILED_TEST_ARTIFACTS != ''
       run: ci/print-test-failures.sh
-    - name: Upload failed tests' directories
+    - name: Upload failed/timed-out tests' directories
       if: failure() && env.FAILED_TEST_ARTIFACTS != '' && matrix.vector.jobname != 'linux32'
       uses: actions/upload-artifact@v3
       with:


### PR DESCRIPTION
I frequently run into CI that times out due to hanging tests. This is an attempt to help with that. This patch series starts out with two slightly-related fixes, then establishes the paradigm with the `win test` matrix, and then applies the same paradigm to the rest of the jobs that run Git's test suite.