### PR TITLE
rebase -r: a bugfix and two status-related improvements

### DIFF
--- a/sequencer.c
+++ b/sequencer.c
@@ -4349,6 +4349,7 @@ static int do_merge(struct repository *r,
 		error(_("could not even attempt to merge '%.*s'"),
 		      merge_arg_len, arg);
 		unlink(git_path_merge_msg(r));
+		unlink(git_path_merge_head(r));
 		goto leave_merge;
 	}
 	/*
@@ -5364,7 +5365,7 @@ static int commit_staged_changes(struct repository *r,
 		flags |= AMEND_MSG;
 	}
 
-	if (is_clean) {
+	if (is_clean && !file_exists(git_path_merge_head(r))) {
 		if (refs_ref_exists(get_main_ref_store(r),
 				    "CHERRY_PICK_HEAD") &&
 		    refs_delete_ref(get_main_ref_store(r), "",

--- a/t/t3418-rebase-continue.sh
+++ b/t/t3418-rebase-continue.sh
@@ -111,6 +111,30 @@ test_expect_success 'rebase -r passes merge strategy options correctly' '
 	git rebase --continue
 '
 
+test_expect_success '--continue creates merge commit after empty resolution' '
+	git reset --hard main &&
+	git checkout -b rebase_i_merge &&
+	test_commit unrelated &&
+	git checkout -b rebase_i_merge_side &&
+	test_commit side2 main.txt &&
+	git checkout rebase_i_merge &&
+	test_commit side1 main.txt &&
+	PICK=$(git rev-parse --short rebase_i_merge) &&
+	test_must_fail git merge rebase_i_merge_side &&
+	echo side1 >main.txt &&
+	git add main.txt &&
+	test_tick &&
+	git commit --no-edit &&
+	FAKE_LINES="1 2 3 5 6 7 8 9 10 11" &&
+	export FAKE_LINES &&
+	test_must_fail git rebase -ir main &&
+	echo side1 >main.txt &&
+	git add main.txt &&
+	git rebase --continue &&
+	git log --merges >out &&
+	test_grep "Merge branch '\''rebase_i_merge_side'\''" out
+'
+
 test_expect_success '--skip after failed fixup cleans commit message' '
 	test_when_finished "test_might_fail git rebase --abort" &&
 	git checkout -b with-conflicting-fixup &&

--- a/wt-status.h
+++ b/wt-status.h
@@ -87,6 +87,7 @@ struct wt_status_state {
 	int am_empty_patch;
 	int rebase_in_progress;
 	int rebase_interactive_in_progress;
+	int merge_during_rebase_in_progress;
 	int cherry_pick_in_progress;
 	int bisect_in_progress;
 	int revert_in_progress;


### PR DESCRIPTION
Hi,

this series started as only 3/3, which I wrote when I noticed that 'git status'
suggested 'git commit' instead of 'git rebase --continue' to conclude a merge,
and doing that I lost the original authorship of the merge commit.

2/3 is a small improvement I noticed along the way, and while testing these I
discovered the bug which I fix in 1/3. I guess 1/3 could go in a different
series, if we prefer, but for simplicity I'm submitting them together.

CC: Phillip Wood <phillip.wood@dunelm.org.uk>
CC: Johannes Schindelin <Johannes.Schindelin@gmx.de>
cc: Eric Sunshine <sunshine@sunshineco.com>
cc: Phillip Wood <phillip.wood123@gmail.com>