### PR TITLE
sequencer: remove unnecessary variable setting

### DIFF
--- a/sequencer.c
+++ b/sequencer.c
@@ -6277,7 +6277,6 @@ int sequencer_make_script(struct repository *r, struct strbuf *out,
 	revs.sort_order = REV_SORT_IN_GRAPH_ORDER;
 	revs.topo_order = 1;
 
-	revs.pretty_given = 1;
 	repo_config_get_string(the_repository, "rebase.instructionFormat", &format);
 	if (!format || !*format) {
 		free(format);


### PR DESCRIPTION
Random thing I noticed a few years ago, I believe while investigating our tangled web of revision fields and parsing.  Either way, it's still valid and I'm finally sending it upstream.

cc: Patrick Steinhardt <ps@pks.im>