### PR TITLE
git gui: add directly calling merge tool from gitconfig

### DIFF
--- a/git-gui/lib/mergetool.tcl
+++ b/git-gui/lib/mergetool.tcl
@@ -272,8 +272,26 @@ proc merge_resolve_tool2 {} {
 		}
 	}
 	default {
-		error_popup [mc "Unsupported merge tool '%s'" $tool]
-		return
+		set tool_cmd [get_config mergetool.$tool.cmd]
+		if {$tool_cmd ne {}} {
+			if {([string first {[} $tool_cmd] != -1) || ([string first {]} $tool_cmd] != -1)} {
+				error_popup [mc "Unable to process square brackets in mergetool.$tool.cmd configuration option.
+
+Please remove the square brackets."]
+				return
+			} else {
+				set cmdline {}
+				foreach command_part $tool_cmd {
+					lappend cmdline [subst -nobackslashes -nocommands $command_part]
+				}
+			}
+		} else {
+			error_popup [mc "Unsupported merge tool '%s'.
+
+To use this tool, configure \"mergetool.%s.cmd\" as shown in the git-config\
+manual page." $tool $tool]
+			return
+		}
 	}
 	}
 


### PR DESCRIPTION
cc: Johannes Sixt <j6t@kdbg.org>

Changes since v1:
- Used existing option mergetool.cmd in gitconfig to trigger the direct call of the merge tool configured in the config instead adding a new option mergeToolFromConfig
- Removed assignment of merge tool path to a variable and reused the already existing one: merget_tool_path
- Changed formatting of the commit message
- Added more context and an examples to the commit message

Changes since v2:
- Changed commit ident
- Added hint to add a mergetool as an unsupprted tool
- Minor typos
- Highlighted proper nouns in commit message
- Only using mergetool.cmd now - not using mergetool.path anymore
- Removed gitconfig term in user message
- Changed lines length of commit message
- tcl commands in mergetool.cmd are now detected and not executed anymore
- mergetool.cmd string parts are now substituted as list, not as a whole string
- Made a more clear user hint on how to configure an unsupported mergetool

Changes since v3:
- Corrected wrong configuration option in commit message
- Replaced "config" and "gitconfig" with "configuration" in commit message
- Initialised cmdline list before appending values in loop
- Removed hint that unsupported tools have degraded support
- Changed popup message formatting in the popup and in the source code

Changes since v4:
- Removed trailing whitespace

cc: Johannes Sixt <j6t@kdbg.org>