### PR TITLE
Cleanup rebase signoff tests

### DIFF
--- a/t/t3428-rebase-signoff.sh
+++ b/t/t3428-rebase-signoff.sh
@@ -38,8 +38,8 @@ test_expect_success 'setup' '
 
 # We configure an alias to do the rebase --signoff so that
 # on the next subtest we can show that --no-signoff overrides the alias
-test_expect_success 'rebase --signoff adds a sign-off line' '
-	git rbs HEAD^ &&
+test_expect_success 'rebase --apply --signoff adds a sign-off line' '
+	git rbs --apply HEAD^ &&
 	test_commit_message HEAD expected-signed
 '
 

--- a/t/t3428-rebase-signoff.sh
+++ b/t/t3428-rebase-signoff.sh
@@ -8,37 +8,37 @@ This test runs git rebase --signoff and make sure that it works.
 TEST_PASSES_SANITIZE_LEAK=true
 . ./test-lib.sh
 
-# A simple file to commit
-cat >file <<EOF
-a
-EOF
+test_expect_success 'setup' '
+	git commit --allow-empty -m "Initial empty commit" &&
+	test_commit first file a &&
 
-# Expected commit message for initial commit after rebase --signoff
-cat >expected-initial-signed <<EOF
-Initial empty commit
+	ident="$GIT_COMMITTER_NAME <$GIT_COMMITTER_EMAIL>" &&
 
-Signed-off-by: $(git var GIT_COMMITTER_IDENT | sed -e "s/>.*/>/")
-EOF
+	# Expected commit message for initial commit after rebase --signoff
+	cat >expected-initial-signed <<-EOF &&
+	Initial empty commit
 
-# Expected commit message after rebase --signoff
-cat >expected-signed <<EOF
-first
+	Signed-off-by: $ident
+	EOF
 
-Signed-off-by: $(git var GIT_COMMITTER_IDENT | sed -e "s/>.*/>/")
-EOF
+	# Expected commit message after rebase --signoff
+	cat >expected-signed <<-EOF &&
+	first
 
-# Expected commit message after rebase without --signoff (or with --no-signoff)
-cat >expected-unsigned <<EOF
-first
-EOF
+	Signed-off-by: $ident
+	EOF
 
+	# Expected commit message after rebase without --signoff (or with --no-signoff)
+	cat >expected-unsigned <<-EOF &&
+	first
+	EOF
+
+	git config alias.rbs "rebase --signoff"
+'
 
 # We configure an alias to do the rebase --signoff so that
 # on the next subtest we can show that --no-signoff overrides the alias
 test_expect_success 'rebase --signoff adds a sign-off line' '
-	git commit --allow-empty -m "Initial empty commit" &&
-	git add file && git commit -m first &&
-	git config alias.rbs "rebase --signoff" &&
 	git rbs HEAD^ &&
 	git cat-file commit HEAD | sed -e "1,/^\$/d" > actual &&
 	test_cmp expected-signed actual

--- a/t/t3428-rebase-signoff.sh
+++ b/t/t3428-rebase-signoff.sh
@@ -40,15 +40,13 @@ test_expect_success 'setup' '
 # on the next subtest we can show that --no-signoff overrides the alias
 test_expect_success 'rebase --signoff adds a sign-off line' '
 	git rbs HEAD^ &&
-	git cat-file commit HEAD | sed -e "1,/^\$/d" > actual &&
-	test_cmp expected-signed actual
+	test_commit_message HEAD expected-signed
 '
 
 test_expect_success 'rebase --no-signoff does not add a sign-off line' '
 	git commit --amend -m "first" &&
 	git rbs --no-signoff HEAD^ &&
-	git cat-file commit HEAD | sed -e "1,/^\$/d" > actual &&
-	test_cmp expected-unsigned actual
+	test_commit_message HEAD expected-unsigned
 '
 
 test_expect_success 'rebase --exec --signoff adds a sign-off line' '
@@ -56,30 +54,25 @@ test_expect_success 'rebase --exec --signoff adds a sign-off line' '
 	git commit --amend -m "first" &&
 	git rebase --exec "touch exec" --signoff HEAD^ &&
 	test_path_is_file exec &&
-	git cat-file commit HEAD | sed -e "1,/^\$/d" >actual &&
-	test_cmp expected-signed actual
+	test_commit_message HEAD expected-signed
 '
 
 test_expect_success 'rebase --root --signoff adds a sign-off line' '
 	git commit --amend -m "first" &&
 	git rebase --root --keep-empty --signoff &&
-	git cat-file commit HEAD^ | sed -e "1,/^\$/d" >actual &&
-	test_cmp expected-initial-signed actual &&
-	git cat-file commit HEAD | sed -e "1,/^\$/d" >actual &&
-	test_cmp expected-signed actual
+	test_commit_message HEAD^ expected-initial-signed &&
+	test_commit_message HEAD expected-signed
 '
 
 test_expect_success 'rebase -i --signoff fails' '
 	git commit --amend -m "first" &&
 	git rebase -i --signoff HEAD^ &&
-	git cat-file commit HEAD | sed -e "1,/^\$/d" >actual &&
-	test_cmp expected-signed actual
+	test_commit_message HEAD expected-signed
 '
 
 test_expect_success 'rebase -m --signoff fails' '
 	git commit --amend -m "first" &&
 	git rebase -m --signoff HEAD^ &&
-	git cat-file commit HEAD | sed -e "1,/^\$/d" >actual &&
-	test_cmp expected-signed actual
+	test_commit_message HEAD expected-signed
 '
 test_done


### PR DESCRIPTION
This series cleans up the tests for "git rebase --signoff" in preparation for extending them and fixing a couple of bugs in a future series.  The cleanups are:
 - move test setup into "test_expect_success"
 - stop running git upstream of a pipe
 - restore "git rebase --apply --signoff" coverage

cc: Phillip Wood <phillip.wood123@gmail.com>