### PR TITLE
merge-ort: fix a crash in process_renames for a file transitively renamed to itself

### DIFF
--- a/merge-ort.c
+++ b/merge-ort.c
@@ -3048,7 +3048,8 @@ static int process_renames(struct merge_options *opt,
 			}
 		}
 
-		assert(source_deleted || oldinfo->filemask & old_sidemask);
+		assert(source_deleted || oldinfo->filemask & old_sidemask ||
+		       !strcmp(pair->one->path, pair->two->path));
 
 		/* Need to check for special types of rename conflicts... */
 		if (collision && !source_deleted) {

--- a/t/t6423-merge-rename-directories.sh
+++ b/t/t6423-merge-rename-directories.sh
@@ -5360,6 +5360,47 @@ test_expect_merge_algorithm failure success '12m: Change parent of renamed-dir t
 	)
 '
 
+test_setup_12n () {
+	git init 12n &&
+	(
+		cd 12n &&
+
+		mkdir tools &&
+		echo hello >tools/hello &&
+		git add tools/hello &&
+		git commit -m "O" &&
+
+		git branch O &&
+		git branch A &&
+		git branch B &&
+
+		git switch A &&
+		echo world >world &&
+		git add world &&
+		git commit -q world -m 'Add world' &&
+
+		git mv world tools/world &&
+		git commit -m "Move world into tools/" &&
+
+		git switch B &&
+		git mv tools/hello hello &&
+		git commit -m "Move hello from tools/ to toplevel"
+	)
+}
+
+test_expect_failure '12n: Directory rename transitively makes rename back to self' '
+	test_setup_12n &&
+	(
+		cd 12n &&
+
+		git checkout -q B^0 &&
+
+		test_must_fail git cherry-pick A^0 >out &&
+		grep "CONFLICT (file location).*should perhaps be moved" out
+	)
+'
+
+
 ###########################################################################
 # SECTION 13: Checking informational and conflict messages
 #

--- a/t/t6423-merge-rename-directories.sh
+++ b/t/t6423-merge-rename-directories.sh
@@ -5388,7 +5388,7 @@ test_setup_12n () {
 	)
 }
 
-test_expect_failure '12n: Directory rename transitively makes rename back to self' '
+test_expect_success '12n: Directory rename transitively makes rename back to self' '
 	test_setup_12n &&
 	(
 		cd 12n &&


### PR DESCRIPTION
Maintainer note: this is not a recent regression; it need not be included in v2.49.0.

This is a follow-up to Dmitry's report of a case where both merge-ort and merge-recursive fail to properly handle a very specific type of conflict.  See https://lore.kernel.org/git/20240921024533.15249-2-dgoncharov@users.sf.net/ for the earlier thread; the first patch is an adaptation of his demonstrating the issue, and the second patch is my fix for it.

cc: Dmitry Goncharov <dgoncharov@users.sf.net>
cc: Taylor Blau <me@ttaylorr.com>
cc: Elijah Newren <newren@gmail.com>