### PR TITLE
modified template shell scripts

### DIFF
--- a/templates/hooks--applypatch-msg.sample
+++ b/templates/hooks--applypatch-msg.sample
@@ -11,5 +11,5 @@
 
 . git-sh-setup
 commitmsg="$(git rev-parse --git-path hooks/commit-msg)"
-test -x "$commitmsg" && exec "$commitmsg" ${1+"$@"}
+[ -x "$commitmsg" ] && exec "$commitmsg" ${1+"$@"}
 :

--- a/templates/hooks--commit-msg.sample
+++ b/templates/hooks--commit-msg.sample
@@ -17,8 +17,8 @@
 
 # This example catches duplicate Signed-off-by lines.
 
-test "" = "$(grep '^Signed-off-by: ' "$1" |
-	 sort | uniq -c | sed -e '/^[ 	]*1[ 	]/d')" || {
+[ -z "$(grep '^Signed-off-by: ' "$1" |
+	 sort | uniq -c | sed -e '/^[ 	]*1[ 	]/d')" ] || {
 	echo >&2 Duplicate Signed-off-by lines.
 	exit 1
 }

--- a/templates/hooks--pre-applypatch.sample
+++ b/templates/hooks--pre-applypatch.sample
@@ -10,5 +10,5 @@
 
 . git-sh-setup
 precommit="$(git rev-parse --git-path hooks/pre-commit)"
-test -x "$precommit" && exec "$precommit" ${1+"$@"}
+[ -x "$precommit" ] && exec "$precommit" ${1+"$@"}
 :

--- a/templates/hooks--pre-commit.sample
+++ b/templates/hooks--pre-commit.sample
@@ -7,8 +7,7 @@
 #
 # To enable this hook, rename this file to "pre-commit".
 
-if git rev-parse --verify HEAD >/dev/null 2>&1
-then
+if git rev-parse --verify HEAD >/dev/null 2>&1; then
 	against=HEAD
 else
 	# Initial commit: diff against an empty tree object
@@ -28,8 +27,8 @@ if [ "$allownonascii" != "true" ] &&
 	# Note that the use of brackets around a tr range is ok here, (it's
 	# even required, for portability to Solaris 10's /usr/bin/tr), since
 	# the square bracket bytes happen to fall in the designated range.
-	test $(git diff-index --cached --name-only --diff-filter=A -z $against |
-	  LC_ALL=C tr -d '[ -~]\0' | wc -c) != 0
+	[ "$(git diff-index --cached --name-only --diff-filter=A -z "$against" |
+	  LC_ALL=C tr -d '[ -~]\0' | wc -c)" -ne 0 ] 
 then
 	cat <<\EOF
 Error: Attempt to add a non-ASCII file name.
@@ -46,4 +45,4 @@ EOF
 fi
 
 # If there are whitespace errors, print the offending file names and fail.
-exec git diff-index --check --cached $against --
+exec git diff-index --check --cached "$against" --

--- a/templates/hooks--pre-merge-commit.sample
+++ b/templates/hooks--pre-merge-commit.sample
@@ -8,6 +8,5 @@
 # To enable this hook, rename this file to "pre-merge-commit".
 
 . git-sh-setup
-test -x "$GIT_DIR/hooks/pre-commit" &&
-        exec "$GIT_DIR/hooks/pre-commit"
+[ -x "$GIT_DIR/hooks/pre-commit" ] && exec "$GIT_DIR/hooks/pre-commit"
 :

--- a/templates/hooks--pre-push.sample
+++ b/templates/hooks--pre-push.sample
@@ -22,17 +22,14 @@
 remote="$1"
 url="$2"
 
-zero=$(git hash-object --stdin </dev/null | tr '[0-9a-f]' '0')
+zero=$(git hash-object --stdin </dev/null | tr '[:alnum:]' '0')
 
-while read local_ref local_oid remote_ref remote_oid
-do
-	if test "$local_oid" = "$zero"
-	then
+while read -r local_ref local_oid remote_ref remote_oid; do
+	if [ "$local_oid" = "$zero" ]; then
 		# Handle delete
 		:
 	else
-		if test "$remote_oid" = "$zero"
-		then
+		if [ "$remote_oid" = "$zero" ]; then
 			# New branch, examine all commits
 			range="$local_oid"
 		else
@@ -42,8 +39,7 @@ do
 
 		# Check for WIP commit
 		commit=$(git rev-list -n 1 --grep '^WIP' "$range")
