### PR TITLE
blame: respect .git-blame-ignore-revs automatically

### DIFF
--- a/builtin/blame.c
+++ b/builtin/blame.c
@@ -69,6 +69,7 @@ static int coloring_mode;
 static struct string_list ignore_revs_file_list = STRING_LIST_INIT_DUP;
 static int mark_unblamable_lines;
 static int mark_ignored_lines;
+static int override_ignore_revs = 0;
 
 static struct date_mode blame_date_mode = { DATE_ISO8601 };
 static size_t blame_date_width;
@@ -901,6 +902,7 @@ int cmd_blame(int argc,
 		OPT_BIT('w', NULL, &xdl_opts, N_("ignore whitespace differences"), XDF_IGNORE_WHITESPACE),
 		OPT_STRING_LIST(0, "ignore-rev", &ignore_rev_list, N_("rev"), N_("ignore <rev> when blaming")),
 		OPT_STRING_LIST(0, "ignore-revs-file", &ignore_revs_file_list, N_("file"), N_("ignore revisions from <file>")),
+		OPT_BOOL('O', "override-ignore-revs", &override_ignore_revs, N_("override all configurations that exclude revisions")),
 		OPT_BIT(0, "color-lines", &output_option, N_("color redundant metadata from previous line differently"), OUTPUT_COLOR_LINE),
 		OPT_BIT(0, "color-by-age", &output_option, N_("color lines by age"), OUTPUT_SHOW_AGE_WITH_COLOR),
 		OPT_BIT(0, "minimal", &xdl_opts, N_("spend extra cycles to find better match"), XDF_NEED_MINIMAL),
@@ -1119,7 +1121,11 @@ parse_done:
 	sb.reverse = reverse;
 	sb.repo = the_repository;
 	sb.path = path;
-	build_ignorelist(&sb, &ignore_revs_file_list, &ignore_rev_list);
+
+	if (!override_ignore_revs) {
+		build_ignorelist(&sb, &ignore_revs_file_list, &ignore_rev_list);
+	}
+
 	string_list_clear(&ignore_revs_file_list, 0);
 	string_list_clear(&ignore_rev_list, 0);
 	setup_scoreboard(&sb, &o);

--- a/builtin/blame.c
+++ b/builtin/blame.c
@@ -1105,6 +1105,14 @@ parse_done:
 		add_pending_object(&revs, &head_commit->object, "HEAD");
 	}
 
+	/*
+	* By default, add .git-blame-ignore-revs to the list of files
+	* containing revisions to ignore if it exists.
+	*/
+	if (access(".git-blame-ignore-revs", F_OK) == 0) {
+		string_list_append(&ignore_revs_file_list, ".git-blame-ignore-revs");
+	}
+
 	init_scoreboard(&sb);
 	sb.revs = &revs;
 	sb.contents_from = contents_from;

--- a/t/t8015-blame-default-ignore-revs.sh
+++ b/t/t8015-blame-default-ignore-revs.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+test_description='default revisions to ignore when blaming'
+
+TEST_PASSES_SANITIZE_LEAK=true
+. ./test-lib.sh
+
+test_expect_success 'blame: default-ignore-revs-file' '
+    test_commit first-commit hello.txt hello &&
+
+    echo world >>hello.txt &&
+    test_commit second-commit hello.txt &&
+
+    sed "1s/hello/hi/" <hello.txt > hello.txt.tmp &&
+    mv hello.txt.tmp hello.txt &&
+    test_commit third-commit hello.txt &&
+
+    git rev-parse HEAD >ignored-file &&
+    git blame --ignore-revs-file=ignored-file hello.txt >expect &&
+    git rev-parse HEAD >.git-blame-ignore-revs &&
+    git blame hello.txt >actual &&
+
+    test_cmp expect actual
+'
+
+test_done

--- a/t/t8016-blame-override-ignore-revs.sh
+++ b/t/t8016-blame-override-ignore-revs.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+test_description='default revisions to ignore when blaming'
+
+TEST_PASSES_SANITIZE_LEAK=true
+. ./test-lib.sh
+
+test_expect_success 'blame: override-ignore-revs' '
+    test_commit first-commit hello.txt hello &&
+
+    echo world >>hello.txt &&
+    test_commit second-commit hello.txt &&
+
+    sed "1s/hello/hi/" <hello.txt > hello.txt.tmp &&
+    mv hello.txt.tmp hello.txt &&
+    test_commit third-commit hello.txt &&
+
+    git blame hello.txt >expect &&
+    git rev-parse HEAD >.git-blame-ignore-revs &&
+    git blame -O hello.txt >actual &&
+
+    test_cmp expect actual
+'
+
+test_done


### PR DESCRIPTION
## Summary
This patch introduces the ability for git blame to automatically respect the .git-blame-ignore-revs file, which can help users streamline their workflows by ignoring revisions for non-functional changes.

The feature is inspired by similar practices in other projects like Chromium, and it aligns with needs expressed by users in discussions around revision-ignoring mechanisms for git blame.

I have incorporated suggestions provided during the review of patch v1, including improvements to the commit message and addressing how to override ignore revisions using a new option.

## Patch Updates and Improvements

### Changes since v1
- Updated the commit message for the first patch. I incorporated Kristoffer’s suggestions by directly using the example he provided, ensuring the commit message aligns with the project's standards.
- Attempted to use --no-ignore-revs-file to bypass the .git-blame-ignore-revs file, but observed that it did not ignore the specified revisions.
- Introduced the --override-ignore-revs option (short form: -O) as a straightforward method to override any configured revision ignores, providing users with more control.
- For the second commit, I applied Kristoffer’s feedback in writing the commit message to ensure consistency and clarity.

cc: "Kristoffer Haugsbakk" <code@khaugsbakk.name>
cc: Phillip Wood <phillip.wood123@gmail.com>
cc: Eric Sunshine <sunshine@sunshineco.com>
cc: Taylor Blau <me@ttaylorr.com>