### PR TITLE
doc: commit: document special date keywords for --date

### DIFF
--- a/Documentation/date-formats.adoc
+++ b/Documentation/date-formats.adoc
@@ -28,4 +28,16 @@ ifdef::git-commit[]
 In addition to recognizing all date formats above, the `--date` option
 will also try to make sense of other, more human-centric date formats,
 such as relative dates like "yesterday" or "last Friday at noon".
++
+The following special keywords are also recognized:
++
+`now`;; the current date and time.
+`yesterday`;; yesterday's date at the current time.
+`noon`;; today (or the given date) at 12:00.
+`midnight`;; today (or the given date) at 00:00.
+`tea`;; today (or the given date) at 17:00.
+`never`;; a zero timestamp (used e.g. by linkgit:git-reflog[1]).
++
+These keywords can be combined with other date constructs, for
+example `yesterday noon` or `3.days.ago`.
 endif::git-commit[]

--- a/Documentation/git-commit.adoc
+++ b/Documentation/git-commit.adoc
@@ -181,7 +181,10 @@ See linkgit:git-rebase[1] for details.
 	the commit author is then copied from the first such commit found.
 
 `--date=<date>`::
-	Override the author date used in the commit.
+	Override the author date used in the commit.  See the
+	"DATE FORMATS" section below for accepted formats,
+	including human-readable strings like `now`, `yesterday`,
+	and `noon`.
 
 `-m <msg>`::
 `--message=<msg>`::


### PR DESCRIPTION
The --date option in git-commit accepts human-readable keywords
like "now", "yesterday", "noon", "midnight", "tea", and "never",
but these were not documented. Add them to the "DATE FORMATS"
section of git-commit(1), and expand the --date option description
to point readers there.

This addresses https://github.com/gitgitgadget/git/issues/302

Signed-off-by: mdferdousalam <mdferdousalam1989@yahoo.com>
cc: Engr Md Ferdous Alam <mdferdousalam1989@yahoo.com>