### PR TITLE
git-jump: make `diff` work with filenames containing spaces

### DIFF
--- a/contrib/git-jump/git-jump
+++ b/contrib/git-jump/git-jump
@@ -44,7 +44,7 @@ open_editor() {
 mode_diff() {
 	git diff --no-prefix --relative "$@" |
 	perl -ne '
-	if (m{^\+\+\+ (.*)}) { $file = $1 eq "/dev/null" ? undef : $1; next }
+	if (m{^\+\+\+ (.*?)\t?$}) { $file = $1 eq "/dev/null" ? undef : $1; next }
 	defined($file) or next;
 	if (m/^@@ .*?\+(\d+)/) { $line = $1; next }
 	defined($line) or next;


### PR DESCRIPTION
Changed since v1:

- No code changes, but reworded commit message
  to include examples of quoted paths.

Turns out that quoted paths never worked, so
this commit isn't "robbing Peter to pay Paul",
but rather, "giving something to Paul for free
(Peter, sadly, is still out of luck)".

cc: "D. Ben Knoble" <ben.knoble@gmail.com>
cc: Phillip Wood <phillip.wood123@gmail.com>
cc: Jeff King <peff@peff.net>