### PR TITLE
docs: fix repository-layout when building with breaking changes

### DIFF
--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -224,6 +224,10 @@ asciidoc.conf: asciidoc.conf.in FORCE
 	$(QUIET_GEN)$(call version_gen,"$(shell pwd)/..",$<,$@)
 endif
 
+ifdef WITH_BREAKING_CHANGES
+ASCIIDOC_EXTRA += -awith-breaking-changes
+endif
+
 ASCIIDOC_DEPS += docinfo.html
 
 SHELL_PATH ?= $(SHELL)

--- a/Documentation/gitrepository-layout.adoc
+++ b/Documentation/gitrepository-layout.adoc
@@ -152,6 +152,7 @@ config.worktree::
 	working directory in multiple working directory setup (see
 	linkgit:git-worktree[1]).
 
+ifndef::with-breaking-changes[]
 branches::
 	A deprecated way to store shorthands to be used
 	to specify a URL to 'git fetch', 'git pull' and 'git push'.
@@ -164,6 +165,7 @@ branches::
 	"$GIT_COMMON_DIR/branches" will be used instead.
 +
 Git will stop reading remotes from this directory in Git 3.0.
+endif::with-breaking-changes[]
 
 hooks::
 	Hooks are customization scripts used by various Git
@@ -231,6 +233,7 @@ info/sparse-checkout::
 	This file stores sparse checkout patterns.
 	See also: linkgit:git-read-tree[1].
 
+ifndef::with-breaking-changes[]
 remotes::
 	Stores shorthands for URL and default refnames for use
 	when interacting with remote repositories via 'git fetch',
@@ -241,6 +244,7 @@ remotes::
 	"$GIT_COMMON_DIR/remotes" will be used instead.
 +
 Git will stop reading remotes from this directory in Git 3.0.
+endif::with-breaking-changes[]
 
 logs::
 	Records of changes made to refs are stored in this directory.

--- a/Documentation/meson.build
+++ b/Documentation/meson.build
@@ -284,6 +284,10 @@ elif docs_backend == 'asciidoctor'
   ]
 endif
 
+if get_option('breaking_changes')
+   asciidoc_common_options += ['--attribute', 'with-breaking-changes']
+endif
+
 xmlto = find_program('xmlto', dirs: program_path)
 
 cmd_lists = [


### PR DESCRIPTION
Thanks to Junio and Patrick for their comments on V1. I've renamed the attribute to `with-breaking-changes` as suggested. I'll add a patch to rename the test prerequisite to match this when I re-roll https://lore.kernel.org/git/pull.1863.git.1740149837.gitgitgadget@gmail.com/ to use WITH_BREAKING_CHANGES.

Cc: Patrick Steinhardt <ps@pks.im>
Cc: Junio C Hamano <gitster@pobox.com>
cc: Phillip Wood <phillip.wood123@gmail.com>
cc: Karthik Nayak <karthik.188@gmail.com>