### PR TITLE
merge-file doc: set conflict-marker-size attribute

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,6 +13,7 @@ CODE_OF_CONDUCT.md -whitespace
 /mergetools/* text eol=lf
 /t/oid-info/* text eol=lf
 /Documentation/git-merge.adoc conflict-marker-size=32
+/Documentation/git-merge-file.adoc conflict-marker-size=32
 /Documentation/gitk.adoc conflict-marker-size=32
 /Documentation/user-manual.adoc conflict-marker-size=32
 /t/t????-*.sh conflict-marker-size=32


### PR DESCRIPTION
Grepping around I can't find any other files with conflict markers without this attribute set. (If there were I think my pre-commit hook would have complained about them as well)