### PR TITLE
[PATCH]: psuh subcommand implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,6 +119,7 @@
 /git-patch-id
 /git-prune
 /git-prune-packed
+/git-psuh
 /git-pull
 /git-push
 /git-quiltimport

--- a/Documentation/git-psuh.txt
+++ b/Documentation/git-psuh.txt
@@ -1,0 +1,32 @@
+git-psuh(1)
+===========
+
+NAME
+----
+git-psuh - Delight users' typo with a shy horse
+
+
+SYNOPSIS
+--------
+[verse]
+'git-psuh [<arg>...]'
+
+DESCRIPTION
+-----------
+Prints the commandline variables,
+gets the user's current working directory and prints it,
+the user's name in the git config file, the current branch
+and also the commitline.
+
+
+OPTIONS[[OPTIONS]]
+------------------
+...
+
+OUTPUT
+------
+...
+
+GIT
+---
+Part of the git[1] suite

--- a/Makefile
+++ b/Makefile
@@ -1280,6 +1280,7 @@ BUILTIN_OBJS += builtin/pack-refs.o
 BUILTIN_OBJS += builtin/patch-id.o
 BUILTIN_OBJS += builtin/prune-packed.o
 BUILTIN_OBJS += builtin/prune.o
+BUILTIN_OBJS += builtin/psuh.o
 BUILTIN_OBJS += builtin/pull.o
 BUILTIN_OBJS += builtin/push.o
 BUILTIN_OBJS += builtin/range-diff.o

