### PR TITLE
The merge-base logic vs missing commit objects (follow-up)

### DIFF
--- a/merge-ort.c
+++ b/merge-ort.c
@@ -1819,6 +1819,7 @@ static int merge_submodule(struct merge_options *opt,
 			 _("Failed to merge submodule %s "
 			   "(repository corrupt)"),
 			 path);
+		ret = -1;
 		goto cleanup;
 	}
 	if (ret2 > 0)
@@ -1829,6 +1830,7 @@ static int merge_submodule(struct merge_options *opt,
 			 _("Failed to merge submodule %s "
 			   "(repository corrupt)"),
 			 path);
+		ret = -1;
 		goto cleanup;
 	}
 	if (!ret2) {
@@ -1848,6 +1850,7 @@ static int merge_submodule(struct merge_options *opt,
 			 _("Failed to merge submodule %s "
 			   "(repository corrupt)"),
 			 path);
+		ret = -1;
 		goto cleanup;
 	}
 	if (ret2 > 0) {
@@ -1866,6 +1869,7 @@ static int merge_submodule(struct merge_options *opt,
 			 _("Failed to merge submodule %s "
 			   "(repository corrupt)"),
 			 path);
+		ret = -1;
 		goto cleanup;
 	}
 	if (ret2 > 0) {
@@ -1899,6 +1903,7 @@ static int merge_submodule(struct merge_options *opt,
 			 _("Failed to merge submodule %s "
 			   "(repository corrupt)"),
 			 path);
+		ret = -1;
 		break;
 	case 0:
 		path_msg(opt, CONFLICT_SUBMODULE_FAILED_TO_MERGE, 0,

--- a/merge-recursive.c
+++ b/merge-recursive.c
@@ -1246,12 +1246,14 @@ static int merge_submodule(struct merge_options *opt,
 	ret2 = repo_in_merge_bases(&subrepo, commit_base, commit_a);
 	if (ret2 < 0) {
 		output(opt, 1, _("Failed to merge submodule %s (repository corrupt)"), path);
+		ret = -1;
 		goto cleanup;
 	}
 	if (ret2 > 0)
 		ret2 = repo_in_merge_bases(&subrepo, commit_base, commit_b);
 	if (ret2 < 0) {
 		output(opt, 1, _("Failed to merge submodule %s (repository corrupt)"), path);
+		ret = -1;
 		goto cleanup;
 	}
 	if (!ret2) {
@@ -1263,6 +1265,7 @@ static int merge_submodule(struct merge_options *opt,
 	ret2 = repo_in_merge_bases(&subrepo, commit_a, commit_b);
 	if (ret2 < 0) {
 		output(opt, 1, _("Failed to merge submodule %s (repository corrupt)"), path);
+		ret = -1;
 		goto cleanup;
 	}
 	if (ret2) {
@@ -1281,6 +1284,7 @@ static int merge_submodule(struct merge_options *opt,
 	ret2 = repo_in_merge_bases(&subrepo, commit_b, commit_a);
 	if (ret2 < 0) {
 		output(opt, 1, _("Failed to merge submodule %s (repository corrupt)"), path);
+		ret = -1;
 		goto cleanup;
 	}
 	if (ret2) {
@@ -1312,6 +1316,10 @@ static int merge_submodule(struct merge_options *opt,
 	parent_count = find_first_merges(&subrepo, &merges, path,
 					 commit_a, commit_b);
 	switch (parent_count) {
+	case -1:
+		output(opt, 1,_("Failed to merge submodule %s (repository corrupt)"), path);
+		ret = -1;
+		break;
 	case 0:
 		output(opt, 1, _("Failed to merge submodule %s (merge following commits not found)"), path);
 		break;

--- a/merge-recursive.c
+++ b/merge-recursive.c
@@ -1426,13 +1426,14 @@ static int merge_mode_and_contents(struct merge_options *opt,
 			/* FIXME: bug, what if modes didn't match? */
 			result->clean = (merge_status == 0);
 		} else if (S_ISGITLINK(a->mode)) {
-			result->clean = merge_submodule(opt, &result->blob.oid,
-							o->path,
-							&o->oid,
-							&a->oid,
-							&b->oid);
-			if (result->clean < 0)
+			int clean = merge_submodule(opt, &result->blob.oid,
+						    o->path,
+						    &o->oid,
+						    &a->oid,
+						    &b->oid);
+			if (clean < 0)
 				return -1;
+			result->clean = clean;
 		} else if (S_ISLNK(a->mode)) {
 			switch (opt->recursive_variant) {
 			case MERGE_VARIANT_NORMAL:


### PR DESCRIPTION
Jeff King reported that Coverity pointed out a problem in the patch series "The merge-base logic vs missing commit objects" (which made it into the `next` branch already): The return value of `merge_submodules()` is assigned to an unsigned, single-bit variable, which as a consequence is not able to hold a negative value indicating a non-recoverable error.

I looked into this issue and am happy to report that there are no other instances of the same issue in that patch series. The first patch in this here patch series addresses that issue.

While looking into this issue I also noticed that the `merge_submodule()` function did not even return negative values! This was an oversight on my part (which I attribute with a large amount of self-compassion to my utter lack of enthusiasm for submodules as a Git feature), and the second patch in this here patch series addresses that.

This is a follow-up for https://lore.kernel.org/git/pull.1657.v4.git.1709113457.gitgitgadget@gmail.com/, based on the `js/merge-base-with-missing-commit` branch.

cc: Patrick Steinhardt <ps@pks.im>
cc: Dirk Gouders <dirk@gouders.net>
cc: Jeff King <peff@peff.net>
cc: Elijah Newren <newren@gmail.com>