### PR TITLE
merge-base, ls-remote, ls-tree: fix error message formatting

### DIFF
--- a/builtin/ls-remote.c
+++ b/builtin/ls-remote.c
@@ -128,7 +128,7 @@ int cmd_ls_remote(int argc,
 	if (!remote) {
 		if (dest)
 			die("bad repository '%s'", dest);
-		die("No remote configured to list refs from.");
+		die("no remote configured to list refs from");
 	}
 
 	if (get_url) {

--- a/builtin/ls-tree.c
+++ b/builtin/ls-tree.c
@@ -406,7 +406,7 @@ int cmd_ls_tree(int argc,
 		usage_with_options(ls_tree_usage, ls_tree_options);
 	if (repo_get_oid_with_flags(the_repository, argv[0], &oid,
 				    GET_OID_HASH_ANY))
-		die("Not a valid object name %s", argv[0]);
+		die("not a valid object name %s", argv[0]);
 
 	/*
 	 * show_recursive() rolls its own matching code and is

--- a/builtin/merge-base.c
+++ b/builtin/merge-base.c
@@ -47,10 +47,10 @@ static struct commit *get_commit_reference(const char *arg)
 	struct commit *r;
 
 	if (repo_get_oid(the_repository, arg, &revkey))
-		die("Not a valid object name %s", arg);
+		die("not a valid object name %s", arg);
 	r = lookup_commit_reference(the_repository, &revkey);
 	if (!r)
-		die("Not a valid commit name %s", arg);
+		die("not a valid commit name %s", arg);
 
 	return r;
 }
@@ -131,7 +131,7 @@ static int handle_fork_point(int argc, const char **argv)
 
 	commitname = (argc == 2) ? argv[1] : "HEAD";
 	if (repo_get_oid(the_repository, commitname, &oid))
-		die("Not a valid object name: '%s'", commitname);
+		die("not a valid object name: '%s'", commitname);
 
 	derived = lookup_commit_reference(the_repository, &oid);
 


### PR DESCRIPTION
Standardize error messages in builtin/merge-base.c, builtin/ls-remote.c,
and builtin/ls-tree.c to follow Git's coding guidelines: begin messages
with a lowercase letter and remove trailing periods.

This addresses https://github.com/gitgitgadget/git/issues/635

Signed-off-by: mdferdousalam <mdferdousalam1989@yahoo.com>