### PR TITLE
hashmap: ensure hashmaps are reusable after hashmap_clear()

### DIFF
--- a/hashmap.c
+++ b/hashmap.c
@@ -205,8 +205,9 @@ void hashmap_clear_(struct hashmap *map, ssize_t entry_offset)
 		return;
 	if (entry_offset >= 0)  /* called by hashmap_clear_and_free */
 		free_individual_entries(map, entry_offset);
-	free(map->table);
-	memset(map, 0, sizeof(*map));
+	FREE_AND_NULL(map->table);
+	map->tablesize = 0;
+	map->private_size = 0;
 }
 
 struct hashmap_entry *hashmap_get(const struct hashmap *map,


### PR DESCRIPTION
Ran into a NULL pointer dereference of cmpfn a few months ago when trying to reuse one of {strmap, strset, strintmap} (don't remember which one) after calling the relevant ${TYPE}_clear() variant, and tracked the NULL pointer back to hashmap_clear().  Turned out to not be relevant to those patches because I ended up not needing to reuse the map after all, but I kept a note to myself to send in a fix.

I was surprised this wasn't a bug we were already hitting somewhere, but I looked through the codebase and it appears that the only time we attempt to reuse a hashmap after clearing is when we specifically use hashmap_partial_clear().  So, this is just a latent bug waiting as a trap for someone.