### PR TITLE
doc: git-reset: clarify DESCRIPTION section

### DIFF
--- a/Documentation/git-reset.adoc
+++ b/Documentation/git-reset.adoc
@@ -79,29 +79,24 @@ linkgit:git-add[1]).
 
 `git reset [-q] [<tree-ish>] [--] <pathspec>...`::
 `git reset [-q] [--pathspec-from-file=<file> [--pathspec-file-nul]] [<tree-ish>]`::
-	These forms reset the index entries for all paths that match the
-	_<pathspec>_ to their state at _<tree-ish>_.  (It does not affect
-	the working tree or the current branch.)
+	For all specified files or directories, set the staged version to
+	the version from the given commit or tree (which defaults to `HEAD`).
 +
 This means that `git reset <pathspec>` is the opposite of `git add
-<pathspec>`. This command is equivalent to
-`git restore [--source=<tree-ish>] --staged <pathspec>...`.
+<pathspec>`: it unstages all changes to the specified file(s) or
+directories. This is equivalent to `git restore --staged <pathspec>...`.
 +
-After running `git reset <pathspec>` to update the index entry, you can
-use linkgit:git-restore[1] to check the contents out of the index to
-the working tree. Alternatively, using linkgit:git-restore[1]
-and specifying a commit with `--source`, you
-can copy the contents of a path out of a commit to the index and to the
-working tree in one go.
+`git reset` only modifies the index: use linkgit:git-restore[1] instead
+if you'd like to also update the file in your working directory.
 
 `git reset (--patch | -p) [<tree-ish>] [--] [<pathspec>...]`::
-	Interactively select hunks in the difference between the index
-	and _<tree-ish>_ (defaults to `HEAD`).  The chosen hunks are applied
-	in reverse to the index.
+	Interactively select changes from the difference between the index
+	and the specified commit or tree (which defaults to `HEAD`).
+	The chosen changes are unstaged.
 +
 This means that `git reset -p` is the opposite of `git add -p`, i.e.
-you can use it to selectively reset hunks. See the "Interactive Mode"
-section of linkgit:git-add[1] to learn how to operate the `--patch` mode.
+you can use it to selectively unstage changes. See the "Interactive Mode"
+section of linkgit:git-add[1] to learn how to use the `--patch` option.
 
 See "Reset, restore and revert" in linkgit:git[1] for the differences
 between the three commands.


### PR DESCRIPTION
I got feedback from 24 Git users about the current `git reset` man page, using this tool: https://text-feedback.wizardzines.com/git-reset.

My main goals here are to highlight the `git reset [--soft | --hard | --mixed...] <commit>` use of `git reset` that many users commenting said they considered the "main" use (which is currently at the end), explain how `--soft`, `--hard` and `--mixed` work more clearly, and to avoid using terminology that users don't understand when that's realistic.

Like we discussed with `git checkout`, there's some tension about using the word "index" since on one hand many users don't know what it means, but on the other hand (especially with commands like `git reset --hard`) it gets very awkward to talk about what's going on precisely without using that word, since the index is a core concept in Git's data model. I've done my best here to use the word "index" where I think it's appropriate and use the word "staged" otherwise.

There were also quite a few comments about the EXAMPLES section which I think could also be made clearer, but I'll defer that to a separate patch series to keep the size of this one under control.

cc: Ben Knoble <ben.knoble@gmail.com>
cc: "D. Ben Knoble" <ben.knoble+github@gmail.com>
cc: Jean-Noël AVILA <jn.avila@free.fr>