### PR TITLE
ref-filter.c: sort formatted dates by byte value

### DIFF
--- a/Documentation/git-for-each-ref.txt
+++ b/Documentation/git-for-each-ref.txt
@@ -359,9 +359,11 @@ In any case, a field name that refers to a field inapplicable to
 the object referred by the ref does not cause an error.  It
 returns an empty string instead.
 
-As a special case for the date-type fields, you may specify a format for
-the date by adding `:` followed by date format name (see the
-values the `--date` option to linkgit:git-rev-list[1] takes).
+As a special case for the date-type fields, you may specify a format for the
+date by adding `:` followed by date format name (see the values the `--date`
+option to linkgit:git-rev-list[1] takes). If this formatting is provided in
+a `--sort` key, references will be sorted according to the byte-value of the
+formatted string rather than the numeric value of the underlying timestamp.
 
 Some atoms like %(align) and %(if) always require a matching %(end).
 We call them "opening atoms" and sometimes denote them as %($open).

--- a/ref-filter.c
+++ b/ref-filter.c
@@ -1611,6 +1611,12 @@ static void grab_date(const char *buf, struct atom_value *v, const char *atomnam
 	if (formatp) {
 		formatp++;
 		parse_date_format(formatp, &date_mode);
+
+		/*
+		 * If this is a sort field and a format was specified, we'll
+		 * want to compare formatted date by string value.
+		 */
+		v->atom->type = FIELD_STR;
 	}
 
 	if (!eoemail)


### PR DESCRIPTION
I came across a use case for 'git for-each-ref' at $DAYJOB in which I'd want to sort by a portion of a formatted 'creatordate' (e.g., only the time of day, sans date). When I tried to run something like 'git for-each-ref --sort=creatordate:format:%H:%M:%S', though, I was surprised to find that the refs were still sorted according to the full date/time value (as they would be with '--sort=creatordate'). 

This patch attempts to make date-based sorting a bit more flexible by ordering based on the formatted date string *if and only if* a custom format is specified. The implementation is fairly simple (manually set the comparison type to 'FIELD_STR' if the format string is not null), but I'm interested in hearing from reviewers whether this seems like a reasonable extension to 'git for-each-ref --sort', or if there's another (better) way to add this kind of functionality.

Thanks!
- Victoria