### PR TITLE
mingw: drop bogus (and unneeded) declaration of `_pgmptr`

### DIFF
--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -16,7 +16,6 @@ static const int delay[] = { 0, 1, 10, 20, 40 };
 void open_in_gdb(void)
 {
 	static struct child_process cp = CHILD_PROCESS_INIT;
-	extern char *_pgmptr;
 
 	argv_array_pushl(&cp.args, "mintty", "gdb", NULL);
 	argv_array_pushf(&cp.args, "--pid=%d", getpid());


### PR DESCRIPTION
Ran into  this in https://github.com/git-for-windows/git-sdk-64/actions/runs/9558244721/job/26346637793.

cc: Mike Hommey <mh@glandium.org>