### PR TITLE
make strip: include `scalar`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2565,7 +2565,7 @@ please_set_SHELL_PATH_to_a_more_modern_shell:
 
 shell_compatibility_test: please_set_SHELL_PATH_to_a_more_modern_shell
 
-strip: $(PROGRAMS) git$X
+strip: $(PROGRAMS) git$X scalar$X
 	$(STRIP) $(STRIP_OPTS) $^
 
 ### Target-specific flags and dependencies


### PR DESCRIPTION
This is something I noticed while working on aligning Git for Windows better with MSYS2.

cc: Patrick Steinhardt <ps@pks.im>