### PR TITLE
doc: convert git log man page to new synopsis format

### DIFF
--- a/Documentation/asciidoc.conf.in
+++ b/Documentation/asciidoc.conf.in
@@ -43,7 +43,7 @@ ifdef::doctype-book[]
 endif::doctype-book[]
 
 [literal-inlinemacro]
-{eval:re.sub(r'(&lt;[-a-zA-Z0-9.]+&gt;)', r'<emphasis>\1</emphasis>', re.sub(r'([\[\s|()>]|^|\]|&gt;)(\.?([-a-zA-Z0-9:+=~@\\\*\/_^\$]+\.?)+|,)',r'\1<literal>\2</literal>', re.sub(r'(\.\.\.?)([^\]$.])', r'<literal>\1</literal>\2', macros.passthroughs[int(attrs['passtext'][1:-1])] if attrs['passtext'][1:-1].isnumeric() else attrs['passtext'][1:-1])))}
+{eval:re.sub(r'(&lt;[-a-zA-Z0-9.]+&gt;)', r'<emphasis>\1</emphasis>', re.sub(r'([\[\s|()>]|^|\]|&gt;)(\.?([-a-zA-Z0-9:+=~@\\\*\/_^\$%]+\.?)+|,)',r'\1<literal>\2</literal>', re.sub(r'(\.\.\.?)([^\]$.])', r'<literal>\1</literal>\2', macros.passthroughs[int(attrs['passtext'][1:-1])] if attrs['passtext'][1:-1].isnumeric() else attrs['passtext'][1:-1])))}
 
 endif::backend-docbook[]
 

--- a/Documentation/asciidoctor-extensions.rb.in
+++ b/Documentation/asciidoctor-extensions.rb.in
@@ -73,7 +73,7 @@ module Git
         elsif type == :monospaced
           node.text.gsub(/(\.\.\.?)([^\]$\.])/, '<literal>\1</literal>\2')
               .gsub(/^\.\.\.?$/, '<literal>\0</literal>')
-              .gsub(%r{([\[\s|()>.]|^|\]|&gt;)(\.?([-a-zA-Z0-9:+=~@/_^\$\\\*]+\.{0,2})+|,)}, '\1<literal>\2</literal>')
+              .gsub(%r{([\[\s|()>.]|^|\]|&gt;)(\.?([-a-zA-Z0-9:+=~@/_^\$\\\*%]+\.{0,2})+|,)}, '\1<literal>\2</literal>')
               .gsub(/(&lt;[-a-zA-Z0-9.]+&gt;)/, '<emphasis>\1</emphasis>')
         else
           open, close, supports_phrase = QUOTE_TAGS[type]
@@ -102,7 +102,7 @@ module Git
         if node.type == :monospaced
           node.text.gsub(/(\.\.\.?)([^\]$.])/, '<code>\1</code>\2')
               .gsub(/^\.\.\.?$/, '<code>\0</code>')
-              .gsub(%r{([\[\s|()>.]|^|\]|&gt;)(\.?([-a-zA-Z0-9:+=~@,/_^\$\\\*]+\.{0,2})+)}, '\1<code>\2</code>')
+              .gsub(%r{([\[\s|()>.]|^|\]|&gt;)(\.?([-a-zA-Z0-9:+=~@,/_^\$\\\*%]+\.{0,2})+)}, '\1<code>\2</code>')
               .gsub(/(&lt;[-a-zA-Z0-9.]+&gt;)/, '<em>\1</em>')
 
         else

--- a/Documentation/config/log.adoc
+++ b/Documentation/config/log.adoc
@@ -1,5 +1,5 @@
-log.abbrevCommit::
-	If true, makes
+`log.abbrevCommit`::
+	If `true`, make
 ifndef::with-breaking-changes[]
 	linkgit:git-log[1], linkgit:git-show[1], and
 	linkgit:git-whatchanged[1]
@@ -10,62 +10,67 @@ endif::with-breaking-changes[]
 	assume `--abbrev-commit`. You may
 	override this option with `--no-abbrev-commit`.
 
-log.date::
-	Set the default date-time mode for the 'log' command.
-	Setting a value for log.date is similar to using 'git log''s
+`log.date`::
+	Set the default date-time mode for the `log` command.
+	Setting a value for log.date is similar to using `git log`'s
 	`--date` option.  See linkgit:git-log[1] for details.
 +
 If the format is set to "auto:foo" and the pager is in use, format
 "foo" will be used for the date format. Otherwise, "default" will
 be used.
 
-log.decorate::
+`log.decorate`::
 	Print out the ref names of any commits that are shown by the log
-	command. If 'short' is specified, the ref name prefixes 'refs/heads/',
-	'refs/tags/' and 'refs/remotes/' will not be printed. If 'full' is
-	specified, the full ref name (including prefix) will be printed.
-	If 'auto' is specified, then if the output is going to a terminal,
-	the ref names are shown as if 'short' were given, otherwise no ref
-	names are shown. This is the same as the `--decorate` option
-	of the `git log`.
+	command. Possible values are:
++
+----
+`short`;; the ref name prefixes `refs/heads/`, `refs/tags/` and
+	`refs/remotes/` are not printed.
+`full`;; the full ref name (including prefix) are printed.
+`auto`;; if the output is going to a terminal,
+	the ref names are shown as if `short` were given, otherwise no ref
+	names are shown.
+----
++
+This is the same as the `--decorate` option of the `git log`.
 
-log.initialDecorationSet::
+`log.initialDecorationSet`::
 	By default, `git log` only shows decorations for certain known ref
 	namespaces. If 'all' is specified, then show all refs as
 	decorations.
 
-log.excludeDecoration::
+`log.excludeDecoration`::
 	Exclude the specified patterns from the log decorations. This is
 	similar to the `--decorate-refs-exclude` command-line option, but
 	the config option can be overridden by the `--decorate-refs`
 	option.
 
-log.diffMerges::
+`log.diffMerges`::
 	Set diff format to be used when `--diff-merges=on` is
 	specified, see `--diff-merges` in linkgit:git-log[1] for
 	details. Defaults to `separate`.
 
-log.follow::
+`log.follow`::
 	If `true`, `git log` will act as if the `--follow` option was used when
 	a single <path> is given.  This has the same limitations as `--follow`,
 	i.e. it cannot be used to follow multiple files and does not work well
 	on non-linear history.
 
-log.graphColors::
+`log.graphColors`::
 	A list of colors, separated by commas, that can be used to draw
 	history lines in `git log --graph`.
 
-log.showRoot::
+`log.showRoot`::
 	If true, the initial commit will be shown as a big creation event.
 	This is equivalent to a diff against an empty tree.
 	Tools like linkgit:git-log[1] or linkgit:git-whatchanged[1], which
 	normally hide the root commit will now show it. True by default.
 
-log.showSignature::
+`log.showSignature`::
 	If true, makes linkgit:git-log[1], linkgit:git-show[1], and
 	linkgit:git-whatchanged[1] assume `--show-signature`.
 
-log.mailmap::
+`log.mailmap`::
 	If true, makes linkgit:git-log[1], linkgit:git-show[1], and
 	linkgit:git-whatchanged[1] assume `--use-mailmap`, otherwise
 	assume `--no-use-mailmap`. True by default.

--- a/Documentation/diff-options.adoc
+++ b/Documentation/diff-options.adoc
@@ -37,32 +37,32 @@ endif::git-diff[]
 endif::git-format-patch[]
 
 ifdef::git-log[]
--m::
+`-m`::
 	Show diffs for merge commits in the default format. This is
 	similar to `--diff-merges=on`, except `-m` will
 	produce no output unless `-p` is given as well.
 
--c::
+`-c`::
 	Produce combined diff output for merge commits.
 	Shortcut for `--diff-merges=combined -p`.
 
---cc::
+`--cc`::
 	Produce dense combined diff output for merge commits.
 	Shortcut for `--diff-merges=dense-combined -p`.
 
---dd::
+`--dd`::
 	Produce diff with respect to first parent for both merge and
 	regular commits.
 	Shortcut for `--diff-merges=first-parent -p`.
 
---remerge-diff::
+`--remerge-diff`::
 	Produce remerge-diff output for merge commits.
 	Shortcut for `--diff-merges=remerge -p`.
 
---no-diff-merges::
+`--no-diff-merges`::
 	Synonym for `--diff-merges=off`.
 
---diff-merges=<format>::
+`--diff-merges=<format>`::
 	Specify diff format to be used for merge commits. Default is
 	{diff-merges-default} unless `--first-parent` is in use, in
 	which case `first-parent` is the default.
@@ -70,48 +70,54 @@ ifdef::git-log[]
 The following formats are supported:
 +
 --
-off, none::
+`off`::
+`none`::
 	Disable output of diffs for merge commits. Useful to override
 	implied value.
 
-on, m::
+`on`::
+`m`::
 	Make diff output for merge commits to be shown in the default
 	format. The default format can be changed using
 	`log.diffMerges` configuration variable, whose default value
 	is `separate`.
 
-first-parent, 1::
+`first-parent`::
+`1`::
 	Show full diff with respect to first parent. This is the same
 	format as `--patch` produces for non-merge commits.
 
-separate::
+`separate`::
 	Show full diff with respect to each of parents.
 	Separate log entry and diff is generated for each parent.
 
-combined, c::
+`combined`::
+`c`::
 	Show differences from each of the parents to the merge
 	result simultaneously instead of showing pairwise diff between
 	a parent and the result one at a time. Furthermore, it lists
 	only files which were modified from all parents.
 
-dense-combined, cc::
+`dense-combined`::
+`cc`::
 	Further compress output produced by `--diff-merges=combined`
 	by omitting uninteresting hunks whose contents in the parents
 	have only two variants and the merge result picks one of them
 	without modification.
 
-remerge, r::
-	Remerge two-parent merge commits to create a temporary tree
+`remerge`::
+`r`:: Remerge two-parent merge commits to create a temporary tree
 	object--potentially containing files with conflict markers
 	and such.  A diff is then shown between that temporary tree
 	and the actual merge commit.
+--
 +
 The output emitted when this option is used is subject to change, and
 so is its interaction with other options (unless explicitly
 documented).
---
 
---combined-all-paths::
+
+`--combined-all-paths`::
 	Cause combined diffs (used for merge commits) to
 	list the name of the file from all parents.  It thus only has
 	effect when `--diff-merges=[dense-]combined` is in use, and

--- a/Documentation/git-log.adoc
+++ b/Documentation/git-log.adoc
@@ -8,8 +8,8 @@ git-log - Show commit logs
 
 SYNOPSIS
 --------
-[verse]
-'git log' [<options>] [<revision-range>] [[--] <path>...]
+[synopsis]
+git log [<options>] [<revision-range>] [[--] <path>...]
 
 DESCRIPTION
 -----------
@@ -27,28 +27,34 @@ each commit introduces are shown.
 OPTIONS
 -------
 
---follow::
+`--follow`::
 	Continue listing the history of a file beyond renames
 	(works only for a single file).
 
