### PR TITLE
Fix `curl_easy_setopt()` parameter type problem, again

### DIFF
--- a/http-push.c
+++ b/http-push.c
@@ -208,7 +208,8 @@ static void curl_setup_http(CURL *curl, const char *url,
 	curl_easy_setopt(curl, CURLOPT_UPLOAD, 1L);
 	curl_easy_setopt(curl, CURLOPT_URL, url);
 	curl_easy_setopt(curl, CURLOPT_INFILE, buffer);
-	curl_easy_setopt(curl, CURLOPT_INFILESIZE, buffer->buf.len);
+	curl_easy_setopt(curl, CURLOPT_INFILESIZE_LARGE,
+			 cast_size_t_to_curl_off_t(buffer->buf.len));
 	curl_easy_setopt(curl, CURLOPT_READFUNCTION, fread_buffer);
 	curl_easy_setopt(curl, CURLOPT_SEEKFUNCTION, seek_buffer);
 	curl_easy_setopt(curl, CURLOPT_SEEKDATA, buffer);

--- a/http.h
+++ b/http.h
@@ -8,6 +8,7 @@ struct packed_git;
 #include <curl/curl.h>
 #include <curl/easy.h>
 
+#include "gettext.h"
 #include "strbuf.h"
 #include "remote.h"
 
@@ -94,6 +95,15 @@ static inline int missing__target(int code, int result)
 }
 
 #define missing_target(a) missing__target((a)->http_code, (a)->curl_result)
+
+static inline curl_off_t cast_size_t_to_curl_off_t(size_t a)
+{
+	uintmax_t size = a;
+	if (size > maximum_signed_value_of_type(curl_off_t))
+		die(_("number too large to represent as curl_off_t "
+		      "on this platform: %"PRIuMAX), (uintmax_t)a);
+	return (curl_off_t)a;
+}
 
 /*
  * Normalize curl results to handle CURL_FAILONERROR (or lack thereof). Failing

--- a/imap-send.c
+++ b/imap-send.c
@@ -1721,7 +1721,7 @@ static int curl_append_msgs_to_imap(struct imap_server_conf *server,
 		lf_to_crlf(&msgbuf.buf);
 
 		curl_easy_setopt(curl, CURLOPT_INFILESIZE_LARGE,
-				 (curl_off_t)(msgbuf.buf.len-prev_len));
+				 cast_size_t_to_curl_off_t(msgbuf.buf.len-prev_len));
 
 		res = curl_easy_perform(curl);
 

--- a/remote-curl.c
+++ b/remote-curl.c
@@ -894,14 +894,6 @@ static int probe_rpc(struct rpc_state *rpc, struct slot_results *results)
 	return err;
 }
 
-static curl_off_t xcurl_off_t(size_t len)
-{
-	uintmax_t size = len;
-	if (size > maximum_signed_value_of_type(curl_off_t))
-		die(_("cannot handle pushes this big"));
-	return (curl_off_t)size;
-}
-
 /*
  * If flush_received is true, do not attempt to read any more; just use what's
  * in rpc->buf.
@@ -999,7 +991,7 @@ retry:
 		 * and we just need to send it.
 		 */
 		curl_easy_setopt(slot->curl, CURLOPT_POSTFIELDS, gzip_body);
-		curl_easy_setopt(slot->curl, CURLOPT_POSTFIELDSIZE_LARGE, xcurl_off_t(gzip_size));
+		curl_easy_setopt(slot->curl, CURLOPT_POSTFIELDSIZE_LARGE, cast_size_t_to_curl_off_t(gzip_size));
 
 	} else if (use_gzip && 1024 < rpc->len) {
 		/* The client backend isn't giving us compressed data so
@@ -1030,7 +1022,7 @@ retry:
 
 		headers = curl_slist_append(headers, "Content-Encoding: gzip");
 		curl_easy_setopt(slot->curl, CURLOPT_POSTFIELDS, gzip_body);
-		curl_easy_setopt(slot->curl, CURLOPT_POSTFIELDSIZE_LARGE, xcurl_off_t(gzip_size));
+		curl_easy_setopt(slot->curl, CURLOPT_POSTFIELDSIZE_LARGE, cast_size_t_to_curl_off_t(gzip_size));
 
 		if (options.verbosity > 1) {
 			fprintf(stderr, "POST %s (gzip %lu to %lu bytes)\n",
@@ -1043,7 +1035,7 @@ retry:
 		 * more normal Content-Length approach.
 		 */
 		curl_easy_setopt(slot->curl, CURLOPT_POSTFIELDS, rpc->buf);
-		curl_easy_setopt(slot->curl, CURLOPT_POSTFIELDSIZE_LARGE, xcurl_off_t(rpc->len));
+		curl_easy_setopt(slot->curl, CURLOPT_POSTFIELDSIZE_LARGE, cast_size_t_to_curl_off_t(rpc->len));
 		if (options.verbosity > 1) {
 			fprintf(stderr, "POST %s (%lu bytes)\n",
 				rpc->service_name, (unsigned long)rpc->len);


### PR DESCRIPTION
As of last week, every CI build of Git for Windows' ARM64 flavor of its SDK started failing (the first failed build is this here: https://github.com/git-for-windows/git-sdk-arm64/actions/runs/17633130672/job/50104373185).

The reason is that we _still_ have one `curl_easy_setopt()` call that is supposed to pass a `long` parameter but doesn't.

Strange thing: GCC does not catch the problem, but LLVM does. And even more strangely, the relevant parts of cURL's `typecheck-gcc.h` haven't changed in a way that explains to me why this starts to trigger _now_.

To prevent more piecemeal solutions, I vetted all calls of `curl_easy_setopt()` and satisifed myself that all remaining calls that want `long` parameters do indeed have arguments matching that type.

As is the custom in the Git project, I use this opportunity to do a bit more than is strictly necessary to address this problem. I replace the affected call with one that expects a wider data type, refactor an already-existing function to cast to said data type, and use it in the modified call as well as in another call which wants to perform the same cast but did so unsafely (not that it mattered in practice, really, yet it is in line with other refactors the Git project has seen).

Note for the curious: The affected call used [`CURLOPT_INFILESIZE`](https://curl.se/libcurl/c/CURLOPT_INFILESIZE.html) and now uses [`CURLOPT_INFILESIZE_LARGE`](https://curl.se/libcurl/c/CURLOPT_INFILESIZE_LARGE.html), and it is a bit strange that the latter wasn't used in the first place, given that it was introduced into cURL over a year before Git itself was born, and almost two years before the call was introduced in 58e60dd2033 (Add support for pushing to a remote repository using HTTP/DAV, 2005-11-02).

For the record, these patches apply cleanly all the way back to v2.22, according to `git replay` (but I did not try to test whether it builds because all kinds of stunts are required nowadays to build this old versions even without patches on top).