### PR TITLE
t-reftable-basics: allow for `malloc` to be `#define`d

### DIFF
--- a/t/unit-tests/t-reftable-basics.c
+++ b/t/unit-tests/t-reftable-basics.c
@@ -157,13 +157,13 @@ int cmd_main(int argc UNUSED, const char *argv[] UNUSED)
 
 		old_alloc = alloc;
 		old_arr = arr;
-		reftable_set_alloc(malloc, realloc_stub, free);
+		reftable_set_alloc(NULL, realloc_stub, NULL);
 		check(REFTABLE_ALLOC_GROW(arr, old_alloc + 1, alloc));
 		check(arr == old_arr);
 		check_uint(alloc, ==, old_alloc);
 
 		old_alloc = alloc;
-		reftable_set_alloc(malloc, realloc, free);
+		reftable_set_alloc(NULL, NULL, NULL);
 		check(!REFTABLE_ALLOC_GROW(arr, old_alloc + 1, alloc));
 		check(arr != NULL);
 		check_uint(alloc, >, old_alloc);
@@ -188,11 +188,11 @@ int cmd_main(int argc UNUSED, const char *argv[] UNUSED)
 		arr[alloc - 1] = 42;
 
 		old_alloc = alloc;
-		reftable_set_alloc(malloc, realloc_stub, free);
+		reftable_set_alloc(NULL, realloc_stub, NULL);
 		REFTABLE_ALLOC_GROW_OR_NULL(arr, old_alloc + 1, alloc);
 		check(arr == NULL);
 		check_uint(alloc, ==, 0);
-		reftable_set_alloc(malloc, realloc, free);
+		reftable_set_alloc(NULL, NULL, NULL);
 
 		reftable_free(arr);
 	}


### PR DESCRIPTION
This is a fix for one of the many issues that force me to delay Git for Windows v2.48.0-rc2 until I can increase my confidence via thorough testing.

The patch is based on `rs/reftable-realloc-errors`. Sadly, the patch fails [the PR build](https://github.com/gitgitgadget/git/actions/runs/12672507500/job/35316720255), but then the base branch [fails in the same way](https://github.com/gitgitgadget/git/actions/runs/12533205564/job/34952668803).

Cc: René Scharfe <l.s.r@web.de>