### PR TITLE
commit.c: ensure find_header_mem() doesn't scan beyond given range

### DIFF
--- a/commit.c
+++ b/commit.c
@@ -1743,15 +1743,11 @@ const char *find_header_mem(const char *msg, size_t len,
 	int key_len = strlen(key);
 	const char *line = msg;
 
-	/*
-	 * NEEDSWORK: It's possible for strchrnul() to scan beyond the range
-	 * given by len. However, current callers are safe because they compute
-	 * len by scanning a NUL-terminated block of memory starting at msg.
-	 * Nonetheless, it would be better to ensure the function does not look
-	 * at msg beyond the len provided by the caller.
-	 */
 	while (line && line < msg + len) {
-		const char *eol = strchrnul(line, '\n');
+		char *eol = (char *) line;
+		for (size_t i = 0; i < len && *eol && *eol != '\n'; i++) {
+			eol++;
+		}
 
 		if (line == eol)
 			return NULL;


### PR DESCRIPTION
Thanks for the feedback, Kyle and René! I have update the 
patch to actually solve the problem at hand but I am not very 
sure about the resulting dropping of const-ness of 'eol' from 
this and how big of a problem it might create (if any). I wonder
if a custom strchrnul() is the best solution to this after all.

cc: René Scharfe <l.s.r@web.de>
cc: Kyle Lippincott <spectral@google.com>
cc: Jeff King <peff@peff.net>