### PR TITLE
prune: mark rebase autostash and orig-head as reachable

### DIFF
--- a/t/t3420-rebase-autostash.sh
+++ b/t/t3420-rebase-autostash.sh
@@ -333,4 +333,14 @@ test_expect_success 'never change active branch' '
 	test_cmp_rev not-the-feature-branch unrelated-onto-branch
 '
 
+test_expect_success 'autostash commit is marked as reachable' '
+	echo changed >file0 &&
+	git rebase --autostash --exec "git prune --expire=now" \
+		feature-branch^ feature-branch &&
+	# git rebase succeeds if the stash cannot be applied so we need to check
+	# the contents of file0
+	echo changed >expect &&
+	test_cmp expect file0
+'
+
 test_done


### PR DESCRIPTION
Thanks for the comments on v1. I've fixed the memory leak and changed the return types as suggested by Eric.

Cc: Orgad Shaneh <orgads@gmail.com>
cc: Eric Sunshine <sunshine@sunshineco.com>