### PR TITLE
meson: wire up contrib/credential

### DIFF
--- a/contrib/credential/libsecret/meson.build
+++ b/contrib/credential/libsecret/meson.build
@@ -1,0 +1,3 @@
+glib = dependency('glib-2.0')
+libsecret = dependency('libsecret-1')
+executable('git-credential-libsecret', 'git-credential-libsecret.c', dependencies: [glib, libsecret])

--- a/contrib/credential/meson.build
+++ b/contrib/credential/meson.build
@@ -1,3 +1,6 @@
 if get_option('credential_wincred')
   subdir('wincred')
 endif
+if get_option('credential_libsecret')
+  subdir('libsecret')
+endif

--- a/contrib/credential/meson.build
+++ b/contrib/credential/meson.build
@@ -1,0 +1,3 @@
+if get_option('credential_wincred')
+  subdir('wincred')
+endif

--- a/contrib/credential/wincred/git-credential-wincred.c
+++ b/contrib/credential/wincred/git-credential-wincred.c
@@ -12,7 +12,9 @@
 
 #define ARRAY_SIZE(x) (sizeof(x)/sizeof(x[0]))
 
+#ifndef _MSC_VER
 __attribute__((format (printf, 1, 2)))
+#endif
 static void die(const char *err, ...)
 {
 	char msg[4096];

--- a/contrib/credential/wincred/meson.build
+++ b/contrib/credential/wincred/meson.build
@@ -1,0 +1,1 @@
+executable('git-credential-wincred', 'git-credential-wincred.c')

--- a/contrib/meson.build
+++ b/contrib/meson.build
@@ -1,3 +1,4 @@
 foreach feature : get_option('contrib')
   subdir(feature)
 endforeach
+subdir('credential')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -29,6 +29,8 @@ option('version', type: 'string', value: '',
 # Features supported by Git.
 option('contrib', type: 'array', value: [ 'completion' ], choices: [ 'completion', 'subtree' ],
   description: 'Contributed features to include.')
+option('credential_wincred', type: 'boolean', value: false,
+  description: 'Build helper git-credential-wincred. Requires Windows SDK.')
 option('curl', type: 'feature', value: 'enabled',
   description: 'Build helpers used to access remotes with the HTTP transport.')
 option('expat', type: 'feature', value: 'enabled',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -29,6 +29,8 @@ option('version', type: 'string', value: '',
 # Features supported by Git.
 option('contrib', type: 'array', value: [ 'completion' ], choices: [ 'completion', 'subtree' ],
   description: 'Contributed features to include.')
+option('credential_libsecret', type: 'boolean', value: false,
+  description: 'Build helper git-credential-libsecret. Requires GLib and libsecret.')
 option('credential_wincred', type: 'boolean', value: false,
   description: 'Build helper git-credential-wincred. Requires Windows SDK.')
 option('curl', type: 'feature', value: 'enabled',


### PR DESCRIPTION
It would be neat to also run test t0303-credential-external with GIT_TEST_CREDENTIAL_HELPER=wincred but I couldn't figure out how to do this.

CC: Patrick Steinhardt <ps@pks.im