### PR TITLE
ci(win+Meson): build in Release mode, avoiding t7001-mv hangs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -265,7 +265,7 @@ jobs:
       run: pip install meson ninja
     - name: Setup
       shell: pwsh
-      run: meson setup build --vsenv -Dperl=disabled -Dcredential_helpers=wincred
+      run: meson setup build --vsenv -Dbuildtype=release -Dperl=disabled -Dcredential_helpers=wincred
     - name: Compile
       shell: pwsh
       run: meson compile -C build


### PR DESCRIPTION
I was surprised to find this issue today, and that this had not been addressed yet.

Changes since v1:
- Rewrote the commit message to reflect that this patch is still needed, even if the symptom that originally motivated the patch was addressed in a different manner, because it was merely a symptom of the underlying root cause that CI builds should not let Visual C build Git in debug mode.

Cc: Patrick Steinhardt <ps@pks.im>
cc: "Kristoffer Haugsbakk" <code@khaugsbakk.name>