-		if test -n "$commit"
-		then
+		if [ -n "$commit" ]; then
 			echo >&2 "Found WIP commit in $local_ref, not pushing"
 			exit 1
 		fi

--- a/templates/hooks--pre-rebase.sample
+++ b/templates/hooks--pre-rebase.sample
@@ -17,11 +17,10 @@
 
 publish=next
 basebranch="$1"
-if test "$#" = 2
-then
+if [ "$#" -eq 2 ]; then
 	topic="refs/heads/$2"
 else
-	topic=`git symbolic-ref HEAD` ||
+	topic=$(git symbolic-ref HEAD) ||
 	exit 0 ;# we do not interrupt rebasing detached HEAD
 fi
 
@@ -43,28 +42,25 @@ git show-ref -q "$topic" || {
 }
 
 # Is topic fully merged to master?
-not_in_master=`git rev-list --pretty=oneline ^master "$topic"`
-if test -z "$not_in_master"
-then
+not_in_master=$(git rev-list --pretty=oneline ^master "$topic")
+if [ -z "$not_in_master" ]; then
 	echo >&2 "$topic is fully merged to master; better remove it."
 	exit 1 ;# we could allow it, but there is no point.
 fi
 
 # Is topic ever merged to next?  If so you should not be rebasing it.
-only_next_1=`git rev-list ^master "^$topic" ${publish} | sort`
-only_next_2=`git rev-list ^master           ${publish} | sort`
-if test "$only_next_1" = "$only_next_2"
-then
-	not_in_topic=`git rev-list "^$topic" master`
-	if test -z "$not_in_topic"
-	then
+only_next_1=$(git rev-list ^master "^$topic" ${publish} | sort)
+only_next_2=$(git rev-list ^master           ${publish} | sort)
+if [ "$only_next_1" = "$only_next_2" ]; then
+	not_in_topic=$(git rev-list "^$topic" master)
+	if [ -z "$not_in_topic" ]; then
 		echo >&2 "$topic is already up to date with master"
 		exit 1 ;# we could allow it, but there is no point.
 	else
 		exit 0
 	fi
 else
-	not_in_next=`git rev-list --pretty=oneline ^${publish} "$topic"`
+	not_in_next=$(git rev-list --pretty=oneline ^${publish} "$topic")
 	@PERL_PATH@ -e '
 		my $topic = $ARGV[0];
 		my $msg = "* $topic has commits already merged to public branch:\n";

--- a/templates/hooks--pre-receive.sample
+++ b/templates/hooks--pre-receive.sample
@@ -6,11 +6,9 @@
 #
 # To enable this hook, rename this file to "pre-receive".
 
-if test -n "$GIT_PUSH_OPTION_COUNT"
-then
+if [ -n "$GIT_PUSH_OPTION_COUNT" ]; then
 	i=0
-	while test "$i" -lt "$GIT_PUSH_OPTION_COUNT"
-	do
+	while [ "$i" -lt "$GIT_PUSH_OPTION_COUNT" ]; do
 		eval "value=\$GIT_PUSH_OPTION_$i"
 		case "$value" in
 		echoback=*)

