### PR TITLE
completion: zsh: stop leaking local cache variable

### DIFF
--- a/contrib/completion/git-completion.zsh
+++ b/contrib/completion/git-completion.zsh
@@ -272,6 +272,7 @@ _git ()
 {
 	local _ret=1
 	local cur cword prev
+	local __git_repo_path
 
 	cur=${words[CURRENT]}
 	prev=${words[CURRENT-1]}


### PR DESCRIPTION
Prevent leaking a local variable used to cache the repo path, which
breaks future completions in different repositories using the shell,
when using contributed Zsh completion.

---

I made a few attempts at starting a test script for this based on https://unix.stackexchange.com/a/668827/301073, but that code doesn't work and it was all becoming precariously complicated (sh starting zsh to start zsh in a pty which would receive keystrokes and check specific outputs: I couldn't make certain pieces work in a normal way locally, let alone as part of Git's test suite). Suffice to say I have tested this myself?

CC: Felipe Contreras <felipe.contreras@gmail.com>
