### PR TITLE
l10n: bump actions/setup-go from 5 to 6

### DIFF
--- a/.github/workflows/l10n.yml
+++ b/.github/workflows/l10n.yml
@@ -63,7 +63,7 @@ jobs:
             origin \
             ${{ github.ref }} \
             $args
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: '>=1.16'
           cache: false


### PR DESCRIPTION
(Originally opened at https://github.com/git-for-windows/git/pull/5811, then at https://github.com/git-l10n/git-po/pull/870)

Bumps [actions/setup-go](https://github.com/actions/setup-go) from 5 to 6.
- [Release notes](https://github.com/actions/setup-go/releases)
- [Commits](https://github.com/actions/setup-go/compare/v5...v6)

## What's Changed in `actions/setup-go@v6`

### Breaking Changes

-   Improve toolchain handling to ensure more reliable and consistent toolchain selection and management by [@matthewhughes934](https://github.com/matthewhughes934) in [#460](https://github.com/actions/setup-go/pull/460)
-   Upgrade Nodejs runtime from node20 to node 24 by [@salmanmkc](https://github.com/salmanmkc) in [#624](https://github.com/actions/setup-go/pull/624)

Make sure your runner is on version v2.327.1 or later to ensure compatibility with this release. [See Release Notes](https://github.com/actions/runner/releases/tag/v2.327.1)

Cc: Jiang Xin <worldhello.net@gmail.com>