### PR TITLE
merge: avoid write merge state when unable to write index

### DIFF
--- a/builtin/merge.c
+++ b/builtin/merge.c
@@ -701,7 +701,7 @@ static int try_merge_strategy(const char *strategy, struct commit_list *common,
 	if (repo_refresh_and_write_index(the_repository, REFRESH_QUIET,
 					 SKIP_IF_UNCHANGED, 0, NULL, NULL,
 					 NULL) < 0)
-		return error(_("Unable to write index."));
+		die(_("Unable to write index."));
 
 	if (!strcmp(strategy, "recursive") || !strcmp(strategy, "subtree") ||
 	    !strcmp(strategy, "ort")) {

--- a/t/t7600-merge.sh
+++ b/t/t7600-merge.sh
@@ -236,6 +236,16 @@ test_expect_success 'merge c1 with c2' '
 	verify_parents $c1 $c2
 '
 
+test_expect_success 'merge c1 with c2 when index.lock exists' '
+	test_when_finished rm .git/index.lock &&
+	git reset --hard c1 &&
+	>.git/index.lock &&
+	test_must_fail git merge c2 &&
+	test_path_is_missing .git/MERGE_HEAD &&
+	test_path_is_missing .git/MERGE_MODE &&
+	test_path_is_missing .git/MERGE_MSG
+'
+
 test_expect_success 'merge --squash c3 with c7' '
 	git reset --hard c3 &&
 	test_must_fail git merge --squash c7 &&


### PR DESCRIPTION
In some of our monorepos, code is sometimes lost after merging.

After investigation, we discovered the problem.

This happens if we perform "git pull" or "git merge" when another git process is writing to the index, especially in a monorepo (because its index will be larger).

How to reproduce:
```bash
git init demo
cd demo
touch 1.txt && git add . && git commit -m "1"
git checkout -b source-branch
touch 2.txt && git add . && git commit -m "2"
git checkout master
echo "1" >> 1.txt && git add . && git commit -m "3"
# another git process runnning
touch .git/index.lock
git merge source-branch
# another git process finished
rm .git/index.lock
git commit -m "4"
```

Then the modifications from the source branch are lost.

Regards,
Kyle