---no-decorate::
---decorate[=short|full|auto|no]::
-	Print out the ref names of any commits that are shown. If 'short' is
-	specified, the ref name prefixes 'refs/heads/', 'refs/tags/' and
-	'refs/remotes/' will not be printed. If 'full' is specified, the
-	full ref name (including prefix) will be printed. If 'auto' is
-	specified, then if the output is going to a terminal, the ref names
-	are shown as if 'short' were given, otherwise no ref names are
-	shown. The option `--decorate` is short-hand for `--decorate=short`.
-	Default to configuration value of `log.decorate` if configured,
-	otherwise, `auto`.
+`--no-decorate`::
+`--decorate[=(short|full|auto|no)]`::
+	Print out the ref names of any commits that are shown. Possible values
+	are:
++
+----
+`short`;; the ref name prefixes `refs/heads/`, `refs/tags/` and
+	`refs/remotes/` are not printed.
+`full`;; the full ref name (including prefix) is printed.
+`auto`:: if the output is going to a terminal, the ref names
+	are shown as if `short` were given, otherwise no ref names are
+	shown.
+----
++
+The option `--decorate` is short-hand for `--decorate=short`. Default to
+configuration value of `log.decorate` if configured, otherwise, `auto`.
 
---decorate-refs=<pattern>::
---decorate-refs-exclude=<pattern>::
+`--decorate-refs=<pattern>`::
+`--decorate-refs-exclude=<pattern>`::
 	For each candidate reference, do not use it for decoration if it
-	matches any patterns given to `--decorate-refs-exclude` or if it
-	doesn't match any of the patterns given to `--decorate-refs`. The
-	`log.excludeDecoration` config option allows excluding refs from
+	matches any of the _<pattern>_ parameters given to
+	`--decorate-refs-exclude` or if it doesn't match any of the
+	_<pattern>_ parameters given to `--decorate-refs`.
+	The `log.excludeDecoration` config option allows excluding refs from
 	the decorations, but an explicit `--decorate-refs` pattern will
 	override a match in `log.excludeDecoration`.
 +
@@ -56,51 +62,51 @@ If none of these options or config settings are given, then references are
 used as decoration if they match `HEAD`, `refs/heads/`, `refs/remotes/`,
 `refs/stash/`, or `refs/tags/`.
 
---clear-decorations::
+`--clear-decorations`::
 	When specified, this option clears all previous `--decorate-refs`
 	or `--decorate-refs-exclude` options and relaxes the default
 	decoration filter to include all references. This option is
 	assumed if the config value `log.initialDecorationSet` is set to
 	`all`.
 
---source::
+`--source`::
 	Print out the ref name given on the command line by which each
 	commit was reached.
 
---[no-]mailmap::
---[no-]use-mailmap::
+`--[no-]mailmap`::
+`--[no-]use-mailmap`::
 	Use mailmap file to map author and committer names and email
 	addresses to canonical real names and email addresses. See
 	linkgit:git-shortlog[1].
 
---full-diff::
+`--full-diff`::
 	Without this flag, `git log -p <path>...` shows commits that
 	touch the specified paths, and diffs about the same specified
 	paths.  With this, the full diff is shown for commits that touch
-	the specified paths; this means that "<path>..." limits only
+	the specified paths; this means that "`<path>...`" limits only
 	commits, and doesn't limit diff for those commits.
 +
 Note that this affects all diff-based output types, e.g. those
 produced by `--stat`, etc.
 
---log-size::
-	Include a line ``log size <number>'' in the output for each commit,
-	where <number> is the length of that commit's message in bytes.
+`--log-size`::
+	Include a line `log size <number>` in the output for each commit,
+	where _<number>_ is the length of that commit's message in bytes.
 	Intended to speed up tools that read log messages from `git log`
 	output by allowing them to allocate space in advance.
 
 include::line-range-options.adoc[]
 
-<revision-range>::
+_<revision-range>_::
 	Show only commits in the specified revision range.  When no