--- a/templates/hooks--push-to-checkout.sample
+++ b/templates/hooks--push-to-checkout.sample
@@ -47,32 +47,27 @@ die () {
 # the working tree, you will have to adapt your code accordingly, e.g.
 # by adding "cd .." or using relative paths.
 
-if ! git update-index -q --ignore-submodules --refresh
-then
+if ! git update-index -q --ignore-submodules --refresh; then
 	die "Up-to-date check failed"
 fi
 
-if ! git diff-files --quiet --ignore-submodules --
-then
+if ! git diff-files --quiet --ignore-submodules --; then
 	die "Working directory has unstaged changes"
 fi
 
 # This is a rough translation of:
 #
 #   head_has_history() ? "HEAD" : EMPTY_TREE_SHA1_HEX
-if git cat-file -e HEAD 2>/dev/null
-then
+if git cat-file -e HEAD 2>/dev/null; then
 	head=HEAD
 else
 	head=$(git hash-object -t tree --stdin </dev/null)
 fi
 
-if ! git diff-index --quiet --cached --ignore-submodules $head --
-then
+if ! git diff-index --quiet --cached --ignore-submodules "$head" --; then
 	die "Working directory has staged changes"
 fi
 
-if ! git read-tree -u -m "$commit"
-then
+if ! git read-tree -u -m "$commit"; then
 	die "Could not update working tree to new HEAD"
 fi

--- a/templates/hooks--sendemail-validate.sample
+++ b/templates/hooks--sendemail-validate.sample
@@ -45,8 +45,7 @@ validate_series () {
 
 # main -------------------------------------------------------------------------
 
-if test "$GIT_SENDEMAIL_FILE_COUNTER" = 1
-then
+if [ "$GIT_SENDEMAIL_FILE_COUNTER" = 1 ]; then
 	remote=$(git config --default origin --get sendemail.validateRemote) &&
 	ref=$(git config --default HEAD --get sendemail.validateRemoteRef) &&
 	worktree=$(mktemp --tmpdir -d sendemail-validate.XXXXXXX) &&
@@ -62,15 +61,13 @@ fi || {
 unset GIT_DIR GIT_WORK_TREE
 cd "$worktree" &&
 
-if grep -q "^diff --git " "$1"
-then
+if grep -q "^diff --git " "$1"; then
 	validate_patch "$1"
 else
 	validate_cover_letter "$1"
 fi &&
 
-if test "$GIT_SENDEMAIL_FILE_COUNTER" = "$GIT_SENDEMAIL_FILE_TOTAL"
-then
+if [ "$GIT_SENDEMAIL_FILE_COUNTER" = "$GIT_SENDEMAIL_FILE_TOTAL" ]; then
 	git config --unset-all sendemail.validateWorktree &&
 	trap 'git worktree remove -ff "$worktree"' EXIT &&
 	validate_series

--- a/templates/hooks--update.sample
+++ b/templates/hooks--update.sample
@@ -37,7 +37,7 @@ if [ -z "$GIT_DIR" ]; then
 	exit 1
 fi
 
-if [ -z "$refname" -o -z "$oldrev" -o -z "$newrev" ]; then
+if [ -z "$refname" ] || [ -z "$oldrev" ] || [ -z "$newrev" ]; then
 	echo "usage: $0 <ref> <oldrev> <newrev>" >&2
 	exit 1
 fi
@@ -60,11 +60,11 @@ esac
 
 # --- Check types
 # if $newrev is 0000...0000, it's a commit to delete a ref.
-zero=$(git hash-object --stdin </dev/null | tr '[0-9a-f]' '0')
+zero=$(git hash-object --stdin </dev/null | tr '[:alnum:]' '0')
 if [ "$newrev" = "$zero" ]; then
 	newrev_type=delete
 else
-	newrev_type=$(git cat-file -t $newrev)
+	newrev_type=$(git cat-file -t "$newrev")
 fi
 
 case "$refname","$newrev_type" in
@@ -86,7 +86,7 @@ case "$refname","$newrev_type" in
 		;;
 	refs/tags/*,tag)
 		# annotated tag
-		if [ "$allowmodifytag" != "true" ] && git rev-parse $refname > /dev/null 2>&1
+		if [ "$allowmodifytag" != "true" ] && git rev-parse "$refname" > /dev/null 2>&1
 		then
 			echo "*** Tag '$refname' already exists." >&2
 			echo "*** Modifying a tag is not allowed in this repository." >&2
@@ -95,7 +95,7 @@ case "$refname","$newrev_type" in
 		;;
 	refs/heads/*,commit)
 		# branch
-		if [ "$oldrev" = "$zero" -a "$denycreatebranch" = "true" ]; then
+		if [ "$oldrev" = "$zero" ] && [ "$denycreatebranch" = "true" ]; then
 			echo "*** Creating a branch is not allowed in this repository" >&2
 			exit 1
 		fi


### PR DESCRIPTION
Changed according to:
1) recommendations from shellcheck
such as quoting variables and removing backticks

2) change test commands to use bracket notation
`test "$var" `-> `[ "$var" ]`

3) changed if and while conditionals to have "then" on same line
```
if [ "$var" ]
then
```
to
`if [ "$var" ]; then`

4) `tr '[0-9a-f]' '0'` to `tr '[:alnum:]' '0'`
This changes tr to use the alphanumeric class. This future-proofs the command in case that we later have hashes that are bigger than base-16.

Thanks for taking the time to contribute to Git! Please be advised that the
Git community does not use github.com for their contributions. Instead, we use
a mailing list (git@vger.kernel.org) for code submissions, code reviews, and
bug reports. Nevertheless, you can use GitGitGadget (https://gitgitgadget.github.io/)
to conveniently send your Pull Requests commits to our mailing list.

Please read the "guidelines for contributing" linked above!
