### PR TITLE
Fix early wrapping of the command line when using git-prompt.sh

### DIFF
--- a/contrib/completion/git-prompt.sh
+++ b/contrib/completion/git-prompt.sh
@@ -147,7 +147,7 @@ printf -v __git_printf_supports_v -- '%s' yes >/dev/null 2>&1
 
 # like __git_SOH=$'\001' etc but works also in shells without $'...'
 eval "$(printf '
-	__git_SOH="\001" __git_STX="\002" __git_ESC="\033"
+	__git_SOH="\\001" __git_STX="\\002" __git_ESC="\033"
 	__git_LF="\n" __git_CRLF="\r\n"
 ')"
 

--- a/t/t9903-bash-prompt.sh
+++ b/t/t9903-bash-prompt.sh
@@ -13,10 +13,10 @@ export GIT_TEST_DEFAULT_INITIAL_BRANCH_NAME
 . "$GIT_BUILD_DIR/contrib/completion/git-prompt.sh"
 
 actual="$TRASH_DIRECTORY/actual"
-c_red='\001\e[31m\002'
-c_green='\001\e[32m\002'
-c_lblue='\001\e[1;34m\002'
-c_clear='\001\e[0m\002'
+c_red='\\001\e[31m\\002'
+c_green='\\001\e[32m\\002'
+c_lblue='\\001\e[1;34m\\002'
+c_clear='\\001\e[0m\\002'
 
 test_expect_success 'setup for prompt tests' '
 	git init otherrepo &&


### PR DESCRIPTION
When running git-prompt in Bash, the lack of `\001` and `\002` causes the command line to wrap early.

The issue is the current `\001` and `\002` were not themselves escaped and so resulted in binary `0b1` and `0b10` being present, rather than the strings `"\001"` and `"\002"`.
