### PR TITLE
commit-graph: fix a progress indicator bug

### DIFF
--- a/commit-graph.c
+++ b/commit-graph.c
@@ -1597,7 +1597,7 @@ static void compute_reachable_generation_numbers(
 		timestamp_t gen;
 		repo_parse_commit(info->r, c);
 		gen = info->get_generation(c, info->data);
-		display_progress(info->progress, info->progress_cnt + 1);
+		display_progress(info->progress, ++info->progress_cnt);
 
 		if (gen != GENERATION_NUMBER_ZERO && gen != GENERATION_NUMBER_INFINITY)
 			continue;

--- a/t/t6500-gc.sh
+++ b/t/t6500-gc.sh
@@ -158,7 +158,7 @@ test_expect_success TTY 'with TTY: gc --no-quiet' '
 		git -c gc.writeCommitGraph=true gc --no-quiet >stdout 2>stderr &&
 	test_must_be_empty stdout &&
 	test_grep "Enumerating objects" stderr &&
-	test_grep "Computing commit graph generation numbers" stderr
+	test_grep "Computing commit graph generation numbers: 100% (4/4), done." stderr
 '
 
 test_expect_success 'gc --quiet' '


### PR DESCRIPTION
Stolee noticed this bug when integrating the `for-each-ref --ahead-behind` patches into GitHub's internal fork of Git, and fixed it. For a variety of reasons, upstreaming this fix fell between the cracks. Until now.

Changes since v1:
- Adjusted  Stolee's email address to a non-bouncing one
- Added test coverage helpfully provided by Patrick

Cc: Derrick Stolee <stolee@gmail.com>
cc: Patrick Steinhardt <ps@pks.im>
cc: Taylor Blau <me@ttaylorr.com>