### PR TITLE
git-compat-util: move `convert_slashes` from compat/mingw.h and rename it

### DIFF
--- a/abspath.c
+++ b/abspath.c
@@ -58,7 +58,7 @@ static void get_root_part(struct strbuf *resolved, struct strbuf *remaining)
 	strbuf_reset(resolved);
 	strbuf_add(resolved, remaining->buf, offset);
 #ifdef GIT_WINDOWS_NATIVE
-	convert_slashes(resolved->buf);
+	change_path_separators(resolved->buf);
 #endif
 	strbuf_remove(remaining, 0, offset);
 }
@@ -278,7 +278,7 @@ char *prefix_filename(const char *pfx, const char *arg)
 
 	strbuf_addstr(&path, arg);
 #ifdef GIT_WINDOWS_NATIVE
-	convert_slashes(path.buf + pfx_len);
+	change_path_separators(path.buf + pfx_len);
 #endif
 	return strbuf_detach(&path, NULL);
 }

--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -1170,7 +1170,7 @@ char *mingw_getcwd(char *pointer, int len)
 	}
 	if (xwcstoutf(pointer, wpointer, len) < 0)
 		return NULL;
-	convert_slashes(pointer);
+	change_path_separators(pointer);
 	return pointer;
 }
 
@@ -2636,7 +2636,7 @@ static void setup_windows_environment(void)
 		 * executable (by not mistaking the dir separators
 		 * for escape characters).
 		 */
-		convert_slashes(tmp);
+		change_path_separators(tmp);
 	}
 
 	/* simulate TERM to enable auto-color (see color.c) */

--- a/compat/mingw.h
+++ b/compat/mingw.h
@@ -448,12 +448,6 @@ HANDLE winansi_get_osfhandle(int fd);
  * git specific compatibility
  */
 
-static inline void convert_slashes(char *path)
-{
-	for (; *path; path++)
-		if (*path == '\\')
-			*path = '/';
-}
 #define PATH_SEP ';'
 char *mingw_query_user_email(void);
 #define query_user_email mingw_query_user_email

--- a/git-compat-util.h
+++ b/git-compat-util.h
@@ -1309,6 +1309,13 @@ static inline int strtol_i(char const *s, int base, int *result)
 	return 0;
 }
 
+static inline void change_path_separators(char *path)
+{
+	for (; *path; path++)
+		if (*path == '\\')
+			*path = '/';
+}
+
 void git_stable_qsort(void *base, size_t nmemb, size_t size,
 		      int(*compar)(const void *, const void *));
 #ifdef INTERNAL_QSORT

--- a/path.c
+++ b/path.c
@@ -758,7 +758,7 @@ char *interpolate_path(const char *path, int real_home)
 			else
 				strbuf_addstr(&user_path, home);
 #ifdef GIT_WINDOWS_NATIVE
-			convert_slashes(user_path.buf);
+			change_path_separators(user_path.buf);
 #endif
 		} else {
 			struct passwd *pw = getpw_str(username, username_len);

--- a/t/unit-tests/test-lib.c
+++ b/t/unit-tests/test-lib.c
@@ -52,9 +52,7 @@ static const char *make_relative(const char *location)
 		prefix_len = len - needle_len;
 		if (prefix[prefix_len + 1] == '/') {
 			/* Oh, we're not Windows */
-			for (size_t i = 0; i < needle_len; i++)
-				if (needle[i] == '\\')
-					needle[i] = '/';
+			change_path_separators(&needle[0]);
 			need_bs_to_fs = 0;
 		} else {
 			need_bs_to_fs = 1;
@@ -88,9 +86,8 @@ static const char *make_relative(const char *location)
 
 	/* convert backslashes to forward slashes */
 	strlcpy(buf, location + prefix_len, sizeof(buf));
-	for (p = buf; *p; p++)
-		if (*p == '\\')
-			*p = '/';
+	p = buf;
+	change_path_separators(p);
 	return buf;
 }
 


### PR DESCRIPTION
Hi all,

This series aims to complete a #leftoverbits: https://lore.kernel.org/
git/[xmqqzfw43xad.fsf@gitster.g](mailto:xmqqzfw43xad.fsf@gitster.g)/ by moving convert_slashes() to
git-compat-util.h and renaming it to change_path_separators().

I appreciate your review and feedback on this patch series.

Best regards,
Mohit Marathe
