### PR TITLE
gitk: use headoutlinecolor, headbgcolor, and tagfgcolor config settings to change the color of the tags and head outlines and fill 

### DIFF
--- a/gitk-git/gitk
+++ b/gitk-git/gitk
@@ -6831,16 +6831,18 @@ proc drawtags {id x xt y1} {
         } else {
             # draw a head or other ref
             if {[incr nheads -1] >= 0} {
-                set col $headbgcolor
+                set refoutlinecol $headoutlinecolor
+                set reffillcol $headbgcolor
                 if {$tag eq $mainhead} {
                     set font mainfontbold
                 }
             } else {
-                set col "#ddddff"
+                set refoutlinecol black
+                set reffillcol "#ddddff"
             }
             set xl [expr {$xl - $delta/2}]
             $canv create polygon $x $yt $xr $yt $xr $yb $x $yb \
-                -width 1 -outline black -fill $col -tags tag.$id
+                -width 1 -outline $refoutlinecol -fill $reffillcol -tags tag.$id
             if {[regexp {^(remotes/.*/|remotes/)} $tag match remoteprefix]} {
                 set rwid [font measure mainfont $remoteprefix]
                 set xi [expr {$x + 1}]
@@ -6850,7 +6852,8 @@ proc drawtags {id x xt y1} {
                         -width 0 -fill $remotebgcolor -tags tag.$id
             }
         }
-        set t [$canv create text $xl $y1 -anchor w -text $tag -fill $headfgcolor \
+        set textfgcolor [expr {$ntags >= 0 ? $tagfgcolor : $headfgcolor}]
+        set t [$canv create text $xl $y1 -anchor w -text $tag -fill $textfgcolor \
                    -font $font -tags [list tag.$id text]]
         if {$ntags >= 0} {
             $canv bind $t <1> $tagclick


### PR DESCRIPTION
This patch makes the config settings, headoutlinecolor and tagfgcolor, work.
These are existing config settings but not used in the code.

(I noticed that tagfgcolor was not working while making an extension for vscode that exports its color theme to gitk.)
(Upon review of the code I found that headoutlinecolor was also not used and investigated and fixed it.)

This simple patch has them affect the target UI elements while drawing refs and their outlined boxes.
Tags are drawn in their own code branch then heads and non-heads are drawn in another one.
Because both head and non-head refs are drawn in the same loop the colors used to draw (and fill) toggle between the head colors and (still hard-coded) non-head ref colors.

Image showing it working, reviewing the patch that made it work.
<img width="1549" height="1055" alt="gitk-colors" src="https://github.com/user-attachments/assets/0eea207d-0891-41c8-8c6d-1464a96a1c76" />

CC: Johannes Sixt <j6t@kdbg.org>