### PR TITLE
ci(linux32): do make Javascript Actions work

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -348,19 +348,27 @@ jobs:
       jobname: ${{matrix.vector.jobname}}
       distro: ${{matrix.vector.distro}}
     runs-on: ubuntu-latest
-    container: ${{matrix.vector.image}}
+    container:
+      image: ${{matrix.vector.image}}
+      volumes:
+        # override /__e/node20 on 32-bit because it is 64-bit
+        - /tmp:/__e${{matrix.vector.jobname != 'linux32' && '-x86' || ''}}/node20
     steps:
-    - uses: actions/checkout@v4
-      if: matrix.vector.jobname != 'linux32'
-    - uses: actions/checkout@v1 # cannot be upgraded because Node.js Actions aren't supported in this container
+    - name: prepare x86 variant of node20
       if: matrix.vector.jobname == 'linux32'
+      run: |
+        apt -q update && apt -q -y install curl &&
+        NODE_URL=https://unofficial-builds.nodejs.org/download/release/v20.17.0/node-v20.17.0-linux-x86.tar.gz &&
+        curl -Lo /tmp/node.tar.gz $NODE_URL &&
+        tar -C /__e/node20 -x --strip-components=1 -f /tmp/node.tar.gz
+    - uses: actions/checkout@v4
     - run: ci/install-dependencies.sh
     - run: ci/run-build-and-tests.sh
     - name: print test failures
       if: failure() && env.FAILED_TEST_ARTIFACTS != ''
       run: ci/print-test-failures.sh
     - name: Upload failed tests' directories
-      if: failure() && env.FAILED_TEST_ARTIFACTS != '' && matrix.vector.jobname != 'linux32'
+      if: failure() && env.FAILED_TEST_ARTIFACTS != ''
       uses: actions/upload-artifact@v4
       with:
         name: failed-tests-${{matrix.vector.jobname}}


### PR DESCRIPTION
I propose this alternative to 9c261856c91 (ci: use regular action versions for linux32 job, 2024-09-12), keeping the updates to Javascript Actions.

The benefit is that it keeps the 32-bit container used in the `linux32` job clean of any 64-bit libraries so that we don't accidentally end up testing 64-bit stuff without wanting it.

For good measure, I also reported this problem with that deprecation at https://github.com/actions/upload-artifact/issues/616 even though I know that the GitHub Actions team saw a headcount-losing reorg recently and therefore I do not really expect that they have any bandwidth to help with this. So this work-around is the best we can do for now, I believe.

Cc: Jeff King <peff@peff.net>