### PR TITLE
fast-import: disallow "." and ".." path components

### DIFF
--- a/builtin/fast-import.c
+++ b/builtin/fast-import.c
@@ -1466,6 +1466,8 @@ static int tree_content_set(
 		root->tree = t = grow_tree_content(t, t->entry_count);
 	e = new_tree_entry();
 	e->name = to_atom(p, n);
+	if (is_dot_or_dotdot(e->name->str_dat))
+		die("path %s contains invalid component", p);
 	e->versions[0].mode = 0;
 	oidclr(&e->versions[0].oid, the_repository->hash_algo);
 	t->entries[t->entry_count++] = e;

--- a/t/t9300-fast-import.sh
+++ b/t/t9300-fast-import.sh
@@ -522,6 +522,26 @@ test_expect_success 'B: fail on invalid committer (5)' '
 	test_must_fail git fast-import <input
 '
 
+test_expect_success 'B: fail on invalid file path' '
+	cat >input <<-INPUT_END &&
+	blob
+	mark :1
+	data <<EOF
+	File contents
+	EOF
+
+	commit refs/heads/badpath
+	committer Name <email> $GIT_COMMITTER_DATE
+	data <<COMMIT
+	Commit Message
+	COMMIT
+	M 100644 :1 ../invalid-path
+	INPUT_END
+
+	test_when_finished "git update-ref -d refs/heads/badpath" &&
+	test_must_fail git fast-import <input
+'
+
 ###
 ### series C
 ###


### PR DESCRIPTION
Changes since v1:
  * make use of is_dot_or_dotdot() from dir.h
  * fix style issue

cc: Eric Sunshine <sunshine@sunshineco.com>
cc: Patrick Steinhardt <ps@pks.im>
cc: "Kristoffer Haugsbakk" <kristofferhaugsbakk@fastmail.com>
cc: Jeff King <peff@peff.net>