### PR TITLE
sparse-checkout: disable advice in 'disable'

### DIFF
--- a/builtin/sparse-checkout.c
+++ b/builtin/sparse-checkout.c
@@ -924,6 +924,11 @@ static int sparse_checkout_disable(int argc, const char **argv,
 			     builtin_sparse_checkout_disable_options,
 			     builtin_sparse_checkout_disable_usage, 0);
 
+	/*
+	 * Disable the advice message for expanding a sparse index, as we
+	 * are expecting to do that when disabling sparse-checkout.
+	 */
+	give_advice_on_expansion = 0;
 	repo_read_index(the_repository);
 
 	memset(&pl, 0, sizeof(pl));

--- a/sparse-index.c
+++ b/sparse-index.c
@@ -19,9 +19,10 @@
  * advice for advice.sparseIndexExpanded when expanding a sparse index to a full
  * one. However, this is sometimes done on purpose, such as in the sparse-checkout
  * builtin, even when index.sparse=false. This may be disabled in
- * convert_to_sparse().
+ * convert_to_sparse() or by commands that know they will lead to a full
+ * expansion, but this message is not actionable.
  */
-static int give_advice_on_expansion = 1;
+int give_advice_on_expansion = 1;
 #define ADVICE_MSG \
 	"The sparse index is expanding to a full index, a slow operation.\n"   \
 	"Your working directory likely has contents that are outside of\n"     \

--- a/sparse-index.h
+++ b/sparse-index.h
@@ -1,6 +1,13 @@
 #ifndef SPARSE_INDEX_H__
 #define SPARSE_INDEX_H__
 
+/*
+ * If performing an operation where the index is supposed to expand to a
+ * full index, then disable the advice message by setting this global to
+ * zero.
+ */
+extern int give_advice_on_expansion;
+
 struct index_state;
 #define SPARSE_INDEX_MEMORY_ONLY (1 << 0)
 int is_sparse_index_allowed(struct index_state *istate, int flags);

--- a/t/t1092-sparse-checkout-compatibility.sh
+++ b/t/t1092-sparse-checkout-compatibility.sh
@@ -2355,7 +2355,10 @@ test_expect_success 'advice.sparseIndexExpanded' '
 	mkdir -p sparse-index/deep/deeper2/deepest &&
 	touch sparse-index/deep/deeper2/deepest/bogus &&
 	git -C sparse-index status 2>err &&
-	grep "The sparse index is expanding to a full index" err
+	grep "The sparse index is expanding to a full index" err &&
+
+	git -C sparse-index sparse-checkout disable 2>err &&
+	test_line_count = 0 err
 '
 
 test_expect_success 'cat-file -p' '


### PR DESCRIPTION
I found this while someone was demoing some behavior that included disabling the sparse-checkout feature. Having this message pop up during that interaction was embarassing.

Thanks, -Stolee

cc: gitster@pobox.com
cc: newren@gmail.com