### PR TITLE
doc: fix the max number of git show-branches shown

### DIFF
--- a/Documentation/git-show-branch.txt
+++ b/Documentation/git-show-branch.txt
@@ -22,7 +22,7 @@ Shows the commit ancestry graph starting from the commits named
 with <rev>s or <glob>s (or all refs under refs/heads
 and/or refs/tags) semi-visually.
 
-It cannot show more than 29 branches and commits at a time.
+It cannot show more than 26 branches and commits at a time.
 
 It uses `showbranch.default` multi-valued configuration items if
 no <rev> or <glob> is given on the command line.


### PR DESCRIPTION
Changes since v1:
- Explain in the commit message why "26" is the correct number.
- No change (to rename GitHub and re-send).
- Change the author of the commit.
- Fixed code block in commit message.

cc: Jeff King <peff@peff.net>