### PR TITLE
Range-check array index before access

### DIFF
--- a/diff.c
+++ b/diff.c
@@ -892,7 +892,7 @@ static void fill_es_indent_data(struct emitted_diff_symbol *es)
 
 	/* skip any \v \f \r at start of indentation */
 	while (s[off] == '\f' || s[off] == '\v' ||
-	       (s[off] == '\r' && off < len - 1))
+	       (off < len - 1 && s[off] == '\r'))
 		off++;
 
 	/* calculate the visual width of indentation */


### PR DESCRIPTION
If we want to check the range of an array index, it makes much more sense to do it _before_ accessing the corresponding array element, not afterwards.

There are two more instances of this in the `clar` code, fixes for which I offer in https://github.com/clar-test/clar/pull/115.

Changes since v2:
- Rebased on top of `js/range-check-codeql-workaround`.
- Rephrased the commit message.

Changes since v1:
- Clarified in the commit message of the second patch that this range-check technically was already right before the array access it wants to guard, but that it still makes sense to move that range-check to the beginning of the loop condition.

cc: Jeff King <peff@peff.net>
cc: Phillip Wood <phillip.wood123@gmail.com>