### PR TITLE
gitk: small quality of life improvements for themed Tk

### DIFF
--- a/gitk-git/gitk
+++ b/gitk-git/gitk
@@ -11991,6 +11991,12 @@ proc setselbg {c} {
 # radiobuttons look bad.  This chooses white for selectColor if the
 # background color is light, or black if it is dark.
 proc setui {c} {
+    global use_ttk
+
+    if {$use_ttk} {
+        return
+    }
+
     if {[tk windowingsystem] eq "win32"} { return }
     set bg [winfo rgb . $c]
     set selc black

--- a/gitk-git/gitk
+++ b/gitk-git/gitk
@@ -2133,7 +2133,31 @@ proc setoptions {} {
     option add *Listbox.font mainfont startupFile
 }
 
+proc createttkimages {} {
+    global uicolor
+
+    image create bitmap img:myVerticalSash -foreground $uicolor -data {
+        #define xbm_width 5
+        #define xbm_height 47
+        static unsigned char xbm_bits[] = {
+        0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04,
+        0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x00, 0x00, 0x0e, 0x00, 0x00, 0x0e,
+        0x00, 0x00, 0x0e, 0x00, 0x00, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04,
+        0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04 };
+    }
+
+    image create bitmap img:myHorizontalSash -foreground $uicolor -data {
+        #define xbm_width 47
+        #define xbm_height 5
+        static unsigned char xbm_bits[] = {
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x90, 0x04, 0x00, 0x00,
+        0xff, 0xff, 0x93, 0xe4, 0xff, 0x7f, 0x00, 0x00, 0x90, 0x04, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+    }
+}
+
 proc setttkstyle {} {
+
     eval font configure TkDefaultFont [fontflags mainfont]
     eval font configure TkTextFont [fontflags textfont]
     eval font configure TkHeadingFont [fontflags mainfont]
@@ -2143,6 +2167,16 @@ proc setttkstyle {} {
     eval font configure TkIconFont    [fontflags uifont]
     eval font configure TkMenuFont    [fontflags uifont]
     eval font configure TkSmallCaptionFont [fontflags uifont]
+
+    createttkimages
+
+    ttk::style element create myVerticalSash image img:myVerticalSash -sticky ew
+
+    ttk::style element create myHorizontalSash image img:myHorizontalSash -sticky ns
+
+    ttk::style layout Vertical.Sash { myVerticalSash }
+
+    ttk::style layout Horizontal.Sash { myHorizontalSash }
 }
 
 # Make a menu and submenus.
@@ -11825,7 +11859,7 @@ proc prefspage_colors {notebook} {
     grid $page.cdisp - -sticky w -pady 10
     label $page.ui -padx 40 -relief sunk -background $uicolor
     ${NS}::button $page.uibut -text [mc "Interface"] \
-       -command [list choosecolor uicolor {} $page.ui [mc "interface"] setui]
+       -command [list choosecolor uicolor {} $page.ui [mc "interface"] setui_dialog]
     grid x $page.uibut $page.ui -sticky w
     label $page.bg -padx 40 -relief sunk -background $bgcolor
     ${NS}::button $page.bgbut -text [mc "Background"] \
@@ -12004,6 +12038,14 @@ proc setui {c} {
         set selc white
     }
     tk_setPalette background $c selectColor $selc
+}
+
+proc setui_dialog {c} {
+    global uicolor
+
+    setui $c
+
+    createttkimages
 }
 
 proc setbg {c} {
@@ -12706,8 +12748,6 @@ eval font create textfontbold [fontflags textfont 1]
 parsefont uifont $uifont
 eval font create uifont [fontflags uifont]
 
-setui $uicolor
-
 setoptions
 
 # check that we can find a .git directory somewhere...
@@ -12787,6 +12827,8 @@ if {![info exists have_ttk]} {
 }
 set use_ttk [expr {$have_ttk && $want_ttk}]
 set NS [expr {$use_ttk ? "ttk" : ""}]
+
+setui $uicolor
 
 if {$use_ttk} {
     setttkstyle

--- a/gitk-git/gitk
+++ b/gitk-git/gitk
@@ -11767,13 +11767,11 @@ proc prefspage_general {notebook} {
     grid x $page.tabstopl $page.tabstop -sticky w
 
     ${NS}::label $page.wrapcommentl -text [mc "Wrap comment text"]
-    ${NS}::combobox $page.wrapcomment -values {none char word} -state readonly \
-        -textvariable wrapcomment
+    makedroplist $page.wrapcomment wrapcomment "none" "char" "word"
     grid x $page.wrapcommentl $page.wrapcomment -sticky w
 
     ${NS}::label $page.wrapdefaultl -text [mc "Wrap other text"]
-    ${NS}::combobox $page.wrapdefault -values {none char word} -state readonly \
-        -textvariable wrapdefault
+    makedroplist $page.wrapdefault wrapdefault "none" "char" "word"
     grid x $page.wrapdefaultl $page.wrapdefault -sticky w
 
     ${NS}::checkbutton $page.ntag -text [mc "Display nearby tags/heads"] \


### PR DESCRIPTION
These three closely related patches build on <https://lore.kernel.org/git/pull.1835.git.1733767737.gitgitgadget@gmail.com> to:

1. also allow changing text wrapping preferences for users that do not use themed Tk (that is, users that have turned the "use themed widgets" preference off);
2. no longer change the background color when using themed Tk (the default) as - at least on the platforms I tried - most widgets and the main window do not change their background color anyhow, whereas some widgets do, leading to a messy looking UI where different widgets seemingly assume different background colors; and
3. use the now-available uicolor preference to draw a "sash" (grab handle) between the many panes of the main window when using themed Tk; on the platforms I tried, themed Tk was both the default and it was not rendering any sash, thus requiring users to guess where to click to resize window panes. Manually setting uicolor to a platform-dependent color (see <https://www.tcl-lang.org/man/tcl/TkCmd/colors.htm#M4>) in the config file works to get sashes that automatically adapt to light mode and dark mode.

cc: Johannes Sixt <j6t@kdbg.org>