### PR TITLE
merge-ort: fix missing early return

### DIFF
--- a/merge-ort.c
+++ b/merge-ort.c
@@ -3618,6 +3618,7 @@ static int read_oid_strbuf(struct merge_options *opt,
 		path_msg(opt, ERROR_OBJECT_NOT_A_BLOB, 0,
 			 path, NULL, NULL, NULL,
 			 _("error: object %s is not a blob"), oid_to_hex(oid));
+		return -1;
 	}
 	strbuf_attach(dst, buf, size, size + 1);
 	return 0;


### PR DESCRIPTION
This is a patch on top of en/ort-inner-merge-error-fix which is in next.

cc: Jeff King <peff@peff.net>
cc: Elijah Newren <newren@gmail.com>