-	<revision-range> is specified, it defaults to `HEAD` (i.e. the
+	_<revision-range>_ is specified, it defaults to `HEAD` (i.e. the
 	whole history leading to the current commit).  `origin..HEAD`
 	specifies all the commits reachable from the current commit
 	(i.e. `HEAD`), but not from `origin`. For a complete list of
-	ways to spell <revision-range>, see the 'Specifying Ranges'
+	ways to spell _<revision-range>_, see the 'Specifying Ranges'
 	section of linkgit:gitrevisions[7].
 
-[--] <path>...::
+`[--] <path>...`::
 	Show only commits that are enough to explain how the files
 	that match the specified paths came to be.  See 'History
 	Simplification' below for details and other simplification
@@ -145,14 +151,14 @@ EXAMPLES
 
 `git log --since="2 weeks ago" -- gitk`::
 
-	Show the changes during the last two weeks to the file 'gitk'.
+	Show the changes during the last two weeks to the file `gitk`.
 	The `--` is necessary to avoid confusion with the *branch* named
-	'gitk'
+	`gitk`
 
 `git log --name-status release..test`::
 
-	Show the commits that are in the "test" branch but not yet
-	in the "release" branch, along with the list of paths
+	Show the commits that are in the "`test`" branch but not yet
+	in the "`release`" branch, along with the list of paths
 	each commit modifies.
 
 `git log --follow builtin/rev-list.c`::
@@ -164,7 +170,7 @@ EXAMPLES
 `git log --branches --not --remotes=origin`::
 
 	Shows all commits that are in any of local branches but not in
-	any of remote-tracking branches for 'origin' (what you have that
+	any of remote-tracking branches for `origin` (what you have that
 	origin doesn't).
 
 `git log master --not --remotes=*/master`::
@@ -200,11 +206,11 @@ CONFIGURATION
 See linkgit:git-config[1] for core variables and linkgit:git-diff[1]
 for settings related to diff generation.
 
-format.pretty::
+`format.pretty`::
 	Default for the `--format` option.  (See 'Pretty Formats' above.)
 	Defaults to `medium`.
 
-i18n.logOutputEncoding::
+`i18n.logOutputEncoding`::
 	Encoding to use when displaying logs.  (See 'Discussion' above.)
 	Defaults to the value of `i18n.commitEncoding` if set, and UTF-8
 	otherwise.

--- a/Documentation/line-range-format.adoc
+++ b/Documentation/line-range-format.adoc
@@ -1,30 +1,30 @@
-'<start>' and '<end>' can take one of these forms:
+_<start>_ and _<end>_ can take one of these forms:
 
-- number
+- _<number>_
 +
-If '<start>' or '<end>' is a number, it specifies an
+If _<start>_ or _<end>_ is a number, it specifies an
 absolute line number (lines count from 1).
 +
 
-- `/regex/`
+- `/<regex>/`
 +
 This form will use the first line matching the given
-POSIX regex. If '<start>' is a regex, it will search from the end of
+POSIX _<regex>_. If _<start>_ is a regex, it will search from the end of
 the previous `-L` range, if any, otherwise from the start of file.
-If '<start>' is `^/regex/`, it will search from the start of file.
-If '<end>' is a regex, it will search
-starting at the line given by '<start>'.
+If _<start>_ is `^/<regex>/`, it will search from the start of file.
+If _<end>_ is a regex, it will search starting at the line given by
+_<start>_.
 +
 
-- +offset or -offset
+- `+<offset>` or `-<offset>`
 +
-This is only valid for '<end>' and will specify a number
-of lines before or after the line given by '<start>'.
+This is only valid for _<end>_ and will specify a number
+of lines before or after the line given by _<start>_.
 
 +
-If `:<funcname>` is given in place of '<start>' and '<end>', it is a
+If `:<funcname>` is given in place of _<start>_ and _<end>_, it is a
 regular expression that denotes the range from the first funcname line
-that matches '<funcname>', up to the next funcname line. `:<funcname>`
+that matches _<funcname>_, up to the next funcname line. `:<funcname>`
 searches from the end of the previous `-L` range, if any, otherwise
 from the start of file. `^:<funcname>` searches from the start of
 file. The function names are determined in the same way as `git diff`

--- a/Documentation/line-range-options.adoc
+++ b/Documentation/line-range-options.adoc
@@ -1,12 +1,12 @@
--L<start>,<end>:<file>::
--L:<funcname>:<file>::
+`-L<start>,<end>:<file>`::
+`-L:<funcname>:<file>`::
 
-	Trace the evolution of the line range given by '<start>,<end>',
-	or by the function name regex '<funcname>', within the '<file>'. You may
+	Trace the evolution of the line range given by `<start>,<end>`,
+	or by the function name regex _<funcname>_, within the _<file>_. You may
 	not give any pathspec limiters.  This is currently limited to
 	a walk starting from a single revision, i.e., you may only
 	give zero or one positive revision arguments, and
-	'<start>' and '<end>' (or '<funcname>') must exist in the starting revision.
+	_<start>_ and _<end>_ (or _<funcname>_) must exist in the starting revision.
 	You can specify this option more than once. Implies `--patch`.
 	Patch output can be suppressed using `--no-patch`, but other diff formats
 	(namely `--raw`, `--numstat`, `--shortstat`, `--dirstat`, `--summary`,

--- a/Documentation/pretty-formats.adoc
+++ b/Documentation/pretty-formats.adoc
@@ -2,11 +2,11 @@ PRETTY FORMATS
 --------------
 
 If the commit is a merge, and if the pretty-format
-is not 'oneline', 'email' or 'raw', an additional line is
-inserted before the 'Author:' line.  This line begins with
+is not `oneline`, `email` or `raw`, an additional line is
+inserted before the `Author:` line.  This line begins with
 "Merge: " and the hashes of ancestral commits are printed,
 separated by spaces.  Note that the listed commits may not
-necessarily be the list of the *direct* parent commits if you
+necessarily be the list of the 'direct' parent commits if you
 have limited your view of history: for example, if you are
 only interested in changes related to a certain directory or
 file.
@@ -14,24 +14,24 @@ file.
 There are several built-in formats, and you can define
 additional formats by setting a pretty.<name>
 config option to either another format name, or a
-'format:' string, as described below (see
+`format:` string, as described below (see
 linkgit:git-config[1]). Here are the details of the
 built-in formats:
 
-* 'oneline'
+* `oneline`
 
 	  <hash> <title-line>
 +
 This is designed to be as compact as possible.
 
-* 'short'
+* `short`
 
 	  commit <hash>
 	  Author: <author>
 
 	      <title-line>
 
-* 'medium'
+* `medium`
 
 	  commit <hash>
 	  Author: <author>
@@ -41,7 +41,7 @@ This is designed to be as compact as possible.
 
 	      <full-commit-message>
 
-* 'full'
+* `full`
 
 	  commit <hash>
 	  Author: <author>
@@ -51,7 +51,7 @@ This is designed to be as compact as possible.
 
 	      <full-commit-message>
 
-* 'fuller'
+* `fuller`
 
 	  commit <hash>
 	  Author:     <author>
@@ -63,18 +63,18 @@ This is designed to be as compact as possible.
 
 	       <full-commit-message>
 
-* 'reference'
+* `reference`
 
 	  <abbrev-hash> (<title-line>, <short-author-date>)
 +
 This format is used to refer to another commit in a commit message and
-is the same as `--pretty='format:%C(auto)%h (%s, %ad)'`.  By default,
+is the same as ++--pretty=\'format:%C(auto)%h (%s, %ad)'++.  By default,
 the date is formatted with `--date=short` unless another `--date` option
 is explicitly specified.  As with any `format:` with format
 placeholders, its output is not affected by other options like
 `--decorate` and `--walk-reflogs`.
 
-* 'email'
+* `email`
 
 	  From <hash> <date>
 	  From: <author>
@@ -83,30 +83,30 @@ placeholders, its output is not affected by other options like
 
 	  <full-commit-message>
 
-* 'mboxrd'
+* `mboxrd`
 +
-Like 'email', but lines in the commit message starting with "From "
+Like `email`, but lines in the commit message starting with "From "
 (preceded by zero or more ">") are quoted with ">" so they aren't
 confused as starting a new commit.
 
-* 'raw'
+* `raw`
 +
-The 'raw' format shows the entire commit exactly as
+The `raw` format shows the entire commit exactly as
 stored in the commit object.  Notably, the hashes are
-displayed in full, regardless of whether --abbrev or
---no-abbrev are used, and 'parents' information show the
+displayed in full, regardless of whether `--abbrev` or
+`--no-abbrev` are used, and 'parents' information show the
 true parent commits, without taking grafts or history
 simplification into account. Note that this format affects the way
 commits are displayed, but not the way the diff is shown e.g. with
 `git log --raw`. To get full object names in a raw diff format,
 use `--no-abbrev`.
 
-* 'format:<format-string>'
+* `format:<format-string>`
 +
-The 'format:<format-string>' format allows you to specify which information
+The `format:<format-string>` format allows you to specify which information
 you want to show. It works a little bit like printf format,
-with the notable exception that you get a newline with '%n'
-instead of '\n'.
+with the notable exception that you get a newline with `%n`
+instead of `\n`.
 +
 E.g, 'format:"The author of %h was %an, %ar%nThe title was >>%s<<%n"'
 would show something like this:
@@ -120,158 +120,161 @@ The title was >>t4119: test autocomputing -p<n> for traditional diff input.<<
 The placeholders are:
 
 - Placeholders that expand to a single literal character:
-'%n':: newline
-'%%':: a raw '%'
-'%x00':: '%x' followed by two hexadecimal digits is replaced with a
+++%n++:: newline
+++%%++:: a raw ++%++
+++%x00++:: ++%x++ followed by two hexadecimal digits is replaced with a
 	 byte with the hexadecimal digits' value (we will call this
 	 "literal formatting code" in the rest of this document).
 
 - Placeholders that affect formatting of later placeholders:
-'%Cred':: switch color to red
-'%Cgreen':: switch color to green
-'%Cblue':: switch color to blue
-'%Creset':: reset color
-'%C(...)':: color specification, as described under Values in the
+++%Cred++:: switch color to red
+++%Cgreen++:: switch color to green
+++%Cblue++:: switch color to blue
+++%Creset++:: reset color
+++%C(++_<spec>_++)++:: color specification, as described under Values in the
 	    "CONFIGURATION FILE" section of linkgit:git-config[1].  By
 	    default, colors are shown only when enabled for log output
 	    (by `color.diff`, `color.ui`, or `--color`, and respecting
 	    the `auto` settings of the former if we are going to a
-	    terminal). `%C(auto,...)` is accepted as a historical
-	    synonym for the default (e.g., `%C(auto,red)`). Specifying
-	    `%C(always,...)` will show the colors even when color is
+	    terminal). ++%C(auto,++_<spec>_++)++ is accepted as a historical
+	    synonym for the default (e.g., ++%C(auto,red)++). Specifying
+	    ++%C(always,++_<spec>_++)++ will show the colors even when color is
 	    not otherwise enabled (though consider just using
-	    `--color=always` to enable color for the whole output,
+	    `--color=always` to enable color for the  whole output,
 	    including this format and anything else git might color).
-	    `auto` alone (i.e. `%C(auto)`) will turn on auto coloring
+	    `auto` alone (i.e. ++%C(auto)++) will turn on auto coloring
 	    on the next placeholders until the color is switched
 	    again.
-'%m':: left (`<`), right (`>`) or boundary (`-`) mark
-'%w([<w>[,<i1>[,<i2>]]])':: switch line wrapping, like the -w option of
+++%m++:: left (`<`), right (`>`) or boundary (`-`) mark
+++%w(++`[<w>[,<i1>[,<i2>]]]`++)++:: switch line wrapping, like the `-w` option of
 			    linkgit:git-shortlog[1].
-'%<( <N> [,trunc|ltrunc|mtrunc])':: make the next placeholder take at
+++%<(++`<n>[,(trunc|ltrunc|mtrunc)]`++)++:: make the next placeholder take at
 				  least N column widths, padding spaces on
 				  the right if necessary.  Optionally
-				  truncate (with ellipsis '..') at the left (ltrunc) `..ft`,
+				  truncate (with ellipsis `..`) at the left (ltrunc) `..ft`,
 				  the middle (mtrunc) `mi..le`, or the end
 				  (trunc) `rig..`, if the output is longer than
-				  N columns.
+				  _<n>_ columns.
 				  Note 1: that truncating
-				  only works correctly with N >= 2.
-				  Note 2: spaces around the N and M (see below)
+				  only works correctly with _<n>_ >= 2.
+				  Note 2: spaces around the _<n>_ and _<m>_ (see below)
 				  values are optional.
 				  Note 3: Emojis and other wide characters
 				  will take two display columns, which may
 				  over-run column boundaries.
 				  Note 4: decomposed character combining marks
 				  may be misplaced at padding boundaries.
-'%<|( <M> )':: make the next placeholder take at least until Mth
+++%<|(++_<m>_ ++)++:: make the next placeholder take at least until _<m>_ th
 	     display column, padding spaces on the right if necessary.
-	     Use negative M values for column positions measured
+	     Use negative _<m>_ values for column positions measured
 	     from the right hand edge of the terminal window.
-'%>( <N> )', '%>|( <M> )':: similar to '%<( <N> )', '%<|( <M> )' respectively,
+++%>(++_<n>_++)++::
+++%>|(++_<m>_++)++:: similar to ++%<(++_<n>_++)++, ++%<|(++_<m>_++)++ respectively,
 			but padding spaces on the left
-'%>>( <N> )', '%>>|( <M> )':: similar to '%>( <N> )', '%>|( <M> )'
+++%>>(++_<n>_++)++::
+++%>>|(++_<m>_++)++:: similar to ++%>(++_<n>_++)++, ++%>|(++_<m>_++)++
 			  respectively, except that if the next
 			  placeholder takes more spaces than given and
 			  there are spaces on its left, use those
 			  spaces
-'%><( <N> )', '%><|( <M> )':: similar to '%<( <N> )', '%<|( <M> )'
+++%><(++_<n>_++)++::
+++%><|(++_<m>_++)++:: similar to ++%<(++_<n>_++)++, ++%<|(++_<m>_++)++
 			  respectively, but padding both sides
 			  (i.e. the text is centered)
 
 - Placeholders that expand to information extracted from the commit:
-'%H':: commit hash
-'%h':: abbreviated commit hash
-'%T':: tree hash
-'%t':: abbreviated tree hash
-'%P':: parent hashes
-'%p':: abbreviated parent hashes
-'%an':: author name
-'%aN':: author name (respecting .mailmap, see linkgit:git-shortlog[1]
++%H+:: commit hash
++%h+:: abbreviated commit hash
++%T+:: tree hash
++%t+:: abbreviated tree hash
++%P+:: parent hashes
++%p+:: abbreviated parent hashes
++%an+:: author name
++%aN+:: author name (respecting .mailmap, see linkgit:git-shortlog[1]
 	or linkgit:git-blame[1])
-'%ae':: author email
-'%aE':: author email (respecting .mailmap, see linkgit:git-shortlog[1]
++%ae+:: author email
++%aE+:: author email (respecting .mailmap, see linkgit:git-shortlog[1]
 	or linkgit:git-blame[1])
-'%al':: author email local-part (the part before the '@' sign)
-'%aL':: author local-part (see '%al') respecting .mailmap, see
++%al+:: author email local-part (the part before the `@` sign)
++%aL+:: author local-part (see +%al+) respecting .mailmap, see
 	linkgit:git-shortlog[1] or linkgit:git-blame[1])
-'%ad':: author date (format respects --date= option)
-'%aD':: author date, RFC2822 style
-'%ar':: author date, relative
-'%at':: author date, UNIX timestamp
-'%ai':: author date, ISO 8601-like format
-'%aI':: author date, strict ISO 8601 format
-'%as':: author date, short format (`YYYY-MM-DD`)
-'%ah':: author date, human style (like the `--date=human` option of
++%ad+:: author date (format respects --date= option)
++%aD+:: author date, RFC2822 style
++%ar+:: author date, relative
++%at+:: author date, UNIX timestamp
++%ai+:: author date, ISO 8601-like format
++%aI+:: author date, strict ISO 8601 format
++%as+:: author date, short format (`YYYY-MM-DD`)
++%ah+:: author date, human style (like the `--date=human` option of
 	linkgit:git-rev-list[1])
-'%cn':: committer name
-'%cN':: committer name (respecting .mailmap, see
++%cn+:: committer name
++%cN+:: committer name (respecting .mailmap, see
 	linkgit:git-shortlog[1] or linkgit:git-blame[1])
-'%ce':: committer email
-'%cE':: committer email (respecting .mailmap, see
++%ce+:: committer email
++%cE+:: committer email (respecting .mailmap, see
 	linkgit:git-shortlog[1] or linkgit:git-blame[1])
-'%cl':: committer email local-part (the part before the '@' sign)
-'%cL':: committer local-part (see '%cl') respecting .mailmap, see
++%cl+:: committer email local-part (the part before the `@` sign)
++%cL+:: committer local-part (see +%cl+) respecting .mailmap, see
 	linkgit:git-shortlog[1] or linkgit:git-blame[1])
-'%cd':: committer date (format respects --date= option)
-'%cD':: committer date, RFC2822 style
-'%cr':: committer date, relative
-'%ct':: committer date, UNIX timestamp
-'%ci':: committer date, ISO 8601-like format
-'%cI':: committer date, strict ISO 8601 format
-'%cs':: committer date, short format (`YYYY-MM-DD`)
-'%ch':: committer date, human style (like the `--date=human` option of
++%cd+:: committer date (format respects --date= option)
++%cD+:: committer date, RFC2822 style
++%cr+:: committer date, relative
++%ct+:: committer date, UNIX timestamp
++%ci+:: committer date, ISO 8601-like format
++%cI+:: committer date, strict ISO 8601 format
++%cs+:: committer date, short format (`YYYY-MM-DD`)
++%ch+:: committer date, human style (like the `--date=human` option of
 	linkgit:git-rev-list[1])
-'%d':: ref names, like the --decorate option of linkgit:git-log[1]
-'%D':: ref names without the " (", ")" wrapping.
-'%(decorate[:<options>])'::
++%d+:: ref names, like the --decorate option of linkgit:git-log[1]
++%D+:: ref names without the " (", ")" wrapping.
+++%(decorate++`[:<option>,...]`++)++::
 ref names with custom decorations. The `decorate` string may be followed by a
 colon and zero or more comma-separated options. Option values may contain
 literal formatting codes. These must be used for commas (`%x2C`) and closing
 parentheses (`%x29`), due to their role in the option syntax.
 +
-** 'prefix=<value>': Shown before the list of ref names.  Defaults to "{nbsp}`(`".
-** 'suffix=<value>': Shown after the list of ref names.  Defaults to "`)`".
-** 'separator=<value>': Shown between ref names.  Defaults to "`,`{nbsp}".
-** 'pointer=<value>': Shown between HEAD and the branch it points to, if any.
-		      Defaults to "{nbsp}`->`{nbsp}".
-** 'tag=<value>': Shown before tag names. Defaults to "`tag:`{nbsp}".
+** `prefix=<value>`: Shown before the list of ref names.  Defaults to "{nbsp}+(+".
+** `suffix=<value>`: Shown after the list of ref names.  Defaults to "+)+".
+** `separator=<value>`: Shown between ref names.  Defaults to "+,+{nbsp}".
+** `pointer=<value>`: Shown between HEAD and the branch it points to, if any.
+		      Defaults to "{nbsp}+->+{nbsp}".
+** `tag=<value>`: Shown before tag names. Defaults to "`tag:`{nbsp}".
 
 +
 For example, to produce decorations with no wrapping
 or tag annotations, and spaces as separators:
 +
-`%(decorate:prefix=,suffix=,tag=,separator= )`
+++%(decorate:prefix=,suffix=,tag=,separator= )++
 
-'%(describe[:<options>])'::
+++%(describe++`[:<option>,...]`++)++::
 human-readable name, like linkgit:git-describe[1]; empty string for
 undescribable commits.  The `describe` string may be followed by a colon and
 zero or more comma-separated options.  Descriptions can be inconsistent when
 tags are added or removed at the same time.
 +
-** 'tags[=<bool-value>]': Instead of only considering annotated tags,
+** `tags[=<bool-value>]`: Instead of only considering annotated tags,
    consider lightweight tags as well.
-** 'abbrev=<number>': Instead of using the default number of hexadecimal digits
+** `abbrev=<number>`: Instead of using the default number of hexadecimal digits
    (which will vary according to the number of objects in the repository with a
    default of 7) of the abbreviated object name, use <number> digits, or as many
    digits as needed to form a unique object name.
-** 'match=<pattern>': Only consider tags matching the given
-   `glob(7)` pattern, excluding the "refs/tags/" prefix.
-** 'exclude=<pattern>': Do not consider tags matching the given
-   `glob(7)` pattern, excluding the "refs/tags/" prefix.
+** `match=<pattern>`: Only consider tags matching the given
+   `glob(7)` _<pattern>_, excluding the `refs/tags/` prefix.
+** `exclude=<pattern>`: Do not consider tags matching the given
+   `glob(7)` _<pattern>_, excluding the `refs/tags/` prefix.
 
-'%S':: ref name given on the command line by which the commit was reached
++%S+:: ref name given on the command line by which the commit was reached
        (like `git log --source`), only works with `git log`
-'%e':: encoding
-'%s':: subject
-'%f':: sanitized subject line, suitable for a filename
-'%b':: body
-'%B':: raw body (unwrapped subject and body)
++%e+:: encoding
++%s+:: subject
++%f+:: sanitized subject line, suitable for a filename
++%b+:: body
++%B+:: raw body (unwrapped subject and body)
 ifndef::git-rev-list[]
-'%N':: commit notes
++%N+:: commit notes
 endif::git-rev-list[]
-'%GG':: raw verification message from GPG for a signed commit
-'%G?':: show "G" for a good (valid) signature,
++%GG+:: raw verification message from GPG for a signed commit
++%G?+:: show "G" for a good (valid) signature,
 	"B" for a bad signature,
 	"U" for a good signature with unknown validity,
 	"X" for a good signature that has expired,
@@ -279,86 +282,86 @@ endif::git-rev-list[]
 	"R" for a good signature made by a revoked key,
 	"E" if the signature cannot be checked (e.g. missing key)
 	and "N" for no signature
-'%GS':: show the name of the signer for a signed commit
-'%GK':: show the key used to sign a signed commit
-'%GF':: show the fingerprint of the key used to sign a signed commit
-'%GP':: show the fingerprint of the primary key whose subkey was used
++%GS+:: show the name of the signer for a signed commit
++%GK+:: show the key used to sign a signed commit
++%GF+:: show the fingerprint of the key used to sign a signed commit
++%GP+:: show the fingerprint of the primary key whose subkey was used
 	to sign a signed commit
-'%GT':: show the trust level for the key used to sign a signed commit
-'%gD':: reflog selector, e.g., `refs/stash@{1}` or `refs/stash@{2
++%GT+:: show the trust level for the key used to sign a signed commit
++%gD+:: reflog selector, e.g., `refs/stash@{1}` or `refs/stash@{2
 	minutes ago}`; the format follows the rules described for the
 	`-g` option. The portion before the `@` is the refname as
 	given on the command line (so `git log -g refs/heads/master`
 	would yield `refs/heads/master@{0}`).
-'%gd':: shortened reflog selector; same as `%gD`, but the refname
++%gd+:: shortened reflog selector; same as `%gD`, but the refname
 	portion is shortened for human readability (so
 	`refs/heads/master` becomes just `master`).
-'%gn':: reflog identity name
-'%gN':: reflog identity name (respecting .mailmap, see
++%gn+:: reflog identity name
++%gN+:: reflog identity name (respecting .mailmap, see
 	linkgit:git-shortlog[1] or linkgit:git-blame[1])
-'%ge':: reflog identity email
-'%gE':: reflog identity email (respecting .mailmap, see
++%ge+:: reflog identity email
++%gE+:: reflog identity email (respecting .mailmap, see
 	linkgit:git-shortlog[1] or linkgit:git-blame[1])
-'%gs':: reflog subject
-'%(trailers[:<options>])'::
++%gs+:: reflog subject
+++%(trailers++`[:<option>,...]`++)++::
 display the trailers of the body as interpreted by
 linkgit:git-interpret-trailers[1]. The `trailers` string may be followed by
 a colon and zero or more comma-separated options. If any option is provided
 multiple times, the last occurrence wins.
 +
-** 'key=<key>': only show trailers with specified <key>. Matching is done
+** `key=<key>`: only show trailers with specified <key>. Matching is done
    case-insensitively and trailing colon is optional. If option is
    given multiple times trailer lines matching any of the keys are
    shown. This option automatically enables the `only` option so that
    non-trailer lines in the trailer block are hidden. If that is not
    desired it can be disabled with `only=false`.  E.g.,
-   `%(trailers:key=Reviewed-by)` shows trailer lines with key
+   +%(trailers:key=Reviewed-by)+ shows trailer lines with key
    `Reviewed-by`.
-** 'only[=<bool>]': select whether non-trailer lines from the trailer
+** `only[=<bool>]`: select whether non-trailer lines from the trailer
    block should be included.
-** 'separator=<sep>': specify the separator inserted between trailer
+** `separator=<sep>`: specify the separator inserted between trailer
    lines. Defaults to a line feed character. The string <sep> may contain
    the literal formatting codes described above. To use comma as
    separator one must use `%x2C` as it would otherwise be parsed as
-   next option. E.g., `%(trailers:key=Ticket,separator=%x2C )`
+   next option. E.g., +%(trailers:key=Ticket,separator=%x2C )+
    shows all trailer lines whose key is "Ticket" separated by a comma
    and a space.
-** 'unfold[=<bool>]': make it behave as if interpret-trailer's `--unfold`
+** `unfold[=<bool>]`: make it behave as if interpret-trailer's `--unfold`
    option was given. E.g.,
-   `%(trailers:only,unfold=true)` unfolds and shows all trailer lines.
-** 'keyonly[=<bool>]': only show the key part of the trailer.
-** 'valueonly[=<bool>]': only show the value part of the trailer.
-** 'key_value_separator=<sep>': specify the separator inserted between
+   +%(trailers:only,unfold=true)+ unfolds and shows all trailer lines.
+** `keyonly[=<bool>]`: only show the key part of the trailer.
+** `valueonly[=<bool>]`: only show the value part of the trailer.
+** `key_value_separator=<sep>`: specify the separator inserted between
    the key and value of each trailer. Defaults to ": ". Otherwise it
-   shares the same semantics as 'separator=<sep>' above.
+   shares the same semantics as `separator=<sep>` above.
 
 NOTE: Some placeholders may depend on other options given to the
-revision traversal engine. For example, the `%g*` reflog options will
+revision traversal engine. For example, the +%g*+ reflog options will
 insert an empty string unless we are traversing reflog entries (e.g., by
-`git log -g`). The `%d` and `%D` placeholders will use the "short"
+`git log -g`). The +%d+ and +%D+ placeholders will use the "short"
 decoration format if `--decorate` was not already provided on the command
 line.
 
 The boolean options accept an optional value `[=<bool-value>]`. The
-values taken by `--type=bool` git-config[1], like `yes` and `off`,
+values taken by `--type=bool` linkgit:git-config[1], like `yes` and `off`,
 are all accepted.  Giving a boolean option without `=<value>` is
 equivalent to giving it with `=true`.
 
-If you add a `+` (plus sign) after '%' of a placeholder, a line-feed
+If you add a `+` (plus sign) after +%+ of a placeholder, a line-feed
 is inserted immediately before the expansion if and only if the
 placeholder expands to a non-empty string.
 
-If you add a `-` (minus sign) after '%' of a placeholder, all consecutive
+If you add a `-` (minus sign) after +%+ of a placeholder, all consecutive
 line-feeds immediately preceding the expansion are deleted if and only if the
 placeholder expands to an empty string.
 
-If you add a ` ` (space) after '%' of a placeholder, a space
+If you add a `' '` (space) after +%+ of a placeholder, a space
 is inserted immediately before the expansion if and only if the
 placeholder expands to a non-empty string.
 
-* 'tformat:'
+* `tformat:`
 +
-The 'tformat:' format works exactly like 'format:', except that it
+The `tformat:` format works exactly like `format:`, except that it
 provides "terminator" semantics instead of "separator" semantics. In
 other words, each commit has the message terminator character (usually a
 newline) appended, rather than a separator placed between entries.
@@ -378,7 +381,7 @@ $ git log -2 --pretty=tformat:%h 4da45bef \
 7134973
 ---------------------
 +
-In addition, any unrecognized string that has a `%` in it is interpreted
+In addition, any unrecognized string that has a +%+ in it is interpreted
 as if it has `tformat:` in front of it.  For example, these two are
 equivalent:
 +

--- a/Documentation/pretty-options.adoc
+++ b/Documentation/pretty-options.adoc
@@ -1,38 +1,38 @@
---pretty[=<format>]::
---format=<format>::
+`--pretty[=<format>]`::
+`--format=<format>`::
 
 	Pretty-print the contents of the commit logs in a given format,
-	where '<format>' can be one of 'oneline', 'short', 'medium',
-	'full', 'fuller', 'reference', 'email', 'raw', 'format:<string>'
-	and 'tformat:<string>'.  When '<format>' is none of the above,
-	and has '%placeholder' in it, it acts as if
-	'--pretty=tformat:<format>' were given.
+	where '<format>' can be one of `oneline`, `short`, `medium`,
+	`full`, `fuller`, `reference`, `email`, `raw`, `format:<string>`
+	and `tformat:<string>`.  When _<format>_ is none of the above,
+	and has `%<placeholder>` in it, it acts as if
+	`--pretty=tformat:<format>` were given.
 +
 See the "PRETTY FORMATS" section for some additional details for each
-format.  When '=<format>' part is omitted, it defaults to 'medium'.
+format.  When `=<format>` part is omitted, it defaults to `medium`.
 +
-Note: you can specify the default pretty format in the repository
+NOTE: you can specify the default pretty format in the repository
 configuration (see linkgit:git-config[1]).
 
---abbrev-commit::
+`--abbrev-commit`::
 	Instead of showing the full 40-byte hexadecimal commit object
 	name, show a prefix that names the object uniquely.
-	"--abbrev=<n>" (which also modifies diff output, if it is displayed)
+	`--abbrev=<n>` (which also modifies diff output, if it is displayed)
 	option can be used to specify the minimum length of the prefix.
 +
-This should make "--pretty=oneline" a whole lot more readable for
+This should make `--pretty=oneline` a whole lot more readable for
 people using 80-column terminals.
 
---no-abbrev-commit::
+`--no-abbrev-commit`::
 	Show the full 40-byte hexadecimal commit object name. This negates
 	`--abbrev-commit`, either explicit or implied by other options such
-	as "--oneline". It also overrides the `log.abbrevCommit` variable.
+	as `--oneline`. It also overrides the `log.abbrevCommit` variable.
 
---oneline::
-	This is a shorthand for "--pretty=oneline --abbrev-commit"
+`--oneline`::
+	This is a shorthand for `--pretty=oneline --abbrev-commit`
 	used together.
 
---encoding=<encoding>::
+`--encoding=<encoding>`::
 	Commit objects record the character encoding used for the log message
 	in their encoding header; this option can be used to tell the
 	command to re-code the commit log message in the encoding
@@ -44,22 +44,22 @@ people using 80-column terminals.
 	to convert the commit, we will quietly output the original
 	object verbatim.
 
---expand-tabs=<n>::
---expand-tabs::
---no-expand-tabs::
+`--expand-tabs=<n>`::
+`--expand-tabs`::
+`--no-expand-tabs`::
 	Perform a tab expansion (replace each tab with enough spaces
-	to fill to the next display column that is a multiple of '<n>')
+	to fill to the next display column that is a multiple of _<n>_)
 	in the log message before showing it in the output.
 	`--expand-tabs` is a short-hand for `--expand-tabs=8`, and
 	`--no-expand-tabs` is a short-hand for `--expand-tabs=0`,
 	which disables tab expansion.
 +
 By default, tabs are expanded in pretty formats that indent the log
-message by 4 spaces (i.e.  'medium', which is the default, 'full',
-and 'fuller').
+message by 4 spaces (i.e.  `medium`, which is the default, `full`,
+and `fuller`).
 
 ifndef::git-rev-list[]
---notes[=<ref>]::
+`--notes[=<ref>]`::
 	Show the notes (see linkgit:git-notes[1]) that annotate the
 	commit, when showing the commit log message.  This is the default
 ifndef::with-breaking-changes[]
@@ -80,28 +80,29 @@ to display.  The ref can specify the full refname when it begins
 with `refs/notes/`; when it begins with `notes/`, `refs/` and otherwise
 `refs/notes/` is prefixed to form the full name of the ref.
 +
-Multiple --notes options can be combined to control which notes are
-being displayed. Examples: "--notes=foo" will show only notes from
-"refs/notes/foo"; "--notes=foo --notes" will show both notes from
+Multiple `--notes` options can be combined to control which notes are
+being displayed. Examples: "`--notes=foo`" will show only notes from
+`refs/notes/foo`; "`--notes=foo --notes`" will show both notes from
 "refs/notes/foo" and from the default notes ref(s).
 
---no-notes::
+`--no-notes`::
 	Do not show notes. This negates the above `--notes` option, by
 	resetting the list of notes refs from which notes are shown.
 	Options are parsed in the order given on the command line, so e.g.
-	"--notes --notes=foo --no-notes --notes=bar" will only show notes
-	from "refs/notes/bar".
+	"`--notes --notes=foo --no-notes --notes=bar`" will only show notes
+	from `refs/notes/bar`.
 
---show-notes-by-default::
+`--show-notes-by-default`::
 	Show the default notes unless options for displaying specific
 	notes are given.
 
---show-notes[=<ref>]::
---[no-]standard-notes::
-	These options are deprecated. Use the above --notes/--no-notes
+`--show-notes[=<ref>]`::
+`--standard-notes`::
+`--no-standard-notes`::
+	These options are deprecated. Use the above `--notes`/`--no-notes`
 	options instead.
 endif::git-rev-list[]
 
---show-signature::
+`--show-signature`::
 	Check the validity of a signed commit object by passing the signature
 	to `gpg --verify` and show the output.

--- a/Documentation/rev-list-description.adoc
+++ b/Documentation/rev-list-description.adoc
@@ -26,8 +26,8 @@ endif::git-log[]
 means "list all the commits which are reachable from 'foo' or 'bar', but
 not from 'baz'".
 
-A special notation "'<commit1>'..'<commit2>'" can be used as a
-short-hand for "^'<commit1>' '<commit2>'". For example, either of
+A special notation "`<commit1>..<commit2>`" can be used as a
+short-hand for "`^<commit1> <commit2>`". For example, either of
 the following may be used interchangeably:
 
 ifdef::git-rev-list[]
@@ -43,7 +43,7 @@ $ git log HEAD ^origin
 -----------------------------------------------------------------------
 endif::git-log[]
 
-Another special notation is "'<commit1>'...'<commit2>'" which is useful
+Another special notation is "`<commit1>...<commit2>`" which is useful
 for merges.  The resulting set of commits is the symmetric difference
 between the two operands.  The following two commands are equivalent:
 

--- a/Documentation/rev-list-options.adoc
+++ b/Documentation/rev-list-options.adoc
@@ -6,60 +6,60 @@ special notations explained in the description, additional commit
 limiting may be applied.
 
 Using more options generally further limits the output (e.g.
-`--since=<date1>` limits to commits newer than `<date1>`, and using it
+`--since=<date1>` limits to commits newer than _<date1>_, and using it
 with `--grep=<pattern>` further limits to commits whose log message
-has a line that matches `<pattern>`), unless otherwise noted.
+has a line that matches _<pattern>_), unless otherwise noted.
 
 Note that these are applied before commit
 ordering and formatting options, such as `--reverse`.
 
--<number>::
--n <number>::
---max-count=<number>::
-	Limit the number of commits to output.
+`-<number>`::
+`-n <number>`::
+`--max-count=<number>`::
+	Limit the output to _<number>_ commits.
 
---skip=<number>::
-	Skip 'number' commits before starting to show the commit output.
+`--skip=<number>`::
+	Skip _<number>_ commits before starting to show the commit output.
 
---since=<date>::
---after=<date>::
-	Show commits more recent than a specific date.
+`--since=<date>`::
+`--after=<date>`::
+	Show commits more recent than _<date>_.
 
---since-as-filter=<date>::
-	Show all commits more recent than a specific date. This visits
+`--since-as-filter=<date>`::
+	Show all commits more recent than _<date>_. This visits
 	all commits in the range, rather than stopping at the first commit which
-	is older than a specific date.
+	is older than _<date>_.
 
---until=<date>::
---before=<date>::
-	Show commits older than a specific date.
+`--until=<date>`::
+`--before=<date>`::
+	Show commits older than _<date>_.
 
 ifdef::git-rev-list[]
---max-age=<timestamp>::
---min-age=<timestamp>::
+`--max-age=<timestamp>`::
+`--min-age=<timestamp>`::
 	Limit the commits output to specified time range.
 endif::git-rev-list[]
 
---author=<pattern>::
---committer=<pattern>::
+`--author=<pattern>`::
+`--committer=<pattern>`::
 	Limit the commits output to ones with author/committer
-	header lines that match the specified pattern (regular
-	expression).  With more than one `--author=<pattern>`,
-	commits whose author matches any of the given patterns are
+	header lines that match the _<pattern>_ regular
+	expression.  With more than one `--author=<pattern>`,
+	commits whose author matches any of the _<pattern>_ are
 	chosen (similarly for multiple `--committer=<pattern>`).
 
---grep-reflog=<pattern>::
+`--grep-reflog=<pattern>`::
 	Limit the commits output to ones with reflog entries that
-	match the specified pattern (regular expression). With
+	match the _<pattern>_ regular expression. With
 	more than one `--grep-reflog`, commits whose reflog message
 	matches any of the given patterns are chosen.  It is an
 	error to use this option unless `--walk-reflogs` is in use.
 
---grep=<pattern>::
+`--grep=<pattern>`::
 	Limit the commits output to ones with a log message that
-	matches the specified pattern (regular expression).  With
+	matches the _<pattern>_ regular expression.  With
 	more than one `--grep=<pattern>`, commits whose message
-	matches any of the given patterns are chosen (but see
+	matches any of the _<pattern>_ are chosen (but see
 	`--all-match`).
 ifndef::git-rev-list[]
 +
@@ -67,35 +67,35 @@ When `--notes` is in effect, the message from the notes is
 matched as if it were part of the log message.
 endif::git-rev-list[]
 
---all-match::
+`--all-match`::
 	Limit the commits output to ones that match all given `--grep`,
 	instead of ones that match at least one.
 
---invert-grep::
+`--invert-grep`::
 	Limit the commits output to ones with a log message that do not
-	match the pattern specified with `--grep=<pattern>`.
+	match the _<pattern>_ specified with `--grep=<pattern>`.
 
--i::
---regexp-ignore-case::
+`-i`::
+`--regexp-ignore-case`::
 	Match the regular expression limiting patterns without regard to letter
 	case.
 
---basic-regexp::
+`--basic-regexp`::
 	Consider the limiting patterns to be basic regular expressions;
 	this is the default.
 
--E::
---extended-regexp::
+`-E`::
+`--extended-regexp`::
 	Consider the limiting patterns to be extended regular expressions
 	instead of the default basic regular expressions.
 
--F::
---fixed-strings::
+`-F`::
+`--fixed-strings`::
 	Consider the limiting patterns to be fixed strings (don't interpret
 	pattern as a regular expression).
 
--P::
---perl-regexp::
+`-P`::
+`--perl-regexp`::
 	Consider the limiting patterns to be Perl-compatible regular
 	expressions.
 +
@@ -103,20 +103,20 @@ Support for these types of regular expressions is an optional
 compile-time dependency. If Git wasn't compiled with support for them
 providing this option will cause it to die.
 
---remove-empty::
+`--remove-empty`::
 	Stop when a given path disappears from the tree.
 
---merges::
+`--merges`::
 	Print only merge commits. This is exactly the same as `--min-parents=2`.
 
---no-merges::
+`--no-merges`::
 	Do not print commits with more than one parent. This is
 	exactly the same as `--max-parents=1`.
 
---min-parents=<number>::
---max-parents=<number>::
---no-min-parents::
---no-max-parents::
+`--min-parents=<number>`::
+`--max-parents=<number>`::
+`--no-min-parents`::
+`--no-max-parents`::
 	Show only commits which have at least (or at most) that many parent
 	commits. In particular, `--max-parents=1` is the same as `--no-merges`,
 	`--min-parents=2` is the same as `--merges`.  `--max-parents=0`
@@ -126,7 +126,7 @@ providing this option will cause it to die.
 again.  Equivalent forms are `--min-parents=0` (any commit has 0 or more
 parents) and `--max-parents=-1` (negative numbers denote no upper limit).
 
---first-parent::
+`--first-parent`::
 	When finding commits to include, follow only the first
 	parent commit upon seeing a merge commit.  This option
 	can give a better overview when viewing the evolution of
@@ -141,14 +141,14 @@ This option also changes default diff format for merge commits
 to `first-parent`, see `--diff-merges=first-parent` for details.
 endif::git-log[]
 
---exclude-first-parent-only::
+`--exclude-first-parent-only`::
 	When finding commits to exclude (with a '{caret}'), follow only
 	the first parent commit upon seeing a merge commit.
 	This can be used to find the set of changes in a topic branch
 	from the point where it diverged from the remote branch, given
 	that arbitrary merges can be valid topic branch changes.
 
---not::
+`--not`::
 	Reverses the meaning of the '{caret}' prefix (or lack thereof)
 	for all following revision specifiers, up to the next `--not`.
 	When used on the command line before --stdin, the revisions passed
@@ -156,37 +156,37 @@ endif::git-log[]
 	via standard input, the revisions passed on the command line will
 	not be affected by it.
 
---all::
+`--all`::
 	Pretend as if all the refs in `refs/`, along with `HEAD`, are
-	listed on the command line as '<commit>'.
+	listed on the command line as _<commit>_.
 
---branches[=<pattern>]::
+`--branches[=<pattern>]`::
 	Pretend as if all the refs in `refs/heads` are listed
-	on the command line as '<commit>'. If '<pattern>' is given, limit
-	branches to ones matching given shell glob. If pattern lacks '?',
+	on the command line as _<commit>_. If _<pattern>_ is given, limit
+	branches to ones matching given shell glob. If _<pattern>_ lacks '?',
 	'{asterisk}', or '[', '/{asterisk}' at the end is implied.
 
---tags[=<pattern>]::
+`--tags[=<pattern>]`::
 	Pretend as if all the refs in `refs/tags` are listed
-	on the command line as '<commit>'. If '<pattern>' is given, limit
+	on the command line as _<commit>_. If _<pattern>_ is given, limit
 	tags to ones matching given shell glob. If pattern lacks '?', '{asterisk}',
 	or '[', '/{asterisk}' at the end is implied.
 
---remotes[=<pattern>]::
+`--remotes[=<pattern>]`::
 	Pretend as if all the refs in `refs/remotes` are listed
-	on the command line as '<commit>'. If '<pattern>' is given, limit
+	on the command line as _<commit>_. If _<pattern>_ is given, limit
 	remote-tracking branches to ones matching given shell glob.
 	If pattern lacks '?', '{asterisk}', or '[', '/{asterisk}' at the end is implied.
 
---glob=<glob-pattern>::
-	Pretend as if all the refs matching shell glob '<glob-pattern>'
-	are listed on the command line as '<commit>'. Leading 'refs/',
+`--glob=<glob-pattern>`::
+	Pretend as if all the refs matching shell glob _<glob-pattern>_
+	are listed on the command line as _<commit>_. Leading 'refs/',
 	is automatically prepended if missing. If pattern lacks '?', '{asterisk}',
 	or '[', '/{asterisk}' at the end is implied.
 
---exclude=<glob-pattern>::
+`--exclude=<glob-pattern>`::
 
-	Do not include refs matching '<glob-pattern>' that the next `--all`,
+	Do not include refs matching _<glob-pattern>_ that the next `--all`,
 	`--branches`, `--tags`, `--remotes`, or `--glob` would otherwise
 	consider. Repetitions of this option accumulate exclusion patterns
 	up to the next `--all`, `--branches`, `--tags`, `--remotes`, or
@@ -199,7 +199,7 @@ respectively, and they must begin with `refs/` when applied to `--glob`
 or `--all`. If a trailing '/{asterisk}' is intended, it must be given
 explicitly.
 
---exclude-hidden=[fetch|receive|uploadpack]::
+`--exclude-hidden=(fetch|receive|uploadpack)`::
 	Do not include refs that would be hidden by `git-fetch`,
 	`git-receive-pack` or `git-upload-pack` by consulting the appropriate
 	`fetch.hideRefs`, `receive.hideRefs` or `uploadpack.hideRefs`
@@ -207,11 +207,11 @@ explicitly.
 	linkgit:git-config[1]). This option affects the next pseudo-ref option
 	`--all` or `--glob` and is cleared after processing them.
 
---reflog::
+`--reflog`::
 	Pretend as if all objects mentioned by reflogs are listed on the
-	command line as `<commit>`.
+	command line as _<commit>_.
 
---alternate-refs::
+`--alternate-refs`::
 	Pretend as if all objects mentioned as ref tips of alternate
 	repositories were listed on the command line. An alternate
 	repository is any repository whose object directory is specified
@@ -219,7 +219,7 @@ explicitly.
 	be modified by `core.alternateRefsCommand`, etc. See
 	linkgit:git-config[1].
 
---single-worktree::
+`--single-worktree`::
 	By default, all working trees will be examined by the
 	following options when there are more than one (see
 	linkgit:git-worktree[1]): `--all`, `--reflog` and
@@ -227,19 +227,19 @@ explicitly.
 	This option forces them to examine the current working tree
 	only.
 
---ignore-missing::
+`--ignore-missing`::
 	Upon seeing an invalid object name in the input, pretend as if
 	the bad input was not given.
 
 ifndef::git-rev-list[]
---bisect::
+`--bisect`::
 	Pretend as if the bad bisection ref `refs/bisect/bad`
 	was listed and as if it was followed by `--not` and the good
 	bisection refs `refs/bisect/good-*` on the command
 	line.
 endif::git-rev-list[]
 
---stdin::
+`--stdin`::
 	In addition to getting arguments from the command line, read
 	them from standard input as well. This accepts commits and
 	pseudo-options like `--all` and `--glob=`. When a `--` separator
@@ -249,15 +249,15 @@ endif::git-rev-list[]
 	influence any subsequent command line arguments.
 
 ifdef::git-rev-list[]
---quiet::
+`--quiet`::
 	Don't print anything to standard output.  This form
 	is primarily meant to allow the caller to
 	test the exit status to see if a range of objects is fully
 	connected (or not).  It is faster than redirecting stdout
 	to `/dev/null` as the output does not have to be formatted.
 
---disk-usage::
---disk-usage=human::
+`--disk-usage`::
+`--disk-usage=human`::
 	Suppress normal output; instead, print the sum of the bytes used
 	for on-disk storage by the selected commits or objects. This is
 	equivalent to piping the output into `git cat-file
@@ -269,11 +269,11 @@ ifdef::git-rev-list[]
 	in human-readable string(e.g. 12.24 Kib, 3.50 Mib).
 endif::git-rev-list[]
 
---cherry-mark::
+`--cherry-mark`::
 	Like `--cherry-pick` (see below) but mark equivalent commits
 	with `=` rather than omitting them, and inequivalent ones with `+`.
 
---cherry-pick::
+`--cherry-pick`::
 	Omit any commit that introduces the same change as
 	another commit on the ``other side'' when the set of
 	commits are limited with symmetric difference.
@@ -286,8 +286,8 @@ cherry-picked from the other branch (for example, ``3rd on b'' may be
 cherry-picked from branch A). With this option, such pairs of commits are
 excluded from the output.
 
---left-only::
---right-only::
+`--left-only`::
+`--right-only`::
 	List only commits on the respective side of a symmetric difference,
 	i.e. only those which would be marked `<` resp. `>` by
 	`--left-right`.
@@ -298,20 +298,20 @@ commits from `B` which are in `A` or are patch-equivalent to a commit in
 More precisely, `--cherry-pick --right-only --no-merges` gives the exact
 list.
 
---cherry::
+`--cherry`::
 	A synonym for `--right-only --cherry-mark --no-merges`; useful to
 	limit the output to the commits on our side and mark those that
 	have been applied to the other side of a forked history with
 	`git log --cherry upstream...mybranch`, similar to
 	`git cherry upstream mybranch`.
 
--g::
---walk-reflogs::
+`-g`::
+`--walk-reflogs`::
 	Instead of walking the commit ancestry chain, walk
 	reflog entries from the most recent one to older ones.
 	When this option is used you cannot specify commits to
-	exclude (that is, '{caret}commit', 'commit1..commit2',
-	and 'commit1\...commit2' notations cannot be used).
+	exclude (that is, `^<commit>`, `<commit1>..<commit2>`,
+	and `<commit1>...<commit2>` notations cannot be used).
 +
 With `--pretty` format other than `oneline` and `reference` (for obvious reasons),
 this causes the output to have two extra lines of information
@@ -340,29 +340,29 @@ See also linkgit:git-reflog[1].
 +
 Under `--pretty=reference`, this information will not be shown at all.
 
---merge::
+`--merge`::
 	Show commits touching conflicted paths in the range `HEAD...<other>`,
 	where `<other>` is the first existing pseudoref in `MERGE_HEAD`,
 	`CHERRY_PICK_HEAD`, `REVERT_HEAD` or `REBASE_HEAD`. Only works
 	when the index has unmerged entries. This option can be used to show
 	relevant commits when resolving conflicts from a 3-way merge.
 
---boundary::
+`--boundary`::
 	Output excluded boundary commits. Boundary commits are
 	prefixed with `-`.
 
 ifdef::git-rev-list[]
---use-bitmap-index::
+`--use-bitmap-index`::
 
 	Try to speed up the traversal using the pack bitmap index (if
 	one is available). Note that when traversing with `--objects`,
 	trees and blobs will not have their associated path printed.
 
---progress=<header>::
+`--progress=<header>`::
 	Show progress reports on stderr as objects are considered. The
 	`<header>` text will be printed with each progress update.
 
--z::
+`-z`::
 	Instead of being newline-delimited, each outputted object and its
 	accompanying metadata is delimited using NUL bytes. Output is printed
 	in the following form:
@@ -397,56 +397,56 @@ is how to do it, as there are various strategies to simplify the history.
 
 The following options select the commits to be shown:
 
-<paths>::
+`<paths>`::
 	Commits modifying the given <paths> are selected.
 
---simplify-by-decoration::
+`--simplify-by-decoration`::
 	Commits that are referred by some branch or tag are selected.
 
 Note that extra commits can be shown to give a meaningful history.
 
 The following options affect the way the simplification is performed:
 
-Default mode::
+`Default mode`::
 	Simplifies the history to the simplest history explaining the
 	final state of the tree. Simplest because it prunes some side
 	branches if the end result is the same (i.e. merging branches
 	with the same content)
 
---show-pulls::
+`--show-pulls`::
 	Include all commits from the default mode, but also any merge
 	commits that are not TREESAME to the first parent but are
 	TREESAME to a later parent. This mode is helpful for showing
 	the merge commits that "first introduced" a change to a branch.
 
---full-history::
+`--full-history`::
 	Same as the default mode, but does not prune some history.
 
---dense::
+`--dense`::
 	Only the selected commits are shown, plus some to have a
 	meaningful history.
 
---sparse::
+`--sparse`::
 	All commits in the simplified history are shown.
 
---simplify-merges::
+`--simplify-merges`::
 	Additional option to `--full-history` to remove some needless
 	merges from the resulting history, as there are no selected
 	commits contributing to this merge.
 
---ancestry-path[=<commit>]::
-	When given a range of commits to display (e.g. 'commit1..commit2'
-	or 'commit2 {caret}commit1'), and a commit <commit> in that range,
+`--ancestry-path[=<commit>]`::
+	When given a range of commits to display (e.g. `<commit1>..<commit2>`
+	or `<commit2> ^<commit1>`), and a commit _<commit>_ in that range,
 	only display commits in that range
-	that are ancestors of <commit>, descendants of <commit>, or
-	<commit> itself.  If no commit is specified, use 'commit1' (the
-	excluded part of the range) as <commit>.  Can be passed multiple
+	that are ancestors of _<commit>_, descendants of _<commit>_, or
+	_<commit>_ itself.  If no commit is specified, use _<commit1>_ (the
+	excluded part of the range) as _<commit>_.  Can be passed multiple
 	times; if so, a commit is included if it is any of the commits
 	given or if it is an ancestor or descendant of one of them.
 
 A more detailed explanation follows.
 
-Suppose you specified `foo` as the <paths>.  We shall call commits
+Suppose you specified `foo` as the _<paths>_.  We shall call commits
 that modify `foo` !TREESAME, and the rest TREESAME.  (In a diff
 filtered for `foo`, they look different and equal, respectively.)
 
@@ -466,22 +466,22 @@ The horizontal line of history A---Q is taken to be the first parent of
 each merge.  The commits are:
 
 * `I` is the initial commit, in which `foo` exists with contents
-  ``asdf'', and a file `quux` exists with contents ``quux''. Initial
+  `asdf`, and a file `quux` exists with contents `quux`. Initial
   commits are compared to an empty tree, so `I` is !TREESAME.
 
-* In `A`, `foo` contains just ``foo''.
+* In `A`, `foo` contains just `foo`.
 
 * `B` contains the same change as `A`.  Its merge `M` is trivial and
   hence TREESAME to all parents.
 
-* `C` does not change `foo`, but its merge `N` changes it to ``foobar'',
+* `C` does not change `foo`, but its merge `N` changes it to `foobar`,
   so it is not TREESAME to any parent.
 
-* `D` sets `foo` to ``baz''. Its merge `O` combines the strings from
-  `N` and `D` to ``foobarbaz''; i.e., it is not TREESAME to any parent.
+* `D` sets `foo` to `baz`. Its merge `O` combines the strings from
+  `N` and `D` to `foobarbaz`; i.e., it is not TREESAME to any parent.
 
-* `E` changes `quux` to ``xyzzy'', and its merge `P` combines the
-  strings to ``quux xyzzy''. `P` is TREESAME to `O`, but not to `E`.
+* `E` changes `quux` to `xyzzy`, and its merge `P` combines the
+  strings to `quux xyzzy`. `P` is TREESAME to `O`, but not to `E`.
 
 * `X` is an independent root commit that added a new file `side`, and `Y`
   modified it. `Y` is TREESAME to `X`. Its merge `Q` added `side` to `P`, and
@@ -517,7 +517,7 @@ Parent/child relations are only visible with `--parents`, but that does
 not affect the commits selected in default mode, so we have shown the
 parent lines.
 
---full-history without parent rewriting::
+`--full-history` without parent rewriting::
 	This mode differs from the default in one point: always follow
 	all parents of a merge, even if it is TREESAME to one of them.
 	Even if more than one side of the merge has commits that are
@@ -536,7 +536,7 @@ Note that without parent rewriting, it is not really possible to talk
 about the parent/child relationships between the commits, so we show
 them disconnected.
 
---full-history with parent rewriting::
+`--full-history` with parent rewriting::
 	Ordinary commits are only included if they are !TREESAME
 	(though this can be changed, see `--sparse` below).
 +
@@ -560,18 +560,18 @@ rewritten to contain `E`'s parent `I`.  The same happened for `C` and
 In addition to the above settings, you can change whether TREESAME
 affects inclusion:
 
---dense::
+`--dense`::
 	Commits that are walked are included if they are not TREESAME
 	to any parent.
 
---sparse::
+`--sparse`::
 	All commits that are walked are included.
 +
 Note that without `--full-history`, this still simplifies merges: if
 one of the parents is TREESAME, we follow only that one, so the other
 sides of the merge are never walked.
 
---simplify-merges::
+`--simplify-merges`::
 	First, build a history graph in the same way that
 	`--full-history` with parent rewriting does (see above).
 +
@@ -618,9 +618,9 @@ Note the major differences in `N`, `P`, and `Q` over `--full-history`:
 
 There is another simplification mode available:
 
---ancestry-path[=<commit>]::
+`--ancestry-path[=<commit>]`::
 	Limit the displayed commits to those which are an ancestor of
-	<commit>, or which are a descendant of <commit>, or are <commit>
+	_<commit>_, or which are a descendant of _<commit>_, or are _<commit>_
 	itself.
 +
 As an example use case, consider the following commit history:
@@ -636,15 +636,15 @@ As an example use case, consider the following commit history:
 A regular 'D..M' computes the set of commits that are ancestors of `M`,
 but excludes the ones that are ancestors of `D`. This is useful to see
 what happened to the history leading to `M` since `D`, in the sense
-that ``what does `M` have that did not exist in `D`''. The result in this
+that "what does `M` have that did not exist in `D`". The result in this
 example would be all the commits, except `A` and `B` (and `D` itself,
 of course).
 +
 When we want to find out what commits in `M` are contaminated with the
 bug introduced by `D` and need fixing, however, we might want to view
-only the subset of 'D..M' that are actually descendants of `D`, i.e.
+only the subset of `D..M` that are actually descendants of `D`, i.e.
 excluding `C` and `K`. This is exactly what the `--ancestry-path`
-option does. Applied to the 'D..M' range, it results in:
+option does. Applied to the `D..M` range, it results in:
 +
 -----------------------------------------------------------------------
 		E-------F
@@ -655,7 +655,7 @@ option does. Applied to the 'D..M' range, it results in:
 -----------------------------------------------------------------------
 +
 We can also use `--ancestry-path=D` instead of `--ancestry-path` which
-means the same thing when applied to the 'D..M' range but is just more
+means the same thing when applied to the `D..M` range but is just more
 explicit.
 +
 If we instead are interested in a given topic within this range, and all
@@ -770,7 +770,7 @@ into the important branch. This commit may have information about why
 the change `X` came to override the changes from `A` and `B` in its
 commit message.
 
---show-pulls::
+`--show-pulls`::
 	In addition to the commits shown in the default history, show
 	each merge commit that is not TREESAME to its first parent but
 	is TREESAME to a later parent.
@@ -819,7 +819,7 @@ ifdef::git-rev-list[]
 Bisection Helpers
 ~~~~~~~~~~~~~~~~~
 
---bisect::
+`--bisect`::
 	Limit output to the one commit object which is roughly halfway between
 	included and excluded commits. Note that the bad bisection ref
 	`refs/bisect/bad` is added to the included commits (if it
@@ -843,7 +843,7 @@ introduces a regression is thus reduced to a binary search: repeatedly
 generate and test new 'midpoint's until the commit chain is of length
 one.
 
---bisect-vars::
+`--bisect-vars`::
 	This calculates the same as `--bisect`, except that refs in
 	`refs/bisect/` are not used, and except that this outputs
 	text ready to be eval'ed by the shell. These lines will assign the
@@ -855,7 +855,7 @@ one.
 	`bisect_bad`, and the number of commits we are bisecting right now to
 	`bisect_all`.
 
---bisect-all::
+`--bisect-all`::
 	This outputs all the commit objects between the included and excluded
 	commits, ordered by their distance to the included and excluded
 	commits. Refs in `refs/bisect/` are not used. The farthest
@@ -878,15 +878,15 @@ Commit Ordering
 
 By default, the commits are shown in reverse chronological order.
 
---date-order::
+`--date-order`::
 	Show no parents before all of its children are shown, but
 	otherwise show commits in the commit timestamp order.
 
---author-date-order::
+`--author-date-order`::
 	Show no parents before all of its children are shown, but
 	otherwise show commits in the author timestamp order.
 
---topo-order::
+`--topo-order`::
 	Show no parents before all of its children are shown, and
 	avoid showing commits on multiple lines of history
 	intermixed.
@@ -910,8 +910,8 @@ With `--topo-order`, they would show 8 6 5 3 7 4 2 1 (or 8 7 4 2 6 5
 avoid showing the commits from two parallel development track mixed
 together.
 
---reverse::
-	Output the commits chosen to be shown (see Commit Limiting
+`--reverse`::
+	Output the commits chosen to be shown (see 'Commit Limiting'
 	section above) in reverse order. Cannot be combined with
 	`--walk-reflogs`.
 endif::git-shortlog[]
@@ -923,39 +923,39 @@ Object Traversal
 These options are mostly targeted for packing of Git repositories.
 
 ifdef::git-rev-list[]
---objects::
+`--objects`::
 	Print the object IDs of any object referenced by the listed
-	commits.  `--objects foo ^bar` thus means ``send me
+	commits.  `--objects foo ^bar` thus means "send me
 	all object IDs which I need to download if I have the commit
-	object _bar_ but not _foo_''. See also `--object-names` below.
+	object `bar` but not `foo`". See also `--object-names` below.
 
---in-commit-order::
+`--in-commit-order`::
 	Print tree and blob ids in order of the commits. The tree
 	and blob ids are printed after they are first referenced
 	by a commit.
 
---objects-edge::
+`--objects-edge`::
 	Similar to `--objects`, but also print the IDs of excluded
-	commits prefixed with a ``-'' character.  This is used by
+	commits prefixed with a "`-`" character.  This is used by
 	linkgit:git-pack-objects[1] to build a ``thin'' pack, which records
 	objects in deltified form based on objects contained in these
 	excluded commits to reduce network traffic.
 
---objects-edge-aggressive::
+`--objects-edge-aggressive`::
 	Similar to `--objects-edge`, but it tries harder to find excluded
 	commits at the cost of increased time.  This is used instead of
 	`--objects-edge` to build ``thin'' packs for shallow repositories.
 
---indexed-objects::
+`--indexed-objects`::
 	Pretend as if all trees and blobs used by the index are listed
 	on the command line.  Note that you probably want to use
 	`--objects`, too.
 
---unpacked::
+`--unpacked`::
 	Only useful with `--objects`; print the object IDs that are not
 	in packs.
 
---object-names::
+`--object-names`::
 	Only useful with `--objects`; print the names of the object IDs
 	that are found. This is the default behavior. Note that the
 	"name" of each object is ambiguous, and mostly intended as a
@@ -964,52 +964,52 @@ ifdef::git-rev-list[]
 	to remove newlines; and if an object would appear multiple times
 	with different names, only one name is shown.
 
---no-object-names::
+`--no-object-names`::
 	Only useful with `--objects`; does not print the names of the object
 	IDs that are found. This inverts `--object-names`. This flag allows
 	the output to be more easily parsed by commands such as
 	linkgit:git-cat-file[1].
 
---filter=<filter-spec>::
+`--filter=<filter-spec>`::
 	Only useful with one of the `--objects*`; omits objects (usually
-	blobs) from the list of printed objects.  The '<filter-spec>'
+	blobs) from the list of printed objects.  The _<filter-spec>_
 	may be one of the following:
 +
-The form '--filter=blob:none' omits all blobs.
+The form `--filter=blob:none` omits all blobs.
 +
-The form '--filter=blob:limit=<n>[kmg]' omits blobs of size at least n
-bytes or units.  n may be zero.  The suffixes k, m, and g can be used
-to name units in KiB, MiB, or GiB.  For example, 'blob:limit=1k'
+The form `--filter=blob:limit=<n>[kmg]` omits blobs of size at least _<n>_
+bytes or units.  _<n>_ may be zero.  The suffixes `k`, `m`, and `g` can be used
+to name units in KiB, MiB, or GiB.  For example, `blob:limit=1k`
 is the same as 'blob:limit=1024'.
 +
-The form '--filter=object:type=(tag|commit|tree|blob)' omits all objects
+The form `--filter=object:type=(tag|commit|tree|blob)` omits all objects
 which are not of the requested type.
 +
-The form '--filter=sparse:oid=<blob-ish>' uses a sparse-checkout
-specification contained in the blob (or blob-expression) '<blob-ish>'
+The form `--filter=sparse:oid=<blob-ish>` uses a sparse-checkout
+specification contained in the blob (or blob-expression) _<blob-ish>_
 to omit blobs that would not be required for a sparse checkout on
 the requested refs.
 +
-The form '--filter=tree:<depth>' omits all blobs and trees whose depth
-from the root tree is >= <depth> (minimum depth if an object is located
-at multiple depths in the commits traversed). <depth>=0 will not include
+The form `--filter=tree:<depth>` omits all blobs and trees whose depth
+from the root tree is >= _<depth>_ (minimum depth if an object is located
+at multiple depths in the commits traversed). _<depth>_=0 will not include
 any trees or blobs unless included explicitly in the command-line (or
-standard input when --stdin is used). <depth>=1 will include only the
+standard input when `--stdin` is used). _<depth>_=1 will include only the
 tree and blobs which are referenced directly by a commit reachable from
-<commit> or an explicitly-given object. <depth>=2 is like <depth>=1
+_<commit>_ or an explicitly-given object. _<depth>_=2 is like <depth>=1
 while also including trees and blobs one more level removed from an
 explicitly-given commit or tree.
 +
-Note that the form '--filter=sparse:path=<path>' that wants to read
+Note that the form `--filter=sparse:path=<path>` that wants to read
 from an arbitrary path on the filesystem has been dropped for security
 reasons.
 +
-Multiple '--filter=' flags can be specified to combine filters. Only
+Multiple `--filter=` flags can be specified to combine filters. Only
 objects which are accepted by every filter are included.
 +
-The form '--filter=combine:<filter1>+<filter2>+...<filterN>' can also be
+The form `--filter=combine:<filter1>+<filter2>+...<filterN>` can also be
 used to combined several filters, but this is harder than just repeating
-the '--filter' flag and is usually not necessary. Filters are joined by
+the `--filter` flag and is usually not necessary. Filters are joined by
 '{plus}' and individual filters are %-encoded (i.e. URL-encoded).
 Besides the '{plus}' and '%' characters, the following characters are
 reserved and also must be encoded: `~!@#$^&*()[]{}\;",<>?`+&#39;&#96;+
@@ -1017,52 +1017,52 @@ as well as all characters with ASCII code &lt;= `0x20`, which includes
 space and newline.
 +
 Other arbitrary characters can also be encoded. For instance,
-'combine:tree:3+blob:none' and 'combine:tree%3A3+blob%3Anone' are
+`combine:tree:3+blob:none` and `combine:tree%3A3+blob%3Anone` are
 equivalent.
 
---no-filter::
+`--no-filter`::
 	Turn off any previous `--filter=` argument.
 
---filter-provided-objects::
+`--filter-provided-objects`::
 	Filter the list of explicitly provided objects, which would otherwise
 	always be printed even if they did not match any of the filters. Only
 	useful with `--filter=`.
 
---filter-print-omitted::
+`--filter-print-omitted`::
 	Only useful with `--filter=`; prints a list of the objects omitted
 	by the filter.  Object IDs are prefixed with a ``~'' character.
 
---missing=<missing-action>::
+`--missing=<missing-action>`::
 	A debug option to help with future "partial clone" development.
 	This option specifies how missing objects are handled.
 +
-The form '--missing=error' requests that rev-list stop with an error if
+The form `--missing=error` requests that rev-list stop with an error if
 a missing object is encountered.  This is the default action.
 +
-The form '--missing=allow-any' will allow object traversal to continue
+The form `--missing=allow-any` will allow object traversal to continue
 if a missing object is encountered.  Missing objects will silently be
 omitted from the results.
 +
-The form '--missing=allow-promisor' is like 'allow-any', but will only
+The form `--missing=allow-promisor` is like `allow-any`, but will only
 allow object traversal to continue for EXPECTED promisor missing objects.
 Unexpected missing objects will raise an error.
 +
-The form '--missing=print' is like 'allow-any', but will also print a
+The form `--missing=print` is like `allow-any`, but will also print a
 list of the missing objects.  Object IDs are prefixed with a ``?'' character.
 +
-The form '--missing=print-info' is like 'print', but will also print additional
+The form `--missing=print-info` is like `print`, but will also print additional
 information about the missing object inferred from its containing object. The
 information is all printed on the same line with the missing object ID in the
 form: `?<oid> [<token>=<value>]...`. The `<token>=<value>` pairs containing
-additional information are separated from each other by a SP. The value is
-encoded in a token specific fashion, but SP or LF contained in value are always
+additional information are separated from each other by a _SP_. The value is
+encoded in a token specific fashion, but _SP_ or _LF_ contained in value are always
 expected to be represented in such a way that the resulting encoded value does
 not have either of these two problematic bytes. Each `<token>=<value>` may be
 one of the following:
 +
 --
 * The `path=<path>` shows the path of the missing object inferred from a
-  containing object. A path containing SP or special characters is enclosed in
+  containing object. A path containing _SP_ or special characters is enclosed in
   double-quotes in the C style as needed.
 +
 * The `type=<type>` shows the type of the missing object inferred from a
@@ -1073,7 +1073,7 @@ If some tips passed to the traversal are missing, they will be
 considered as missing too, and the traversal will ignore them. In case
 we cannot get their Object ID though, an error will be raised.
 
---exclude-promisor-objects::
+`--exclude-promisor-objects`::
 	(For internal use only.)  Prefilter object traversal at
 	promisor boundary.  This is used with partial clone.  This is
 	stronger than `--missing=allow-promisor` because it limits the
@@ -1081,7 +1081,7 @@ we cannot get their Object ID though, an error will be raised.
 	objects.
 endif::git-rev-list[]
 
---no-walk[=(sorted|unsorted)]::
+`--no-walk[=(sorted|unsorted)]`::
 	Only show the given commits, but do not traverse their ancestors.
 	This has no effect if a range is specified. If the argument
 	`unsorted` is given, the commits are shown in the order they were
@@ -1090,7 +1090,7 @@ endif::git-rev-list[]
 	by commit time.
 	Cannot be combined with `--graph`.
 
---do-walk::
+`--do-walk`::
 	Overrides a previous `--no-walk`.
 endif::git-shortlog[]
 
@@ -1111,10 +1111,10 @@ endif::git-rev-list[]
 
 include::pretty-options.adoc[]
 
---relative-date::
+`--relative-date`::
 	Synonym for `--date=relative`.
 
---date=<format>::
+`--date=<format>`::
 	Only takes effect for dates shown in human-readable format, such
 	as when using `--pretty`. `log.date` config variable sets a default
 	value for the log command's `--date` option. By default, dates
@@ -1164,12 +1164,12 @@ omitted.
 1970).  As with `--raw`, this is always in UTC and therefore `-local`
 has no effect.
 
-`--date=format:...` feeds the format `...` to your system `strftime`,
-except for %s, %z, and %Z, which are handled internally.
+`--date=format:<format>` feeds the _<format>_ to your system `strftime`,
+except for `%s`, `%z`, and `%Z`, which are handled internally.
 Use `--date=format:%c` to show the date in your system locale's
-preferred format.  See the `strftime` manual for a complete list of
+preferred format.  See the `strftime`(3) manual for a complete list of
 format placeholders. When using `-local`, the correct syntax is
-`--date=format-local:...`.
+`--date=format-local:<format>`.
 
 `--date=default` is the default format, and is based on ctime(3)
 output.  It shows a single line with three-letter day of the week,
@@ -1179,33 +1179,33 @@ the local time zone is used, e.g. `Thu Jan 1 00:00:00 1970 +0000`.
 --
 
 ifdef::git-rev-list[]
---header::
+`--header`::
 	Print the contents of the commit in raw-format; each record is
 	separated with a NUL character.
 
---no-commit-header::
+`--no-commit-header`::
 	Suppress the header line containing "commit" and the object ID printed before
 	the specified format.  This has no effect on the built-in formats; only custom
 	formats are affected.
 
---commit-header::
+`--commit-header`::
 	Overrides a previous `--no-commit-header`.
 endif::git-rev-list[]
 
---parents::
+`--parents`::
 	Print also the parents of the commit (in the form "commit parent...").
 	Also enables parent rewriting, see 'History Simplification' above.
 
---children::
+`--children`::
 	Print also the children of the commit (in the form "commit child...").
 	Also enables parent rewriting, see 'History Simplification' above.
 
 ifdef::git-rev-list[]
---timestamp::
+`--timestamp`::
 	Print the raw commit timestamp.
 endif::git-rev-list[]
 
---left-right::
+`--left-right`::
 	Mark which side of a symmetric difference a commit is reachable from.
 	Commits from the left side are prefixed with `<` and those from
 	the right with `>`.  If combined with `--boundary`, those
@@ -1234,7 +1234,7 @@ you would get an output like this:
 	-xxxxxxx... 1st on a
 -----------------------------------------------------------------------
 
---graph::
+`--graph`::
 	Draw a text-based graphical representation of the commit history
 	on the left hand side of the output.  This may cause extra lines
 	to be printed in between commits, in order for the graph history
@@ -1246,15 +1246,15 @@ This enables parent rewriting, see 'History Simplification' above.
 This implies the `--topo-order` option by default, but the
 `--date-order` option may also be specified.
 
---show-linear-break[=<barrier>]::
-	When --graph is not used, all history branches are flattened
+`--show-linear-break[=<barrier>]`::
+	When `--graph` is not used, all history branches are flattened
 	which can make it hard to see that the two consecutive commits
 	do not belong to a linear branch. This option puts a barrier
-	in between them in that case. If `<barrier>` is specified, it
+	in between them in that case. If _<barrier>_ is specified, it
 	is the string that will be shown instead of the default one.
 
 ifdef::git-rev-list[]
---count::
+`--count`::
 	Print a number stating how many commits would have been
 	listed, and suppress all other output.  When used together
 	with `--left-right`, instead print the counts for left and


### PR DESCRIPTION
This series converts the man page of git log to the synopsis format style. Git log is the second largest manpage after git config, which makes the changes quite large.

A special note about the log format description which required escaping the synopsis processing of parentheses.

Changes since V1:
 * rework the grammar style when refering to plural placeholders . The text is more descriptive and does not rely on puns. Puns may be difficult to understand and to translate.
 * change commit message to reflect the conversion of inline description of several option to a list.

cc: "Kristoffer Haugsbakk" <kristofferhaugsbakk@fastmail.com>