### PR TITLE
t0050: use explicit branch name and verify checkout result

### DIFF
--- a/t/t0050-filesystem.sh
+++ b/t/t0050-filesystem.sh
@@ -118,7 +118,7 @@ $test_unicode 'merge (silent unicode normalization)' '
 '
 
 test_expect_success CASE_INSENSITIVE_FS 'checkout with no pathspec and a case insensitive fs' '
-	git init repo &&
+	git init -b main repo &&
 	(
 		cd repo &&
 
@@ -133,7 +133,8 @@ test_expect_success CASE_INSENSITIVE_FS 'checkout with no pathspec and a case in
 		git add gitweb &&
 		git commit -m "add gitweb/subdir/file" &&
 
-		git checkout main
+		git checkout main &&
+		test_path_is_file Gitweb
 	)
 '
 


### PR DESCRIPTION
The test 'checkout with no pathspec and a case insensitive fs' in
t0050 relies on the script-wide GIT_TEST_DEFAULT_INITIAL_BRANCH_NAME
to set the initial branch to 'main'.  Use 'git init -b main' instead,
so that the test is self-contained.  Also add a test_path_is_file
check to verify the checkout result.

Changes since v1:
- Kept the test in t0050 instead of moving it to t2018 (Elijah Newren)
- Kept the CASE_INSENSITIVE_FS prereq which is critical to the
  original bug (Elijah Newren)
- Used 'git init -b main' for explicit branch name instead of
  relying on GIT_TEST_DEFAULT_INITIAL_BRANCH_NAME (Junio C Hamano)
- Fixed Signed-off-by to use full name (Elijah Newren)

cc: Elijah Newren <newren@gmail.com>