### PR TITLE
Win32: detect unix socket support at runtime

### DIFF
--- a/builtin/credential-cache--daemon.c
+++ b/builtin/credential-cache--daemon.c
@@ -294,6 +294,8 @@ int cmd_credential_cache_daemon(int argc, const char **argv, const char *prefix)
 	argc = parse_options(argc, argv, prefix, options, usage, 0);
 	socket_path = argv[0];
 
+	if (!have_unix_sockets())
+		die(_("credential-cache--daemon unavailable; no unix socket support"));
 	if (!socket_path)
 		usage_with_options(usage, options);
 

--- a/builtin/credential-cache.c
+++ b/builtin/credential-cache.c
@@ -149,6 +149,9 @@ int cmd_credential_cache(int argc, const char **argv, const char *prefix)
 		usage_with_options(usage, options);
 	op = argv[0];
 
+	if (!have_unix_sockets())
+		die(_("credential-cache unavailable; no unix socket support"));
+
 	if (!socket_path)
 		socket_path = get_socket_path();
 	if (!socket_path)

--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -3158,3 +3158,22 @@ int uname(struct utsname *buf)
 		  "%u", (v >> 16) & 0x7fff);
 	return 0;
 }
+
+int mingw_have_unix_sockets(void)
+{
+	SC_HANDLE scm, srvc;
+	SERVICE_STATUS_PROCESS status;
+	DWORD bytes;
+	int ret = 0;
+	scm = OpenSCManagerA(NULL, NULL, SC_MANAGER_CONNECT);
+	if (scm) {
+		srvc = OpenServiceA(scm, "afunix", SERVICE_QUERY_STATUS);
+		if (srvc) {
+			if(QueryServiceStatusEx(srvc, SC_STATUS_PROCESS_INFO, (LPBYTE)&status, sizeof(SERVICE_STATUS_PROCESS), &bytes))
+				ret = status.dwCurrentState == SERVICE_RUNNING;
+			CloseServiceHandle(srvc);
+		}
+		CloseServiceHandle(scm);
+	}
+	return ret;
+}

--- a/compat/mingw.h
+++ b/compat/mingw.h
@@ -631,3 +631,9 @@ void open_in_gdb(void);
  * Used by Pthread API implementation for Windows
  */
 int err_win_to_posix(DWORD winerr);
+
+#ifndef NO_UNIX_SOCKETS
+int mingw_have_unix_sockets(void);
+#undef have_unix_sockets
+#define have_unix_sockets mingw_have_unix_sockets
+#endif

--- a/config.mak.uname
+++ b/config.mak.uname
@@ -447,7 +447,6 @@ ifeq ($(uname_S),Windows)
 	NO_POLL = YesPlease
 	NO_SYMLINK_HEAD = YesPlease
 	NO_IPV6 = YesPlease
-	NO_UNIX_SOCKETS = YesPlease
 	NO_SETENV = YesPlease
 	NO_STRCASESTR = YesPlease
 	NO_STRLCPY = YesPlease
@@ -661,7 +660,6 @@ ifeq ($(uname_S),MINGW)
 	NO_LIBGEN_H = YesPlease
 	NO_POLL = YesPlease
 	NO_SYMLINK_HEAD = YesPlease
-	NO_UNIX_SOCKETS = YesPlease
 	NO_SETENV = YesPlease
 	NO_STRCASESTR = YesPlease
 	NO_STRLCPY = YesPlease

--- a/git-compat-util.h
+++ b/git-compat-util.h
@@ -218,6 +218,18 @@ struct strbuf;
 #define GIT_WINDOWS_NATIVE
 #endif
 
+#if defined(NO_UNIX_SOCKETS) || !defined(GIT_WINDOWS_NATIVE)
+static inline int _have_unix_sockets(void)
+{
+#if defined(NO_UNIX_SOCKETS)
+	return 0;
+#else
+	return 1;
+#endif
+}
+#define have_unix_sockets _have_unix_sockets
+#endif
+
 #include <unistd.h>
 #include <stdio.h>
 #include <sys/stat.h>

--- a/t/t0301-credential-cache.sh
+++ b/t/t0301-credential-cache.sh
@@ -8,6 +8,14 @@ test -z "$NO_UNIX_SOCKETS" || {
 	skip_all='skipping credential-cache tests, unix sockets not available'
 	test_done
 }
+if test_have_prereq MINGW
+then
+	service_running=$(sc query afunix | grep "4  RUNNING")
+	test -z "$service_running" || {
+		skip_all='skipping credential-cache tests, unix sockets not available'
+		test_done
+	}
+fi
 
 uname_s=$(uname -s)
 case $uname_s in


### PR DESCRIPTION
Microsoft recommends checking for unix socket support on the command line trough the `sc` command. [1][2]

> Check whether your Windows build has support for unix socket by running “sc query afunix” from a Windows admin command prompt.

That command queries wether the Service `afunix` exists and what it's current status is. [2]

Using OpenSCManagerA() [3], OpenServiceA() [4], QueryServiceStatusEx() [5]
and CloseServiceHandle() [6] we can query the same information without spawning a new process and parsing the output.

All the used APIs are available Windows XP/Server 2003. [3][4][5][6]. They're also available on Nano Server images [7] and should thus be available in docker containers.

A quick test with `time git credential-cache exit` shows a negligible startup penalty of 2ms.

I've decided against introducing a third behaviour (disabled at compile time/dynamic detection/enabled at compile time), because the main difference would be a more cryptic error message on unsupported systems and the aforementioned ~2ms startup time difference.

This conflicts slightly with the patch series at [8], but rebasing onto v2 made little sense with a v3 seemongly in the making.

[1] https://devblogs.microsoft.com/commandline/af_unix-comes-to-windows/
[2] https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/sc-query
[3] https://learn.microsoft.com/en-us/windows/win32/api/winsvc/nf-winsvc-openscmanagera
[4] https://learn.microsoft.com/en-us/windows/win32/api/winsvc/nf-winsvc-openservicea
[5] https://learn.microsoft.com/en-us/windows/win32/api/winsvc/nf-winsvc-queryservicestatusex
[6] https://learn.microsoft.com/en-us/windows/win32/api/winsvc/nf-winsvc-closeservicehandle
[7] https://learn.microsoft.com/en-us/previous-versions/windows/desktop/legacy/mt588480(v=vs.85)
[8] https://lore.kernel.org/git/pull.1681.git.git.1708506863243.gitgitgadget@gmail.com/

cc: Eric Wong <e@80x24.org>
cc: Leslie Cheng <leslie.cheng5@gmail.com>
cc: Johannes Schindelin <Johannes.Schindelin@gmx.de>
cc: M Hickford <mirth.hickford@gmail.com>
cc: Carlo Marcelo Arenas Belón <carenas@gmail.com>
cc: Denton Liu <liu.denton@gmail.com>
cc: SZEDER Gábor <szeder.dev@gmail.com>
cc: Jeff King <peff@peff.net>