### PR TITLE
Remove duplicate forward declaration of struct repository

### DIFF
--- a/dir.h
+++ b/dir.h
@@ -43,7 +43,6 @@ struct repository;
  *
  */
 
-struct repository;
 
 struct dir_entry {
 	unsigned int len;


### PR DESCRIPTION
## Summary
While exploring how Git searches for `.gitignore` files and manages ignored files, I came across `dir.h`. While reading through the file, I noticed that `struct repository;` was forward-declared twice. This duplication appears unnecessary, and removing the second declaration compiles cleanly.