### PR TITLE
completion: Make sed command that generates config-list.h portable.

### DIFF
--- a/generate-configlist.sh
+++ b/generate-configlist.sh
@@ -19,7 +19,8 @@ EOF
 	s/::$//;
 	s/`//g;
 	s/^.*$/	"&",/;
-	s/,  */",\n	"/g;
+	s/,  */",\
+	"/g;
 	p;};
 d' \
 	    "$SOURCE_DIR"/Documentation/*config.adoc \


### PR DESCRIPTION
The OpenBSD 'sed' command does not support '\n' to represent newlines in sed expressions. This leads to the follow compiler error:

    In file included from builtin/help.c:15:
    ./config-list.h:282:18: error: use of undeclared identifier 'n'
            "gitcvs.dbUser",n       "gitcvs.dbPass",
                            ^
    1 error generated.
    gmake: *** [Makefile:2821: builtin/help.o] Error 1

We can use a backslash followed by a newline to fix this.

This portably issue was introduced in e1b81f54da (completion: take into account the formatting backticks for options, 2025-03-19)

