### PR TITLE
blame: respect .git-blame-ignore-revs automatically

### DIFF
--- a/builtin/blame.c
+++ b/builtin/blame.c
@@ -1105,6 +1105,10 @@ parse_done:
 		add_pending_object(&revs, &head_commit->object, "HEAD");
 	}
 
+	if (!ignore_revs_file_list.nr) {
+		string_list_insert(&ignore_revs_file_list, ".git-blame-ignore-revs");
+	}
+
 	init_scoreboard(&sb);
 	sb.revs = &revs;
 	sb.contents_from = contents_from;

--- a/t/t8015-blame-default-ignore-revs.sh
+++ b/t/t8015-blame-default-ignore-revs.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+test_description='default revisions to ignore when blaming'
+
+TEST_PASSES_SANITIZE_LEAK=true
+. ./test-lib.sh
+
+test_expect_success 'blame: default-ignore-revs-file' '
+    test_commit first-commit hello.txt hello &&
+
+    echo world >>hello.txt &&
+    test_commit second-commit hello.txt &&
+
+    sed "1s/hello/hi/" <hello.txt > hello.txt.tmp &&
+    mv hello.txt.tmp hello.txt &&
+    test_commit third-commit hello.txt &&
+
+    git rev-parse HEAD >ignored-file &&
+    git blame --ignore-revs-file=ignored-file hello.txt >expect &&
+    git rev-parse HEAD >.git-blame-ignore-revs &&
+    git blame hello.txt >actual &&
+
+    test_cmp expect actual
+'
+
+test_done


### PR DESCRIPTION
## Introduction
Hi, I'm Abhijeet (Ethan0456), and this is my first contribution to the Git project. I currently work as an ML Engineer at an early-stage startup, and I’m excited to contribute to this open-source project.

## Why the Change?
I came across this enhancement request on the bug tracker and found it beginner-friendly, making it a great opportunity for me to get familiar with the Git codebase. The ability for git blame to automatically respect the .git-blame-ignore-revs file is something that can streamline workflows for many users, and I felt it would be a valuable addition.

## Feedback
While I’m confident in the changes made to builtin/blame.c and the new test case in t/t8015-blame-ignore-revs.sh, I welcome any feedback or suggestions to improve both my code and approach. I’m eager to learn from the community and improve where needed.

## Community Need
There is precedent for this functionality in other projects:

- [Chromium](https://chromium.googlesource.com/chromium/src.git/+/f0596779e57f46fccb115a0fd65f0305894e3031/.git-blame-ignore-revs), which powers many popular browsers, uses .git-blame-ignore-revs to simplify the blame process by ignoring non-functional changes.
- [Rob Allen's blog post](https://akrabat.com/ignoring-revisions-with-git-blame/) discusses the need for ignoring revisions with git blame, and a commenter specifically suggests that it would be helpful if Git automatically respected .git-blame-ignore-revs.

I hope this change aligns with community needs and improves the git blame experience for users.