### PR TITLE
Makefile: fix dependency for $(UNIT_TEST_DIR)/clar/clar.o

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3910,6 +3910,7 @@ $(UNIT_TEST_DIR)/clar-decls.h: $(patsubst %,$(UNIT_TEST_DIR)/%.c,$(CLAR_TEST_SUI
 	done >$@
 $(UNIT_TEST_DIR)/clar.suite: $(UNIT_TEST_DIR)/clar-decls.h
 	$(QUIET_GEN)awk -f $(UNIT_TEST_DIR)/clar-generate.awk $< >$(UNIT_TEST_DIR)/clar.suite
+$(UNIT_TEST_DIR)/clar/clar.o: $(UNIT_TEST_DIR)/clar.suite
 $(CLAR_TEST_OBJS): $(UNIT_TEST_DIR)/clar-decls.h
 $(CLAR_TEST_OBJS): EXTRA_CPPFLAGS = -I$(UNIT_TEST_DIR)
 $(CLAR_TEST_PROG): $(UNIT_TEST_DIR)/clar.suite $(CLAR_TEST_OBJS) $(GITLIBS) GIT-LDFLAGS


### PR DESCRIPTION
v2:
Compared to v1, I just moved the new line one line up 
to keep the dependencies of `$(CLAR_TEST_OBJS)` together.

Regarding what I wrote in [1], I took a closer look and 
actually clar.suite is already added to GENERATED_H. 
The issue really is that for generated headers, the dependency 
must be specified manually. This is the case for other generated 
headers (command-list.h, etc). So my initial approach is correct.

[1] https://lore.kernel.org/git/C05B01E0-5007-4FB9-94CD-CBE74E79F9B7@gmail.com/

v1:
Hi Patrick,

I tried building v2.47.0 and stumbled onto this small issue. It reproduces for me from a fresh clone on my old 2009 Mac with `make -j -l 2.5`, it's a little curious that no one ran into this yet.

I found it best to declare the dependency directly on `clar.o`, instead of adjusting the dependencies of `CLAR_TEST_OBJS` on the line above, since it is really only this `clar.c` that includes `clar.suite`

CC: Patrick Steinhardt <ps@pks.im>
cc: Philippe Blain <levraiphilippeblain@gmail.com>
cc: Taylor Blau <me@ttaylorr.com>