### PR TITLE
merge-tree: add new --quiet option

### DIFF
--- a/Documentation/git-merge-tree.adoc
+++ b/Documentation/git-merge-tree.adoc
@@ -65,6 +65,12 @@ OPTIONS
 	default is to include these messages if there are merge
 	conflicts, and to omit them otherwise.
 
+--quiet::
+	Disable all output from the program.  Useful when you are only
+	interested in the exit status.  Allows merge-tree to exit
+	early when it finds a conflict, and allows it to avoid writing
+	most objects created by merges.
+
 --allow-unrelated-histories::
 	merge-tree will by default error out if the two branches specified
 	share no common history.  This flag can be given to override that

--- a/merge-ort.h
+++ b/merge-ort.h
@@ -83,6 +83,7 @@ struct merge_options {
 	/* miscellaneous control options */
 	const char *subtree_shift;
 	unsigned renormalize : 1;
+	unsigned mergeability_only : 1; /* exit early, write fewer objects */
 	unsigned record_conflict_msgs_as_headers : 1;
 	const char *msg_header_prefix;
 


### PR DESCRIPTION
Changes since v3:
  * Renamed --dry-run -> --quiet .  Any further naming suggestions?

Changes since v2:
  * Converted locations missed in v1 in changing --mergeability-only -> --dry-run

Changes since v1:
  * Renamed --mergeability-only flag to --dry-run, as per suggestion from Junio
  * added some commit message clarifications

This adds a new flag, --dry-run, to `git merge-tree`, which suppresses all output and leaves only the exit status (reflecting successful merge or conflict). This is useful for Git Forges in cases where they are only interested in whether two branches can be merged, without needing the actual merge result or conflict details.

The advantage of the flag is two fold:
  * The merge machinery can exit once it detects a conflict, instead of continuing to compute merge result information
  * The merge machinery can avoid writing merged blobs and trees to the object store when in the outer layer of the merging process (more details in the first commit message).

cc: Elijah Newren <newren@gmail.com>
cc: "Kristoffer Haugsbakk" <kristofferhaugsbakk@fastmail.com>
cc: Phillip Wood <phillip.wood123@gmail.com>