### PR TITLE
log: --remerge-diff needs to keep around commit parents

### DIFF
--- a/builtin/log.c
+++ b/builtin/log.c
@@ -522,10 +522,14 @@ static int cmd_log_walk_no_free(struct rev_info *rev)
 			 * but we didn't actually show the commit.
 			 */
 			rev->max_count++;
-		if (!rev->reflog_info) {
+		if (!rev->reflog_info && !rev->remerge_diff) {
 			/*
 			 * We may show a given commit multiple times when
-			 * walking the reflogs.
+			 * walking the reflogs. Therefore we still need it.
+			 *
+			 * Likewise, we potentially still need the parents
+			 * of * already shown commits to determine merge
+			 * bases when showing remerge diffs.
 			 */
 			free_commit_buffer(the_repository->parsed_objects,
 					   commit);

--- a/t/t4069-remerge-diff.sh
+++ b/t/t4069-remerge-diff.sh
@@ -317,4 +317,11 @@ test_expect_success 'remerge-diff turns off history simplification' '
 	test_cmp expect actual
 '
 
+test_expect_success 'remerge-diff with --reverse' '
+	git log -1 --remerge-diff --oneline ab_resolution^ >expect &&
+	git log -1 --remerge-diff --oneline ab_resolution >>expect &&
+	git log -2 --remerge-diff --oneline ab_resolution --reverse >actual &&
+	test_cmp expect actual
+'
+
 test_done


### PR DESCRIPTION
This fixes a bug that is pretty much as old as the remerge-diff machinery itself. I noticed it while writing my reply to Hannes Sixt's concerns about my `range-diff --diff-merges=<mode>` patch (https://lore.kernel.org/git/af576487-5de2-fba3-b341-3c082322c9ec@gmx.de/).

Changes since v2:
- Amended the commit message to illustrate why reverse walks are not the only instances where this fix is relevant.

Changes since v1:
- Amended the code comment of the affected conditional code block in harmony with the newly-added condition.

Cc: Johannes Sixt <j6t@kdbg.org>
Cc: Elijah Newren <newren@gmail.com>