### PR TITLE
diff: avoid misleading statement about -l option

### DIFF
--- a/diff.c
+++ b/diff.c
@@ -6186,7 +6186,7 @@ struct option *add_diff_options(const struct option *opts,
 			       N_("continue listing the history of a file beyond renames"),
 			       PARSE_OPT_NOARG, diff_opt_follow),
 		OPT_INTEGER('l', NULL, &options->rename_limit,
-			    N_("prevent rename/copy detection if the number of rename/copy targets exceeds given limit")),
+			    N_("limit to cheap rename/copy detection if the number of rename/copy targets exceeds this value")),
 
 		OPT_GROUP(N_("Diff algorithm options")),
 		OPT_CALLBACK_F(0, "minimal", options, NULL,


### PR DESCRIPTION
Changes since v1:
  * Fixed author to match signoff
  * Simplified the wording a bit, along the lines of Junio's suggestion