### PR TITLE
diff: avoid segfault with freed entries

### DIFF
--- a/diff.c
+++ b/diff.c
@@ -7046,6 +7046,7 @@ static void diffcore_skip_stat_unmatch(struct diff_options *diffopt)
 			if (!diffopt->flags.no_index)
 				diffopt->skip_stat_unmatch++;
 			diff_free_filepair(p);
+			q->queue[i] = NULL;
 		}
 	}
 	free(q->queue);
@@ -7089,6 +7090,10 @@ void diff_queued_diff_prefetch(void *repository)
 
 	for (i = 0; i < q->nr; i++) {
 		struct diff_filepair *p = q->queue[i];
+
+		if (!p)
+			continue;
+
 		diff_add_if_missing(repo, &to_fetch, p->one);
 		diff_add_if_missing(repo, &to_fetch, p->two);
 	}


### PR DESCRIPTION
I found this segfault in the wild in a pipeline that was using the microsoft/git fork, but the error can be reproduced without that fork. It requires partial clone, though.

Thanks,
-Stolee

cc: gitster@pobox.com
cc: "Kristoffer Haugsbakk" <kristofferhaugsbakk@fastmail.com>