### PR TITLE
Added commit.signoff configuration option

### DIFF
--- a/Documentation/config/commit.txt
+++ b/Documentation/config/commit.txt
@@ -27,3 +27,7 @@ commit.template::
 commit.verbose::
 	A boolean or int to specify the level of verbosity with `git commit`.
 	See linkgit:git-commit[1].
+
+commit.sigoff::
+	A boolean value which lets you enable the `-s/--signoff` option of
+	commit by default.

--- a/builtin/commit.c
+++ b/builtin/commit.c
@@ -1620,6 +1620,10 @@ static int git_commit_config(const char *k, const char *v,
 		include_status = git_config_bool(k, v);
 		return 0;
 	}
+	if (!strcmp(k, "commit.signoff")) {
+		signoff = git_config_bool(k, v);
+		return 0;
+	}
 	if (!strcmp(k, "commit.cleanup"))
 		return git_config_string(&cleanup_arg, k, v);
 	if (!strcmp(k, "commit.gpgsign")) {


### PR DESCRIPTION
This allows to automatically signoff commits without having to pass the `-s` flag.

---

This is my first contrib, and I'm very rusty at C, be kind please :) 