### PR TITLE
Disallow verify_path() failures from fast-import

### DIFF
--- a/builtin/fast-import.c
+++ b/builtin/fast-import.c
@@ -13,6 +13,7 @@
 #include "delta.h"
 #include "pack.h"
 #include "path.h"
+#include "read-cache-ll.h"
 #include "refs.h"
 #include "csum-file.h"
 #include "quote.h"
@@ -1468,8 +1469,6 @@ static int tree_content_set(
 		root->tree = t = grow_tree_content(t, t->entry_count);
 	e = new_tree_entry();
 	e->name = to_atom(p, n);
-	if (is_dot_or_dotdot(e->name->str_dat))
-		die("path %s contains invalid component", p);
 	e->versions[0].mode = 0;
 	oidclr(&e->versions[0].oid, the_repository->hash_algo);
 	t->entries[t->entry_count++] = e;
@@ -2416,6 +2415,9 @@ static void file_change_m(const char *p, struct branch *b)
 		tree_content_replace(&b->branch_tree, &oid, mode, NULL);
 		return;
 	}
+
+	if (!verify_path(path.buf, mode))
+		die("invalid path '%s'", path.buf);
 	tree_content_set(&b->branch_tree, path.buf, &oid, mode, NULL);
 }
 
@@ -2453,6 +2455,8 @@ static void file_change_cr(const char *p, struct branch *b, int rename)
 			leaf.tree);
 		return;
 	}
+	if (!verify_path(dest.buf, leaf.versions[1].mode))
+		die("invalid path '%s'", dest.buf);
 	tree_content_set(&b->branch_tree, dest.buf,
 		&leaf.versions[1].oid,
 		leaf.versions[1].mode,

--- a/t/t9300-fast-import.sh
+++ b/t/t9300-fast-import.sh
@@ -522,7 +522,7 @@ test_expect_success 'B: fail on invalid committer (5)' '
 	test_must_fail git fast-import <input
 '
 
-test_expect_success 'B: fail on invalid file path' '
+test_expect_success 'B: fail on invalid file path of ..' '
 	cat >input <<-INPUT_END &&
 	blob
 	mark :1
@@ -536,6 +536,86 @@ test_expect_success 'B: fail on invalid file path' '
 	Commit Message
 	COMMIT
 	M 100644 :1 ../invalid-path
+	INPUT_END
+
+	test_when_finished "git update-ref -d refs/heads/badpath" &&
+	test_must_fail git fast-import <input
+'
+
+test_expect_success 'B: fail on invalid file path of .' '
+	cat >input <<-INPUT_END &&
+	blob
+	mark :1
+	data <<EOF
+	File contents
+	EOF
+
+	commit refs/heads/badpath
+	committer Name <email> $GIT_COMMITTER_DATE
+	data <<COMMIT
+	Commit Message
+	COMMIT
+	M 100644 :1 ./invalid-path
+	INPUT_END
+
+	test_when_finished "git update-ref -d refs/heads/badpath" &&
+	test_must_fail git fast-import <input
+'
+
+test_expect_success WINDOWS 'B: fail on invalid file path of C:' '
+	cat >input <<-INPUT_END &&
+	blob
+	mark :1
+	data <<EOF
+	File contents
+	EOF
+
+	commit refs/heads/badpath
+	committer Name <email> $GIT_COMMITTER_DATE
+	data <<COMMIT
+	Commit Message
+	COMMIT
+	M 100644 :1 C:/invalid-path
+	INPUT_END
+
+	test_when_finished "git update-ref -d refs/heads/badpath" &&
+	test_must_fail git fast-import <input
+'
+
+test_expect_success 'B: fail on invalid file path of .git' '
+	cat >input <<-INPUT_END &&
+	blob
+	mark :1
+	data <<EOF
+	File contents
+	EOF
+
+	commit refs/heads/badpath
+	committer Name <email> $GIT_COMMITTER_DATE
+	data <<COMMIT
+	Commit Message
+	COMMIT
+	M 100644 :1 .git/invalid-path
+	INPUT_END
+
+	test_when_finished "git update-ref -d refs/heads/badpath" &&
+	test_must_fail git fast-import <input
+'
+
+test_expect_success 'B: fail on invalid file path of .gitmodules' '
+	cat >input <<-INPUT_END &&
+	blob
+	mark :1
+	data <<EOF
+	File contents
+	EOF
+
+	commit refs/heads/badpath
+	committer Name <email> $GIT_COMMITTER_DATE
+	data <<COMMIT
+	Commit Message
+	COMMIT
+	M 120000 :1 .gitmodules
 	INPUT_END
 
 	test_when_finished "git update-ref -d refs/heads/badpath" &&
@@ -966,7 +1046,7 @@ test_expect_success 'L: verify internal tree sorting' '
 	:100644 100644 M	ba
 	EXPECT_END
 
-	git fast-import <input &&
+	git -c core.protectNTFS=false fast-import <input &&
 	GIT_PRINT_SHA1_ELLIPSIS="yes" git diff-tree --abbrev --raw L^ L >output &&
 	cut -d" " -f1,2,5 output >actual &&
 	test_cmp expect actual
@@ -3117,7 +3197,7 @@ test_path_eol_success () {
 	test_expect_success "S: paths at EOL with $test must work" '
 		test_when_finished "git branch -D S-path-eol" &&
 
-		git fast-import --export-marks=marks.out <<-EOF >out 2>err &&
+		git -c core.protectNTFS=false fast-import --export-marks=marks.out <<-EOF >out 2>err &&
 		blob
 		mark :401
 		data <<BLOB
@@ -3226,7 +3306,7 @@ test_path_space_success () {
 	test_expect_success "S: paths before space with $test must work" '
 		test_when_finished "git branch -D S-path-space" &&
 
-		git fast-import --export-marks=marks.out <<-EOF 2>err &&
+		git -c core.protectNTFS=false fast-import --export-marks=marks.out <<-EOF 2>err &&
 		blob
 		mark :401
 		data <<BLOB

--- a/t/t9350-fast-export.sh
+++ b/t/t9350-fast-export.sh
@@ -631,7 +631,7 @@ test_expect_success 'fast-export quotes pathnames' '
 	 git rev-list HEAD >expect &&
 	 git init result &&
 	 cd result &&
-	 git fast-import <../export.out &&
+	 git -c core.protectNTFS=false fast-import <../export.out &&
 	 git rev-list HEAD >actual &&
 	 test_cmp ../expect actual
 	)


### PR DESCRIPTION
Since en/fast-import-path-sanitize has already made it to next, this commit is based on that.  (See https://lore.kernel.org/git/pull.1831.v2.git.1732561248717.gitgitgadget@gmail.com/ for discussion of that series.)

Changes relative to that commit: this fixes up the error message as suggested by Kristoffer, and makes the checks more encompassing as suggested by Patrick and Peff -- in particular, using verify_path() as suggested by Peff.

Changes since v1:
  * Moved the check to a higher level, as suggested by Peff.

cc: Eric Sunshine <sunshine@sunshineco.com>
cc: Patrick Steinhardt <ps@pks.im>
cc: "Kristoffer Haugsbakk" <kristofferhaugsbakk@fastmail.com>
cc: Jeff King <peff@peff.net>
cc: Elijah Newren <newren@gmail.com>