### PR TITLE
mingw_rename: do support directory renames

### DIFF
--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -2273,7 +2273,7 @@ repeat:
 
 		old_handle = CreateFileW(wpold, DELETE,
 					 FILE_SHARE_WRITE | FILE_SHARE_READ | FILE_SHARE_DELETE,
-					 NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+					 NULL, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, NULL);
 		if (old_handle == INVALID_HANDLE_VALUE) {
 			errno = err_win_to_posix(GetLastError());
 			return -1;


### PR DESCRIPTION
This is not quite a critical bug fix for Git because (unlike Git for Windows) it attempts `_wrename()` first. If that succeeds, we'll not bother with the POSIX semantics.

However, Git for Windows knows how to deal with symbolic links, and `_wrename()` does not work for them. Therefore, that `_wrename()` call was patched out there and we rely on the native Win32 API call to `SetFileInformationByHandle()` to rename files and directories.

It is that latter part that is at heart of this here bug fix: To be able to call `SetFileInformationByHandle()`, we need a handle, and `CreateFileW()` is what we use, for files, and crucially, also for directories.

So while it is not critical for Git to take this patch, it still is important because that `_wrename()` call _can_ fail, even when renaming directories, and then we want the fallback to fail not because we tried to obtain a handle using incorrect flags, but only because the actual rename operation failed.

This patch is based on `ps/mingw-rename`.

Cc: Patrick Steinhardt <ps@pks.im>