### PR TITLE
cmake: rename clar-related variables to avoid confusion

### DIFF
--- a/contrib/buildsystems/CMakeLists.txt
+++ b/contrib/buildsystems/CMakeLists.txt
@@ -1004,14 +1004,14 @@ foreach(unit_test ${unit_test_PROGRAMS})
 	endif()
 endforeach()
 
-parse_makefile_for_scripts(unit_tests_SUITES "UNIT_TESTS_SUITES" "")
+parse_makefile_for_scripts(clar_test_SUITES "CLAR_TEST_SUITES" "")
 
 set(clar_decls "")
 set(clar_cbs "")
 set(clar_cbs_count 0)
 set(clar_suites "static struct clar_suite _clar_suites[] = {\n")
-list(LENGTH unit_tests_SUITES clar_suites_count)
-foreach(suite ${unit_tests_SUITES})
+list(LENGTH clar_test_SUITES clar_suites_count)
+foreach(suite ${clar_test_SUITES})
 	file(STRINGS "${CMAKE_SOURCE_DIR}/t/unit-tests/${suite}.c" decls
 		REGEX "^void test_${suite}__[a-zA-Z_0-9][a-zA-Z_0-9]*\\(void\\)$")
 
@@ -1042,9 +1042,9 @@ string(APPEND clar_suites
 file(WRITE "${CMAKE_BINARY_DIR}/t/unit-tests/clar-decls.h" "${clar_decls}")
 file(WRITE "${CMAKE_BINARY_DIR}/t/unit-tests/clar.suite" "${clar_decls}" "${clar_cbs}" "${clar_suites}")
 
-list(TRANSFORM unit_tests_SUITES PREPEND "${CMAKE_SOURCE_DIR}/t/unit-tests/")
-list(TRANSFORM unit_tests_SUITES APPEND ".c")
-add_library(unit-tests-lib ${unit_tests_SUITES} "${CMAKE_SOURCE_DIR}/t/unit-tests/clar/clar.c")
+list(TRANSFORM clar_test_SUITES PREPEND "${CMAKE_SOURCE_DIR}/t/unit-tests/")
+list(TRANSFORM clar_test_SUITES APPEND ".c")
+add_library(unit-tests-lib ${clar_test_SUITES} "${CMAKE_SOURCE_DIR}/t/unit-tests/clar/clar.c")
 target_include_directories(unit-tests-lib PRIVATE "${CMAKE_SOURCE_DIR}/t/unit-tests")
 add_executable(unit-tests "${CMAKE_SOURCE_DIR}/t/unit-tests/unit-test.c")
 target_link_libraries(unit-tests unit-tests-lib common-main)


### PR DESCRIPTION
This is an add-on for `ps/clar-unit-tests` to let it build with CMake and Visual C.

cc: Patrick Steinhardt <ps@pks.im>