### PR TITLE
doc: git diff reformatting

### DIFF
--- a/Documentation/config/diff.txt
+++ b/Documentation/config/diff.txt
@@ -1,18 +1,25 @@
-diff.autoRefreshIndex::
-	When using 'git diff' to compare with work tree
+`diff.autoRefreshIndex`::
+	When using `git diff` to compare with work tree
 	files, do not consider stat-only changes as changed.
 	Instead, silently run `git update-index --refresh` to
 	update the cached stat information for paths whose
 	contents in the work tree match the contents in the
-	index.  This option defaults to true.  Note that this
-	affects only 'git diff' Porcelain, and not lower level
-	'diff' commands such as 'git diff-files'.
+	index.  This option defaults to `true`.  Note that this
+	affects only `git diff` Porcelain, and not lower level
+	`diff` commands such as `git diff-files`.
 
-diff.dirstat::
+`diff.dirstat`::
+ifdef::git-diff[]
+	A comma separated list of `--dirstat` parameters specifying the
+	default behavior of the `--dirstat` option to `git diff` and friends.
+endif::git-diff[]
+ifndef::git-diff[]
 	A comma separated list of `--dirstat` parameters specifying the
 	default behavior of the `--dirstat` option to linkgit:git-diff[1]
-	and friends. The defaults can be overridden on the command line
-	(using `--dirstat=<param1,param2,...>`). The fallback defaults
+	and friends.
+endif::git-diff[]
+	The defaults can be overridden on the command line
+	(using `--dirstat=<param>,...`). The fallback defaults
 	(when not changed by `diff.dirstat`) are `changes,noncumulative,3`.
 	The following parameters are available:
 +
@@ -41,7 +48,7 @@ diff.dirstat::
 	Note that when using `cumulative`, the sum of the percentages
 	reported may exceed 100%. The default (non-cumulative) behavior can
 	be specified with the `noncumulative` parameter.
-<limit>;;
+_<limit>_;;
 	An integer parameter specifies a cut-off percent (3% by default).
 	Directories contributing less than this percentage of the changes
 	are not shown in the output.
@@ -52,58 +59,58 @@ directories with less than 10% of the total amount of changed files,
 and accumulating child directory counts in the parent directories:
 `files,10,cumulative`.
 
-diff.statNameWidth::
-	Limit the width of the filename part in --stat output. If set, applies
-	to all commands generating --stat output except format-patch.
+`diff.statNameWidth`::
+	Limit the width of the filename part in `--stat` output. If set, applies
+	to all commands generating `--stat` output except `format-patch`.
 
-diff.statGraphWidth::
-	Limit the width of the graph part in --stat output. If set, applies
-	to all commands generating --stat output except format-patch.
+`diff.statGraphWidth`::
+	Limit the width of the graph part in `--stat` output. If set, applies
+	to all commands generating `--stat` output except `format-patch`.
 
-diff.context::
-	Generate diffs with <n> lines of context instead of the default
-	of 3. This value is overridden by the -U option.
+`diff.context`::
+	Generate diffs with _<n>_ lines of context instead of the default
+	of 3. This value is overridden by the `-U` option.
 
-diff.interHunkContext::
+`diff.interHunkContext`::
 	Show the context between diff hunks, up to the specified number
 	of lines, thereby fusing the hunks that are close to each other.
 	This value serves as the default for the `--inter-hunk-context`
 	command line option.
 
-diff.external::
+`diff.external`::
 	If this config variable is set, diff generation is not
 	performed using the internal diff machinery, but using the
