### PR TITLE
 mingw: special-case administrators even more

### DIFF
--- a/t/helper/test-path-utils.c
+++ b/t/helper/test-path-utils.c
@@ -504,6 +504,25 @@ int cmd__path_utils(int argc, const char **argv)
 		return !!res;
 	}
 
+	if (argc > 1 && !strcmp(argv[1], "is_path_owned_by_current_user")) {
+		int res = 0;
+
+		for (int i = 2; i < argc; i++) {
+			struct strbuf buf = STRBUF_INIT;
+
+			if (is_path_owned_by_current_user(argv[i], &buf))
+				printf("'%s' is owned by current SID\n", argv[i]);
+			else {
+				printf("'%s' is not owned by current SID: %s\n", argv[i], buf.buf);
+				res = 1;
+			}
+
+			strbuf_release(&buf);
+		}
+
+		return res;
+	}
+
 	fprintf(stderr, "%s: unknown function name: %s\n", argv[0],
 		argv[1] ? argv[1] : "(there was none)");
 	return 1;


### PR DESCRIPTION
On Windows, a file created by a process running in elevated mode is owned by the Administrators group (not by the user's account who would otherwise be able to modify or delete the file in non-elevated mode). Let's adjust the "safe directory" feature accordingly.

Naturally, this patch series does not add a regression test (because it can't, you cannot automate elevating processes).

This patch series is a companion of https://github.com/microsoft/git/pull/712.