### PR TITLE
remote: align --verbose output with spaces

### DIFF
--- a/t/t5505-remote.sh
+++ b/t/t5505-remote.sh
@@ -249,8 +249,8 @@ test_expect_success 'without subcommand' '
 
 test_expect_success 'without subcommand accepts -v' '
 	cat >expect <<-EOF &&
-	origin	$(pwd)/one (fetch)
-	origin	$(pwd)/one (push)
+	origin $(pwd)/one (fetch)
+	origin $(pwd)/one (push)
 	EOF
 	git -C test remote -v >actual &&
 	test_cmp expect actual


### PR DESCRIPTION
Changes in v2:

* Use for_each_string_list_item() to traverse string lists.
* Calculate the max width outside of the loop.

cc: shejialuo <shejialuo@gmail.com>