-	given command.  Can be overridden with the `GIT_EXTERNAL_DIFF'
+	given command.  Can be overridden with the `GIT_EXTERNAL_DIFF`
 	environment variable.  The command is called with parameters
 	as described under "git Diffs" in linkgit:git[1].  Note: if
 	you want to use an external diff program only on a subset of
 	your files, you might want to use linkgit:gitattributes[5] instead.
 
-diff.trustExitCode::
-	If this boolean value is set to true then the
+`diff.trustExitCode`::
+	If this boolean value is set to `true` then the
 	`diff.external` command is expected to return exit code
 	0 if it considers the input files to be equal or 1 if it
-	considers them to be different, like `diff(1)`.
-	If it is set to false, which is the default, then the command
-	is expected to return exit code 0 regardless of equality.
+	considers them to be different, like `diff`(1).
+	If it is set to `false`, which is the default, then the command
+	is expected to return exit code `0` regardless of equality.
 	Any other exit code causes Git to report a fatal error.
 
-diff.ignoreSubmodules::
-	Sets the default value of --ignore-submodules. Note that this
-	affects only 'git diff' Porcelain, and not lower level 'diff'
-	commands such as 'git diff-files'. 'git checkout'
-	and 'git switch' also honor
+`diff.ignoreSubmodules`::
+	Sets the default value of `--ignore-submodules`. Note that this
+	affects only `git diff` Porcelain, and not lower level `diff`
+	commands such as `git diff-files`. `git checkout`
+	and `git switch` also honor
 	this setting when reporting uncommitted changes. Setting it to
-	'all' disables the submodule summary normally shown by 'git commit'
-	and 'git status' when `status.submoduleSummary` is set unless it is
-	overridden by using the --ignore-submodules command-line option.
-	The 'git submodule' commands are not affected by this setting.
+	`all` disables the submodule summary normally shown by `git commit`
+	and `git status` when `status.submoduleSummary` is set unless it is
+	overridden by using the `--ignore-submodules` command-line option.
+	The `git submodule` commands are not affected by this setting.
 	By default this is set to untracked so that any untracked
 	submodules are ignored.
 
-diff.mnemonicPrefix::
-	If set, 'git diff' uses a prefix pair that is different from the
-	standard "a/" and "b/" depending on what is being compared.  When
+`diff.mnemonicPrefix`::
+	If set, `git diff` uses a prefix pair that is different from the
+	standard `a/` and `b/` depending on what is being compared.  When
 	this configuration is in effect, reverse diff output also swaps
 	the order of the prefixes:
 `git diff`;;
@@ -112,111 +119,117 @@ diff.mnemonicPrefix::
 	 compares a (c)ommit and the (w)ork tree;
 `git diff --cached`;;
 	compares a (c)ommit and the (i)ndex;
-`git diff HEAD:file1 file2`;;
+`git diff HEAD:<file1> <file2>`;;
 	compares an (o)bject and a (w)ork tree entity;
-`git diff --no-index a b`;;
-	compares two non-git things (1) and (2).
+`git diff --no-index <a> <b>`;;
+	compares two non-git things _<a>_ and _<b>_.
 
-diff.noPrefix::
-	If set, 'git diff' does not show any source or destination prefix.
+`diff.noPrefix`::
+	If set, `git diff` does not show any source or destination prefix.
 
-diff.srcPrefix::
-	If set, 'git diff' uses this source prefix. Defaults to "a/".
+`diff.srcPrefix`::
+	If set, `git diff` uses this source prefix. Defaults to `a/`.
 
-diff.dstPrefix::
-	If set, 'git diff' uses this destination prefix. Defaults to "b/".
+`diff.dstPrefix`::
+	If set, `git diff` uses this destination prefix. Defaults to `b/`.
 
-diff.relative::
-	If set to 'true', 'git diff' does not show changes outside of the directory
+`diff.relative`::
+	If set to `true`, `git diff` does not show changes outside of the directory
 	and show pathnames relative to the current directory.
 
-diff.orderFile::
+`diff.orderFile`::
 	File indicating how to order files within a diff.
-	See the '-O' option to linkgit:git-diff[1] for details.
+ifdef::git-diff[]
+	See the `-O` option for details.
+endif::git-diff[]
+ifndef::git-diff[]
+	See the `-O` option to linkgit:git-diff[1] for details.
+endif::git-diff[]
 	If `diff.orderFile` is a relative pathname, it is treated as
 	relative to the top of the working tree.
 
-diff.renameLimit::
+`diff.renameLimit`::
 	The number of files to consider in the exhaustive portion of
-	copy/rename detection; equivalent to the 'git diff' option
+	copy/rename detection; equivalent to the `git diff` option
 	`-l`.  If not set, the default value is currently 1000.  This
 	setting has no effect if rename detection is turned off.
 
-diff.renames::
-	Whether and how Git detects renames.  If set to "false",
-	rename detection is disabled. If set to "true", basic rename
-	detection is enabled.  If set to "copies" or "copy", Git will
-	detect copies, as well.  Defaults to true.  Note that this
-	affects only 'git diff' Porcelain like linkgit:git-diff[1] and
+`diff.renames`::
+	Whether and how Git detects renames.  If set to `false`,
+	rename detection is disabled. If set to `true`, basic rename
+	detection is enabled.  If set to `copies` or `copy`, Git will
+	detect copies, as well.  Defaults to `true`.  Note that this
+	affects only `git diff` Porcelain like linkgit:git-diff[1] and
 	linkgit:git-log[1], and not lower level commands such as
 	linkgit:git-diff-files[1].
 
-diff.suppressBlankEmpty::
+`diff.suppressBlankEmpty`::
 	A boolean to inhibit the standard behavior of printing a space
-	before each empty output line. Defaults to false.
+	before each empty output line. Defaults to `false`.
 
-diff.submodule::
+`diff.submodule`::
 	Specify the format in which differences in submodules are
-	shown.  The "short" format just shows the names of the commits
-	at the beginning and end of the range. The "log" format lists
+	shown.  The `short` format just shows the names of the commits
+	at the beginning and end of the range. The `log` format lists
 	the commits in the range like linkgit:git-submodule[1] `summary`
-	does. The "diff" format shows an inline diff of the changed
-	contents of the submodule. Defaults to "short".
+	does. The `diff` format shows an inline diff of the changed
+	contents of the submodule. Defaults to `short`.
 
-diff.wordRegex::
+`diff.wordRegex`::
 	A POSIX Extended Regular Expression used to determine what is a "word"
 	when performing word-by-word difference calculations.  Character
 	sequences that match the regular expression are "words", all other
 	characters are *ignorable* whitespace.
 
-diff.<driver>.command::
+`diff.<driver>.command`::
 	The custom diff driver command.  See linkgit:gitattributes[5]
 	for details.
 
-diff.<driver>.trustExitCode::
-	If this boolean value is set to true then the
+`diff.<driver>.trustExitCode`::
+	If this boolean value is set to `true` then the
 	`diff.<driver>.command` command is expected to return exit code
 	0 if it considers the input files to be equal or 1 if it
-	considers them to be different, like `diff(1)`.
-	If it is set to false, which is the default, then the command
+	considers them to be different, like `diff`(1).
+	If it is set to `false`, which is the default, then the command
 	is expected to return exit code 0 regardless of equality.
 	Any other exit code causes Git to report a fatal error.
 
-diff.<driver>.xfuncname::
+`diff.<driver>.xfuncname`::
 	The regular expression that the diff driver should use to
 	recognize the hunk header.  A built-in pattern may also be used.
 	See linkgit:gitattributes[5] for details.
 
-diff.<driver>.binary::
-	Set this option to true to make the diff driver treat files as
+`diff.<driver>.binary`::
+	Set this option to `true` to make the diff driver treat files as
 	binary.  See linkgit:gitattributes[5] for details.
 
-diff.<driver>.textconv::
+`diff.<driver>.textconv`::
 	The command that the diff driver should call to generate the
 	text-converted version of a file.  The result of the
 	conversion is used to generate a human-readable diff.  See
 	linkgit:gitattributes[5] for details.
 
-diff.<driver>.wordRegex::
+`diff.<driver>.wordRegex`::
 	The regular expression that the diff driver should use to
 	split words in a line.  See linkgit:gitattributes[5] for
 	details.
 
-diff.<driver>.cachetextconv::
-	Set this option to true to make the diff driver cache the text
+`diff.<driver>.cachetextconv`::
+	Set this option to `true` to make the diff driver cache the text
 	conversion outputs.  See linkgit:gitattributes[5] for details.
 
 include::../mergetools-diff.txt[]
 
-diff.indentHeuristic::
+`diff.indentHeuristic`::
 	Set this option to `false` to disable the default heuristics
 	that shift diff hunk boundaries to make patches easier to read.
 
-diff.algorithm::
+`diff.algorithm`::
 	Choose a diff algorithm.  The variants are as follows:
 +
 --
-`default`, `myers`;;
+`default`;;
+`myers`;;
 	The basic greedy diff algorithm. Currently, this is the default.
 `minimal`;;
 	Spend extra time to make sure the smallest possible diff is
@@ -229,7 +242,7 @@ diff.algorithm::
 --
 +
 
-diff.wsErrorHighlight::
+`diff.wsErrorHighlight`::
 	Highlight whitespace errors in the `context`, `old` or `new`
 	lines of the diff.  Multiple values are separated by comma,
 	`none` resets previous values, `default` reset the list to
@@ -238,14 +251,19 @@ diff.wsErrorHighlight::
 	The command line option `--ws-error-highlight=<kind>`
 	overrides this setting.
 
-diff.colorMoved::
-	If set to either a valid `<mode>` or a true value, moved lines
-	in a diff are colored differently, for details of valid modes
-	see '--color-moved' in linkgit:git-diff[1]. If simply set to
-	true the default color mode will be used. When set to false,
-	moved lines are not colored.
+`diff.colorMoved`::
+	If set to either a valid _<mode>_ or a `true` value, moved lines
+	in a diff are colored differently.
+ifdef::git-diff[]
+	For details of valid modes see `--color-moved`.
+endif::git-diff[]
+ifndef::git-diff[]
+	For details of valid modes see `--color-moved` in linkgit:git-diff[1].
+endif::git-diff[]
+	If simply set to `true` the default color mode will be used. When
+	set to `false`, moved lines are not colored.
 
-diff.colorMovedWS::
+`diff.colorMovedWS`::
 	When moved lines are colored using e.g. the `diff.colorMoved` setting,
-	this option controls the `<mode>` how spaces are treated.
-	For details of valid modes see '--color-moved-ws' in linkgit:git-diff[1].
+	this option controls the mode how spaces are treated.
+	For details of valid modes see `--color-moved-ws` in linkgit:git-diff[1].

--- a/Documentation/diff-format.txt
+++ b/Documentation/diff-format.txt
@@ -1,25 +1,25 @@
 Raw output format
 -----------------
 
-The raw output format from "git-diff-index", "git-diff-tree",
-"git-diff-files" and "git diff --raw" are very similar.
+The raw output format from `git-diff-index`, `git-diff-tree`,
+`git-diff-files` and `git diff --raw` are very similar.
 
 These commands all compare two sets of things; what is
 compared differs:
 
-git-diff-index <tree-ish>::
-        compares the <tree-ish> and the files on the filesystem.
+`git-diff-index <tree-ish>`::
+	compares the _<tree-ish>_ and the files on the filesystem.
 
-git-diff-index --cached <tree-ish>::
-        compares the <tree-ish> and the index.
+`git-diff-index --cached <tree-ish>`::
+	compares the _<tree-ish>_ and the index.
 
-git-diff-tree [-r] <tree-ish-1> <tree-ish-2> [<pattern>...]::
+`git-diff-tree [-r] <tree-ish-1> <tree-ish-2> [<pattern>...]`::
         compares the trees named by the two arguments.
 
-git-diff-files [<pattern>...]::
+`git-diff-files [<pattern>...]`::
         compares the index and the files on the filesystem.
 
-The "git-diff-tree" command begins its output by printing the hash of
+The `git-diff-tree` command begins its output by printing the hash of
 what is being compared. After that, all the commands print one output
 line per changed file.
 
@@ -54,19 +54,19 @@ That is, from the left to the right:
 
 Possible status letters are:
 
-- A: addition of a file
-- C: copy of a file into a new one
-- D: deletion of a file
-- M: modification of the contents or mode of a file
-- R: renaming of a file
-- T: change in the type of the file (regular file, symbolic link or submodule)
-- U: file is unmerged (you must complete the merge before it can
+- `A`: addition of a file
+- `C`: copy of a file into a new one
+- `D`: deletion of a file
+- `M`: modification of the contents or mode of a file
+- `R`: renaming of a file
+- `T`: change in the type of the file (regular file, symbolic link or submodule)
+- `U`: file is unmerged (you must complete the merge before it can
   be committed)
-- X: "unknown" change type (most probably a bug, please report it)
+- `X`: "unknown" change type (most probably a bug, please report it)
 
-Status letters C and R are always followed by a score (denoting the
+Status letters `C` and `R` are always followed by a score (denoting the
 percentage of similarity between the source and target of the move or
-copy).  Status letter M may be followed by a score (denoting the
+copy).  Status letter `M` may be followed by a score (denoting the
 percentage of dissimilarity) for file rewrites.
 
 The sha1 for "dst" is shown as all 0's if a file on the filesystem
@@ -86,7 +86,7 @@ verbatim and the line is terminated by a NUL byte.
 diff format for merges
 ----------------------
 
-"git-diff-tree", "git-diff-files" and "git-diff --raw"
+`git-diff-tree`, `git-diff-files` and `git-diff --raw`
 can take `-c` or `--cc` option
 to generate diff output also for merge commits.  The output differs
 from the format described above in the following way:
@@ -128,7 +128,7 @@ other diff formats
 ------------------
 
 The `--summary` option describes newly added, deleted, renamed and
-copied files.  The `--stat` option adds diffstat(1) graph to the
+copied files.  The `--stat` option adds `diffstat`(1) graph to the
 output.  These options can be combined with other options, such as
 `-p`, and are meant for human consumption.
 

--- a/Documentation/diff-generate-patch.txt
+++ b/Documentation/diff-generate-patch.txt
@@ -14,7 +14,7 @@ You can customize the creation of patch text via the
 `GIT_EXTERNAL_DIFF` and the `GIT_DIFF_OPTS` environment variables
 (see linkgit:git[1]), and the `diff` attribute (see linkgit:gitattributes[5]).
 
-What the -p option produces is slightly different from the traditional
+What the `-p` option produces is slightly different from the traditional
 diff format:
 
 1.   It is preceded by a "git diff" header that looks like this:
@@ -30,20 +30,21 @@ name of the source file of the rename/copy and the name of
 the file that the rename/copy produces, respectively.
 
 2.   It is followed by one or more extended header lines:
-
-       old mode <mode>
-       new mode <mode>
-       deleted file mode <mode>
-       new file mode <mode>
-       copy from <path>
-       copy to <path>
-       rename from <path>
-       rename to <path>
-       similarity index <number>
-       dissimilarity index <number>
-       index <hash>..<hash> <mode>
 +
-File modes are printed as 6-digit octal numbers including the file type
+[synopsis]
+old mode <mode>
+new mode <mode>
+deleted file mode <mode>
+new file mode <mode>
+copy from <path>
+copy to <path>
+rename from <path>
+rename to <path>
+similarity index <number>
+dissimilarity index <number>
+index <hash>..<hash> <mode>
++
+File modes _<mode>_ are printed as 6-digit octal numbers including the file type
 and file permission bits.
 +
 Path names in extended headers do not include the `a/` and `b/` prefixes.
@@ -56,7 +57,7 @@ files, while 100% dissimilarity means that no line from the old
 file made it into the new one.
 +
 The index line includes the blob object names before and after the change.
-The <mode> is included if the file mode does not change; otherwise,
+The _<mode>_ is included if the file mode does not change; otherwise,
 separate lines indicate the old and the new mode.
 
 3.  Pathnames with "unusual" characters are quoted as explained for
@@ -134,17 +135,18 @@ or like this (when the `--cc` option is used):
 
 2.   It is followed by one or more extended header lines
      (this example shows a merge with two parents):
-
-       index <hash>,<hash>..<hash>
-       mode <mode>,<mode>..<mode>
-       new file mode <mode>
-       deleted file mode <mode>,<mode>
++
+[synopsis]
+index <hash>,<hash>..<hash>
+mode <mode>,<mode>`..`<mode>
+new file mode <mode>
+deleted file mode <mode>,<mode>
 +
 The `mode <mode>,<mode>..<mode>` line appears only if at least one of
 the <mode> is different from the rest. Extended headers with
 information about detected content movement (renames and
 copying detection) are designed to work with the diff of two
-<tree-ish> and are not used by combined diff format.
+_<tree-ish>_ and are not used by combined diff format.
 
 3.   It is followed by a two-line from-file/to-file header:
 

--- a/Documentation/diff-options.txt
+++ b/Documentation/diff-options.txt
@@ -19,16 +19,16 @@ ifdef::git-format-patch[]
 endif::git-format-patch[]
 
 ifndef::git-format-patch[]
--p::
--u::
---patch::
+`-p`::
+`-u`::
+`--patch`::
 	Generate patch (see <<generate_patch_text_with_p>>).
 ifdef::git-diff[]
 	This is the default.
 endif::git-diff[]
 
--s::
---no-patch::
+`-s`::
+`--no-patch`::
 	Suppress all output from the diff machinery.  Useful for
 	commands like `git show` that show the patch by default to
 	squelch their output, or to cancel the effect of options like
@@ -39,28 +39,28 @@ endif::git-format-patch[]
 ifdef::git-log[]
 -m::
 	Show diffs for merge commits in the default format. This is
-	similar to '--diff-merges=on', except `-m` will
+	similar to `--diff-merges=on`, except `-m` will
 	produce no output unless `-p` is given as well.
 
 -c::
 	Produce combined diff output for merge commits.
-	Shortcut for '--diff-merges=combined -p'.
+	Shortcut for `--diff-merges=combined -p`.
 
 --cc::
 	Produce dense combined diff output for merge commits.
-	Shortcut for '--diff-merges=dense-combined -p'.
+	Shortcut for `--diff-merges=dense-combined -p`.
 
 --dd::
 	Produce diff with respect to first parent for both merge and
 	regular commits.
-	Shortcut for '--diff-merges=first-parent -p'.
+	Shortcut for `--diff-merges=first-parent -p`.
 
 --remerge-diff::
 	Produce remerge-diff output for merge commits.
-	Shortcut for '--diff-merges=remerge -p'.
+	Shortcut for `--diff-merges=remerge -p`.
 
 --no-diff-merges::
-	Synonym for '--diff-merges=off'.
+	Synonym for `--diff-merges=off`.
 
 --diff-merges=<format>::
 	Specify diff format to be used for merge commits. Default is
@@ -73,33 +73,33 @@ The following formats are supported:
 off, none::
 	Disable output of diffs for merge commits. Useful to override
 	implied value.
-+
+
 on, m::
 	Make diff output for merge commits to be shown in the default
 	format. The default format can be changed using
 	`log.diffMerges` configuration variable, whose default value
 	is `separate`.
-+
+
 first-parent, 1::
 	Show full diff with respect to first parent. This is the same
 	format as `--patch` produces for non-merge commits.
-+
+
 separate::
 	Show full diff with respect to each of parents.
 	Separate log entry and diff is generated for each parent.
-+
+
 combined, c::
 	Show differences from each of the parents to the merge
 	result simultaneously instead of showing pairwise diff between
 	a parent and the result one at a time. Furthermore, it lists
 	only files which were modified from all parents.
-+
+
 dense-combined, cc::
 	Further compress output produced by `--diff-merges=combined`
 	by omitting uninteresting hunks whose contents in the parents
 	have only two variants and the merge result picks one of them
 	without modification.
-+
+
 remerge, r::
 	Remerge two-parent merge commits to create a temporary tree
 	object--potentially containing files with conflict markers
@@ -112,33 +112,33 @@ documented).
 --
 
 --combined-all-paths::
-	This flag causes combined diffs (used for merge commits) to
+	Cause combined diffs (used for merge commits) to
 	list the name of the file from all parents.  It thus only has
 	effect when `--diff-merges=[dense-]combined` is in use, and
 	is likely only useful if filename changes are detected (i.e.
 	when either rename or copy detection have been requested).
 endif::git-log[]
 
--U<n>::
---unified=<n>::
-	Generate diffs with <n> lines of context instead of
+`-U<n>`::
+`--unified=<n>`::
+	Generate diffs with _<n>_ lines of context instead of
 	the usual three.
 ifndef::git-format-patch[]
 	Implies `--patch`.
 endif::git-format-patch[]
 
---output=<file>::
+`--output=<file>`::
 	Output to a specific file instead of stdout.
 
---output-indicator-new=<char>::
---output-indicator-old=<char>::
---output-indicator-context=<char>::
+`--output-indicator-new=<char>`::
+`--output-indicator-old=<char>`::
+`--output-indicator-context=<char>`::
 	Specify the character used to indicate new, old or context
-	lines in the generated patch. Normally they are '+', '-' and
+	lines in the generated patch. Normally they are `+`, `-` and
 	' ' respectively.
 
 ifndef::git-format-patch[]
---raw::
+`--raw`::
 ifndef::git-log[]
 	Generate the diff in raw format.
 ifdef::git-diff-core[]
@@ -155,54 +155,55 @@ endif::git-log[]
 endif::git-format-patch[]
 
 ifndef::git-format-patch[]
---patch-with-raw::
+`--patch-with-raw`::
 	Synonym for `-p --raw`.
 endif::git-format-patch[]
 
 ifdef::git-log[]
--t::
+`-t`::
 	Show the tree objects in the diff output.
 endif::git-log[]
 
---indent-heuristic::
+`--indent-heuristic`::
 	Enable the heuristic that shifts diff hunk boundaries to make patches
 	easier to read. This is the default.
 
---no-indent-heuristic::
+`--no-indent-heuristic`::
 	Disable the indent heuristic.
 
---minimal::
+`--minimal`::
 	Spend extra time to make sure the smallest possible
 	diff is produced.
 
---patience::
+`--patience`::
 	Generate a diff using the "patience diff" algorithm.
 
---histogram::
+`--histogram`::
 	Generate a diff using the "histogram diff" algorithm.
 
---anchored=<text>::
+`--anchored=<text>`::
 	Generate a diff using the "anchored diff" algorithm.
 +
 This option may be specified more than once.
 +
 If a line exists in both the source and destination, exists only once,
-and starts with this text, this algorithm attempts to prevent it from
+and starts with _<text>_, this algorithm attempts to prevent it from
 appearing as a deletion or addition in the output. It uses the "patience
 diff" algorithm internally.
 
---diff-algorithm={patience|minimal|histogram|myers}::
+`--diff-algorithm=(patience|minimal|histogram|myers)`::
 	Choose a diff algorithm. The variants are as follows:
 +
 --
-`default`, `myers`;;
+   `default`;;
+   `myers`;;
 	The basic greedy diff algorithm. Currently, this is the default.
-`minimal`;;
+   `minimal`;;
 	Spend extra time to make sure the smallest possible diff is
 	produced.
-`patience`;;
+   `patience`;;
 	Use "patience diff" algorithm when generating patches.
-`histogram`;;
+   `histogram`;;
 	This algorithm extends the patience algorithm to "support
 	low-occurrence common elements".
 --
@@ -211,47 +212,47 @@ For instance, if you configured the `diff.algorithm` variable to a
 non-default value and want to use the default one, then you
 have to use `--diff-algorithm=default` option.
 
---stat[=<width>[,<name-width>[,<count>]]]::
+`--stat[=<width>[,<name-width>[,<count>]]]`::
 	Generate a diffstat. By default, as much space as necessary
 	will be used for the filename part, and the rest for the graph
 	part. Maximum width defaults to terminal width, or 80 columns
 	if not connected to a terminal, and can be overridden by
-	`<width>`. The width of the filename part can be limited by
-	giving another width `<name-width>` after a comma or by setting
-	`diff.statNameWidth=<width>`. The width of the graph part can be
-	limited by using `--stat-graph-width=<width>` or by setting
-	`diff.statGraphWidth=<width>`. Using `--stat` or
+	_<width>_. The width of the filename part can be limited by
+	giving another width _<name-width>_ after a comma or by setting
+	`diff.statNameWidth=<name-width>`. The width of the graph part can be
+	limited by using `--stat-graph-width=<graph-width>` or by setting
+	`diff.statGraphWidth=<graph-width>`. Using `--stat` or
 	`--stat-graph-width` affects all commands generating a stat graph,
 	while setting `diff.statNameWidth` or `diff.statGraphWidth`
 	does not affect `git format-patch`.
-	By giving a third parameter `<count>`, you can limit the output to
-	the first `<count>` lines, followed by `...` if there are more.
+	By giving a third parameter _<count>_, you can limit the output to
+	the first _<count>_ lines, followed by `...` if there are more.
 +
 These parameters can also be set individually with `--stat-width=<width>`,
 `--stat-name-width=<name-width>` and `--stat-count=<count>`.
 
---compact-summary::
+`--compact-summary`::
 	Output a condensed summary of extended header information such
-	as file creations or deletions ("new" or "gone", optionally "+l"
-	if it's a symlink) and mode changes ("+x" or "-x" for adding
+	as file creations or deletions ("new" or "gone", optionally `+l`
+	if it's a symlink) and mode changes (`+x` or `-x` for adding
 	or removing executable bit respectively) in diffstat. The
 	information is put between the filename part and the graph
 	part. Implies `--stat`.
 
---numstat::
+`--numstat`::
 	Similar to `--stat`, but shows number of added and
 	deleted lines in decimal notation and pathname without
 	abbreviation, to make it more machine friendly.  For
 	binary files, outputs two `-` instead of saying
 	`0 0`.
 
---shortstat::
+`--shortstat`::
 	Output only the last line of the `--stat` format containing total
 	number of modified files, as well as number of added and deleted
 	lines.
 
--X[<param1,param2,...>]::
---dirstat[=<param1,param2,...>]::
+`-X [<param>,...]`::
+`--dirstat[=<param>,...]`::
 	Output the distribution of relative amount of changes for each
 	sub-directory. The behavior of `--dirstat` can be customized by
 	passing it a comma separated list of parameters.
@@ -284,7 +285,7 @@ These parameters can also be set individually with `--stat-width=<width>`,
 	Note that when using `cumulative`, the sum of the percentages
 	reported may exceed 100%. The default (non-cumulative) behavior can
 	be specified with the `noncumulative` parameter.
-<limit>;;
+_<limit>_;;
 	An integer parameter specifies a cut-off percent (3% by default).
 	Directories contributing less than this percentage of the changes
 	are not shown in the output.
@@ -295,29 +296,29 @@ directories with less than 10% of the total amount of changed files,
 and accumulating child directory counts in the parent directories:
 `--dirstat=files,10,cumulative`.
 
---cumulative::
-	Synonym for --dirstat=cumulative
+`--cumulative`::
+	Synonym for `--dirstat=cumulative`.
 
---dirstat-by-file[=<param1,param2>...]::
-	Synonym for --dirstat=files,<param1>,<param2>...
+`--dirstat-by-file[=<param>,...]`::
+	Synonym for `--dirstat=files,<param>,...`.
 
---summary::
+`--summary`::
 	Output a condensed summary of extended header information
 	such as creations, renames and mode changes.
 
 ifndef::git-format-patch[]
---patch-with-stat::
+`--patch-with-stat`::
 	Synonym for `-p --stat`.
 endif::git-format-patch[]
 
 ifndef::git-format-patch[]
 
--z::
+`-z`::
 ifdef::git-log[]
-	Separate the commits with NULs instead of newlines.
+	Separate the commits with __NUL__s instead of newlines.
 +
 Also, when `--raw` or `--numstat` has been given, do not munge
-pathnames and use NULs as output field terminators.
+pathnames and use __NUL__s as output field terminators.
 endif::git-log[]
 ifndef::git-log[]
 	When `--raw`, `--numstat`, `--name-only` or `--name-status` has been
@@ -328,89 +329,89 @@ Without this option, pathnames with "unusual" characters are quoted as
 explained for the configuration variable `core.quotePath` (see
 linkgit:git-config[1]).
 
---name-only::
+`--name-only`::
 	Show only the name of each changed file in the post-image tree.
 	The file names are often encoded in UTF-8.
 	For more information see the discussion about encoding in the linkgit:git-log[1]
 	manual page.
 
---name-status::
+`--name-status`::
 	Show only the name(s) and status of each changed file. See the description
 	of the `--diff-filter` option on what the status letters mean.
 	Just like `--name-only` the file names are often encoded in UTF-8.
 
---submodule[=<format>]::
+`--submodule[=<format>]`::
 	Specify how differences in submodules are shown.  When specifying
-	`--submodule=short` the 'short' format is used.  This format just
+	`--submodule=short` the `short` format is used.  This format just
 	shows the names of the commits at the beginning and end of the range.
-	When `--submodule` or `--submodule=log` is specified, the 'log'
+	When `--submodule` or `--submodule=log` is specified, the `log`
 	format is used.  This format lists the commits in the range like
 	linkgit:git-submodule[1] `summary` does.  When `--submodule=diff`
-	is specified, the 'diff' format is used.  This format shows an
+	is specified, the `diff` format is used.  This format shows an
 	inline diff of the changes in the submodule contents between the
-	commit range.  Defaults to `diff.submodule` or the 'short' format
+	commit range.  Defaults to `diff.submodule` or the `short` format
 	if the config option is unset.
 
---color[=<when>]::
+`--color[=<when>]`::
 	Show colored diff.
-	`--color` (i.e. without '=<when>') is the same as `--color=always`.
-	'<when>' can be one of `always`, `never`, or `auto`.
+	`--color` (i.e. without `=<when>`) is the same as `--color=always`.
+	_<when>_ can be one of `always`, `never`, or `auto`.
 ifdef::git-diff[]
 	It can be changed by the `color.ui` and `color.diff`
 	configuration settings.
 endif::git-diff[]
 
---no-color::
+`--no-color`::
 	Turn off colored diff.
 ifdef::git-diff[]
 	This can be used to override configuration settings.
 endif::git-diff[]
 	It is the same as `--color=never`.
 
---color-moved[=<mode>]::
+`--color-moved[=<mode>]`::
 	Moved lines of code are colored differently.
 ifdef::git-diff[]
 	It can be changed by the `diff.colorMoved` configuration setting.
 endif::git-diff[]
-	The <mode> defaults to 'no' if the option is not given
-	and to 'zebra' if the option with no mode is given.
+	The _<mode>_ defaults to `no` if the option is not given
+	and to `zebra` if the option with no mode is given.
 	The mode must be one of:
 +
 --
-no::
+`no`::
 	Moved lines are not highlighted.
-default::
+`default`::
 	Is a synonym for `zebra`. This may change to a more sensible mode
 	in the future.
-plain::
+`plain`::
 	Any line that is added in one location and was removed
-	in another location will be colored with 'color.diff.newMoved'.
-	Similarly 'color.diff.oldMoved' will be used for removed lines
+	in another location will be colored with `color.diff.newMoved`.
+	Similarly `color.diff.oldMoved` will be used for removed lines
 	that are added somewhere else in the diff. This mode picks up any
 	moved line, but it is not very useful in a review to determine
 	if a block of code was moved without permutation.
-blocks::
+`blocks`::
 	Blocks of moved text of at least 20 alphanumeric characters
 	are detected greedily. The detected blocks are
-	painted using either the 'color.diff.{old,new}Moved' color.
+	painted using either the `color.diff.(old|new)Moved` color.
 	Adjacent blocks cannot be told apart.
-zebra::
-	Blocks of moved text are detected as in 'blocks' mode. The blocks
-	are painted using either the 'color.diff.{old,new}Moved' color or
-	'color.diff.{old,new}MovedAlternative'. The change between
+`zebra`::
+	Blocks of moved text are detected as in `blocks` mode. The blocks
+	are painted using either the `color.diff.(old|new)Moved` color or
+	`color.diff.(old|new)MovedAlternative`. The change between
 	the two colors indicates that a new block was detected.
-dimmed-zebra::
-	Similar to 'zebra', but additional dimming of uninteresting parts
+`dimmed-zebra`::
+	Similar to `zebra`, but additional dimming of uninteresting parts
 	of moved code is performed. The bordering lines of two adjacent
 	blocks are considered interesting, the rest is uninteresting.
 	`dimmed_zebra` is a deprecated synonym.
 --
 
---no-color-moved::
+`--no-color-moved`::
 	Turn off move detection. This can be used to override configuration
 	settings. It is the same as `--color-moved=no`.
 
---color-moved-ws=<modes>::
+`--color-moved-ws=<mode>,...`::
 	This configures how whitespace is ignored when performing the
 	move detection for `--color-moved`.
 ifdef::git-diff[]
@@ -419,63 +420,62 @@ endif::git-diff[]
 	These modes can be given as a comma separated list:
 +
 --
-no::
+`no`::
 	Do not ignore whitespace when performing move detection.
-ignore-space-at-eol::
+`ignore-space-at-eol`::
 	Ignore changes in whitespace at EOL.
-ignore-space-change::
+`ignore-space-change`::
 	Ignore changes in amount of whitespace.  This ignores whitespace
 	at line end, and considers all other sequences of one or
 	more whitespace characters to be equivalent.
-ignore-all-space::
+`ignore-all-space`::
 	Ignore whitespace when comparing lines. This ignores differences
 	even if one line has whitespace where the other line has none.
-allow-indentation-change::
+`allow-indentation-change`::
 	Initially ignore any whitespace in the move detection, then
 	group the moved code blocks only into a block if the change in
 	whitespace is the same per line. This is incompatible with the
 	other modes.
 --
 
---no-color-moved-ws::
+`--no-color-moved-ws`::
 	Do not ignore whitespace when performing move detection. This can be
 	used to override configuration settings. It is the same as
 	`--color-moved-ws=no`.
 
---word-diff[=<mode>]::
-	Show a word diff, using the <mode> to delimit changed words.
+`--word-diff[=<mode>]`::
 	By default, words are delimited by whitespace; see
-	`--word-diff-regex` below.  The <mode> defaults to 'plain', and
+	`--word-diff-regex` below.  The _<mode>_ defaults to `plain`, and
 	must be one of:
 +
 --
-color::
+`color`::
 	Highlight changed words using only colors.  Implies `--color`.
-plain::
-	Show words as `[-removed-]` and `{+added+}`.  Makes no
+`plain`::
+	Show words as ++[-removed-]++ and ++{+added+}++.  Makes no
 	attempts to escape the delimiters if they appear in the input,
 	so the output may be ambiguous.
-porcelain::
+`porcelain`::
 	Use a special line-based format intended for script
 	consumption.  Added/removed/unchanged runs are printed in the
 	usual unified diff format, starting with a `+`/`-`/` `
 	character at the beginning of the line and extending to the
 	end of the line.  Newlines in the input are represented by a
 	tilde `~` on a line of its own.
-none::
+`none`::
 	Disable word diff again.
 --
 +
 Note that despite the name of the first mode, color is used to
 highlight the changed parts in all modes if enabled.
 
---word-diff-regex=<regex>::
-	Use <regex> to decide what a word is, instead of considering
+`--word-diff-regex=<regex>`::
+	Use _<regex>_ to decide what a word is, instead of considering
 	runs of non-whitespace to be a word.  Also implies
 	`--word-diff` unless it was already enabled.
 +
 Every non-overlapping match of the
-<regex> is considered a word.  Anything between these matches is
+_<regex>_ is considered a word.  Anything between these matches is
 considered whitespace and ignored(!) for the purposes of finding
 differences.  You may want to append `|[^[:space:]]` to your regular
 expression to make sure that it matches all non-whitespace characters.
@@ -490,20 +490,20 @@ linkgit:gitattributes[5] or linkgit:git-config[1].  Giving it explicitly
 overrides any diff driver or configuration setting.  Diff drivers
 override configuration settings.
 
---color-words[=<regex>]::
+`--color-words[=<regex>]`::
 	Equivalent to `--word-diff=color` plus (if a regex was
 	specified) `--word-diff-regex=<regex>`.
 endif::git-format-patch[]
 
---no-renames::
+`--no-renames`::
 	Turn off rename detection, even when the configuration
 	file gives the default to do so.
 
---[no-]rename-empty::
+`--[no-]rename-empty`::
 	Whether to use empty blobs as rename source.
 
 ifndef::git-format-patch[]
---check::
+`--check`::
 	Warn if changes introduce conflict markers or whitespace errors.
 	What are considered whitespace errors is controlled by `core.whitespace`
 	configuration.  By default, trailing whitespaces (including
@@ -511,9 +511,9 @@ ifndef::git-format-patch[]
 	that is immediately followed by a tab character inside the
 	initial indent of the line are considered whitespace errors.
 	Exits with non-zero status if problems are found. Not compatible
-	with --exit-code.
+	with `--exit-code`.
 
---ws-error-highlight=<kind>::
+`--ws-error-highlight=<kind>`::
 	Highlight whitespace errors in the `context`, `old` or `new`
 	lines of the diff.  Multiple values are separated by comma,
 	`none` resets previous values, `default` reset the list to
@@ -525,30 +525,30 @@ ifndef::git-format-patch[]
 
 endif::git-format-patch[]
 
---full-index::
+`--full-index`::
 	Instead of the first handful of characters, show the full
 	pre- and post-image blob object names on the "index"
 	line when generating patch format output.
 
---binary::
+`--binary`::
 	In addition to `--full-index`, output a binary diff that
 	can be applied with `git-apply`.
 ifndef::git-format-patch[]
 	Implies `--patch`.
 endif::git-format-patch[]
 
---abbrev[=<n>]::
+`--abbrev[=<n>]`::
 	Instead of showing the full 40-byte hexadecimal object
 	name in diff-raw format output and diff-tree header
-	lines, show the shortest prefix that is at least '<n>'
+	lines, show the shortest prefix that is at least _<n>_
 	hexdigits long that uniquely refers the object.
 	In diff-patch output format, `--full-index` takes higher
 	precedence, i.e. if `--full-index` is specified, full blob
 	names will be shown regardless of `--abbrev`.
 	Non default number of digits can be specified with `--abbrev=<n>`.
 
--B[<n>][/<m>]::
---break-rewrites[=[<n>][/<m>]]::
+`-B[<n>][/<m>]`::
+`--break-rewrites[=[<n>][/<m>]]`::
 	Break complete rewrite changes into pairs of delete and
 	create. This serves two purposes:
 +
@@ -556,22 +556,22 @@ It affects the way a change that amounts to a total rewrite of a file
 not as a series of deletion and insertion mixed together with a very
 few lines that happen to match textually as the context, but as a
 single deletion of everything old followed by a single insertion of
-everything new, and the number `m` controls this aspect of the -B
+everything new, and the number _<m>_ controls this aspect of the `-B`
 option (defaults to 60%). `-B/70%` specifies that less than 30% of the
 original should remain in the result for Git to consider it a total
 rewrite (i.e. otherwise the resulting patch will be a series of
 deletion and insertion mixed together with context lines).
 +
-When used with -M, a totally-rewritten file is also considered as the
-source of a rename (usually -M only considers a file that disappeared
-as the source of a rename), and the number `n` controls this aspect of
-the -B option (defaults to 50%). `-B20%` specifies that a change with
+When used with `-M`, a totally-rewritten file is also considered as the
+source of a rename (usually `-M` only considers a file that disappeared
+as the source of a rename), and the number _<n>_ controls this aspect of
+the `-B` option (defaults to 50%). `-B20%` specifies that a change with
 addition and deletion compared to 20% or more of the file's size are
 eligible for being picked up as a possible source of a rename to
 another file.
 
--M[<n>]::
---find-renames[=<n>]::
+`-M[<n>]`::
+`--find-renames[=<n>]`::
 ifndef::git-log[]
 	Detect renames.
 endif::git-log[]
@@ -580,7 +580,7 @@ ifdef::git-log[]
 	For following files across renames while traversing history, see
 	`--follow`.
 endif::git-log[]
-	If `n` is specified, it is a threshold on the similarity
+	If _<n>_ is specified, it is a threshold on the similarity
 	index (i.e. amount of addition/deletions compared to the
 	file's size). For example, `-M90%` means Git should consider a
 	delete/add pair to be a rename if more than 90% of the file
@@ -590,12 +590,12 @@ endif::git-log[]
 	the same as `-M5%`.  To limit detection to exact renames, use
 	`-M100%`.  The default similarity index is 50%.
 
--C[<n>]::
---find-copies[=<n>]::
+`-C[<n>]`::
+`--find-copies[=<n>]`::
 	Detect copies as well as renames.  See also `--find-copies-harder`.
-	If `n` is specified, it has the same meaning as for `-M<n>`.
+	If _<n>_ is specified, it has the same meaning as for `-M<n>`.
 
---find-copies-harder::
+`--find-copies-harder`::
 	For performance reasons, by default, `-C` option finds copies only
 	if the original file of the copy was modified in the same
 	changeset.  This flag makes the command
@@ -604,8 +604,8 @@ endif::git-log[]
 	projects, so use it with caution.  Giving more than one
 	`-C` option has the same effect.
 
--D::
---irreversible-delete::
+`-D`::
+`--irreversible-delete`::
 	Omit the preimage for deletes, i.e. print only the header but not
 	the diff between the preimage and `/dev/null`. The resulting patch
 	is not meant to be applied with `patch` or `git apply`; this is
@@ -617,7 +617,7 @@ endif::git-log[]
 When used together with `-B`, omit also the preimage in the deletion part
 of a delete/create pair.
 
--l<num>::
+`-l<num>`::
 	The `-M` and `-C` options involve some preliminary steps that
 	can detect subsets of renames/copies cheaply, followed by an
 	exhaustive fallback portion that compares all remaining
@@ -627,11 +627,11 @@ of a delete/create pair.
 	destinations, this exhaustive check is O(N^2).  This option
 	prevents the exhaustive portion of rename/copy detection from
 	running if the number of source/destination files involved
-	exceeds the specified number.  Defaults to diff.renameLimit.
+	exceeds the specified number.  Defaults to `diff.renameLimit`.
 	Note that a value of 0 is treated as unlimited.
 
 ifndef::git-format-patch[]
---diff-filter=[(A|C|D|M|R|T|U|X|B)...[*]]::
+`--diff-filter=[(A|C|D|M|R|T|U|X|B)...[*]]`::
 	Select only files that are Added (`A`), Copied (`C`),
 	Deleted (`D`), Modified (`M`), Renamed (`R`), have their
 	type (i.e. regular file, symlink, submodule, ...) changed (`T`),
@@ -649,9 +649,9 @@ Also, these upper-case letters can be downcased to exclude.  E.g.
 Note that not all diffs can feature all types. For instance, copied and
 renamed entries cannot appear if detection for those types is disabled.
 
--S<string>::
+`-S<string>`::
 	Look for differences that change the number of occurrences of
-	the specified string (i.e. addition/deletion) in a file.
+	the specified _<string>_ (i.e. addition/deletion) in a file.
 	Intended for the scripter's use.
 +
 It is useful when you're looking for an exact block of code (like a
@@ -662,11 +662,11 @@ very first version of the block.
 +
 Binary files are searched as well.
 
--G<regex>::
+`-G<regex>`::
 	Look for differences whose patch text contains added/removed
-	lines that match <regex>.
+	lines that match _<regex>_.
 +
-To illustrate the difference between `-S<regex> --pickaxe-regex` and
+To illustrate the difference between `-S<regex>` `--pickaxe-regex` and
 `-G<regex>`, consider a commit with the following diff in the same
 file:
 +
@@ -686,7 +686,7 @@ filter will be ignored.
 See the 'pickaxe' entry in linkgit:gitdiffcore[7] for more
 information.
 
---find-object=<object-id>::
+`--find-object=<object-id>`::
 	Look for differences that change the number of occurrences of
 	the specified object. Similar to `-S`, just the argument is different
 	in that it doesn't search for a specific string but for a specific
@@ -695,25 +695,25 @@ information.
 The object can be a blob or a submodule commit. It implies the `-t` option in
 `git-log` to also find trees.
 
---pickaxe-all::
+`--pickaxe-all`::
 	When `-S` or `-G` finds a change, show all the changes in that
 	changeset, not just the files that contain the change
-	in <string>.
+	in _<string>_.
 
---pickaxe-regex::
-	Treat the <string> given to `-S` as an extended POSIX regular
+`--pickaxe-regex`::
+	Treat the _<string>_ given to `-S` as an extended POSIX regular
 	expression to match.
 
 endif::git-format-patch[]
 
--O<orderfile>::
+`-O<orderfile>`::
 	Control the order in which files appear in the output.
 	This overrides the `diff.orderFile` configuration variable
 	(see linkgit:git-config[1]).  To cancel `diff.orderFile`,
 	use `-O/dev/null`.
 +
 The output order is determined by the order of glob patterns in
-<orderfile>.
+_<orderfile>_.
 All files with pathnames that match the first pattern are output
 first, all files with pathnames that match the second pattern (but not
 the first) are output next, and so on.
@@ -724,7 +724,7 @@ If multiple pathnames have the same rank (they match the same pattern
 but no earlier patterns), their output order relative to each other is
 the normal order.
 +
-<orderfile> is parsed as follows:
+_<orderfile>_ is parsed as follows:
 +
 --
  - Blank lines are ignored, so they can be used as separators for
@@ -738,106 +738,107 @@ the normal order.
 --
 +
 Patterns have the same syntax and semantics as patterns used for
-fnmatch(3) without the FNM_PATHNAME flag, except a pathname also
+`fnmatch`(3) without the `FNM_PATHNAME` flag, except a pathname also
 matches a pattern if removing any number of the final pathname
 components matches the pattern.  For example, the pattern "`foo*bar`"
 matches "`fooasdfbar`" and "`foo/bar/baz/asdf`" but not "`foobarx`".
 
---skip-to=<file>::
---rotate-to=<file>::
-	Discard the files before the named <file> from the output
+`--skip-to=<file>`::
+`--rotate-to=<file>`::
+	Discard the files before the named _<file>_ from the output
 	(i.e. 'skip to'), or move them to the end of the output
 	(i.e. 'rotate to').  These options were invented primarily for the use
 	of the `git difftool` command, and may not be very useful
 	otherwise.
 
 ifndef::git-format-patch[]
--R::
+`-R`::
 	Swap two inputs; that is, show differences from index or
 	on-disk file to tree contents.
 endif::git-format-patch[]
 
---relative[=<path>]::
---no-relative::
+`--relative[=<path>]`::
+`--no-relative`::
 	When run from a subdirectory of the project, it can be
 	told to exclude changes outside the directory and show
 	pathnames relative to it with this option.  When you are
 	not in a subdirectory (e.g. in a bare repository), you
 	can name which subdirectory to make the output relative
-	to by giving a <path> as an argument.
+	to by giving a _<path>_ as an argument.
 	`--no-relative` can be used to countermand both `diff.relative` config
 	option and previous `--relative`.
 
--a::
---text::
+`-a`::
+`--text`::
 	Treat all files as text.
 
---ignore-cr-at-eol::
+`--ignore-cr-at-eol`::
 	Ignore carriage-return at the end of line when doing a comparison.
 
---ignore-space-at-eol::
+`--ignore-space-at-eol`::
 	Ignore changes in whitespace at EOL.
 
--b::
---ignore-space-change::
+`-b`::
+`--ignore-space-change`::
 	Ignore changes in amount of whitespace.  This ignores whitespace
 	at line end, and considers all other sequences of one or
 	more whitespace characters to be equivalent.
 
--w::
---ignore-all-space::
+`-w`::
+`--ignore-all-space`::
 	Ignore whitespace when comparing lines.  This ignores
 	differences even if one line has whitespace where the other
 	line has none.
 
---ignore-blank-lines::
+`--ignore-blank-lines`::
 	Ignore changes whose lines are all blank.
 
--I<regex>::
---ignore-matching-lines=<regex>::
-	Ignore changes whose all lines match <regex>.  This option may
+
+`-I<regex>`::
+`--ignore-matching-lines=<regex>`::
+	Ignore changes whose all lines match _<regex>_.  This option may
 	be specified more than once.
 
---inter-hunk-context=<lines>::
-	Show the context between diff hunks, up to the specified number
+`--inter-hunk-context=<number>`::
+	Show the context between diff hunks, up to the specified _<number>_
 	of lines, thereby fusing hunks that are close to each other.
 	Defaults to `diff.interHunkContext` or 0 if the config option
 	is unset.
 
--W::
---function-context::
+`-W`::
+`--function-context`::
 	Show whole function as context lines for each change.
 	The function names are determined in the same way as
-	`git diff` works out patch hunk headers (see 'Defining a
-	custom hunk-header' in linkgit:gitattributes[5]).
+	`git diff` works out patch hunk headers (see "Defining a
+	custom hunk-header" in linkgit:gitattributes[5]).
 
 ifndef::git-format-patch[]
 ifndef::git-log[]
---exit-code::
-	Make the program exit with codes similar to diff(1).
+`--exit-code`::
+	Make the program exit with codes similar to `diff`(1).
 	That is, it exits with 1 if there were differences and
 	0 means no differences.
 
---quiet::
+`--quiet`::
 	Disable all output of the program. Implies `--exit-code`.
 	Disables execution of external diff helpers whose exit code
 	is not trusted, i.e. their respective configuration option
-	`diff.trustExitCode` or `diff.<driver>.trustExitCode` or
+	`diff.trustExitCode` or ++diff.++__<driver>__++.trustExitCode++ or
 	environment variable `GIT_EXTERNAL_DIFF_TRUST_EXIT_CODE` is
 	false.
 endif::git-log[]
 endif::git-format-patch[]
 
---ext-diff::
+`--ext-diff`::
 	Allow an external diff helper to be executed. If you set an
 	external diff driver with linkgit:gitattributes[5], you need
 	to use this option with linkgit:git-log[1] and friends.
 
---no-ext-diff::
+`--no-ext-diff`::
 	Disallow external diff drivers.
 
---textconv::
---no-textconv::
+`--textconv`::
+`--no-textconv`::
 	Allow (or disallow) external text conversion filters to be run
 	when comparing binary files. See linkgit:gitattributes[5] for
 	details. Because textconv filters are typically a one-way
@@ -847,42 +848,42 @@ endif::git-format-patch[]
 	linkgit:git-log[1], but not for linkgit:git-format-patch[1] or
 	diff plumbing commands.
 
---ignore-submodules[=<when>]::
-	Ignore changes to submodules in the diff generation. <when> can be
-	either "none", "untracked", "dirty" or "all", which is the default.
-	Using "none" will consider the submodule modified when it either contains
-	untracked or modified files or its HEAD differs from the commit recorded
+
+`--ignore-submodules[=(none|untracked|dirty|all)]`::
+	Ignore changes to submodules in the diff generation. `all` is the default.
+	Using `none` will consider the submodule modified when it either contains
+	untracked or modified files or its `HEAD` differs from the commit recorded
 	in the superproject and can be used to override any settings of the
-	'ignore' option in linkgit:git-config[1] or linkgit:gitmodules[5]. When
-	"untracked" is used submodules are not considered dirty when they only
+	`ignore` option in linkgit:git-config[1] or linkgit:gitmodules[5]. When
+	`untracked` is used submodules are not considered dirty when they only
 	contain untracked content (but they are still scanned for modified
-	content). Using "dirty" ignores all changes to the work tree of submodules,
+	content). Using `dirty` ignores all changes to the work tree of submodules,
 	only changes to the commits stored in the superproject are shown (this was
-	the behavior until 1.7.0). Using "all" hides all changes to submodules.
+	the behavior until 1.7.0). Using `all` hides all changes to submodules.
 
---src-prefix=<prefix>::
-	Show the given source prefix instead of "a/".
+`--src-prefix=<prefix>`::
+	Show the given source _<prefix>_ instead of "a/".
 
---dst-prefix=<prefix>::
-	Show the given destination prefix instead of "b/".
+`--dst-prefix=<prefix>`::
+	Show the given destination _<prefix>_ instead of "b/".
 
---no-prefix::
+`--no-prefix`::
 	Do not show any source or destination prefix.
 
---default-prefix::
+`--default-prefix`::
 	Use the default source and destination prefixes ("a/" and "b/").
 	This overrides configuration variables such as `diff.noprefix`,
 	`diff.srcPrefix`, `diff.dstPrefix`, and `diff.mnemonicPrefix`
-	(see `git-config`(1)).
+	(see linkgit:git-config[1]).
 
---line-prefix=<prefix>::
-	Prepend an additional prefix to every line of output.
+`--line-prefix=<prefix>`::
+	Prepend an additional _<prefix>_ to every line of output.
 
---ita-invisible-in-index::
-	By default entries added by "git add -N" appear as an existing
-	empty file in "git diff" and a new file in "git diff --cached".
-	This option makes the entry appear as a new file in "git diff"
-	and non-existent in "git diff --cached". This option could be
+`--ita-invisible-in-index`::
+	By default entries added by `git add -N` appear as an existing
+	empty file in `git diff` and a new file in `git diff --cached`.
+	This option makes the entry appear as a new file in `git diff`
+	and non-existent in `git diff --cached`. This option could be
 	reverted with `--ita-visible-in-index`. Both options are
 	experimental and could be removed in future.
 

--- a/Documentation/git-diff.txt
+++ b/Documentation/git-diff.txt
@@ -8,13 +8,13 @@ git-diff - Show changes between commits, commit and working tree, etc
 
 SYNOPSIS
 --------
-[verse]
-'git diff' [<options>] [<commit>] [--] [<path>...]
-'git diff' [<options>] --cached [--merge-base] [<commit>] [--] [<path>...]
-'git diff' [<options>] [--merge-base] <commit> [<commit>...] <commit> [--] [<path>...]
-'git diff' [<options>] <commit>...<commit> [--] [<path>...]
-'git diff' [<options>] <blob> <blob>
-'git diff' [<options>] --no-index [--] <path> <path>
+[synopsis]
+git diff [<options>] [<commit>] [--] [<path>...]
+git diff [<options>] --cached [--merge-base] [<commit>] [--] [<path>...]
+git diff [<options>] [--merge-base] <commit> [<commit>...] <commit> [--] [<path>...]
+git diff [<options>] <commit>...<commit> [--] [<path>...]
+git diff [<options>] <blob> <blob>
+git diff [<options>] --no-index [--] <path> <path>
 
 DESCRIPTION
 -----------
@@ -23,7 +23,7 @@ between the index and a tree, changes between two trees, changes resulting
 from a merge, changes between two blob objects, or changes between two
 files on disk.
 
-'git diff' [<options>] [--] [<path>...]::
+`git diff [<options>] [--] [<path>...]`::
 
 	This form is to view the changes you made relative to
 	the index (staging area for the next commit).  In other
@@ -31,7 +31,7 @@ files on disk.
 	further add to the index but you still haven't.  You can
 	stage these changes by using linkgit:git-add[1].
 
-'git diff' [<options>] --no-index [--] <path> <path>::
+`git diff [<options>] --no-index [--] <path> <path>`::
 
 	This form is to compare the given two paths on the
 	filesystem.  You can omit the `--no-index` option when
@@ -40,82 +40,82 @@ files on disk.
 	or when running the command outside a working tree
 	controlled by Git. This form implies `--exit-code`.
 
-'git diff' [<options>] --cached [--merge-base] [<commit>] [--] [<path>...]::
+`git diff [<options>] --cached [--merge-base] [<commit>] [--] [<path>...]`::
 
 	This form is to view the changes you staged for the next
-	commit relative to the named <commit>.  Typically you
+	commit relative to the named _<commit>_.  Typically you
 	would want comparison with the latest commit, so if you
-	do not give <commit>, it defaults to HEAD.
-	If HEAD does not exist (e.g. unborn branches) and
-	<commit> is not given, it shows all staged changes.
-	--staged is a synonym of --cached.
+	do not give _<commit>_, it defaults to `HEAD`.
+	If `HEAD` does not exist (e.g. unborn branches) and
+	_<commit>_ is not given, it shows all staged changes.
+	`--staged` is a synonym of `--cached`.
 +
-If --merge-base is given, instead of using <commit>, use the merge base
-of <commit> and HEAD.  `git diff --cached --merge-base A` is equivalent to
+If `--merge-base` is given, instead of using _<commit>_, use the merge base
+of _<commit>_ and `HEAD`.  `git diff --cached --merge-base A` is equivalent to
 `git diff --cached $(git merge-base A HEAD)`.
 
-'git diff' [<options>] [--merge-base] <commit> [--] [<path>...]::
+`git diff [<options>] [--merge-base] <commit> [--] [<path>...]`::
 
 	This form is to view the changes you have in your
-	working tree relative to the named <commit>.  You can
-	use HEAD to compare it with the latest commit, or a
+	working tree relative to the named _<commit>_.  You can
+	use `HEAD` to compare it with the latest commit, or a
 	branch name to compare with the tip of a different
 	branch.
 +
-If --merge-base is given, instead of using <commit>, use the merge base
-of <commit> and HEAD.  `git diff --merge-base A` is equivalent to
+If `--merge-base` is given, instead of using _<commit>_, use the merge base
+of _<commit>_ and `HEAD`.  `git diff --merge-base A` is equivalent to
 `git diff $(git merge-base A HEAD)`.
 
-'git diff' [<options>] [--merge-base] <commit> <commit> [--] [<path>...]::
+`git diff [<options>] [--merge-base] <commit> <commit> [--] [<path>...]`::
 
 	This is to view the changes between two arbitrary
-	<commit>.
+	_<commit>_.
 +
-If --merge-base is given, use the merge base of the two commits for the
+If `--merge-base` is given, use the merge base of the two commits for the
 "before" side.  `git diff --merge-base A B` is equivalent to
 `git diff $(git merge-base A B) B`.
 
-'git diff' [<options>] <commit> <commit>... <commit> [--] [<path>...]::
+`git diff [<options>] <commit> <commit>...<commit> [--] [<path>...]`::
 
 	This form is to view the results of a merge commit.  The first
-	listed <commit> must be the merge itself; the remaining two or
+	listed _<commit>_ must be the merge itself; the remaining two or
 	more commits should be its parents.  Convenient ways to produce
-	the desired set of revisions are to use the suffixes `^@` and
-	`^!`.  If A is a merge commit, then `git diff A A^@`,
+	the desired set of revisions are to use the suffixes `@` and
+	`^!`.  If `A` is a merge commit, then `git diff A A^@`,
 	`git diff A^!` and `git show A` all give the same combined diff.
 
-'git diff' [<options>] <commit>..<commit> [--] [<path>...]::
+`git diff [<options>] <commit>..<commit> [--] [<path>...]`::
 
 	This is synonymous to the earlier form (without the `..`) for
-	viewing the changes between two arbitrary <commit>.  If <commit> on
+	viewing the changes between two arbitrary _<commit>_.  If _<commit>_ on
 	one side is omitted, it will have the same effect as
-	using HEAD instead.
+	using `HEAD` instead.
 
-'git diff' [<options>] <commit>\...<commit> [--] [<path>...]::
+`git diff [<options>] <commit>...<commit> [--] [<path>...]`::
 
 	This form is to view the changes on the branch containing
-	and up to the second <commit>, starting at a common ancestor
-	of both <commit>.  `git diff A...B` is equivalent to
+	and up to the second _<commit>_, starting at a common ancestor
+	of both _<commit>_.  `git diff A...B` is equivalent to
 	`git diff $(git merge-base A B) B`.  You can omit any one
-	of <commit>, which has the same effect as using HEAD instead.
+	of _<commit>_, which has the same effect as using `HEAD` instead.
 
 Just in case you are doing something exotic, it should be
-noted that all of the <commit> in the above description, except
+noted that all of the _<commit>_ in the above description, except
 in the `--merge-base` case and in the last two forms that use `..`
-notations, can be any <tree>. A tree of interest is the one pointed to
-by the ref named `AUTO_MERGE`, which is written by the 'ort' merge
+notations, can be any _<tree>_. A tree of interest is the one pointed to
+by the ref named `AUTO_MERGE`, which is written by the `ort` merge
 strategy upon hitting merge conflicts (see linkgit:git-merge[1]).
 Comparing the working tree with `AUTO_MERGE` shows changes you've made
 so far to resolve textual conflicts (see the examples below).
 
-For a more complete list of ways to spell <commit>, see
+For a more complete list of ways to spell _<commit>_, see
 "SPECIFYING REVISIONS" section in linkgit:gitrevisions[7].
-However, "diff" is about comparing two _endpoints_, not ranges,
-and the range notations (`<commit>..<commit>` and
-`<commit>...<commit>`) do not mean a range as defined in the
+However, `diff` is about comparing two _endpoints_, not ranges,
+and the range notations (`<commit>..<commit>` and `<commit>...<commit>`)
+do not mean a range as defined in the
 "SPECIFYING RANGES" section in linkgit:gitrevisions[7].
 
-'git diff' [<options>] <blob> <blob>::
+`git diff [<options>] <blob> <blob>`::
 
 	This form is to view the differences between the raw
 	contents of two blob objects.
@@ -125,22 +125,31 @@ OPTIONS
 :git-diff: 1
 include::diff-options.txt[]
 
--1 --base::
--2 --ours::
--3 --theirs::
-	Compare the working tree with the "base" version (stage #1),
-	"our branch" (stage #2) or "their branch" (stage #3).  The
-	index contains these stages only for unmerged entries i.e.
-	while resolving conflicts.  See linkgit:git-read-tree[1]
-	section "3-Way Merge" for detailed information.
+`-1`::
+`--base`::
+`-2`::
+`--ours`::
+`-3`::
+`--theirs`::
+	Compare the working tree with
++
+--
+ * the "base" version (stage #1) when using `-1` or `--base`,
+ * "our branch" (stage #2) when using `-2` or `--ours`, or
+ * "their branch" (stage #3) when using `-3` or `--theirs`.
+--
++
+The index contains these stages only for unmerged entries i.e.
+while resolving conflicts.  See linkgit:git-read-tree[1]
+section "3-Way Merge" for detailed information.
 
--0::
+`-0`::
 	Omit diff output for unmerged entries and just show
 	"Unmerged".  Can be used only when comparing the working tree
 	with the index.
 
-<path>...::
-	The <paths> parameters, when given, are used to limit
+`<path>...`::
+	The _<path>_ parameters, when given, are used to limit
 	the diff to the named paths (you can give directory
 	names and get diff for all files under them).
 
@@ -225,11 +234,12 @@ CONFIGURATION
 
 include::includes/cmd-config-section-all.txt[]
 
+:git-diff: 1
 include::config/diff.txt[]
 
 SEE ALSO
 --------
-diff(1),
+`diff`(1),
 linkgit:git-difftool[1],
 linkgit:git-log[1],
 linkgit:gitdiffcore[7],


### PR DESCRIPTION
This is the continuation of the editing of the manpages to reflect the new formatting rules.

Changes since V3:

 * rework the description about `-1`, `--base`,...

cc: Johannes Sixt <j6t@kdbg.org>
cc: Patrick Steinhardt <ps@pks.im>