### PR TITLE
merge-ours: sparse-index integration

### DIFF
--- a/builtin/merge-ours.c
+++ b/builtin/merge-ours.c
@@ -10,6 +10,8 @@
 
 #include "git-compat-util.h"
 #include "builtin.h"
+#include "config.h"
+#include "environment.h"
 #include "diff.h"
 
 static const char builtin_merge_ours_usage[] =
@@ -21,6 +23,10 @@ int cmd_merge_ours(int argc,
 		   struct repository *repo)
 {
 	show_usage_if_asked(argc, argv, builtin_merge_ours_usage);
+
+	repo_config(repo, git_default_config, NULL);
+	prepare_repo_settings(repo);
+	repo->settings.command_requires_full_index = 0;
 
 	/*
 	 * The contents of the current index becomes the tree we

--- a/t/t1092-sparse-checkout-compatibility.sh
+++ b/t/t1092-sparse-checkout-compatibility.sh
@@ -2559,4 +2559,18 @@ test_expect_success 'cat-file --batch' '
 	ensure_expanded cat-file --batch <in
 '
 
+test_expect_success 'merge -s ours' '
+	init_repos &&
+
+	test_all_match git rev-parse HEAD^{tree} &&
+	test_all_match git merge -s ours merge-right &&
+	test_all_match git rev-parse HEAD^{tree} &&
+	test_all_match git rev-parse HEAD^2
+'
+
+test_expect_success 'sparse-index is not expanded: merge-ours' '
+	init_repos &&
+	ensure_not_expanded merge -s ours merge-right
+'
+
 test_done


### PR DESCRIPTION
This short series teaches merge-ours to work with a sparse index.

Patch 1 is a preparatory cleanup that converts merge-ours away from
the_repository global, using the `repo` parameter instead.

Patch 2 adds the actual sparse-index integration and tests. Because
merge-ours is invoked as a subprocess by `git merge -s ours` and never
previously read config, the sparse-checkout globals remained unset,
causing the index to be expanded unconditionally. A `repo_config()` call
fixes this.

Developed with AI assistance (Claude).