### PR TITLE
doc: git-pull: fix 'git --rebase abort' typo

### DIFF
--- a/Documentation/git-pull.adoc
+++ b/Documentation/git-pull.adoc
@@ -37,8 +37,8 @@ You can also set the configuration options `pull.rebase`, `pull.squash`,
 or `pull.ff` with your preferred behaviour.
 
 If there's a merge conflict during the merge or rebase that you don't
-want to handle, you can safely abort it with `git merge --abort` or `git
---rebase abort`.
+want to handle, you can safely abort it with `git merge --abort` or
+`git rebase --abort`.
 
 OPTIONS
 -------


### PR DESCRIPTION


cc: "Kristoffer Haugsbakk" <kristofferhaugsbakk@fastmail.com>