### PR TITLE
ci(dockerized): do show the result of failing tests again

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -433,7 +433,7 @@ jobs:
     - run: ci/install-dependencies.sh
     - run: useradd builder --create-home
     - run: chown -R builder .
-    - run: sudo --preserve-env --set-home --user=builder ci/run-build-and-tests.sh
+    - run: chmod o+w $GITHUB_ENV && sudo --preserve-env --set-home --user=builder ci/run-build-and-tests.sh
     - name: print test failures
       if: failure() && env.FAILED_TEST_ARTIFACTS != ''
       run: sudo --preserve-env --set-home --user=builder ci/print-test-failures.sh


### PR DESCRIPTION
It has become quite hard to debug CI failures when they happen in one of the Dockerized jobs, as the actual test failures are now hidden. This was most likely an oversight when 2a21098b98a (github: adapt containerized jobs to be rootless, 2025-01-10) was merged in  2bf3c7fab19 (Merge branch 'ps/ci-misc-updates', 2025-02-06), v2.49.0-rc0~55, and I had reported this as a regression in https://lore.kernel.org/git/e45b9487-b3ae-ed85-fd07-c92cfbf47cbb@gmx.de/. Seeing no movement on my report, and having the pressure of newly-failing tests during the v2.52.0-rc0 rebase of Git for Windows, I was kind of forced into fixing this in Git for Windows. Here I upstream the fix.

cc: Jeff King <peff@peff.net>
cc: Elijah Newren <newren@gmail.com>