### PR TITLE
Fix Coverity builds on Windows

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -149,7 +149,11 @@ jobs:
         run: |
           export PATH="$PATH:$RUNNER_TEMP/cov-analysis/bin" &&
           cov-configure --gcc &&
-          cov-build --dir cov-int make
+          if ! cov-build --dir cov-int make
+          then
+            cat cov-int/build-log.txt
+            exit 1
+          fi
       - name: package the build
         run: tar -czvf cov-int.tgz cov-int
       - name: submit the build to Coverity Scan

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -147,7 +147,7 @@ jobs:
           key: cov-build-${{ env.COVERITY_LANGUAGE }}-${{ env.COVERITY_PLATFORM }}-${{ steps.lookup.outputs.hash }}
       - name: build with cov-build
         run: |
-          export PATH="$RUNNER_TEMP/cov-analysis/bin:$PATH" &&
+          export PATH="$PATH:$RUNNER_TEMP/cov-analysis/bin" &&
           cov-configure --gcc &&
           cov-build --dir cov-int make
       - name: package the build


### PR DESCRIPTION
As of three weeks ago, Git for Windows' [Coverity builds fail](https://github.com/git-for-windows/git/actions/workflows/coverity.yml?query=branch%3Amain).

The reason is most likely the most recent Coverity release, 2025.3. Its [release notes](https://documentation.blackduck.com/bundle/coverity-docs/page/webhelp-files/relnotes_latest.html) do not shed any light into the issue (and do not mention that they bundle JDK20 and JDK22 in addition to a JRE, because what's better than a single Java installation: three, right?).

My investigation turned up `.dll` files that are located in Coverity's `bin/` directory which have the same name as `.dll` files in Git for Windows' SDK. As a consequence, the former override the latter and throw off MSYS2's logic to find the MSYS2 root directory given the location of certain `.dll` files.

This patch series fixes this issue, and while at it, enhances the Coverity workflow to print out the build log in case of failure. It is a companion of https://github.com/git-for-windows/git/pull/5672 and of (https://github.com/microsoft/git/pull/764.

Changes since v1:
- Dropped unnecessary, non-portably `cygpath` call.