### PR TITLE
worktree: detect from secondary worktree if main worktree is bare

### DIFF
--- a/t/t3200-branch.sh
+++ b/t/t3200-branch.sh
@@ -410,6 +410,20 @@ test_expect_success 'bare main worktree has HEAD at branch deleted by secondary 
 	git -C secondary branch -D main
 '
 
+test_expect_success 'secondary worktrees recognize core.bare=true in main config.worktree' '
+	test_when_finished "rm -rf bare_repo non_bare_repo secondary_worktree" &&
+	git init -b main non_bare_repo &&
+	test_commit -C non_bare_repo x &&
+
+	git clone --bare non_bare_repo bare_repo &&
+	git -C bare_repo config extensions.worktreeConfig true &&
+	git -C bare_repo config unset core.bare &&
+	git -C bare_repo config --worktree core.bare true &&
+
+	git -C bare_repo worktree add ../secondary_worktree &&
+	git -C secondary_worktree checkout main
+'
+
 test_expect_success 'git branch --list -v with --abbrev' '
 	test_when_finished "git branch -D t" &&
 	git branch t &&


### PR DESCRIPTION
Changes since v3:
- added a comment to explain why extra check is needed to detect if main worktree bare

CC: Patrick Steinhardt <ps@pks.im>, Eric Sunshine <sunshine@sunshineco.com>, Johannes Schindelin <Johannes.Schindelin@gmx.de>, René Scharfe <l.s.r@web.de>, Junio C Hamano <gitster@pobox.com>