### PR TITLE
Document count-objects pack

### DIFF
--- a/Documentation/git-count-objects.adoc
+++ b/Documentation/git-count-objects.adoc
@@ -28,6 +28,8 @@ size: disk space consumed by loose objects, in KiB (unless -H is specified)
 +
 in-pack: the number of in-pack objects
 +
+packs: the number of pack files
++
 size-pack: disk space consumed by the packs, in KiB (unless -H is specified)
 +
 prune-packable: the number of loose objects that are also present in


### PR DESCRIPTION
Juno added the printing of "packs" with ae72f685418b. When 0bdaa1216 refactored the docs for the -v option, this was missed.