--- a/builtin.h
+++ b/builtin.h
@@ -200,6 +200,7 @@ int cmd_pack_redundant(int argc, const char **argv, const char *prefix, struct r
 int cmd_patch_id(int argc, const char **argv, const char *prefix, struct repository *repo);
 int cmd_prune(int argc, const char **argv, const char *prefix, struct repository *repo);
 int cmd_prune_packed(int argc, const char **argv, const char *prefix, struct repository *repo);
+int cmd_psuh(int argc, const char **argv, const char *prefix, struct repository *repo);
 int cmd_pull(int argc, const char **argv, const char *prefix, struct repository *repo);
 int cmd_push(int argc, const char **argv, const char *prefix, struct repository *repo);
 int cmd_range_diff(int argc, const char **argv, const char *prefix, struct repository *repo);

--- a/builtin/psuh.c
+++ b/builtin/psuh.c
@@ -6,11 +6,15 @@
 #include "gettext.h"
 #include "repository.h"
 #include "wt-status.h"
-
+#include "commit.h"
+#include "pretty.h"
+#include "strbuf.h"
 
 int cmd_psuh(int argc, const char **argv, const char *prefix, struct repository *repo) {
         const char *cfg_name;
         struct wt_status status;
+        struct commit *c = NULL;
+        struct strbuf commitline = STRBUF_INIT;
         int i;
 
         printf("%d\n", repo->different_commondir);
@@ -37,6 +41,14 @@ int cmd_psuh(int argc, const char **argv, const char *prefix, struct repository 
         wt_status_prepare(the_repository, &status);
         git_config(git_default_config, &status);
         printf(_("Your current branch: %s\n"), status.branch);
+
+        // get info from a commit
+        c = lookup_commit_reference_by_name("psuh");
+
+        if (c != NULL) {
+                pp_commit_easy(CMIT_FMT_ONELINE, c, &commitline);
+                printf(_("Current commit: %s"), commitline.buf);
+        }
         return 0;
 
 }

--- a/builtin/psuh.c
+++ b/builtin/psuh.c
@@ -5,30 +5,38 @@
 #include "config.h"
 #include "gettext.h"
 #include "repository.h"
-
-
+#include "wt-status.h"
 
 
 int cmd_psuh(int argc, const char **argv, const char *prefix, struct repository *repo) {
-    const char *cfg_name;
-    int i;
+        const char *cfg_name;
+        struct wt_status status;
+        int i;
 
-    printf("%d\n", repo->different_commondir);
-    printf(_("%s\n"), prefix);
+        printf("%d\n", repo->different_commondir);
+        printf(_("%s\n"), prefix);
 
-    printf(Q_("Your args (there is %d):\n",
-              "Your args (there are %d):\n",
-              argc),
-              argc);
-    for (i = 0; i < argc; i++)
-            printf("%d: %s\n", i, argv[i]);
+        printf(Q_("Your args (there is %d):\n",
+                "Your args (there are %d):\n",
+                argc),
+                argc);
+        for (i = 0; i < argc; i++)
+                printf("%d: %s\n", i, argv[i]);
 
-    printf(_("Your current working directory:\n<top-level>%s%s\n"),
-            prefix ? "/" : "", prefix ? prefix : "");
-    git_config(git_default_config, NULL);
-    if(git_config_get_string_tmp("user.name", &cfg_name) > 0)
-            printf(_("No name is found in config\n"));
-    else
-            printf(_("Your name: %s\n"), cfg_name);
-    return 0;
+        printf(_("Your current working directory:\n<top-level>%s%s\n"),
+                prefix ? "/" : "", prefix ? prefix : "");
+
+        // git config implementation
+        git_config(git_default_config, NULL);
+        if(git_config_get_string_tmp("user.name", &cfg_name) > 0)
+                printf(_("No name is found in config\n"));
+        else
+                printf(_("Your name: %s\n"), cfg_name);
+
+        // getting current branch from status struct
+        wt_status_prepare(the_repository, &status);
+        git_config(git_default_config, &status);
+        printf(_("Your current branch: %s\n"), status.branch);
+        return 0;
+
 }

--- a/builtin/psuh.c
+++ b/builtin/psuh.c
@@ -28,6 +28,7 @@ int cmd_psuh(int argc, const char **argv, const char *prefix, struct repository 
         };
 
         argc = parse_options(argc, argv, prefix, options, psuh_usage, 0);
+        printf(_("Pony saying hello goes here.\n"));
         printf("%d\n", repo->different_commondir);
         printf(_("%s\n"), prefix);
 

--- a/builtin/psuh.c
+++ b/builtin/psuh.c
@@ -1,6 +1,6 @@
 #define USE_THE_REPOSITORY_VARIABLE
 
-#include <stdio.h>
+#include "git-compat-util.h"
 #include "builtin.h"
 #include "config.h"
 #include "gettext.h"
@@ -9,6 +9,12 @@
 #include "commit.h"
 #include "pretty.h"
 #include "strbuf.h"
+#include "parse-options.h"
+
+static const char * const psuh_usage[] = {
+        N_("git psuh [<arg>...]"),
+        NULL,
+};
 
 int cmd_psuh(int argc, const char **argv, const char *prefix, struct repository *repo) {
         const char *cfg_name;
@@ -17,6 +23,11 @@ int cmd_psuh(int argc, const char **argv, const char *prefix, struct repository 
         struct strbuf commitline = STRBUF_INIT;
         int i;
 
+        struct option options[] = {
+                OPT_END()
+        };
+
+        argc = parse_options(argc, argv, prefix, options, psuh_usage, 0);
         printf("%d\n", repo->different_commondir);
         printf(_("%s\n"), prefix);
 

--- a/builtin/psuh.c
+++ b/builtin/psuh.c
@@ -1,10 +1,34 @@
+#define USE_THE_REPOSITORY_VARIABLE
+
 #include <stdio.h>
 #include "builtin.h"
+#include "config.h"
 #include "gettext.h"
+#include "repository.h"
+
+
+
 
 int cmd_psuh(int argc, const char **argv, const char *prefix, struct repository *repo) {
-    printf("%d\n, %s\n, %s\n", argc, argv[1], prefix);
+    const char *cfg_name;
+    int i;
+
     printf("%d\n", repo->different_commondir);
-    printf(_("Pony saying hello goes here.\n"));
+    printf(_("%s\n"), prefix);
+
+    printf(Q_("Your args (there is %d):\n",
+              "Your args (there are %d):\n",
+              argc),
+              argc);
+    for (i = 0; i < argc; i++)
+            printf("%d: %s\n", i, argv[i]);
+
+    printf(_("Your current working directory:\n<top-level>%s%s\n"),
+            prefix ? "/" : "", prefix ? prefix : "");
+    git_config(git_default_config, NULL);
+    if(git_config_get_string_tmp("user.name", &cfg_name) > 0)
+            printf(_("No name is found in config\n"));
+    else
+            printf(_("Your name: %s\n"), cfg_name);
     return 0;
 }

--- a/builtin/psuh.c
+++ b/builtin/psuh.c
@@ -1,0 +1,10 @@
+#include <stdio.h>
+#include "builtin.h"
+#include "gettext.h"
+
+int cmd_psuh(int argc, const char **argv, const char *prefix, struct repository *repo) {
+    printf("%d\n, %s\n, %s\n", argc, argv[1], prefix);
+    printf("%d\n", repo->different_commondir);
+    printf(_("Pony saying hello goes here.\n"));
+    return 0;
+}

--- a/command-list.txt
+++ b/command-list.txt
@@ -149,6 +149,7 @@ git-pack-refs                           ancillarymanipulators
 git-patch-id                            purehelpers
 git-prune                               ancillarymanipulators   complete
 git-prune-packed                        plumbingmanipulators
+git-psuh                                mainporcelain           info
 git-pull                                mainporcelain           remote
 git-push                                mainporcelain           remote
 git-quiltimport                         foreignscminterface

--- a/git.c
+++ b/git.c
@@ -596,6 +596,7 @@ static struct cmd_struct commands[] = {
 	{ "pickaxe", cmd_blame, RUN_SETUP },
 	{ "prune", cmd_prune, RUN_SETUP },
 	{ "prune-packed", cmd_prune_packed, RUN_SETUP },
+	{ "psuh", cmd_psuh, RUN_SETUP },
 	{ "pull", cmd_pull, RUN_SETUP | NEED_WORK_TREE },
 	{ "push", cmd_push, RUN_SETUP },
 	{ "range-diff", cmd_range_diff, RUN_SETUP | USE_PAGER },

--- a/t/t9999-psuh-tutorial.sh
+++ b/t/t9999-psuh-tutorial.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+test_description='git-psuh test
+
+This test runs git-psuh and makes sure it does not crash'
+
+. ./test-lib.sh
+
+test_expect_success "runs corrrectly with no args and good output" '
+        git psuh >actual &&
+        grep Pony actual
+'
+test_done


### PR DESCRIPTION
Our internal metrics indicate widespread interest in the command
git-psuh - that is, many users are trying to use it, but finding it is
unavailable, using some unknown workaround instead.

The following handful of patches add the psuh command and implement some
handy features on top of it.

This patchset is part of the MyFirstContribution tutorial and should not
be merged.
