### PR TITLE
cat-file: add `%(objectmode)` avoid verifying submodules' OIDs

### DIFF
--- a/Documentation/git-cat-file.txt
+++ b/Documentation/git-cat-file.txt
@@ -292,6 +292,11 @@ newline. The available atoms are:
 `objecttype`::
 	The type of the object (the same as `cat-file -t` reports).
 
+`objectmode`::
+	If the specified object has mode information (such as a tree or
+	index entry), the mode expressed as an octal integer. Otherwise,
+	empty string.
+
 `objectsize`::
 	The size, in bytes, of the object (the same as `cat-file -s`
 	reports).

--- a/Documentation/git-cat-file.txt
+++ b/Documentation/git-cat-file.txt
@@ -412,6 +412,11 @@ Note also that multiple copies of an object may be present in the object
 database; in this case, it is undefined which copy's size or delta base
 will be reported.
 
+Submodules are handled specially in `git cat-file`, as the objects
+corresponding to the recorded OIDs are not expected to be present in the
+current repository. For that reason, submodules are reported as having
+type `submodule` and mode 1600000 and all other fields are zeroed out.
+
 GIT
 ---
 Part of the linkgit:git[1] suite

--- a/t/t1006-cat-file.sh
+++ b/t/t1006-cat-file.sh
@@ -1178,6 +1178,16 @@ test_expect_success 'cat-file --batch-check respects replace objects' '
 	test_cmp expect actual
 '
 
+test_expect_success 'batch-command with a submodule' '
+	printf "160000 commit %0.*d\tsub\n" $(test_oid hexsz) 17 >tree-with-sub &&
+	tree=$(git mktree <tree-with-sub) &&
+	git cat-file --batch-check >actual <<-EOF &&
+	$tree:sub
+	EOF
+	printf "%0.*d submodule 0\n" $(test_oid hexsz) 17 >expect &&
+	test_cmp expect actual
+'
+
 # Pull the entry for object with oid "$1" out of the output of
 # "cat-file --batch", including its object content (which requires
 # parsing and reading a set amount of bytes, hence perl).


### PR DESCRIPTION
The `cat-file --batch` command is very valuable in server settings, but so far it is missing a bit of functionality that would come in handy there.

For example, it is sometimes necessary to determine the object mode of a batch of tree objects' children.

This came up in $dayjob recently, and applies cleanly to v2.44.0.

cc: Jeff King <peff@peff.net>