### PR TITLE
docs: document core.hooksPath=/dev/null

### DIFF
--- a/Documentation/config/core.adoc
+++ b/Documentation/config/core.adoc
@@ -512,6 +512,11 @@ centrally configure your Git hooks instead of configuring them on a
 per-repository basis, or as a more flexible and centralized
 alternative to having an `init.templateDir` where you've changed
 default hooks.
++
+You can also disable all hooks entirely by setting `core.hooksPath`
+to `/dev/null`. This is usually only advisable for expert users and
+on a per-command basis using configuration parameters of the form
+`git -c core.hooksPath=/dev/null ...`.
 
 core.editor::
 	Commands such as `commit` and `tag` that let you edit


### PR DESCRIPTION
Based on the discussion of the proposed --no-hooks option in v1, that code change is dropped in favor of this documentation of `core.hooksPath=/dev/null`.

Thanks,
* Stolee

cc: gitster@pobox.com
cc: james@jamesliu.io
cc: "brian m. carlson" <sandals@crustytoothpaste.net>
cc: Phillip Wood <phillip.wood123@gmail.com>
cc: "D. Ben Knoble" <ben.knoble@gmail.com>
cc: Lucas Seiki Oshiro <lucasseikioshiro@gmail.com>