### PR TITLE
safe.bareRepository: default to "explicit" with WITH_BREAKING_CHANGES

### DIFF
--- a/Documentation/BreakingChanges.adoc
+++ b/Documentation/BreakingChanges.adoc
@@ -216,6 +216,30 @@ would be significant, we may decide to defer this change to a subsequent minor
 release. This evaluation will also take into account our own experience with
 how painful it is to keep Rust an optional component.
 
+* The default value of `safe.bareRepository` will change from `all` to
+  `explicit`. It is all too easy for an attacker to trick a user into cloning a
+  repository that contains an embedded bare repository with malicious hooks
+  configured. If the user enters that subdirectory and runs any Git command, Git
+  discovers the bare repository and the hooks fire. The user does not even need
+  to run a Git command explicitly: many shell prompts run `git status` in the
+  background to display branch and dirty state information, and `git status` in
+  turn may invoke the fsmonitor hook if so configured, making the user
+  vulnerable the moment they `cd` into the directory. The `safe.bareRepository`
+  configuration variable was introduced in 8959555cee (setup_git_directory():
+  add an owner check for the top-level directory, 2022-03-02) with a default of
+  `all` to preserve backwards compatibility.
++
+Changing the default to `explicit` means that Git will refuse to work with bare
+repositories that are discovered implicitly by walking up the directory tree.
+Bare repositories specified explicitly via the `--git-dir` command-line option
+or the `GIT_DIR` environment variable continue to work regardless of this
+setting. Repositories that look like a `.git` directory, a worktree, or a
+submodule directory are also unaffected.
++
+Users who rely on implicit discovery of bare repositories can restore the
+previous behavior by setting `safe.bareRepository=all` in their global or
+system configuration.
+
 === Removals
 
 * Support for grafting commits has long been superseded by git-replace(1).

--- a/Documentation/config/safe.adoc
+++ b/Documentation/config/safe.adoc
@@ -2,16 +2,22 @@ safe.bareRepository::
 	Specifies which bare repositories Git will work with. The currently
 	supported values are:
 +
-* `all`: Git works with all bare repositories. This is the default.
+* `all`: Git works with all bare repositories. This is the default in
+  Git 2.x.
 * `explicit`: Git only works with bare repositories specified via
   the top-level `--git-dir` command-line option, or the `GIT_DIR`
-  environment variable (see linkgit:git[1]).
+  environment variable (see linkgit:git[1]). This will be the default
+  in Git 3.0.
 +
 If you do not use bare repositories in your workflow, then it may be
 beneficial to set `safe.bareRepository` to `explicit` in your global
 config. This will protect you from attacks that involve cloning a
 repository that contains a bare repository and running a Git command
 within that directory.
++
+If you use bare repositories regularly and want to preserve the current
+behavior after upgrading to Git 3.0, set `safe.bareRepository` to `all`
+in your global or system config.
 +
 This config setting is only respected in protected configuration (see
 <<SCOPES>>). This prevents untrusted repositories from tampering with

--- a/contrib/subtree/t/t7900-subtree.sh
+++ b/contrib/subtree/t/t7900-subtree.sh
@@ -1005,7 +1005,7 @@ test_expect_success 'push sub dir/ with --rejoin from scratch' '
 		git init --bare "sub proj.git" &&
 		git subtree push --prefix="sub dir" --rejoin ./"sub proj.git" from-mainline &&
 		test "$(last_commit_subject)" = "Split '\''sub dir/'\'' into commit '\''$split_hash'\''" &&
-		test "$split_hash" = "$(git -C "sub proj.git" rev-parse --verify refs/heads/from-mainline)"
+		test "$split_hash" = "$(git --git-dir="sub proj.git" rev-parse --verify refs/heads/from-mainline)"
 	)
 '
 

--- a/git-p4.py
+++ b/git-p4.py
@@ -4360,6 +4360,7 @@ class P4Clone(P4Sync):
         init_cmd = ["git", "init"]
         if self.cloneBare:
             init_cmd.append("--bare")
+            os.environ["GIT_DIR"] = os.getcwd()
         retcode = subprocess.call(init_cmd)
         if retcode:
             raise subprocess.CalledProcessError(retcode, init_cmd)

--- a/setup.c
+++ b/setup.c
@@ -1485,7 +1485,11 @@ static int allowed_bare_repo_cb(const char *key, const char *value,
 
 static enum allowed_bare_repo get_allowed_bare_repo(void)
 {
+#ifdef WITH_BREAKING_CHANGES
+	enum allowed_bare_repo result = ALLOWED_BARE_REPO_EXPLICIT;
+#else
 	enum allowed_bare_repo result = ALLOWED_BARE_REPO_ALL;
+#endif
 	git_protected_config(allowed_bare_repo_cb, &result);
 	return result;
 }

--- a/t/annotate-tests.sh
+++ b/t/annotate-tests.sh
@@ -86,7 +86,7 @@ test_expect_success 'blame with --contents' '
 test_expect_success 'blame with --contents in a bare repo' '
 	git clone --bare . bare-contents.git &&
 	(
-		cd bare-contents.git &&
+		cd bare-contents.git && GIT_DIR=. && export GIT_DIR &&
 		echo "1A quick brown fox jumps over the" >contents &&
 		check_count --contents=contents A 1
 	)
@@ -101,7 +101,7 @@ test_expect_success 'blame with --contents changed' '
 test_expect_success 'blame in a bare repo without starting commit' '
 	git clone --bare . bare.git &&
 	(
-		cd bare.git &&
+		cd bare.git && GIT_DIR=. && export GIT_DIR &&
 		check_count A 2
 	)
 '

--- a/t/helper/test-tool.c
+++ b/t/helper/test-tool.c
@@ -3,9 +3,10 @@
 #include "test-tool-utils.h"
 #include "trace2.h"
 #include "parse-options.h"
+#include "environment.h"
 
 static const char * const test_tool_usage[] = {
-	"test-tool [-C <directory>] <command [<arguments>...]]",
+	"test-tool [-C <directory>] [--git-dir=<path>] <command [<arguments>...]]",
 	NULL
 };
 
@@ -107,9 +108,12 @@ static NORETURN void die_usage(void)
 int cmd_main(int argc, const char **argv)
 {
 	const char *working_directory = NULL;
+	const char *git_dir = NULL;
 	struct option options[] = {
 		OPT_STRING('C', NULL, &working_directory, "directory",
 			   "change the working directory"),
+		OPT_STRING(0, "git-dir", &git_dir, "path",
+			   "set the path to the repository"),
 		OPT_END()
 	};
 
@@ -123,6 +127,8 @@ int cmd_main(int argc, const char **argv)
 
 	if (working_directory && chdir(working_directory) < 0)
 		die("Could not cd to '%s'", working_directory);
+	if (git_dir)
+		setenv(GIT_DIR_ENVIRONMENT, git_dir, 1);
 
 	for (size_t i = 0; i < ARRAY_SIZE(cmds); i++) {
 		if (!strcmp(cmds[i].name, argv[1])) {

--- a/t/lib-bitmap.sh
+++ b/t/lib-bitmap.sh
@@ -207,7 +207,7 @@ basic_bitmap_tests () {
 		rm -fr partial-clone.git &&
 		git clone --no-local --bare --filter=blob:none . partial-clone.git &&
 		(
-			cd partial-clone.git &&
+			cd partial-clone.git && GIT_DIR=. && export GIT_DIR &&
 			pack=$(echo objects/pack/*.pack) &&
 			git verify-pack -v "$pack" >have &&
 			awk "/blob/ { print \$1 }" <have >blobs &&

--- a/t/lib-commit-graph.sh
+++ b/t/lib-commit-graph.sh
@@ -22,16 +22,28 @@ graph_git_two_modes() {
 # NOTE: it is a bug to call this function with <directory> containing
 # any characters in $IFS.
 graph_git_behavior() {
+	BARE=
+	if test "$1" = "--bare"
+	then
+		BARE=t
+		shift
+	fi
 	MSG=$1
 	DIR=$2
 	BRANCH=$3
 	COMPARE=$4
 	test_expect_success "check normal git operations: $MSG" '
-		graph_git_two_modes "${DIR:+-C $DIR} log --oneline $BRANCH" &&
-		graph_git_two_modes "${DIR:+-C $DIR} log --topo-order $BRANCH" &&
-		graph_git_two_modes "${DIR:+-C $DIR} log --graph $COMPARE..$BRANCH" &&
-		graph_git_two_modes "${DIR:+-C $DIR} branch -vv" &&
-		graph_git_two_modes "${DIR:+-C $DIR} merge-base -a $BRANCH $COMPARE"
+		if test -n "$BARE"
+		then
+			DIR_ARGS="${DIR:+--git-dir=$DIR}"
+		else
+			DIR_ARGS="${DIR:+-C $DIR}"
+		fi &&
+		graph_git_two_modes "$DIR_ARGS log --oneline $BRANCH" &&
+		graph_git_two_modes "$DIR_ARGS log --topo-order $BRANCH" &&
+		graph_git_two_modes "$DIR_ARGS log --graph $COMPARE..$BRANCH" &&
+		graph_git_two_modes "$DIR_ARGS branch -vv" &&
+		graph_git_two_modes "$DIR_ARGS merge-base -a $BRANCH $COMPARE"
 	'
 }
 
@@ -39,6 +51,12 @@ graph_read_expect() {
 	OPTIONAL=""
 	NUM_CHUNKS=3
 	DIR="."
+	BARE=
+	if test "$1" = "--bare"
+	then
+		BARE=t
+		shift
+	fi
 	if test "$1" = -C
 	then
 		shift
@@ -68,6 +86,10 @@ graph_read_expect() {
 	EOF
 	(
 		cd "$DIR" &&
+		if test -n "$BARE"
+		then
+			GIT_DIR=. && export GIT_DIR
+		fi &&
 		test-tool read-graph >output &&
 		test_cmp expect output
 	)

--- a/t/lib-diff-alternative.sh
+++ b/t/lib-diff-alternative.sh
@@ -131,14 +131,14 @@ EOF
 	'
 
 	test_expect_success "diff from attributes with bare repo with source" '
-		git -C bare.git --attr-source=branchA -c diff.driver.algorithm=myers \
+		git --git-dir=bare.git --attr-source=branchA -c diff.driver.algorithm=myers \
 			-c diff.driverA.algorithm=$STRATEGY \
 			diff HEAD:file1 HEAD:file2 >output &&
 		test_cmp expect output
 	'
 
 	test_expect_success "diff from attributes with bare repo with invalid source" '
-		test_must_fail git -C bare.git --attr-source=invalid-branch diff \
+		test_must_fail git --git-dir=bare.git --attr-source=invalid-branch diff \
 			HEAD:file1 HEAD:file2
 	'
 

--- a/t/lib-httpd.sh
+++ b/t/lib-httpd.sh
@@ -259,7 +259,7 @@ test_http_push_nonff () {
 
 	test_expect_success 'non-fast-forward push fails' '
 		cd "$REMOTE_REPO" &&
-		HEAD=$(git rev-parse --verify HEAD) &&
+		HEAD=$(git --git-dir=. rev-parse --verify HEAD) &&
 
 		cd "$LOCAL_REPO" &&
 		git checkout $BRANCH &&
@@ -270,7 +270,7 @@ test_http_push_nonff () {
 		(
 			cd "$REMOTE_REPO" &&
 			echo "$HEAD" >expect &&
-			git rev-parse --verify HEAD >actual &&
+			git --git-dir=. rev-parse --verify HEAD >actual &&
 			test_cmp expect actual
 		)
 	'
@@ -284,18 +284,16 @@ test_http_push_nonff () {
 	'
 
 	test_expect_${EXPECT_CAS_RESULT} 'force with lease aka cas' '
-		HEAD=$(	cd "$REMOTE_REPO" && git rev-parse --verify HEAD ) &&
+		HEAD=$(git --git-dir="$REMOTE_REPO" rev-parse --verify HEAD) &&
 		test_when_finished '\''
-			(cd "$REMOTE_REPO" && git update-ref HEAD "$HEAD")
+			git --git-dir="$REMOTE_REPO" update-ref HEAD "$HEAD"
 		'\'' &&
 		(
 			cd "$LOCAL_REPO" &&
 			git push -v --force-with-lease=$BRANCH:$HEAD origin
 		) &&
 		git rev-parse --verify "$BRANCH" >expect &&
-		(
-			cd "$REMOTE_REPO" && git rev-parse --verify HEAD
-		) >actual &&
+		git --git-dir="$REMOTE_REPO" rev-parse --verify HEAD >actual &&
 		test_cmp expect actual
 	'
 }

--- a/t/lib-proto-disable.sh
+++ b/t/lib-proto-disable.sh
@@ -17,7 +17,7 @@ test_allow_var () {
 
 	test_expect_success "fetch $desc (enabled)" '
 		(
-			cd tmp.git &&
+			cd tmp.git && GIT_DIR=. && export GIT_DIR &&
 			GIT_ALLOW_PROTOCOL=$proto &&
 			export GIT_ALLOW_PROTOCOL &&
 			git fetch
@@ -26,7 +26,7 @@ test_allow_var () {
 
 	test_expect_success "push $desc (enabled)" '
 		(
-			cd tmp.git &&
+			cd tmp.git && GIT_DIR=. && export GIT_DIR &&
 			GIT_ALLOW_PROTOCOL=$proto &&
 			export GIT_ALLOW_PROTOCOL &&
 			git push origin HEAD:pushed
@@ -35,7 +35,7 @@ test_allow_var () {
 
 	test_expect_success "push $desc (disabled)" '
 		(
-			cd tmp.git &&
+			cd tmp.git && GIT_DIR=. && export GIT_DIR &&
 			GIT_ALLOW_PROTOCOL=none &&
 			export GIT_ALLOW_PROTOCOL &&
 			test_must_fail git push origin HEAD:pushed
@@ -44,7 +44,7 @@ test_allow_var () {
 
 	test_expect_success "fetch $desc (disabled)" '
 		(
-			cd tmp.git &&
+			cd tmp.git && GIT_DIR=. && export GIT_DIR &&
 			GIT_ALLOW_PROTOCOL=none &&
 			export GIT_ALLOW_PROTOCOL &&
 			test_must_fail git fetch
@@ -119,7 +119,7 @@ test_config () {
 
 	test_expect_success "push $desc (disabled)" '
 		(
-			cd tmp.git &&
+			cd tmp.git && GIT_DIR=. && export GIT_DIR &&
 			GIT_PROTOCOL_FROM_USER=0 &&
 			export GIT_PROTOCOL_FROM_USER &&
 			test_must_fail git -c protocol.$proto.allow=user push origin HEAD:pushed
@@ -128,7 +128,7 @@ test_config () {
 
 	test_expect_success "fetch $desc (disabled)" '
 		(
-			cd tmp.git &&
+			cd tmp.git && GIT_DIR=. && export GIT_DIR &&
 			GIT_PROTOCOL_FROM_USER=0 &&
 			export GIT_PROTOCOL_FROM_USER &&
 			test_must_fail git -c protocol.$proto.allow=user fetch

--- a/t/lib-proto-disable.sh
+++ b/t/lib-proto-disable.sh
@@ -83,19 +83,19 @@ test_config () {
 	'
 
 	test_expect_success "fetch $desc (enabled)" '
-		git -C tmp.git -c protocol.$proto.allow=always fetch
+		git --git-dir=tmp.git -c protocol.$proto.allow=always fetch
 	'
 
 	test_expect_success "push $desc (enabled)" '
-		git -C tmp.git -c protocol.$proto.allow=always  push origin HEAD:pushed
+		git --git-dir=tmp.git -c protocol.$proto.allow=always  push origin HEAD:pushed
 	'
 
 	test_expect_success "push $desc (disabled)" '
-		test_must_fail git -C tmp.git -c protocol.$proto.allow=never push origin HEAD:pushed
+		test_must_fail git --git-dir=tmp.git -c protocol.$proto.allow=never push origin HEAD:pushed
 	'
 
 	test_expect_success "fetch $desc (disabled)" '
-		test_must_fail git -C tmp.git -c protocol.$proto.allow=never fetch
+		test_must_fail git --git-dir=tmp.git -c protocol.$proto.allow=never fetch
 	'
 
 	test_expect_success "clone $desc (disabled)" '
@@ -110,11 +110,11 @@ test_config () {
 	'
 
 	test_expect_success "fetch $desc (enabled)" '
-		git -C tmp.git -c protocol.$proto.allow=user fetch
+		git --git-dir=tmp.git -c protocol.$proto.allow=user fetch
 	'
 
 	test_expect_success "push $desc (enabled)" '
-		git -C tmp.git -c protocol.$proto.allow=user push origin HEAD:pushed
+		git --git-dir=tmp.git -c protocol.$proto.allow=user push origin HEAD:pushed
 	'
 
 	test_expect_success "push $desc (disabled)" '
@@ -153,22 +153,22 @@ test_config () {
 
 	test_expect_success "fetch $desc (enabled)" '
 		test_config_global protocol.allow always &&
-		git -C tmp.git fetch
+		git --git-dir=tmp.git fetch
 	'
 
 	test_expect_success "push $desc (enabled)" '
 		test_config_global protocol.allow always &&
-		git -C tmp.git push origin HEAD:pushed
+		git --git-dir=tmp.git push origin HEAD:pushed
 	'
 
 	test_expect_success "push $desc (disabled)" '
 		test_config_global protocol.allow never &&
-		test_must_fail git -C tmp.git push origin HEAD:pushed
+		test_must_fail git --git-dir=tmp.git push origin HEAD:pushed
 	'
 
 	test_expect_success "fetch $desc (disabled)" '
 		test_config_global protocol.allow never &&
-		test_must_fail git -C tmp.git fetch
+		test_must_fail git --git-dir=tmp.git fetch
 	'
 
 	test_expect_success "clone $desc (disabled)" '

--- a/t/t0001-init.sh
+++ b/t/t0001-init.sh
@@ -20,8 +20,8 @@ check_config () {
 		return 1
 	fi
 
-	bare=$(cd "$1" && git config --bool core.bare)
-	worktree=$(cd "$1" && git config core.worktree) ||
+	bare=$(git --git-dir="$1" config --bool core.bare)
+	worktree=$(git --git-dir="$1" config core.worktree) ||
 	worktree=unset
 
 	test "$bare" = "$2" && test "$worktree" = "$3" || {

--- a/t/t0001-init.sh
+++ b/t/t0001-init.sh
@@ -347,7 +347,7 @@ test_expect_success 'bare & --separate-git-dir incompatible within worktree' '
 	test_when_finished "rm -rf bare.git linkwt seprepo" &&
 	test_commit gumby &&
 	git clone --bare . bare.git &&
-	git -C bare.git worktree add --detach ../linkwt &&
+	git --git-dir=bare.git worktree add --detach linkwt &&
 	test_must_fail git -C linkwt init --separate-git-dir seprepo 2>err &&
 	test_grep "incompatible" err
 '

--- a/t/t0001-init.sh
+++ b/t/t0001-init.sh
@@ -77,6 +77,7 @@ test_expect_success 'plain nested through aliased command' '
 '
 
 test_expect_success 'plain nested in bare through aliased command' '
+	test_config_global safe.bareRepository all &&
 	(
 		git init --bare bare-ancestor-aliased.git &&
 		cd bare-ancestor-aliased.git &&

--- a/t/t0003-attributes.sh
+++ b/t/t0003-attributes.sh
@@ -401,11 +401,11 @@ test_expect_success 'bare repo no longer defaults to reading .gitattributes from
 	git clone --bare test bare_with_gitattribute &&
 
 	echo "f/path: test: unspecified" >expect &&
-	git -C bare_with_gitattribute check-attr test -- f/path >actual &&
+	git --git-dir=bare_with_gitattribute check-attr test -- f/path >actual &&
 	test_cmp expect actual &&
 
 	echo "f/path: test: val" >expect &&
-	git -C bare_with_gitattribute -c attr.tree=HEAD \
+	git --git-dir=bare_with_gitattribute -c attr.tree=HEAD \
 		check-attr test -- f/path >actual &&
 	test_cmp expect actual
 '

--- a/t/t0003-attributes.sh
+++ b/t/t0003-attributes.sh
@@ -346,17 +346,14 @@ test_expect_success 'setup bare' '
 
 test_expect_success 'bare repository: check that .gitattribute is ignored' '
 	(
-		cd bare.git &&
-		(
-			echo "f	test=f" &&
-			echo "a/i test=a/i"
-		) >.gitattributes &&
-		attr_check f unspecified &&
-		attr_check a/f unspecified &&
-		attr_check a/c/f unspecified &&
-		attr_check a/i unspecified &&
-		attr_check subdir/a/i unspecified
-	)
+		echo "f	test=f" &&
+		echo "a/i test=a/i"
+	) >bare.git/.gitattributes &&
+	attr_check f unspecified --git-dir=bare.git &&
+	attr_check a/f unspecified --git-dir=bare.git &&
+	attr_check a/c/f unspecified --git-dir=bare.git &&
+	attr_check a/i unspecified --git-dir=bare.git &&
+	attr_check subdir/a/i unspecified --git-dir=bare.git
 '
 
 bad_attr_source_err="fatal: bad --attr-source or GIT_ATTR_SOURCE"
@@ -449,41 +446,32 @@ test_expect_success 'diff without repository with attr source' '
 '
 
 test_expect_success 'bare repository: with --source' '
-	(
-		cd bare.git &&
-		attr_check_source foo/bar/f f tag-1 &&
-		attr_check_source foo/bar/a/i n tag-1 &&
-		attr_check_source foo/bar/f unspecified tag-2 &&
-		attr_check_source foo/bar/a/i m tag-2 &&
-		attr_check_source foo/bar/g g tag-2 &&
-		attr_check_source foo/bar/g unspecified tag-1
-	)
+	attr_check_source foo/bar/f f tag-1 --git-dir=bare.git &&
+	attr_check_source foo/bar/a/i n tag-1 --git-dir=bare.git &&
+	attr_check_source foo/bar/f unspecified tag-2 --git-dir=bare.git &&
+	attr_check_source foo/bar/a/i m tag-2 --git-dir=bare.git &&
+	attr_check_source foo/bar/g g tag-2 --git-dir=bare.git &&
+	attr_check_source foo/bar/g unspecified tag-1 --git-dir=bare.git
 '
 
 test_expect_success 'bare repository: check that --cached honors index' '
-	(
-		cd bare.git &&
-		GIT_INDEX_FILE=../.git/index \
-		git check-attr --cached --stdin --all <../stdin-all |
-		sort >actual &&
-		test_cmp ../specified-all actual
-	)
+	GIT_INDEX_FILE=.git/index \
+	git --git-dir=bare.git check-attr --cached --stdin --all <stdin-all |
+	sort >actual &&
+	test_cmp specified-all actual
 '
 
 test_expect_success 'bare repository: test info/attributes' '
+	mkdir -p bare.git/info &&
 	(
-		cd bare.git &&
-		mkdir info &&
-		(
-			echo "f	test=f" &&
-			echo "a/i test=a/i"
-		) >info/attributes &&
-		attr_check f f &&
-		attr_check a/f f &&
-		attr_check a/c/f f &&
-		attr_check a/i a/i &&
-		attr_check subdir/a/i unspecified
-	)
+		echo "f	test=f" &&
+		echo "a/i test=a/i"
+	) >bare.git/info/attributes &&
+	attr_check f f --git-dir=bare.git &&
+	attr_check a/f f --git-dir=bare.git &&
+	attr_check a/c/f f --git-dir=bare.git &&
+	attr_check a/i a/i --git-dir=bare.git &&
+	attr_check subdir/a/i unspecified --git-dir=bare.git
 '
 
 test_expect_success 'binary macro expanded by -a' '

--- a/t/t0035-safe-bare-repository.sh
+++ b/t/t0035-safe-bare-repository.sh
@@ -44,9 +44,14 @@ test_expect_success 'setup an embedded bare repo, secondary worktree and submodu
 	test_path_is_dir outer-repo/.git/modules/subn
 '
 
-test_expect_success 'safe.bareRepository unset' '
+test_expect_success !WITH_BREAKING_CHANGES 'safe.bareRepository unset' '
 	test_unconfig --global safe.bareRepository &&
 	expect_accepted_implicit -C outer-repo/bare-repo
+'
+
+test_expect_success WITH_BREAKING_CHANGES 'safe.bareRepository unset (defaults to explicit)' '
+	test_unconfig --global safe.bareRepository &&
+	expect_rejected -C outer-repo/bare-repo
 '
 
 test_expect_success 'safe.bareRepository=all' '
@@ -63,7 +68,8 @@ test_expect_success 'safe.bareRepository in the repository' '
 	# safe.bareRepository must not be "explicit", otherwise
 	# git config fails with "fatal: not in a git directory" (like
 	# safe.directory)
-	test_config -C outer-repo/bare-repo safe.bareRepository all &&
+	test_when_finished "git config --file outer-repo/bare-repo/config --unset safe.bareRepository" &&
+	git config --file outer-repo/bare-repo/config safe.bareRepository all &&
 	test_config_global safe.bareRepository explicit &&
 	expect_rejected -C outer-repo/bare-repo
 '

--- a/t/t0056-git-C.sh
+++ b/t/t0056-git-C.sh
@@ -57,11 +57,13 @@ test_expect_success 'Order should not matter: "--git-dir=a.git -C c" is equivale
 test_expect_success 'Effect on --work-tree option: "-C c/a.git --work-tree=../a"  is equivalent to "--work-tree=c/a --git-dir=c/a.git"' '
 	rm c/a/a.txt &&
 	git --git-dir=c/a.git --work-tree=c/a status >expected &&
+	test_config_global safe.bareRepository all &&
 	git -C c/a.git --work-tree=../a status >actual &&
 	test_cmp expected actual
 '
 
 test_expect_success 'Order should not matter: "--work-tree=../a -C c/a.git" is equivalent to "-C c/a.git --work-tree=../a"' '
+	test_config_global safe.bareRepository all &&
 	git -C c/a.git --work-tree=../a status >expected &&
 	git --work-tree=../a -C c/a.git status >actual &&
 	test_cmp expected actual

--- a/t/t0410-partial-clone.sh
+++ b/t/t0410-partial-clone.sh
@@ -646,10 +646,10 @@ test_expect_success 'exact rename does not need to fetch the blob lazily' '
 	test_config -C repo uploadpack.allowanysha1inwant 1 &&
 
 	git clone --filter=blob:none --bare "file://$(pwd)/repo" partial.git &&
-	git -C partial.git rev-list --objects --missing=print HEAD >out &&
+	git --git-dir=partial.git rev-list --objects --missing=print HEAD >out &&
 	grep "[?]$FILE_HASH" out &&
-	git -C partial.git log --follow -- new-file.txt &&
-	git -C partial.git rev-list --objects --missing=print HEAD >out &&
+	git --git-dir=partial.git log --follow -- new-file.txt &&
+	git --git-dir=partial.git rev-list --objects --missing=print HEAD >out &&
 	grep "[?]$FILE_HASH" out
 '
 
@@ -664,22 +664,22 @@ test_expect_success 'lazy-fetch when accessing object not in the_repository' '
 	FILE_HASH=$(git -C full rev-parse HEAD:file.txt) &&
 
 	# Sanity check that the file is missing
-	git -C partial.git rev-list --objects --missing=print HEAD >out &&
+	git --git-dir=partial.git rev-list --objects --missing=print HEAD >out &&
 	grep "[?]$FILE_HASH" out &&
 
 	# The no-lazy-fetch mechanism prevents Git from fetching
 	test_must_fail env GIT_NO_LAZY_FETCH=1 \
-		git -C partial.git cat-file -e "$FILE_HASH" &&
+		git --git-dir=partial.git cat-file -e "$FILE_HASH" &&
 
 	# The same with command line option to "git"
-	test_must_fail git --no-lazy-fetch -C partial.git cat-file -e "$FILE_HASH" &&
+	test_must_fail git --no-lazy-fetch --git-dir=partial.git cat-file -e "$FILE_HASH" &&
 
 	# The same, forcing a subprocess via an alias
-	test_must_fail git --no-lazy-fetch -C partial.git \
+	test_must_fail git --no-lazy-fetch --git-dir=partial.git \
 		-c alias.foo="!git cat-file" foo -e "$FILE_HASH" &&
 
 	# Sanity check that the file is still missing
-	git -C partial.git rev-list --objects --missing=print HEAD >out &&
+	git --git-dir=partial.git rev-list --objects --missing=print HEAD >out &&
 	grep "[?]$FILE_HASH" out &&
 
 	git -C full cat-file -s "$FILE_HASH" >expect &&
@@ -687,7 +687,7 @@ test_expect_success 'lazy-fetch when accessing object not in the_repository' '
 	test_cmp expect actual &&
 
 	# Sanity check that the file is now present
-	git -C partial.git rev-list --objects --missing=print HEAD >out &&
+	git --git-dir=partial.git rev-list --objects --missing=print HEAD >out &&
 	! grep "[?]$FILE_HASH" out
 '
 

--- a/t/t0600-reffiles-backend.sh
+++ b/t/t0600-reffiles-backend.sh
@@ -428,14 +428,14 @@ test_expect_success SYMLINKS 'git branch -m with symlinked .git/refs' '
 	ln -s ../.git/objects subdir/objects &&
 	ln -s ../.git/packed-refs subdir/packed-refs &&
 
-	git -C subdir rev-parse --absolute-git-dir >subdir.dir &&
+	git --git-dir=subdir rev-parse --absolute-git-dir >subdir.dir &&
 	git rev-parse --absolute-git-dir >our.dir &&
 	! test_cmp subdir.dir our.dir &&
 
-	git -C subdir log &&
-	git -C subdir branch rename-src &&
+	git --git-dir=subdir log &&
+	git --git-dir=subdir branch rename-src &&
 	git rev-parse rename-src >expect &&
-	git -C subdir branch -m rename-src rename-dest &&
+	git --git-dir=subdir branch -m rename-src rename-dest &&
 	git rev-parse rename-dest >actual &&
 	test_cmp expect actual &&
 	git branch -D rename-dest

--- a/t/t1006-cat-file.sh
+++ b/t/t1006-cat-file.sh
@@ -804,7 +804,7 @@ test_expect_success 'clean up broken objects' '
 test_expect_success 'cat-file -t and -s on corrupt loose object' '
 	git init --bare corrupt-loose.git &&
 	(
-		cd corrupt-loose.git &&
+		cd corrupt-loose.git && GIT_DIR=. && export GIT_DIR &&
 
 		# Setup and create the empty blob and its path
 		empty_path=$(git rev-parse --git-path objects/$(test_oid_to_path "$EMPTY_BLOB")) &&

--- a/t/t1020-subdirectory.sh
+++ b/t/t1020-subdirectory.sh
@@ -177,10 +177,7 @@ test_expect_success 'no file/rev ambiguity check inside a bare repo (explicit GI
 test_expect_success 'no file/rev ambiguity check inside a bare repo' '
 	test_when_finished "rm -fr foo.git" &&
 	git clone -s --bare .git foo.git &&
-	(
-		cd foo.git &&
-		git show -s HEAD
-	)
+	git --git-dir=foo.git show -s HEAD
 '
 
 test_expect_success SYMLINKS 'detection should not be fooled by a symlink' '

--- a/t/t1022-read-tree-partial-clone.sh
+++ b/t/t1022-read-tree-partial-clone.sh
@@ -18,7 +18,7 @@ test_expect_success 'read-tree in partial clone prefetches in one batch' '
 	git -C server config uploadpack.allowfilter 1 &&
 	git -C server config uploadpack.allowanysha1inwant 1 &&
 	git clone --bare --filter=blob:none "file://$(pwd)/server" client &&
-	GIT_TRACE_PACKET="$(pwd)/trace" git -C client read-tree $TREE $TREE &&
+	GIT_TRACE_PACKET="$(pwd)/trace" git --git-dir=client read-tree $TREE $TREE &&
 
 	# "done" marks the end of negotiation (once per fetch). Expect that
 	# only one fetch occurs.

--- a/t/t1050-large.sh
+++ b/t/t1050-large.sh
@@ -28,8 +28,8 @@ test_expect_success 'enter "large" codepath, with small core.bigFileThreshold' '
 	test_when_finished "rm -rf repo" &&
 
 	git init --bare repo &&
-	echo large | git -C repo hash-object -w --stdin &&
-	git -C repo -c core.bigfilethreshold=4 fsck
+	echo large | git --git-dir=repo hash-object -w --stdin &&
+	git --git-dir=repo -c core.bigfilethreshold=4 fsck
 '
 
 # add a large file with different settings

--- a/t/t1091-sparse-checkout-builtin.sh
+++ b/t/t1091-sparse-checkout-builtin.sh
@@ -991,8 +991,8 @@ test_expect_success 'check-rules cone mode' '
 	EOF
 
 	git -C bare ls-tree -r --name-only HEAD >all-files &&
-	git -C bare sparse-checkout check-rules --cone \
-		--rules-file ../rules >check-rules-file <all-files &&
+	git --git-dir=bare sparse-checkout check-rules --cone \
+		--rules-file rules >check-rules-file <all-files &&
 
 	git -C repo sparse-checkout set --cone --stdin <rules&&
 	git -C repo ls-files -t >out &&
@@ -1013,7 +1013,7 @@ test_expect_success 'check-rules non-cone mode' '
 	EOF
 
 	git -C bare ls-tree -r --name-only HEAD >all-files &&
-	git -C bare sparse-checkout check-rules --no-cone --rules-file ../rules\
+	git --git-dir=bare sparse-checkout check-rules --no-cone --rules-file rules\
 		>check-rules-file <all-files &&
 
 	git -C repo sparse-checkout set --no-cone --stdin <rules &&
@@ -1051,8 +1051,8 @@ test_expect_success 'check-rules cone mode is default' '
 	git -C repo sparse-checkout check-rules \
 		--rules-file ../rules >actual <all-files &&
 
-	git -C bare sparse-checkout check-rules \
-		--rules-file ../rules >actual-bare <all-files &&
+	git --git-dir=bare sparse-checkout check-rules \
+		--rules-file rules >actual-bare <all-files &&
 
 	test_cmp expect actual &&
 	test_cmp expect actual-bare

--- a/t/t1091-sparse-checkout-builtin.sh
+++ b/t/t1091-sparse-checkout-builtin.sh
@@ -951,32 +951,32 @@ test_expect_success 'setup bare repo' '
 	git clone --bare "file://$(pwd)/repo" bare
 '
 test_expect_success 'list fails outside work tree' '
-	test_must_fail git -C bare sparse-checkout list 2>err &&
+	test_must_fail git --git-dir=bare sparse-checkout list 2>err &&
 	test_grep "this operation must be run in a work tree" err
 '
 
 test_expect_success 'add fails outside work tree' '
-	test_must_fail git -C bare sparse-checkout add deeper 2>err &&
+	test_must_fail git --git-dir=bare sparse-checkout add deeper 2>err &&
 	test_grep "this operation must be run in a work tree" err
 '
 
 test_expect_success 'set fails outside work tree' '
-	test_must_fail git -C bare sparse-checkout set deeper 2>err &&
+	test_must_fail git --git-dir=bare sparse-checkout set deeper 2>err &&
 	test_grep "this operation must be run in a work tree" err
 '
 
 test_expect_success 'init fails outside work tree' '
-	test_must_fail git -C bare sparse-checkout init 2>err &&
+	test_must_fail git --git-dir=bare sparse-checkout init 2>err &&
 	test_grep "this operation must be run in a work tree" err
 '
 
 test_expect_success 'reapply fails outside work tree' '
-	test_must_fail git -C bare sparse-checkout reapply 2>err &&
+	test_must_fail git --git-dir=bare sparse-checkout reapply 2>err &&
 	test_grep "this operation must be run in a work tree" err
 '
 
 test_expect_success 'disable fails outside work tree' '
-	test_must_fail git -C bare sparse-checkout disable 2>err &&
+	test_must_fail git --git-dir=bare sparse-checkout disable 2>err &&
 	test_grep "this operation must be run in a work tree" err
 '
 
@@ -990,7 +990,7 @@ test_expect_success 'check-rules cone mode' '
 	deep/deeper1/deepest
 	EOF
 
-	git -C bare ls-tree -r --name-only HEAD >all-files &&
+	git --git-dir=bare ls-tree -r --name-only HEAD >all-files &&
 	git --git-dir=bare sparse-checkout check-rules --cone \
 		--rules-file rules >check-rules-file <all-files &&
 
@@ -1012,7 +1012,7 @@ test_expect_success 'check-rules non-cone mode' '
 	deep/deeper1/deepest/a
 	EOF
 
-	git -C bare ls-tree -r --name-only HEAD >all-files &&
+	git --git-dir=bare ls-tree -r --name-only HEAD >all-files &&
 	git --git-dir=bare sparse-checkout check-rules --no-cone --rules-file rules\
 		>check-rules-file <all-files &&
 

--- a/t/t1305-config-include.sh
+++ b/t/t1305-config-include.sh
@@ -350,9 +350,9 @@ test_expect_success 'conditional include, onbranch, implicit /** for /' '
 
 test_expect_success 'include cycles are detected' '
 	git init --bare cycle &&
-	git -C cycle config include.path cycle &&
+	git --git-dir=cycle config include.path cycle &&
 	git config -f cycle/cycle include.path config &&
-	test_must_fail git -C cycle config --get-all test.value 2>stderr &&
+	test_must_fail git --git-dir=cycle config --get-all test.value 2>stderr &&
 	grep "exceeded maximum include depth" stderr
 '
 

--- a/t/t1400-update-ref.sh
+++ b/t/t1400-update-ref.sh
@@ -124,22 +124,22 @@ test_expect_success 'update-ref creates reflogs with --create-reflog' '
 '
 
 test_expect_success 'creates no reflog in bare repository' '
-	git -C $bare update-ref $m $bareA &&
-	git -C $bare rev-parse $bareA >expect &&
-	git -C $bare rev-parse $m >actual &&
+	git --git-dir=$bare update-ref $m $bareA &&
+	git --git-dir=$bare rev-parse $bareA >expect &&
+	git --git-dir=$bare rev-parse $m >actual &&
 	test_cmp expect actual &&
-	test_must_fail git -C $bare reflog exists $m
+	test_must_fail git --git-dir=$bare reflog exists $m
 '
 
 test_expect_success 'core.logAllRefUpdates=true creates reflog in bare repository' '
-	test_when_finished "git -C $bare config --unset core.logAllRefUpdates && \
+	test_when_finished "git --git-dir=$bare config --unset core.logAllRefUpdates && \
 		test-tool ref-store main delete-reflog $m" &&
-	git -C $bare config core.logAllRefUpdates true &&
-	git -C $bare update-ref $m $bareB &&
-	git -C $bare rev-parse $bareB >expect &&
-	git -C $bare rev-parse $m >actual &&
+	git --git-dir=$bare config core.logAllRefUpdates true &&
+	git --git-dir=$bare update-ref $m $bareB &&
+	git --git-dir=$bare rev-parse $bareB >expect &&
+	git --git-dir=$bare rev-parse $m >actual &&
 	test_cmp expect actual &&
-	git -C $bare reflog exists $m
+	git --git-dir=$bare reflog exists $m
 '
 
 test_expect_success 'core.logAllRefUpdates=true does not create reflog by default' '

--- a/t/t1400-update-ref.sh
+++ b/t/t1400-update-ref.sh
@@ -29,10 +29,10 @@ test_expect_success setup '
 	git checkout --orphan main &&
 	create_test_commits "" &&
 	mkdir $bare &&
-	cd $bare &&
+	cd $bare && GIT_DIR=. && export GIT_DIR &&
 	git init --bare -b main &&
 	create_test_commits "bare" &&
-	cd -
+	cd - && sane_unset GIT_DIR
 '
 
 test_expect_success "create $m" '

--- a/t/t1416-ref-transaction-hooks.sh
+++ b/t/t1416-ref-transaction-hooks.sh
@@ -123,11 +123,11 @@ test_expect_success 'interleaving hook calls succeed' '
 
 	git init --bare target-repo.git &&
 
-	test_hook -C target-repo.git reference-transaction <<-\EOF &&
+	test_hook --git-dir target-repo.git reference-transaction <<-\EOF &&
 		echo $0 "$@" >>actual
 	EOF
 
-	test_hook -C target-repo.git update <<-\EOF &&
+	test_hook --git-dir target-repo.git update <<-\EOF &&
 		echo $0 "$@" >>actual
 	EOF
 

--- a/t/t1450-fsck.sh
+++ b/t/t1450-fsck.sh
@@ -53,7 +53,7 @@ remove_object () {
 test_expect_success 'object with hash mismatch' '
 	git init --bare hash-mismatch &&
 	(
-		cd hash-mismatch &&
+		cd hash-mismatch && GIT_DIR=. && export GIT_DIR &&
 
 		oid=$(echo blob | git hash-object -w --stdin) &&
 		oldoid=$oid &&
@@ -75,7 +75,7 @@ test_expect_success 'object with hash mismatch' '
 test_expect_success 'zlib corrupt loose object output ' '
 	git init --bare corrupt-loose-output &&
 	(
-		cd corrupt-loose-output &&
+		cd corrupt-loose-output && GIT_DIR=. && export GIT_DIR &&
 		oid=$(git hash-object -w --stdin --literally </dev/null) &&
 		oidf=objects/$(test_oid_to_path "$oid") &&
 		chmod +w $oidf &&
@@ -1064,7 +1064,7 @@ test_expect_success PERL_TEST_HELPERS 'detect corrupt index file in fsck' '
 test_expect_success 'fsck error and recovery on invalid object type' '
 	git init --bare garbage-type &&
 	(
-		cd garbage-type &&
+		cd garbage-type && GIT_DIR=. && export GIT_DIR &&
 
 		garbage_blob=$(loose_obj objects garbage </dev/null) &&
 

--- a/t/t1460-refs-migrate.sh
+++ b/t/t1460-refs-migrate.sh
@@ -8,24 +8,32 @@ export GIT_TEST_DEFAULT_INITIAL_BRANCH_NAME
 . ./test-lib.sh
 
 print_all_reflog_entries () {
-	repo=$1 &&
-	test-tool -C "$repo" ref-store main for-each-reflog >reflogs &&
+	repo_flag=$1 &&
+	repo=$2 &&
+	test-tool "$repo_flag" "$repo" ref-store main for-each-reflog >reflogs &&
 	while read reflog
 	do
 		echo "REFLOG: $reflog" &&
-		test-tool -C "$repo" ref-store main for-each-reflog-ent "$reflog" ||
+		test-tool "$repo_flag" "$repo" ref-store main for-each-reflog-ent "$reflog" ||
 		return 1
 	done <reflogs
 }
 
 # Migrate the provided repository from one format to the other and
 # verify that the references and logs are migrated over correctly.
-# Usage: test_migration <repo> <format> [<skip_reflog_verify> [<options...>]]
+# Usage: test_migration [--git-dir] <repo> <format> [<skip_reflog_verify> [<options...>]]
+#   --git-dir: treat <repo> as a git directory (for bare repositories).
 #   <repo> is the relative path to the repo to be migrated.
 #   <format> is the ref format to be migrated to.
 #   <skip_reflog_verify> (default: false) whether to skip reflog verification.
 #   <options...> are other options be passed directly to 'git refs migrate'.
 test_migration () {
+	repo_flag=-C &&
+	if test "$1" = "--git-dir"
+	then
+		repo_flag=--git-dir &&
+		shift
+	fi &&
 	repo=$1 &&
 	format=$2 &&
 	shift 2 &&
@@ -35,25 +43,25 @@ test_migration () {
 		skip_reflog_verify=$1
 		shift
 	fi &&
-	git -C "$repo" for-each-ref --include-root-refs \
+	git "$repo_flag" "$repo" for-each-ref --include-root-refs \
 		--format='%(refname) %(objectname) %(symref)' >expect &&
 	if ! $skip_reflog_verify
 	then
-		print_all_reflog_entries "$repo" >expect_logs
+		print_all_reflog_entries "$repo_flag" "$repo" >expect_logs
 	fi &&
 
-	git -C "$repo" refs migrate --ref-format="$format" "$@" &&
+	git "$repo_flag" "$repo" refs migrate --ref-format="$format" "$@" &&
 
-	git -C "$repo" for-each-ref --include-root-refs \
+	git "$repo_flag" "$repo" for-each-ref --include-root-refs \
 		--format='%(refname) %(objectname) %(symref)' >actual &&
 	test_cmp expect actual &&
 	if ! $skip_reflog_verify
 	then
-		print_all_reflog_entries "$repo" >actual_logs &&
+		print_all_reflog_entries "$repo_flag" "$repo" >actual_logs &&
 		test_cmp expect_logs actual_logs
 	fi &&
 
-	git -C "$repo" rev-parse --show-ref-format >actual &&
+	git "$repo_flag" "$repo" rev-parse --show-ref-format >actual &&
 	echo "$format" >expect &&
 	test_cmp expect actual
 }
@@ -144,7 +152,7 @@ do
 			git init --ref-format=$from_format repo &&
 			test_commit -C repo initial &&
 			git clone --ref-format=$from_format --mirror repo repo.git &&
-			test_migration repo.git "$to_format"
+			test_migration --git-dir repo.git "$to_format"
 		'
 
 		test_expect_success "$from_format -> $to_format: dangling symref" '

--- a/t/t1512-rev-parse-disambiguation.sh
+++ b/t/t1512-rev-parse-disambiguation.sh
@@ -39,7 +39,7 @@ test_cmp_failed_rev_parse () {
 test_expect_success 'ambiguous blob output' '
 	git init --bare blob.prefix &&
 	(
-		cd blob.prefix &&
+		cd blob.prefix && GIT_DIR=. && export GIT_DIR &&
 
 		# Both start with "dead..", under both SHA-1 and SHA-256
 		echo brocdnra | git hash-object -w --stdin &&
@@ -65,7 +65,7 @@ test_expect_success 'ambiguous blob output' '
 test_expect_success 'ambiguous loose bad object parsed as OBJ_BAD' '
 	git init --bare blob.bad &&
 	(
-		cd blob.bad &&
+		cd blob.bad && GIT_DIR=. && export GIT_DIR &&
 
 		# Both have the prefix "bad0"
 		echo xyzfaowcoh | loose_obj objects bad &&
@@ -81,7 +81,7 @@ test_expect_success 'ambiguous loose bad object parsed as OBJ_BAD' '
 test_expect_success POSIXPERM 'ambigous zlib corrupt loose blob' '
 	git init --bare blob.corrupt &&
 	(
-		cd blob.corrupt &&
+		cd blob.corrupt && GIT_DIR=. && export GIT_DIR &&
 
 		# Both have the prefix "cafe"
 		echo bnkxmdwz | git hash-object -w --stdin &&

--- a/t/t1512-rev-parse-disambiguation.sh
+++ b/t/t1512-rev-parse-disambiguation.sh
@@ -31,7 +31,7 @@ test_cmp_failed_rev_parse () {
 	rev=$2
 
 	cat >expect &&
-	test_must_fail git -C "$dir" rev-parse "$rev" 2>actual.raw &&
+	test_must_fail git --git-dir="$dir" rev-parse "$rev" 2>actual.raw &&
 	sed "s/\($rev\)[0-9a-f]*/\1.../" <actual.raw >actual &&
 	test_cmp expect actual
 }
@@ -50,7 +50,7 @@ test_expect_success 'ambiguous blob output' '
 		echo 1bbfctrkc | git hash-object -w --stdin
 	) &&
 
-	test_must_fail git -C blob.prefix rev-parse dead &&
+	test_must_fail git --git-dir=blob.prefix rev-parse dead &&
 	test_cmp_failed_rev_parse blob.prefix beef <<-\EOF
 	error: short object ID beef... is ambiguous
 	hint: The candidates are:

--- a/t/t1800-hook.sh
+++ b/t/t1800-hook.sh
@@ -533,9 +533,9 @@ test_expect_success 'server hooks expect stdout redirected to stderr' '
 	test_when_finished "rm -f stdout.actual stderr.actual" &&
 	git init --bare remote-server &&
 	git remote add origin-server remote-server &&
-	cd remote-server &&
+	cd remote-server && GIT_DIR=. && export GIT_DIR &&
 	setup_hooks pre-receive update post-receive post-update &&
-	cd .. &&
+	cd .. && sane_unset GIT_DIR &&
 	git push origin-server HEAD:new-branch >stdout.actual 2>stderr.actual &&
 	check_stdout_merged_to_stderr pre-receive update post-receive post-update
 '

--- a/t/t1900-repo-info.sh
+++ b/t/t1900-repo-info.sh
@@ -20,6 +20,7 @@ test_repo_info () {
 	repo_name=$3
 	key=$4
 	expected_value=$5
+	repo_flag=${6:--C}
 
 	test_expect_success "setup: $label" '
 		eval "$init_command $repo_name"
@@ -27,13 +28,13 @@ test_repo_info () {
 
 	test_expect_success "lines: $label" '
 		echo "$key=$expected_value" > expect &&
-		git -C "$repo_name" repo info "$key" >actual &&
+		git $repo_flag "$repo_name" repo info "$key" >actual &&
 		test_cmp expect actual
 	'
 
 	test_expect_success "nul: $label" '
 		printf "%s\n%s\0" "$key" "$expected_value" >expect &&
-		git -C "$repo_name" repo info --format=nul "$key" >actual &&
+		git $repo_flag "$repo_name" repo info --format=nul "$key" >actual &&
 		test_cmp_bin expect actual
 	'
 }
@@ -48,7 +49,7 @@ test_repo_info 'bare repository = false is retrieved correctly' \
 	'git init' 'nonbare' 'layout.bare' 'false'
 
 test_repo_info 'bare repository = true is retrieved correctly' \
-	'git init --bare' 'bare' 'layout.bare' 'true'
+	'git init --bare' 'bare' 'layout.bare' 'true' '--git-dir'
 
 test_repo_info 'shallow repository = false is retrieved correctly' \
 	'git init' 'nonshallow' 'layout.shallow' 'false'

--- a/t/t2400-worktree-add.sh
+++ b/t/t2400-worktree-add.sh
@@ -1068,7 +1068,7 @@ done
 post_checkout_hook () {
 	test_when_finished "rm -rf .git/hooks" &&
 	mkdir .git/hooks &&
-	test_hook -C "$1" post-checkout <<-\EOF
+	test_hook "$@" post-checkout <<-\EOF
 	{
 		echo $*
 		git rev-parse --git-dir --show-toplevel
@@ -1124,7 +1124,7 @@ test_expect_success '"add" in bare repo invokes post-checkout hook' '
 		echo $(pwd)/bare/worktrees/goozy &&
 		echo $(pwd)/goozy
 	} >hook.expect &&
-	post_checkout_hook bare &&
+	post_checkout_hook --git-dir bare &&
 	git -C bare worktree add --detach ../goozy &&
 	test_cmp hook.expect goozy/hook.actual
 '

--- a/t/t2400-worktree-add.sh
+++ b/t/t2400-worktree-add.sh
@@ -177,7 +177,7 @@ test_expect_success '"add" from a bare repo' '
 
 test_expect_success 'checkout from a bare repo without "add"' '
 	(
-		cd bare &&
+		cd bare && GIT_DIR=. && export GIT_DIR &&
 		test_must_fail git checkout main
 	)
 '

--- a/t/t2400-worktree-add.sh
+++ b/t/t2400-worktree-add.sh
@@ -171,11 +171,8 @@ test_expect_success 'not die on re-checking out current branch' '
 '
 
 test_expect_success '"add" from a bare repo' '
-	(
-		git clone --bare . bare &&
-		cd bare &&
-		git worktree add -b bare-main ../there2 main
-	)
+	git clone --bare . bare &&
+	git -C bare --git-dir=. worktree add -b bare-main ../there2 main
 '
 
 test_expect_success 'checkout from a bare repo without "add"' '
@@ -186,15 +183,11 @@ test_expect_success 'checkout from a bare repo without "add"' '
 '
 
 test_expect_success '"add" default branch of a bare repo' '
-	(
-		git clone --bare . bare2 &&
-		cd bare2 &&
-		git worktree add ../there3 main &&
-		cd ../there3 &&
-		# Simple check that a Git command does not
-		# immediately fail with the current setup
-		git status
-	) &&
+	git clone --bare . bare2 &&
+	git -C bare2 --git-dir=. worktree add ../there3 main &&
+	# Simple check that a Git command does not
+	# immediately fail with the current setup
+	git status &&
 	cat >expect <<-EOF &&
 	init.t
 	EOF

--- a/t/t2400-worktree-add.sh
+++ b/t/t2400-worktree-add.sh
@@ -198,7 +198,7 @@ test_expect_success '"add" default branch of a bare repo' '
 test_expect_success '"add" to bare repo with worktree config' '
 	(
 		git clone --bare . bare3 &&
-		cd bare3 &&
+		cd bare3 && GIT_DIR=. && export GIT_DIR &&
 		git config extensions.worktreeconfig true &&
 
 		# Add config values that are erroneous to have in
@@ -212,7 +212,7 @@ test_expect_success '"add" to bare repo with worktree config' '
 		git config --worktree bogus.key value &&
 		git config --unset core.bare &&
 		git worktree add ../there4 main &&
-		cd ../there4 &&
+		cd ../there4 && sane_unset GIT_DIR &&
 
 		# Simple check that a Git command does not
 		# immediately fail with the current setup

--- a/t/t2400-worktree-add.sh
+++ b/t/t2400-worktree-add.sh
@@ -460,7 +460,7 @@ test_expect_success 'local clone from linked checkout' '
 '
 
 test_expect_success 'local clone --shared from linked checkout' '
-	git -C bare worktree add --detach ../baretree &&
+	git --git-dir=bare worktree add --detach baretree &&
 	git clone --local --shared baretree bare-clone &&
 	grep /bare/ bare-clone/.git/objects/info/alternates
 '
@@ -1125,7 +1125,7 @@ test_expect_success '"add" in bare repo invokes post-checkout hook' '
 		echo $(pwd)/goozy
 	} >hook.expect &&
 	post_checkout_hook --git-dir bare &&
-	git -C bare worktree add --detach ../goozy &&
+	git --git-dir=bare worktree add --detach goozy &&
 	test_cmp hook.expect goozy/hook.actual
 '
 

--- a/t/t2400-worktree-add.sh
+++ b/t/t2400-worktree-add.sh
@@ -397,7 +397,7 @@ test_expect_success '"add --orphan" with empty repository' '
 	test_when_finished "rm -rf empty_repo" &&
 	echo refs/heads/newbranch >expected &&
 	GIT_DIR="empty_repo" git init --bare &&
-	git -C empty_repo worktree add --orphan -b newbranch worktreedir &&
+	git --git-dir=empty_repo worktree add --orphan -b newbranch empty_repo/worktreedir &&
 	git -C empty_repo/worktreedir symbolic-ref HEAD >actual &&
 	test_cmp expected actual
 '

--- a/t/t2402-worktree-list.sh
+++ b/t/t2402-worktree-list.sh
@@ -210,17 +210,17 @@ test_expect_success 'bare repo setup' '
 '
 
 test_expect_success '"list" all worktrees from bare main' '
-	test_when_finished "rm -rf there out actual expect && git -C bare1 worktree prune" &&
+	test_when_finished "rm -rf there out actual expect && git --git-dir=bare1 worktree prune" &&
 	git --git-dir=bare1 worktree add --detach there main &&
 	echo "$(pwd)/bare1 (bare)" >expect &&
 	echo "$(git -C there rev-parse --show-toplevel) $(git -C there rev-parse --short HEAD) (detached HEAD)" >>expect &&
-	git -C bare1 worktree list >out &&
+	git --git-dir=bare1 worktree list >out &&
 	sed "s/  */ /g" <out >actual &&
 	test_cmp expect actual
 '
 
 test_expect_success '"list" all worktrees --porcelain from bare main' '
-	test_when_finished "rm -rf there actual expect && git -C bare1 worktree prune" &&
+	test_when_finished "rm -rf there actual expect && git --git-dir=bare1 worktree prune" &&
 	git --git-dir=bare1 worktree add --detach there main &&
 	echo "worktree $(pwd)/bare1" >expect &&
 	echo "bare" >>expect &&
@@ -229,12 +229,12 @@ test_expect_success '"list" all worktrees --porcelain from bare main' '
 	echo "HEAD $(git -C there rev-parse HEAD)" >>expect &&
 	echo "detached" >>expect &&
 	echo >>expect &&
-	git -C bare1 worktree list --porcelain >actual &&
+	git --git-dir=bare1 worktree list --porcelain >actual &&
 	test_cmp expect actual
 '
 
 test_expect_success '"list" all worktrees from linked with a bare main' '
-	test_when_finished "rm -rf there out actual expect && git -C bare1 worktree prune" &&
+	test_when_finished "rm -rf there out actual expect && git --git-dir=bare1 worktree prune" &&
 	git --git-dir=bare1 worktree add --detach there main &&
 	echo "$(pwd)/bare1 (bare)" >expect &&
 	echo "$(git -C there rev-parse --show-toplevel) $(git -C there rev-parse --short HEAD) (detached HEAD)" >>expect &&
@@ -314,7 +314,7 @@ test_expect_success 'linked worktrees with relative paths are shown with absolut
 
 test_expect_success 'worktree path when called in .git directory' '
 	git worktree list >list1 &&
-	git -C .git worktree list >list2 &&
+	git --git-dir=.git worktree list >list2 &&
 	test_cmp list1 list2
 '
 

--- a/t/t2402-worktree-list.sh
+++ b/t/t2402-worktree-list.sh
@@ -211,7 +211,7 @@ test_expect_success 'bare repo setup' '
 
 test_expect_success '"list" all worktrees from bare main' '
 	test_when_finished "rm -rf there out actual expect && git -C bare1 worktree prune" &&
-	git -C bare1 worktree add --detach ../there main &&
+	git --git-dir=bare1 worktree add --detach there main &&
 	echo "$(pwd)/bare1 (bare)" >expect &&
 	echo "$(git -C there rev-parse --show-toplevel) $(git -C there rev-parse --short HEAD) (detached HEAD)" >>expect &&
 	git -C bare1 worktree list >out &&
@@ -221,7 +221,7 @@ test_expect_success '"list" all worktrees from bare main' '
 
 test_expect_success '"list" all worktrees --porcelain from bare main' '
 	test_when_finished "rm -rf there actual expect && git -C bare1 worktree prune" &&
-	git -C bare1 worktree add --detach ../there main &&
+	git --git-dir=bare1 worktree add --detach there main &&
 	echo "worktree $(pwd)/bare1" >expect &&
 	echo "bare" >>expect &&
 	echo >>expect &&
@@ -235,7 +235,7 @@ test_expect_success '"list" all worktrees --porcelain from bare main' '
 
 test_expect_success '"list" all worktrees from linked with a bare main' '
 	test_when_finished "rm -rf there out actual expect && git -C bare1 worktree prune" &&
-	git -C bare1 worktree add --detach ../there main &&
+	git --git-dir=bare1 worktree add --detach there main &&
 	echo "$(pwd)/bare1 (bare)" >expect &&
 	echo "$(git -C there rev-parse --show-toplevel) $(git -C there rev-parse --short HEAD) (detached HEAD)" >>expect &&
 	git -C there worktree list >out &&

--- a/t/t2406-worktree-repair.sh
+++ b/t/t2406-worktree-repair.sh
@@ -81,7 +81,7 @@ test_expect_success 'repair .git file from linked worktree' '
 test_expect_success 'repair .git file from bare.git' '
 	test_when_finished "rm -rf bare.git corrupt && git worktree prune" &&
 	git clone --bare . bare.git &&
-	git -C bare.git worktree add --detach ../corrupt &&
+	git --git-dir=bare.git worktree add --detach corrupt &&
 	git -C corrupt rev-parse --absolute-git-dir >expect &&
 	rm -f corrupt/.git &&
 	git -C bare.git --git-dir=. worktree repair &&

--- a/t/t2406-worktree-repair.sh
+++ b/t/t2406-worktree-repair.sh
@@ -84,7 +84,7 @@ test_expect_success 'repair .git file from bare.git' '
 	git -C bare.git worktree add --detach ../corrupt &&
 	git -C corrupt rev-parse --absolute-git-dir >expect &&
 	rm -f corrupt/.git &&
-	git -C bare.git worktree repair &&
+	git -C bare.git --git-dir=. worktree repair &&
 	git -C corrupt rev-parse --absolute-git-dir >actual &&
 	test_cmp expect actual
 '

--- a/t/t3200-branch.sh
+++ b/t/t3200-branch.sh
@@ -416,9 +416,9 @@ test_expect_success 'secondary worktrees recognize core.bare=true in main config
 	test_commit -C non_bare_repo x &&
 
 	git clone --bare non_bare_repo bare_repo &&
-	git -C bare_repo config extensions.worktreeConfig true &&
-	git -C bare_repo config unset core.bare &&
-	git -C bare_repo config --worktree core.bare true &&
+	git --git-dir=bare_repo config extensions.worktreeConfig true &&
+	git --git-dir=bare_repo config unset core.bare &&
+	git --git-dir=bare_repo config --worktree core.bare true &&
 
 	git --git-dir=bare_repo worktree add secondary_worktree &&
 	git -C secondary_worktree checkout main

--- a/t/t3200-branch.sh
+++ b/t/t3200-branch.sh
@@ -406,7 +406,7 @@ test_expect_success 'bare main worktree has HEAD at branch deleted by secondary 
 	git init -b main nonbare &&
 	test_commit -C nonbare x &&
 	git clone --bare nonbare bare &&
-	git -C bare worktree add --detach ../secondary main &&
+	git --git-dir=bare worktree add --detach secondary main &&
 	git -C secondary branch -D main
 '
 
@@ -420,7 +420,7 @@ test_expect_success 'secondary worktrees recognize core.bare=true in main config
 	git -C bare_repo config unset core.bare &&
 	git -C bare_repo config --worktree core.bare true &&
 
-	git -C bare_repo worktree add ../secondary_worktree &&
+	git --git-dir=bare_repo worktree add secondary_worktree &&
 	git -C secondary_worktree checkout main
 '
 

--- a/t/t3451-history-reword.sh
+++ b/t/t3451-history-reword.sh
@@ -150,7 +150,7 @@ test_expect_success 'can reword in a bare repo' '
 	test_commit -C repo first &&
 	git clone --bare repo repo.git &&
 	(
-		cd repo.git &&
+		cd repo.git && GIT_DIR=. && export GIT_DIR &&
 		reword_with_message HEAD <<-EOF &&
 		reworded
 		EOF

--- a/t/t3650-replay-basics.sh
+++ b/t/t3650-replay-basics.sh
@@ -124,7 +124,7 @@ test_expect_success 'using replay to rebase two branches, one on top of other' '
 '
 
 test_expect_success 'using replay on bare repo to rebase two branches, one on top of other' '
-	git -C bare replay --ref-action=print --onto main topic1..topic2 >result-bare &&
+	git --git-dir=bare replay --ref-action=print --onto main topic1..topic2 >result-bare &&
 	test_cmp expect result-bare
 '
 
@@ -133,7 +133,7 @@ test_expect_success 'using replay to rebase with a conflict' '
 '
 
 test_expect_success 'using replay on bare repo to rebase with a conflict' '
-	test_expect_code 1 git -C bare replay --onto topic1 B..conflict
+	test_expect_code 1 git --git-dir=bare replay --onto topic1 B..conflict
 '
 
 test_expect_success 'using replay to perform basic cherry-pick' '
@@ -158,7 +158,7 @@ test_expect_success 'using replay to perform basic cherry-pick' '
 '
 
 test_expect_success 'using replay on bare repo to perform basic cherry-pick' '
-	git -C bare replay --ref-action=print --advance main topic1..topic2 >result-bare &&
+	git --git-dir=bare replay --ref-action=print --advance main topic1..topic2 >result-bare &&
 	test_cmp expect result-bare
 '
 
@@ -182,7 +182,7 @@ test_expect_success 'commits that become empty are dropped' '
 '
 
 test_expect_success 'replay on bare repo fails with both --advance and --onto' '
-	test_must_fail git -C bare replay --advance main --onto main topic1..topic2 >result-bare
+	test_must_fail git --git-dir=bare replay --advance main --onto main topic1..topic2 >result-bare
 '
 
 test_expect_success 'replay fails when both --advance and --onto are omitted' '
@@ -214,7 +214,7 @@ test_expect_success 'using replay to also rebase a contained branch' '
 '
 
 test_expect_success 'using replay on bare repo to also rebase a contained branch' '
-	git -C bare replay --ref-action=print --contained --onto main main..topic3 >result-bare &&
+	git --git-dir=bare replay --ref-action=print --contained --onto main main..topic3 >result-bare &&
 	test_cmp expect result-bare
 '
 
@@ -243,7 +243,7 @@ test_expect_success 'using replay to rebase multiple divergent branches' '
 '
 
 test_expect_success 'using replay on bare repo to rebase multiple divergent branches, including contained ones' '
-	git -C bare replay --ref-action=print --contained --onto main ^main topic2 topic3 topic4 >result &&
+	git --git-dir=bare replay --ref-action=print --contained --onto main ^main topic2 topic3 topic4 >result &&
 
 	test_line_count = 4 result &&
 	cut -f 3 -d " " result >new-branch-tips &&
@@ -253,7 +253,7 @@ test_expect_success 'using replay on bare repo to rebase multiple divergent bran
 	do
 		printf "update refs/heads/topic$i " >>expect &&
 		printf "%s " $(grep topic$i result | cut -f 3 -d " ") >>expect &&
-		git -C bare rev-parse topic$i >>expect || return 1
+		git --git-dir=bare rev-parse topic$i >>expect || return 1
 	done &&
 
 	test_cmp expect result &&
@@ -265,7 +265,7 @@ test_expect_success 'using replay on bare repo to rebase multiple divergent bran
 
 	for i in 1 2 3 4
 	do
-		git -C bare log --format=%s $(grep topic$i result | cut -f 3 -d " ") >actual &&
+		git --git-dir=bare log --format=%s $(grep topic$i result | cut -f 3 -d " ") >actual &&
 		test_cmp expect$i actual || return 1
 	done
 '
@@ -324,15 +324,15 @@ test_expect_success 'default atomic behavior updates refs directly' '
 
 test_expect_success 'atomic behavior in bare repository' '
 	# Store original state for cleanup
-	START=$(git -C bare rev-parse topic2) &&
-	test_when_finished "git -C bare update-ref refs/heads/topic2 $START" &&
+	START=$(git --git-dir=bare rev-parse topic2) &&
+	test_when_finished "git --git-dir=bare update-ref refs/heads/topic2 $START" &&
 
 	# Test atomic updates work in bare repo
-	git -C bare replay --onto main topic1..topic2 >output &&
+	git --git-dir=bare replay --onto main topic1..topic2 >output &&
 	test_must_be_empty output &&
 
 	# Verify ref was updated in bare repo
-	git -C bare log --format=%s topic2 >actual &&
+	git --git-dir=bare log --format=%s topic2 >actual &&
 	test_write_lines E D M L B A >expect &&
 	test_cmp expect actual
 '

--- a/t/t3800-mktag.sh
+++ b/t/t3800-mktag.sh
@@ -50,15 +50,15 @@ check_verify_failure () {
 		rm -rf bad-tag &&
 
 		git init --bare bad-tag &&
-		bad_tag=$(git -C bad-tag hash-object -t tag -w --stdin --literally <tag.sig)
+		bad_tag=$(git --git-dir=bad-tag hash-object -t tag -w --stdin --literally <tag.sig)
 	'
 
 	test_expect_success "hash-object & fsck unreachable: $subject" '
 		if test -n "$fsck_obj_ok"
 		then
-			git -C bad-tag fsck
+			git --git-dir=bad-tag fsck
 		else
-			test_must_fail git -C bad-tag fsck
+			test_must_fail git --git-dir=bad-tag fsck
 		fi
 	'
 
@@ -68,38 +68,38 @@ check_verify_failure () {
 
 		# The update-ref of the bad content will fail, do it
 		# anyway to see if it segfaults
-		test_might_fail git -C bad-tag update-ref "$tag_ref" "$bad_tag" &&
+		test_might_fail git --git-dir=bad-tag update-ref "$tag_ref" "$bad_tag" &&
 
 		# Manually create the broken, we cannot do it with
 		# update-ref
-		test-tool -C bad-tag ref-store main delete-refs 0 msg "$tag_ref" &&
-		test-tool -C bad-tag ref-store main update-ref msg "$tag_ref" $bad_tag $ZERO_OID REF_SKIP_OID_VERIFICATION &&
+		test-tool --git-dir=bad-tag ref-store main delete-refs 0 msg "$tag_ref" &&
+		test-tool --git-dir=bad-tag ref-store main update-ref msg "$tag_ref" $bad_tag $ZERO_OID REF_SKIP_OID_VERIFICATION &&
 
 		# Unlike fsck-ing unreachable content above, this
 		# will always fail.
-		test_must_fail git -C bad-tag fsck
+		test_must_fail git --git-dir=bad-tag fsck
 	'
 
 	test_expect_success "for-each-ref: $subject" '
 		# Make sure the earlier test created it for us
 		git rev-parse "$bad_tag" &&
 
-		test-tool -C bad-tag ref-store main delete-refs 0 msg "$tag_ref" &&
-		test-tool -C bad-tag ref-store main update-ref msg "$tag_ref" $bad_tag $ZERO_OID REF_SKIP_OID_VERIFICATION &&
+		test-tool --git-dir=bad-tag ref-store main delete-refs 0 msg "$tag_ref" &&
+		test-tool --git-dir=bad-tag ref-store main update-ref msg "$tag_ref" $bad_tag $ZERO_OID REF_SKIP_OID_VERIFICATION &&
 
 		printf "%s tag\t%s\n" "$bad_tag" "$tag_ref" >expected &&
-		git -C bad-tag for-each-ref "$tag_ref" >actual &&
+		git --git-dir=bad-tag for-each-ref "$tag_ref" >actual &&
 		test_cmp expected actual &&
 
-		test_must_fail git -C bad-tag for-each-ref --format="%(*objectname)"
+		test_must_fail git --git-dir=bad-tag for-each-ref --format="%(*objectname)"
 	'
 
 	test_expect_success "fast-export & fast-import: $subject" '
 		# Make sure the earlier test created it for us
 		git rev-parse "$bad_tag" &&
 
-		test_must_fail git -C bad-tag fast-export --all &&
-		test_must_fail git -C bad-tag fast-export "$bad_tag"
+		test_must_fail git --git-dir=bad-tag fast-export --all &&
+		test_must_fail git --git-dir=bad-tag fast-export "$bad_tag"
 	'
 }
 

--- a/t/t4018-diff-funcname.sh
+++ b/t/t4018-diff-funcname.sh
@@ -76,8 +76,8 @@ do
 		git add .gitattributes &&
 		git commit -am "changing gitattributes" &&
 		git clone --bare --no-local . bare.git &&
-		git -C bare.git symbolic-ref HEAD refs/heads/master &&
-		test_expect_code 1 git -C bare.git --attr-source=branchA \
+		git --git-dir=bare.git symbolic-ref HEAD refs/heads/master &&
+		test_expect_code 1 git --git-dir=bare.git --attr-source=branchA \
 			diff --exit-code HEAD:A.java HEAD:B.java 2>msg &&
 		test_grep ! fatal msg &&
 		test_grep ! error msg

--- a/t/t4067-diff-partial-clone.sh
+++ b/t/t4067-diff-partial-clone.sh
@@ -19,7 +19,7 @@ test_expect_success 'git show batches blobs' '
 
 	# Ensure that there is exactly 1 negotiation by checking that there is
 	# only 1 "done" line sent. ("done" marks the end of negotiation.)
-	GIT_TRACE_PACKET="$(pwd)/trace" git -C client show HEAD &&
+	GIT_TRACE_PACKET="$(pwd)/trace" git --git-dir=client show HEAD &&
 	grep "fetch> done" trace >done_lines &&
 	test_line_count = 1 done_lines
 '
@@ -43,7 +43,7 @@ test_expect_success 'diff batches blobs' '
 
 	# Ensure that there is exactly 1 negotiation by checking that there is
 	# only 1 "done" line sent. ("done" marks the end of negotiation.)
-	GIT_TRACE_PACKET="$(pwd)/trace" git -C client diff HEAD^ HEAD &&
+	GIT_TRACE_PACKET="$(pwd)/trace" git --git-dir=client diff HEAD^ HEAD &&
 	grep "fetch> done" trace >done_lines &&
 	test_line_count = 1 done_lines
 '
@@ -69,7 +69,7 @@ test_expect_success 'diff skips same-OID blobs' '
 	echo b | git hash-object --stdin >hash-b &&
 
 	# Ensure that only a and another-a are fetched.
-	GIT_TRACE_PACKET="$(pwd)/trace" git -C client diff HEAD^ HEAD &&
+	GIT_TRACE_PACKET="$(pwd)/trace" git --git-dir=client diff HEAD^ HEAD &&
 	grep "want $(cat hash-old-a)" trace &&
 	grep "want $(cat hash-new-a)" trace &&
 	! grep "want $(cat hash-b)" trace
@@ -102,7 +102,7 @@ test_expect_success 'when fetching missing objects, diff skips GITLINKs' '
 
 	# Ensure that a and another-a are fetched, and check (by successful
 	# execution of the diff) that no invalid OIDs are sent.
-	GIT_TRACE_PACKET="$(pwd)/trace" git -C client diff HEAD^ HEAD &&
+	GIT_TRACE_PACKET="$(pwd)/trace" git --git-dir=client diff HEAD^ HEAD &&
 	grep "want $(cat hash-old-a)" trace &&
 	grep "want $(cat hash-new-a)" trace
 '
@@ -126,7 +126,7 @@ test_expect_success 'diff with rename detection batches blobs' '
 
 	# Ensure that there is exactly 1 negotiation by checking that there is
 	# only 1 "done" line sent. ("done" marks the end of negotiation.)
-	GIT_TRACE_PACKET="$(pwd)/trace" git -C client diff --raw -M HEAD^ HEAD >out &&
+	GIT_TRACE_PACKET="$(pwd)/trace" git --git-dir=client diff --raw -M HEAD^ HEAD >out &&
 	grep ":100644 100644.*R[0-9][0-9][0-9].*b.*c" out &&
 	grep "fetch> done" trace >done_lines &&
 	test_line_count = 1 done_lines
@@ -215,7 +215,7 @@ test_expect_success 'diff does not fetch anything if inexact rename detection is
 	git clone --bare --filter=blob:limit=0 "file://$(pwd)/server" client &&
 
 	# Ensure no fetches.
-	GIT_TRACE_PACKET="$(pwd)/trace" git -C client diff --raw -M HEAD^ HEAD &&
+	GIT_TRACE_PACKET="$(pwd)/trace" git --git-dir=client diff --raw -M HEAD^ HEAD &&
 	test_path_is_missing trace
 '
 
@@ -235,13 +235,13 @@ test_expect_success 'diff --break-rewrites fetches only if necessary, and batche
 	git clone --bare --filter=blob:limit=0 "file://$(pwd)/server" client &&
 
 	# Ensure no fetches.
-	GIT_TRACE_PACKET="$(pwd)/trace" git -C client diff --raw -M HEAD^ HEAD &&
+	GIT_TRACE_PACKET="$(pwd)/trace" git --git-dir=client diff --raw -M HEAD^ HEAD &&
 	test_path_is_missing trace &&
 
 	# But with --break-rewrites, ensure that there is exactly 1 negotiation
 	# by checking that there is only 1 "done" line sent. ("done" marks the
 	# end of negotiation.)
-	GIT_TRACE_PACKET="$(pwd)/trace" git -C client diff --break-rewrites --raw -M HEAD^ HEAD &&
+	GIT_TRACE_PACKET="$(pwd)/trace" git --git-dir=client diff --break-rewrites --raw -M HEAD^ HEAD &&
 	grep "fetch> done" trace >done_lines &&
 	test_line_count = 1 done_lines
 '

--- a/t/t4203-mailmap.sh
+++ b/t/t4203-mailmap.sh
@@ -949,7 +949,7 @@ test_expect_success 'bare repo with --work-tree finds mailmap at top-level' '
 '
 
 test_expect_success 'bare repo does not look in current directory' '
-	git -C loc-bare log -1 --format=%aE >actual &&
+	git --git-dir=loc-bare log -1 --format=%aE >actual &&
 	echo orig@example.com >expect &&
 	test_cmp expect actual
 '

--- a/t/t4203-mailmap.sh
+++ b/t/t4203-mailmap.sh
@@ -432,7 +432,7 @@ test_expect_success 'mailmap.blob defaults to off in non-bare repo' '
 test_expect_success 'mailmap.blob defaults to HEAD:.mailmap in bare repo' '
 	git clone --bare non-bare bare &&
 	(
-		cd bare &&
+		cd bare && GIT_DIR=. && export GIT_DIR &&
 		cat >expect <<-\EOF &&
 		     1	Fake Name
 		EOF

--- a/t/t4203-mailmap.sh
+++ b/t/t4203-mailmap.sh
@@ -943,7 +943,7 @@ test_expect_success 'set up mailmap location tests' '
 '
 
 test_expect_success 'bare repo with --work-tree finds mailmap at top-level' '
-	git -C loc-bare --work-tree=. log -1 --format=%aE >actual &&
+	git -C loc-bare --git-dir=. --work-tree=. log -1 --format=%aE >actual &&
 	echo new@example.com >expect &&
 	test_cmp expect actual
 '

--- a/t/t5001-archive-attr.sh
+++ b/t/t5001-archive-attr.sh
@@ -127,12 +127,12 @@ test_expect_exists	worktree2/ignored-by-tree
 test_expect_missing	worktree2/ignored-by-worktree
 
 test_expect_success 'git archive vs. bare' '
-	(cd bare && git archive HEAD) >bare-archive.tar &&
+	(cd bare && GIT_DIR=. && export GIT_DIR && git archive HEAD) >bare-archive.tar &&
 	test_cmp_bin archive.tar bare-archive.tar
 '
 
 test_expect_success 'git archive with worktree attributes, bare' '
-	(cd bare &&
+	(cd bare && GIT_DIR=. && export GIT_DIR &&
 	git -c attr.tree=HEAD archive --worktree-attributes HEAD) >bare-worktree.tar &&
 	(mkdir bare-worktree && cd bare-worktree && "$TAR" xf -) <bare-worktree.tar
 '

--- a/t/t5003-archive-zip.sh
+++ b/t/t5003-archive-zip.sh
@@ -161,7 +161,7 @@ check_zip d
 
 test_expect_success \
     'git archive --format=zip in a bare repo' \
-    '(cd bare.git && git archive --format=zip HEAD) >d1.zip'
+    '(cd bare.git && GIT_DIR=. && export GIT_DIR && git archive --format=zip HEAD) >d1.zip'
 
 test_expect_success \
     'git archive --format=zip vs. the same in a bare repo' \

--- a/t/t5003-archive-zip.sh
+++ b/t/t5003-archive-zip.sh
@@ -146,7 +146,7 @@ test_expect_success 'create bare clone' '
 	cp .git/info/attributes bare.git/info/attributes &&
 	# Recreate our changes to .git/config rather than just copying it, as
 	# we do not want to clobber core.bare or other settings.
-	git -C bare.git config diff.custom.binary true
+	git --git-dir=bare.git config diff.custom.binary true
 '
 
 test_expect_success \
@@ -284,7 +284,7 @@ start_httpd
 
 test_expect_success "setup for HTTP protocol" '
 	cp -R bare.git "$HTTPD_DOCUMENT_ROOT_PATH/bare.git" &&
-	git -C "$HTTPD_DOCUMENT_ROOT_PATH/bare.git" \
+	git --git-dir="$HTTPD_DOCUMENT_ROOT_PATH/bare.git" \
 		config http.uploadpack true &&
 	set_askpass user@host pass@host
 '

--- a/t/t5300-pack-object.sh
+++ b/t/t5300-pack-object.sh
@@ -171,9 +171,9 @@ check_unpack () {
 	test_when_finished "rm -rf git2" &&
 	git $git_config init --bare git2 &&
 	(
-		git $git_config -C git2 unpack-objects -n <"$packname".pack &&
-		git $git_config -C git2 unpack-objects <"$packname".pack &&
-		git $git_config -C git2 cat-file --batch-check="%(objectname)"
+		git $git_config --git-dir=git2 unpack-objects -n <"$packname".pack &&
+		git $git_config --git-dir=git2 unpack-objects <"$packname".pack &&
+		git $git_config --git-dir=git2 cat-file --batch-check="%(objectname)"
 	) <"$object_list" >current &&
 	cmp "$object_list" current
 }

--- a/t/t5300-pack-object.sh
+++ b/t/t5300-pack-object.sh
@@ -227,7 +227,7 @@ check_use_objects () {
 	git init --bare git2 &&
 	cp "$1".pack "$1".idx git2/objects/pack &&
 	(
-		cd git2 &&
+		cd git2 && GIT_DIR=. && export GIT_DIR &&
 		git diff-tree --root -p $commit &&
 		while read object
 		do

--- a/t/t5310-pack-bitmaps.sh
+++ b/t/t5310-pack-bitmaps.sh
@@ -247,7 +247,7 @@ test_bitmap_cases () {
 		git commit -m "commit with big file" &&
 		git -c pack.packSizeLimit=500k repack -adb &&
 		git init --bare no-bitmaps.git &&
-		git -C no-bitmaps.git fetch .. HEAD
+		git --git-dir=no-bitmaps.git fetch . HEAD
 	'
 
 	test_expect_success 'set up reusable pack' '

--- a/t/t5310-pack-bitmaps.sh
+++ b/t/t5310-pack-bitmaps.sh
@@ -223,7 +223,7 @@ test_bitmap_cases () {
 	test_expect_success JGIT,SHA1 'we can read jgit bitmaps' '
 		git clone --bare . compat-jgit.git &&
 		(
-			cd compat-jgit.git &&
+			cd compat-jgit.git && GIT_DIR=. && export GIT_DIR &&
 			rm -f objects/pack/*.bitmap &&
 			jgit gc &&
 			git rev-list --test-bitmap HEAD
@@ -233,7 +233,7 @@ test_bitmap_cases () {
 	test_expect_success JGIT,SHA1 'jgit can read our bitmaps' '
 		git clone --bare . compat-us.git &&
 		(
-			cd compat-us.git &&
+			cd compat-us.git && GIT_DIR=. && export GIT_DIR &&
 			git config pack.writeBitmapLookupTable '"$writeLookupTable"' &&
 			git repack -adb &&
 			# jgit gc will barf if it does not like our bitmaps
@@ -374,7 +374,7 @@ test_bitmap_cases () {
 		test_when_finished "rm -rf client.git" &&
 		git init --bare client.git &&
 		(
-			cd client.git &&
+			cd client.git && GIT_DIR=. && export GIT_DIR &&
 			git config transfer.unpackLimit 1 &&
 			git fetch .. delta-reuse-old:delta-reuse-old &&
 			git fetch .. delta-reuse-new:delta-reuse-new &&
@@ -388,7 +388,7 @@ test_bitmap_cases () {
 		test_when_finished "rm -rf client.git" &&
 		git init --bare client.git &&
 		(
-			cd client.git &&
+			cd client.git && GIT_DIR=. && export GIT_DIR &&
 
 			# This test relies on reusing a delta, but if the
 			# path-walk machinery is engaged, the base object

--- a/t/t5311-pack-bitmaps-shallow.sh
+++ b/t/t5311-pack-bitmaps-shallow.sh
@@ -47,7 +47,7 @@ test_shallow_bitmaps () {
 	'
 
 	test_expect_success 'shallow fetch from bitmapped repo' '
-		(cd shallow.git && git fetch)
+		(cd shallow.git && GIT_DIR=. && export GIT_DIR && git fetch)
 	'
 }
 

--- a/t/t5318-commit-graph.sh
+++ b/t/t5318-commit-graph.sh
@@ -278,7 +278,7 @@ graph_git_behavior --bare 'bare repo, commit 8 vs merge 1' bare commits/8 merge/
 graph_git_behavior --bare 'bare repo, commit 8 vs merge 2' bare commits/8 merge/2
 
 test_expect_success 'write graph in bare repo' '
-	git -C bare commit-graph write &&
+	git --git-dir=bare commit-graph write &&
 	test_path_is_file bare/objects/info/commit-graph &&
 	graph_read_expect --bare -C bare 11 "generation_data extra_edges"
 '

--- a/t/t5318-commit-graph.sh
+++ b/t/t5318-commit-graph.sh
@@ -274,17 +274,17 @@ test_expect_success 'setup bare repo' '
 	git clone --bare --no-local full bare
 '
 
-graph_git_behavior 'bare repo, commit 8 vs merge 1' bare commits/8 merge/1
-graph_git_behavior 'bare repo, commit 8 vs merge 2' bare commits/8 merge/2
+graph_git_behavior --bare 'bare repo, commit 8 vs merge 1' bare commits/8 merge/1
+graph_git_behavior --bare 'bare repo, commit 8 vs merge 2' bare commits/8 merge/2
 
 test_expect_success 'write graph in bare repo' '
 	git -C bare commit-graph write &&
 	test_path_is_file bare/objects/info/commit-graph &&
-	graph_read_expect -C bare 11 "generation_data extra_edges"
+	graph_read_expect --bare -C bare 11 "generation_data extra_edges"
 '
 
-graph_git_behavior 'bare repo with graph, commit 8 vs merge 1' bare commits/8 merge/1
-graph_git_behavior 'bare repo with graph, commit 8 vs merge 2' bare commits/8 merge/2
+graph_git_behavior --bare 'bare repo with graph, commit 8 vs merge 1' bare commits/8 merge/1
+graph_git_behavior --bare 'bare repo with graph, commit 8 vs merge 2' bare commits/8 merge/2
 
 test_expect_success 'perform fast-forward merge in full repo' '
 	git -C full checkout -b merge-5-to-8 commits/5 &&

--- a/t/t5319-multi-pack-index.sh
+++ b/t/t5319-multi-pack-index.sh
@@ -274,7 +274,7 @@ test_expect_success 'midx picks objects from preferred pack' '
 	test_when_finished rm -rf preferred.git &&
 	git init --bare preferred.git &&
 	(
-		cd preferred.git &&
+		cd preferred.git && GIT_DIR=. && export GIT_DIR &&
 
 		a=$(echo "a" | git hash-object -w --stdin) &&
 		b=$(echo "b" | git hash-object -w --stdin) &&

--- a/t/t5351-unpack-large-objects.sh
+++ b/t/t5351-unpack-large-objects.sh
@@ -10,7 +10,7 @@ test_description='git unpack-objects with large objects'
 prepare_dest () {
 	test_when_finished "rm -rf dest.git" &&
 	git init --bare dest.git &&
-	git -C dest.git config core.bigFileThreshold "$1"
+	git --git-dir=dest.git config core.bigFileThreshold "$1"
 }
 
 test_expect_success "create large objects (1.5 MB) and PACK" '
@@ -31,20 +31,20 @@ test_expect_success 'set memory limitation to 1MB' '
 
 test_expect_success 'unpack-objects failed under memory limitation' '
 	prepare_dest 2m &&
-	test_must_fail git -C dest.git unpack-objects <pack-$PACK.pack 2>err &&
+	test_must_fail git --git-dir=dest.git unpack-objects <pack-$PACK.pack 2>err &&
 	grep "fatal: attempting to allocate" err
 '
 
 test_expect_success 'unpack-objects works with memory limitation in dry-run mode' '
 	prepare_dest 2m &&
-	git -C dest.git unpack-objects -n <pack-$PACK.pack &&
+	git --git-dir=dest.git unpack-objects -n <pack-$PACK.pack &&
 	test_stdout_line_count = 0 find dest.git/objects -type f &&
 	test_dir_is_empty dest.git/objects/pack
 '
 
 test_expect_success 'unpack big object in stream' '
 	prepare_dest 1m &&
-	git -C dest.git unpack-objects <pack-$PACK.pack &&
+	git --git-dir=dest.git unpack-objects <pack-$PACK.pack &&
 	test_dir_is_empty dest.git/objects/pack
 '
 
@@ -69,7 +69,7 @@ test_expect_success 'unpack big object in stream (core.fsyncmethod=batch)' '
 	prepare_dest 1m &&
 	GIT_TRACE2_EVENT="$(pwd)/trace2.txt" \
 	GIT_TEST_FSYNC=true \
-		git -C dest.git $BATCH_CONFIGURATION unpack-objects <pack-$PACK.pack &&
+		git --git-dir=dest.git $BATCH_CONFIGURATION unpack-objects <pack-$PACK.pack &&
 	if grep "core.fsyncMethod = batch is unsupported" trace2.txt
 	then
 		flush_count=7
@@ -82,14 +82,14 @@ test_expect_success 'unpack big object in stream (core.fsyncmethod=batch)' '
 	EOF
 
 	test_dir_is_empty dest.git/objects/pack &&
-	git -C dest.git cat-file --batch-check="%(objectname)" <obj-list >current &&
+	git --git-dir=dest.git cat-file --batch-check="%(objectname)" <obj-list >current &&
 	cmp obj-list current
 '
 
 test_expect_success 'do not unpack existing large objects' '
 	prepare_dest 1m &&
-	git -C dest.git index-pack --stdin <pack-$PACK.pack &&
-	git -C dest.git unpack-objects <pack-$PACK.pack &&
+	git --git-dir=dest.git index-pack --stdin <pack-$PACK.pack &&
+	git --git-dir=dest.git unpack-objects <pack-$PACK.pack &&
 
 	# The destination came up with the exact same pack...
 	DEST_PACK=$(echo dest.git/objects/pack/pack-*.pack) &&

--- a/t/t5400-send-pack.sh
+++ b/t/t5400-send-pack.sh
@@ -147,7 +147,7 @@ test_expect_success 'send-pack --all sends all branches' '
 	git init --bare all.git &&
 	git send-pack --all all.git &&
 	git for-each-ref refs/heads >expect &&
-	git -C all.git for-each-ref refs/heads >actual &&
+	git --git-dir=all.git for-each-ref refs/heads >actual &&
 	test_cmp expect actual
 '
 

--- a/t/t5401-update-hooks.sh
+++ b/t/t5401-update-hooks.sh
@@ -23,14 +23,14 @@ test_expect_success setup '
 	git update-ref refs/heads/main $commit1 &&
 	git update-ref refs/heads/tofail $commit0 &&
 
-	test_hook --setup -C victim.git pre-receive <<-\EOF &&
+	test_hook --setup --git-dir victim.git pre-receive <<-\EOF &&
 	printf %s "$@" >>$GIT_DIR/pre-receive.args
 	cat - >$GIT_DIR/pre-receive.stdin
 	echo STDOUT pre-receive
 	echo STDERR pre-receive >&2
 	EOF
 
-	test_hook --setup -C victim.git update <<-\EOF &&
+	test_hook --setup --git-dir victim.git update <<-\EOF &&
 	echo "$@" >>$GIT_DIR/update.args
 	read x; printf %s "$x" >$GIT_DIR/update.stdin
 	echo STDOUT update $1
@@ -38,14 +38,14 @@ test_expect_success setup '
 	test "$1" = refs/heads/main || exit
 	EOF
 
-	test_hook --setup -C victim.git post-receive <<-\EOF &&
+	test_hook --setup --git-dir victim.git post-receive <<-\EOF &&
 	printf %s "$@" >>$GIT_DIR/post-receive.args
 	cat - >$GIT_DIR/post-receive.stdin
 	echo STDOUT post-receive
 	echo STDERR post-receive >&2
 	EOF
 
-	test_hook --setup -C victim.git post-update <<-\EOF
+	test_hook --setup --git-dir victim.git post-update <<-\EOF
 	echo "$@" >>$GIT_DIR/post-update.args
 	read x; printf %s "$x" >$GIT_DIR/post-update.stdin
 	echo STDOUT post-update
@@ -129,7 +129,7 @@ test_expect_success 'send-pack stderr contains hook messages' '
 '
 
 test_expect_success 'pre-receive hook that forgets to read its input' '
-	test_hook --clobber -C victim.git pre-receive <<-\EOF &&
+	test_hook --clobber --git-dir victim.git pre-receive <<-\EOF &&
 	exit 0
 	EOF
 	rm -f victim.git/hooks/update victim.git/hooks/post-update &&

--- a/t/t5410-receive-pack.sh
+++ b/t/t5410-receive-pack.sh
@@ -26,7 +26,7 @@ test_expect_success 'with core.alternateRefsCommand' '
 			--format="%(objectname)" \
 			refs/heads/public/
 	EOF
-	test_config -C fork core.alternateRefsCommand ./alternate-refs &&
+	test_config --git-dir fork core.alternateRefsCommand ./alternate-refs &&
 	git rev-parse public/branch >expect &&
 	printf "0000" | git receive-pack fork >actual &&
 	extract_haves <actual >actual.haves &&
@@ -34,7 +34,7 @@ test_expect_success 'with core.alternateRefsCommand' '
 '
 
 test_expect_success 'with core.alternateRefsPrefixes' '
-	test_config -C fork core.alternateRefsPrefixes "refs/heads/private" &&
+	test_config --git-dir fork core.alternateRefsPrefixes "refs/heads/private" &&
 	git rev-parse private/branch >expect &&
 	printf "0000" | git receive-pack fork >actual &&
 	extract_haves <actual >actual.haves &&

--- a/t/t5410-receive-pack.sh
+++ b/t/t5410-receive-pack.sh
@@ -71,7 +71,7 @@ test_expect_success TEE_DOES_NOT_HANG \
 
 	test_grep "missing necessary objects" actual &&
 	test_grep "fatal: Failed to traverse parents" err &&
-	test_must_fail git -C remote.git cat-file -e $(git -C repo rev-parse HEAD)
+	test_must_fail git --git-dir=remote.git cat-file -e $(git -C repo rev-parse HEAD)
 '
 
 test_expect_success TEE_DOES_NOT_HANG \
@@ -93,8 +93,8 @@ test_expect_success TEE_DOES_NOT_HANG \
 
 	test_grep ! "missing necessary objects" actual &&
 	test_must_be_empty err &&
-	git -C remote.git cat-file -e $(git -C repo rev-parse HEAD) &&
-	test_must_fail git -C remote.git rev-list $(git -C repo rev-parse HEAD)
+	git --git-dir=remote.git cat-file -e $(git -C repo rev-parse HEAD) &&
+	test_must_fail git --git-dir=remote.git rev-list $(git -C repo rev-parse HEAD)
 '
 
 test_done

--- a/t/t5411-proc-receive-hook.sh
+++ b/t/t5411-proc-receive-hook.sh
@@ -36,7 +36,7 @@ setup_upstream_and_workbench () {
 		TAG=$(git -C workbench rev-parse v123) &&
 
 		# setup pre-receive hook
-		test_hook --setup -C upstream.git pre-receive <<-\EOF &&
+		test_hook --setup --git-dir upstream.git pre-receive <<-\EOF &&
 		exec >&2
 		echo "# pre-receive hook"
 		while read old new ref
@@ -46,7 +46,7 @@ setup_upstream_and_workbench () {
 		EOF
 
 		# setup post-receive hook
-		test_hook --setup -C upstream.git post-receive <<-\EOF &&
+		test_hook --setup --git-dir upstream.git post-receive <<-\EOF &&
 		exec >&2
 		echo "# post-receive hook"
 		while read old new ref

--- a/t/t5411-proc-receive-hook.sh
+++ b/t/t5411-proc-receive-hook.sh
@@ -30,7 +30,7 @@ setup_upstream_and_workbench () {
 			git remote add origin ../upstream.git &&
 			git push origin main &&
 			git update-ref refs/heads/main $A $B &&
-			git -C ../upstream.git update-ref \
+			git --git-dir=../upstream.git update-ref \
 				refs/heads/main $A $B
 		) &&
 		TAG=$(git -C workbench rev-parse v123) &&
@@ -105,7 +105,7 @@ setup_upstream_and_workbench
 # Refs of upstream : main(A)
 # Refs of workbench: main(A)  tags/v123
 test_expect_success "setup for HTTP protocol" '
-	git -C upstream.git config http.receivepack true &&
+	git --git-dir=upstream.git config http.receivepack true &&
 	upstream="$HTTPD_DOCUMENT_ROOT_PATH/upstream.git" &&
 	mv upstream.git "$upstream" &&
 	git -C workbench remote set-url origin "$HTTPD_URL/auth-push/smart/upstream.git" &&

--- a/t/t5411/common-functions.sh
+++ b/t/t5411/common-functions.sh
@@ -59,15 +59,20 @@ format_and_save_expect () {
 
 test_cmp_refs () {
 	indir=
+	gitdir=
 	if test "$1" = "-C"
 	then
 		shift
 		indir="$1"
 		shift
+	elif test "$1" = "--git-dir"
+	then
+		shift
+		gitdir="$1"
+		shift
 	fi
-	indir=${indir:+"$indir"/}
 	cat >show-ref.expect &&
-	git ${indir:+ -C "$indir"} show-ref >show-ref.pristine &&
+	git ${indir:+ -C "$indir"} ${gitdir:+ --git-dir="$gitdir"} show-ref >show-ref.pristine &&
 	make_user_friendly_and_stable_output <show-ref.pristine >show-ref.filtered &&
 	test_cmp show-ref.expect show-ref.filtered
 }

--- a/t/t5411/once-0010-report-status-v1.sh
+++ b/t/t5411/once-0010-report-status-v1.sh
@@ -83,7 +83,7 @@ test_expect_success "proc-receive: report status v1" '
 	EOF
 	test_cmp expect actual &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-A> refs/for/main/topic1
 	<COMMIT-A> refs/heads/foo
 	<COMMIT-B> refs/heads/main

--- a/t/t5411/once-0010-report-status-v1.sh
+++ b/t/t5411/once-0010-report-status-v1.sh
@@ -3,7 +3,7 @@ test_expect_success "setup receive.procReceiveRefs" '
 '
 
 test_expect_success "setup proc-receive hook" '
-	test_hook -C "$upstream" --clobber proc-receive <<-EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
 		-r "ok refs/for/main/topic1" \

--- a/t/t5411/once-0010-report-status-v1.sh
+++ b/t/t5411/once-0010-report-status-v1.sh
@@ -1,5 +1,5 @@
 test_expect_success "setup receive.procReceiveRefs" '
-	git -C "$upstream" config --add receive.procReceiveRefs refs/for
+	git --git-dir="$upstream" config --add receive.procReceiveRefs refs/for
 '
 
 test_expect_success "setup proc-receive hook" '
@@ -42,7 +42,7 @@ test_expect_success "proc-receive: report status v1" '
 		printf "%s %s refs/for/main/topic2\n" \
 			$ZERO_OID $A | packetize &&
 		printf 0000 &&
-		printf "" | git -C "$upstream" pack-objects --stdout
+		printf "" | git --git-dir="$upstream" pack-objects --stdout
 	} | git receive-pack "$upstream" --stateless-rpc \
 	>out 2>&1 &&
 	make_user_friendly_and_stable_output <out >actual &&

--- a/t/t5411/test-0000-standard-git-push.sh
+++ b/t/t5411/test-0000-standard-git-push.sh
@@ -20,7 +20,7 @@ test_expect_success "git-push ($PROTOCOL)" '
 	EOF
 	test_cmp expect actual &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-B> refs/heads/main
 	<COMMIT-A> refs/heads/next
 	EOF
@@ -45,7 +45,7 @@ test_expect_success "git-push --atomic ($PROTOCOL)" '
 	EOF
 	test_cmp expect actual &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-B> refs/heads/main
 	<COMMIT-A> refs/heads/next
 	EOF
@@ -74,7 +74,7 @@ test_expect_success "non-fast-forward git-push ($PROTOCOL)" '
 	EOF
 	test_cmp expect actual &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-B> refs/heads/main
 	<COMMIT-B> refs/heads/next
 	EOF
@@ -114,7 +114,7 @@ test_expect_success "git-push -f ($PROTOCOL)" '
 	EOF
 	test_cmp expect actual &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-A> refs/heads/a/b/c
 	<COMMIT-A> refs/heads/main
 	<COMMIT-A> refs/review/main/topic

--- a/t/t5411/test-0000-standard-git-push.sh
+++ b/t/t5411/test-0000-standard-git-push.sh
@@ -126,7 +126,7 @@ test_expect_success "git-push -f ($PROTOCOL)" '
 # Refs of workbench: main(A)  tags/v123
 test_expect_success "cleanup ($PROTOCOL)" '
 	(
-		cd "$upstream" &&
+		cd "$upstream" && GIT_DIR=. && export GIT_DIR &&
 		git update-ref -d refs/review/main/topic &&
 		git update-ref -d refs/tags/v123 &&
 		git update-ref -d refs/heads/a/b/c

--- a/t/t5411/test-0001-standard-git-push--porcelain.sh
+++ b/t/t5411/test-0001-standard-git-push--porcelain.sh
@@ -130,7 +130,7 @@ test_expect_success "git-push -f ($PROTOCOL/porcelain)" '
 # Refs of workbench: main(A)  tags/v123
 test_expect_success "cleanup ($PROTOCOL/porcelain)" '
 	(
-		cd "$upstream" &&
+		cd "$upstream" && GIT_DIR=. && export GIT_DIR &&
 		git update-ref -d refs/review/main/topic &&
 		git update-ref -d refs/tags/v123 &&
 		git update-ref -d refs/heads/a/b/c

--- a/t/t5411/test-0001-standard-git-push--porcelain.sh
+++ b/t/t5411/test-0001-standard-git-push--porcelain.sh
@@ -21,7 +21,7 @@ test_expect_success "git-push ($PROTOCOL/porcelain)" '
 	EOF
 	test_cmp expect actual &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-B> refs/heads/main
 	<COMMIT-A> refs/heads/next
 	EOF
@@ -47,7 +47,7 @@ test_expect_success "git-push --atomic ($PROTOCOL/porcelain)" '
 	EOF
 	test_cmp expect actual &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-B> refs/heads/main
 	<COMMIT-A> refs/heads/next
 	EOF
@@ -77,7 +77,7 @@ test_expect_success "non-fast-forward git-push ($PROTOCOL/porcelain)" '
 	EOF
 	test_cmp expect actual &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-B> refs/heads/main
 	<COMMIT-B> refs/heads/next
 	EOF
@@ -118,7 +118,7 @@ test_expect_success "git-push -f ($PROTOCOL/porcelain)" '
 	EOF
 	test_cmp expect actual &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-A> refs/heads/a/b/c
 	<COMMIT-A> refs/heads/main
 	<COMMIT-A> refs/review/main/topic

--- a/t/t5411/test-0002-pre-receive-declined.sh
+++ b/t/t5411/test-0002-pre-receive-declined.sh
@@ -21,7 +21,7 @@ test_expect_success "git-push is declined ($PROTOCOL)" '
 	EOF
 	test_cmp expect actual &&
 
-	test_cmp_refs -C "$upstream" <<-\EOF
+	test_cmp_refs --git-dir "$upstream" <<-\EOF
 	<COMMIT-A> refs/heads/main
 	EOF
 '

--- a/t/t5411/test-0002-pre-receive-declined.sh
+++ b/t/t5411/test-0002-pre-receive-declined.sh
@@ -1,6 +1,6 @@
 test_expect_success "setup pre-receive hook ($PROTOCOL)" '
 	mv "$upstream/hooks/pre-receive" "$upstream/hooks/pre-receive.ok" &&
-	test_hook -C "$upstream" --clobber pre-receive <<-\EOF
+	test_hook --git-dir "$upstream" --clobber pre-receive <<-\EOF
 	exit 1
 	EOF
 '

--- a/t/t5411/test-0003-pre-receive-declined--porcelain.sh
+++ b/t/t5411/test-0003-pre-receive-declined--porcelain.sh
@@ -22,7 +22,7 @@ test_expect_success "git-push is declined ($PROTOCOL/porcelain)" '
 	EOF
 	test_cmp expect actual &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-A> refs/heads/main
 	EOF
 '

--- a/t/t5411/test-0003-pre-receive-declined--porcelain.sh
+++ b/t/t5411/test-0003-pre-receive-declined--porcelain.sh
@@ -1,6 +1,6 @@
 test_expect_success "setup pre-receive hook ($PROTOCOL/porcelain)" '
 	mv "$upstream/hooks/pre-receive" "$upstream/hooks/pre-receive.ok" &&
-	test_hook -C "$upstream" --clobber pre-receive <<-\EOF
+	test_hook --git-dir "$upstream" --clobber pre-receive <<-\EOF
 	exit 1
 	EOF
 '

--- a/t/t5411/test-0010-proc-receive-settings.sh
+++ b/t/t5411/test-0010-proc-receive-settings.sh
@@ -1,6 +1,6 @@
 test_expect_success "add two receive.procReceiveRefs settings" '
 	(
-		cd "$upstream" &&
+		cd "$upstream" && GIT_DIR=. && export GIT_DIR &&
 		git config --add receive.procReceiveRefs refs/for &&
 		git config --add receive.procReceiveRefs refs/review/
 	)

--- a/t/t5411/test-0011-no-hook-error.sh
+++ b/t/t5411/test-0011-no-hook-error.sh
@@ -29,7 +29,7 @@ test_expect_success "proc-receive: no hook, fail to push special ref ($PROTOCOL)
 # Refs of upstream : main(A)             next(A)
 # Refs of workbench: main(A)  tags/v123
 test_expect_success "cleanup ($PROTOCOL)" '
-	git -C "$upstream" update-ref -d refs/heads/next
+	git --git-dir="$upstream" update-ref -d refs/heads/next
 '
 
 # Refs of upstream : main(A)

--- a/t/t5411/test-0011-no-hook-error.sh
+++ b/t/t5411/test-0011-no-hook-error.sh
@@ -20,7 +20,7 @@ test_expect_success "proc-receive: no hook, fail to push special ref ($PROTOCOL)
 	EOF
 	test_cmp expect actual &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-A> refs/heads/main
 	<COMMIT-A> refs/heads/next
 	EOF
@@ -54,7 +54,7 @@ test_expect_success "proc-receive: no hook, all failed for atomic push ($PROTOCO
 	EOF
 	test_cmp expect actual &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-A> refs/heads/main
 	EOF
 '

--- a/t/t5411/test-0012-no-hook-error--porcelain.sh
+++ b/t/t5411/test-0012-no-hook-error--porcelain.sh
@@ -30,7 +30,7 @@ test_expect_success "proc-receive: no hook, fail to push special ref ($PROTOCOL/
 # Refs of upstream : main(A)             next(A)
 # Refs of workbench: main(A)  tags/v123
 test_expect_success "cleanup ($PROTOCOL/porcelain)" '
-	git -C "$upstream" update-ref -d refs/heads/next
+	git --git-dir="$upstream" update-ref -d refs/heads/next
 '
 
 # Refs of upstream : main(A)

--- a/t/t5411/test-0012-no-hook-error--porcelain.sh
+++ b/t/t5411/test-0012-no-hook-error--porcelain.sh
@@ -21,7 +21,7 @@ test_expect_success "proc-receive: no hook, fail to push special ref ($PROTOCOL/
 	EOF
 	test_cmp expect actual &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-A> refs/heads/main
 	<COMMIT-A> refs/heads/next
 	EOF
@@ -56,7 +56,7 @@ test_expect_success "proc-receive: no hook, all failed for atomic push ($PROTOCO
 	EOF
 	test_cmp expect actual &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-A> refs/heads/main
 	EOF
 '

--- a/t/t5411/test-0013-bad-protocol.sh
+++ b/t/t5411/test-0013-bad-protocol.sh
@@ -142,7 +142,7 @@ test_expect_success "setup proc-receive hook (hook --die-read-push-options, $PRO
 # Refs of workbench: main(A)  tags/v123
 # git push         :                       refs/for/main/topic(A)
 test_expect_success "proc-receive: bad protocol (hook --die-read-push-options, $PROTOCOL)" '
-	git -C "$upstream" config receive.advertisePushOptions true &&
+	git --git-dir="$upstream" config receive.advertisePushOptions true &&
 	test_must_fail git -C workbench push origin \
 		-o reviewers=user1,user2 \
 		HEAD:refs/for/main/topic \
@@ -231,7 +231,7 @@ test_expect_success "proc-receive: bad protocol (no report, $PROTOCOL)" '
 # Refs of upstream : main(A)             next(A)
 # Refs of workbench: main(A)  tags/v123
 test_expect_success "cleanup ($PROTOCOL)" '
-	git -C "$upstream" update-ref -d refs/heads/next
+	git --git-dir="$upstream" update-ref -d refs/heads/next
 
 '
 

--- a/t/t5411/test-0013-bad-protocol.sh
+++ b/t/t5411/test-0013-bad-protocol.sh
@@ -1,5 +1,5 @@
 test_expect_success "setup proc-receive hook (unknown version, $PROTOCOL)" '
-	test_hook -C "$upstream" --clobber proc-receive <<-\EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-\EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v --version 2
 	EOF
@@ -40,7 +40,7 @@ test_expect_success "proc-receive: bad protocol (unknown version, $PROTOCOL)" '
 '
 
 test_expect_success "setup proc-receive hook (hook --die-read-version, $PROTOCOL)" '
-	test_hook -C "$upstream" --clobber proc-receive <<-\EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-\EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v --die-read-version
 	EOF
@@ -71,7 +71,7 @@ test_expect_success "proc-receive: bad protocol (hook --die-read-version, $PROTO
 '
 
 test_expect_success "setup proc-receive hook (hook --die-write-version, $PROTOCOL)" '
-	test_hook -C "$upstream" --clobber proc-receive <<-\EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-\EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v --die-write-version
 	EOF
@@ -102,7 +102,7 @@ test_expect_success "proc-receive: bad protocol (hook --die-write-version, $PROT
 '
 
 test_expect_success "setup proc-receive hook (hook --die-read-commands, $PROTOCOL)" '
-	test_hook -C "$upstream" --clobber proc-receive <<-\EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-\EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v --die-read-commands
 	EOF
@@ -132,7 +132,7 @@ test_expect_success "proc-receive: bad protocol (hook --die-read-commands, $PROT
 '
 
 test_expect_success "setup proc-receive hook (hook --die-read-push-options, $PROTOCOL)" '
-	test_hook -C "$upstream" --clobber proc-receive <<-\EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-\EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v --die-read-push-options
 	EOF
@@ -164,7 +164,7 @@ test_expect_success "proc-receive: bad protocol (hook --die-read-push-options, $
 '
 
 test_expect_success "setup proc-receive hook (hook --die-write-report, $PROTOCOL)" '
-	test_hook -C "$upstream" --clobber proc-receive <<-\EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-\EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v --die-write-report
 	EOF
@@ -194,7 +194,7 @@ test_expect_success "proc-receive: bad protocol (hook --die-write-report, $PROTO
 '
 
 test_expect_success "setup proc-receive hook (no report, $PROTOCOL)" '
-	test_hook -C "$upstream" --clobber proc-receive <<-\EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-\EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v
 	EOF
@@ -236,7 +236,7 @@ test_expect_success "cleanup ($PROTOCOL)" '
 '
 
 test_expect_success "setup proc-receive hook (no ref, $PROTOCOL)" '
-	test_hook -C "$upstream" --clobber proc-receive <<-\EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-\EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
 		-r "ok"
@@ -269,7 +269,7 @@ test_expect_success "proc-receive: bad protocol (no ref, $PROTOCOL)" '
 '
 
 test_expect_success "setup proc-receive hook (unknown status, $PROTOCOL)" '
-	test_hook -C "$upstream" --clobber proc-receive <<-\EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-\EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
 		-r "xx refs/for/main/topic"

--- a/t/t5411/test-0013-bad-protocol.sh
+++ b/t/t5411/test-0013-bad-protocol.sh
@@ -34,7 +34,7 @@ test_expect_success "proc-receive: bad protocol (unknown version, $PROTOCOL)" '
 	EOF
 	test_cmp expect actual-error &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-A> refs/heads/main
 	EOF
 '
@@ -65,7 +65,7 @@ test_expect_success "proc-receive: bad protocol (hook --die-read-version, $PROTO
 	grep "remote: fatal: die with the --die-read-version option" out-$test_count &&
 	grep "remote: error: fail to negotiate version with proc-receive hook" out-$test_count &&
 
-	test_cmp_refs -C "$upstream" <<-\EOF
+	test_cmp_refs --git-dir "$upstream" <<-\EOF
 	<COMMIT-A> refs/heads/main
 	EOF
 '
@@ -96,7 +96,7 @@ test_expect_success "proc-receive: bad protocol (hook --die-write-version, $PROT
 	grep "remote: fatal: die with the --die-write-version option" out-$test_count &&
 	grep "remote: error: fail to negotiate version with proc-receive hook" out-$test_count &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-A> refs/heads/main
 	EOF
 '
@@ -126,7 +126,7 @@ test_expect_success "proc-receive: bad protocol (hook --die-read-commands, $PROT
 	test_cmp expect actual &&
 	grep "remote: fatal: die with the --die-read-commands option" out-$test_count &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-A> refs/heads/main
 	EOF
 '
@@ -158,7 +158,7 @@ test_expect_success "proc-receive: bad protocol (hook --die-read-push-options, $
 	test_cmp expect actual &&
 	grep "remote: fatal: die with the --die-read-push-options option" out-$test_count &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-A> refs/heads/main
 	EOF
 '
@@ -188,7 +188,7 @@ test_expect_success "proc-receive: bad protocol (hook --die-write-report, $PROTO
 	test_cmp expect actual &&
 	grep "remote: fatal: die with the --die-write-report option" out-$test_count &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-A> refs/heads/main
 	EOF
 '
@@ -222,7 +222,7 @@ test_expect_success "proc-receive: bad protocol (no report, $PROTOCOL)" '
 	EOF
 	test_cmp expect actual &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-A> refs/heads/main
 	<COMMIT-A> refs/heads/next
 	EOF
@@ -263,7 +263,7 @@ test_expect_success "proc-receive: bad protocol (no ref, $PROTOCOL)" '
 	EOF
 	test_cmp expect actual &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-A> refs/heads/main
 	EOF
 '
@@ -296,7 +296,7 @@ test_expect_success "proc-receive: bad protocol (unknown status, $PROTOCOL)" '
 	EOF
 	test_cmp expect actual &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-A> refs/heads/main
 	EOF
 '

--- a/t/t5411/test-0014-bad-protocol--porcelain.sh
+++ b/t/t5411/test-0014-bad-protocol--porcelain.sh
@@ -1,5 +1,5 @@
 test_expect_success "setup proc-receive hook (unknown version, $PROTOCOL/porcelain)" '
-	test_hook -C "$upstream" --clobber proc-receive <<-\EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-\EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v --version 2
 	EOF
@@ -40,7 +40,7 @@ test_expect_success "proc-receive: bad protocol (unknown version, $PROTOCOL/porc
 '
 
 test_expect_success "setup proc-receive hook (hook --die-read-version, $PROTOCOL/porcelain)" '
-	test_hook -C "$upstream" --clobber proc-receive <<-EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v --die-read-version
 	EOF
@@ -71,7 +71,7 @@ test_expect_success "proc-receive: bad protocol (hook --die-read-version, $PROTO
 '
 
 test_expect_success "setup proc-receive hook (hook --die-write-version, $PROTOCOL/porcelain)" '
-	test_hook -C "$upstream" --clobber proc-receive <<-\EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-\EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v --die-write-version
 	EOF
@@ -102,7 +102,7 @@ test_expect_success "proc-receive: bad protocol (hook --die-write-version, $PROT
 '
 
 test_expect_success "setup proc-receive hook (hook --die-read-commands, $PROTOCOL/porcelain)" '
-	test_hook -C "$upstream" --clobber proc-receive <<-\EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-\EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v --die-read-commands
 	EOF
@@ -132,7 +132,7 @@ test_expect_success "proc-receive: bad protocol (hook --die-read-commands, $PROT
 '
 
 test_expect_success "setup proc-receive hook (hook --die-read-push-options, $PROTOCOL/porcelain)" '
-	test_hook -C "$upstream" --clobber proc-receive <<-\EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-\EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v --die-read-push-options
 	EOF
@@ -164,7 +164,7 @@ test_expect_success "proc-receive: bad protocol (hook --die-read-push-options, $
 '
 
 test_expect_success "setup proc-receive hook (hook --die-write-report, $PROTOCOL/porcelain)" '
-	test_hook -C "$upstream" --clobber proc-receive <<-\EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-\EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v --die-write-report
 	EOF
@@ -194,7 +194,7 @@ test_expect_success "proc-receive: bad protocol (hook --die-write-report, $PROTO
 '
 
 test_expect_success "setup proc-receive hook (no report, $PROTOCOL/porcelain)" '
-	test_hook -C "$upstream" --clobber proc-receive <<-\EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-\EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v
 	EOF
@@ -236,7 +236,7 @@ test_expect_success "cleanup ($PROTOCOL/porcelain)" '
 '
 
 test_expect_success "setup proc-receive hook (no ref, $PROTOCOL/porcelain)" '
-	test_hook -C "$upstream" --clobber proc-receive <<-\EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-\EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
 		-r "ok"
@@ -270,7 +270,7 @@ test_expect_success "proc-receive: bad protocol (no ref, $PROTOCOL/porcelain)" '
 '
 
 test_expect_success "setup proc-receive hook (unknown status, $PROTOCOL/porcelain)" '
-	test_hook -C "$upstream" --clobber proc-receive <<-\EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-\EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
 		-r "xx refs/for/main/topic"

--- a/t/t5411/test-0014-bad-protocol--porcelain.sh
+++ b/t/t5411/test-0014-bad-protocol--porcelain.sh
@@ -34,7 +34,7 @@ test_expect_success "proc-receive: bad protocol (unknown version, $PROTOCOL/porc
 	EOF
 	test_cmp expect actual-error &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-A> refs/heads/main
 	EOF
 '
@@ -65,7 +65,7 @@ test_expect_success "proc-receive: bad protocol (hook --die-read-version, $PROTO
 	grep "remote: fatal: die with the --die-read-version option" out-$test_count &&
 	grep "remote: error: fail to negotiate version with proc-receive hook" out-$test_count &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-A> refs/heads/main
 	EOF
 '
@@ -96,7 +96,7 @@ test_expect_success "proc-receive: bad protocol (hook --die-write-version, $PROT
 	grep "remote: fatal: die with the --die-write-version option" out-$test_count &&
 	grep "remote: error: fail to negotiate version with proc-receive hook" out-$test_count &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-A> refs/heads/main
 	EOF
 '
@@ -126,7 +126,7 @@ test_expect_success "proc-receive: bad protocol (hook --die-read-commands, $PROT
 	test_cmp expect actual &&
 	grep "remote: fatal: die with the --die-read-commands option" out-$test_count &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-A> refs/heads/main
 	EOF
 '
@@ -158,7 +158,7 @@ test_expect_success "proc-receive: bad protocol (hook --die-read-push-options, $
 	test_cmp expect actual &&
 	grep "remote: fatal: die with the --die-read-push-options option" out-$test_count &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-A> refs/heads/main
 	EOF
 '
@@ -188,7 +188,7 @@ test_expect_success "proc-receive: bad protocol (hook --die-write-report, $PROTO
 	test_cmp expect actual &&
 	grep "remote: fatal: die with the --die-write-report option" out-$test_count &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-A> refs/heads/main
 	EOF
 '
@@ -223,7 +223,7 @@ test_expect_success "proc-receive: bad protocol (no report, $PROTOCOL/porcelain)
 	EOF
 	test_cmp expect actual &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-A> refs/heads/main
 	<COMMIT-A> refs/heads/next
 	EOF
@@ -264,7 +264,7 @@ test_expect_success "proc-receive: bad protocol (no ref, $PROTOCOL/porcelain)" '
 	EOF
 	test_cmp expect actual &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-A> refs/heads/main
 	EOF
 '
@@ -298,7 +298,7 @@ test_expect_success "proc-receive: bad protocol (unknown status, $PROTOCOL/porce
 	EOF
 	test_cmp expect actual &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-A> refs/heads/main
 	EOF
 '

--- a/t/t5411/test-0014-bad-protocol--porcelain.sh
+++ b/t/t5411/test-0014-bad-protocol--porcelain.sh
@@ -142,7 +142,7 @@ test_expect_success "setup proc-receive hook (hook --die-read-push-options, $PRO
 # Refs of workbench: main(A)  tags/v123
 # git push         :                       refs/for/main/topic(A)
 test_expect_success "proc-receive: bad protocol (hook --die-read-push-options, $PROTOCOL/porcelain)" '
-	git -C "$upstream" config receive.advertisePushOptions true &&
+	git --git-dir="$upstream" config receive.advertisePushOptions true &&
 	test_must_fail git -C workbench push --porcelain origin \
 		-o reviewers=user1,user2 \
 		HEAD:refs/for/main/topic \
@@ -232,7 +232,7 @@ test_expect_success "proc-receive: bad protocol (no report, $PROTOCOL/porcelain)
 # Refs of upstream : main(A)             next(A)
 # Refs of workbench: main(A)  tags/v123
 test_expect_success "cleanup ($PROTOCOL/porcelain)" '
-	git -C "$upstream" update-ref -d refs/heads/next
+	git --git-dir="$upstream" update-ref -d refs/heads/next
 '
 
 test_expect_success "setup proc-receive hook (no ref, $PROTOCOL/porcelain)" '

--- a/t/t5411/test-0020-report-ng.sh
+++ b/t/t5411/test-0020-report-ng.sh
@@ -25,7 +25,7 @@ test_expect_success "proc-receive: fail to update (ng, no message, $PROTOCOL)" '
 	EOF
 	test_cmp expect actual &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-A> refs/heads/main
 	EOF
 '
@@ -57,7 +57,7 @@ test_expect_success "proc-receive: fail to update (ng, with message, $PROTOCOL)"
 	EOF
 	test_cmp expect actual &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-A> refs/heads/main
 	EOF
 '

--- a/t/t5411/test-0020-report-ng.sh
+++ b/t/t5411/test-0020-report-ng.sh
@@ -1,5 +1,5 @@
 test_expect_success "setup proc-receive hook (ng, no message, $PROTOCOL)" '
-	test_hook -C "$upstream" --clobber proc-receive <<-\EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-\EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
 		-r "ng refs/for/main/topic"
@@ -31,7 +31,7 @@ test_expect_success "proc-receive: fail to update (ng, no message, $PROTOCOL)" '
 '
 
 test_expect_success "setup proc-receive hook (ng message, $PROTOCOL)" '
-	test_hook -C "$upstream" --clobber proc-receive <<-\EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-\EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
 		-r "ng refs/for/main/topic error msg"

--- a/t/t5411/test-0021-report-ng--porcelain.sh
+++ b/t/t5411/test-0021-report-ng--porcelain.sh
@@ -1,5 +1,5 @@
 test_expect_success "setup proc-receive hook (ng, no message, $PROTOCOL/porcelain)" '
-	test_hook -C "$upstream" --clobber proc-receive <<-\EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-\EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
 		-r "ng refs/for/main/topic"
@@ -32,7 +32,7 @@ test_expect_success "proc-receive: fail to update (ng, no message, $PROTOCOL/por
 '
 
 test_expect_success "setup proc-receive hook (ng message, $PROTOCOL/porcelain)" '
-	test_hook -C "$upstream" --clobber proc-receive <<-\EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-\EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
 		-r "ng refs/for/main/topic error msg"

--- a/t/t5411/test-0021-report-ng--porcelain.sh
+++ b/t/t5411/test-0021-report-ng--porcelain.sh
@@ -26,7 +26,7 @@ test_expect_success "proc-receive: fail to update (ng, no message, $PROTOCOL/por
 	EOF
 	test_cmp expect actual &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-A> refs/heads/main
 	EOF
 '
@@ -59,7 +59,7 @@ test_expect_success "proc-receive: fail to update (ng, with message, $PROTOCOL/p
 	EOF
 	test_cmp expect actual &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-A> refs/heads/main
 	EOF
 '

--- a/t/t5411/test-0022-report-unexpect-ref.sh
+++ b/t/t5411/test-0022-report-unexpect-ref.sh
@@ -1,5 +1,5 @@
 test_expect_success "setup proc-receive hook (unexpected ref, $PROTOCOL)" '
-	test_hook -C "$upstream" --clobber proc-receive <<-\EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-\EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
 		-r "ok refs/heads/main"

--- a/t/t5411/test-0022-report-unexpect-ref.sh
+++ b/t/t5411/test-0022-report-unexpect-ref.sh
@@ -39,5 +39,5 @@ test_expect_success "proc-receive: report unexpected ref ($PROTOCOL)" '
 # Refs of upstream : main(B)
 # Refs of workbench: main(A)  tags/v123
 test_expect_success "cleanup ($PROTOCOL)" '
-	git -C "$upstream" update-ref refs/heads/main $A
+	git --git-dir="$upstream" update-ref refs/heads/main $A
 '

--- a/t/t5411/test-0022-report-unexpect-ref.sh
+++ b/t/t5411/test-0022-report-unexpect-ref.sh
@@ -31,7 +31,7 @@ test_expect_success "proc-receive: report unexpected ref ($PROTOCOL)" '
 	EOF
 	test_cmp expect actual &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-B> refs/heads/main
 	EOF
 '

--- a/t/t5411/test-0023-report-unexpect-ref--porcelain.sh
+++ b/t/t5411/test-0023-report-unexpect-ref--porcelain.sh
@@ -40,5 +40,5 @@ test_expect_success "proc-receive: report unexpected ref ($PROTOCOL/porcelain)" 
 # Refs of upstream : main(B)
 # Refs of workbench: main(A)  tags/v123
 test_expect_success "cleanup ($PROTOCOL/porcelain)" '
-	git -C "$upstream" update-ref refs/heads/main $A
+	git --git-dir="$upstream" update-ref refs/heads/main $A
 '

--- a/t/t5411/test-0023-report-unexpect-ref--porcelain.sh
+++ b/t/t5411/test-0023-report-unexpect-ref--porcelain.sh
@@ -32,7 +32,7 @@ test_expect_success "proc-receive: report unexpected ref ($PROTOCOL/porcelain)" 
 	EOF
 	test_cmp expect actual &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-B> refs/heads/main
 	EOF
 '

--- a/t/t5411/test-0023-report-unexpect-ref--porcelain.sh
+++ b/t/t5411/test-0023-report-unexpect-ref--porcelain.sh
@@ -1,5 +1,5 @@
 test_expect_success "setup proc-receive hook (unexpected ref, $PROTOCOL/porcelain)" '
-	test_hook -C "$upstream" --clobber proc-receive <<-\EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-\EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
 		-r "ok refs/heads/main"

--- a/t/t5411/test-0024-report-unknown-ref.sh
+++ b/t/t5411/test-0024-report-unknown-ref.sh
@@ -26,7 +26,7 @@ test_expect_success "proc-receive: report unknown reference ($PROTOCOL)" '
 	EOF
 	test_cmp expect actual &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-A> refs/heads/main
 	EOF
 '

--- a/t/t5411/test-0024-report-unknown-ref.sh
+++ b/t/t5411/test-0024-report-unknown-ref.sh
@@ -1,5 +1,5 @@
 test_expect_success "setup proc-receive hook (unexpected ref, $PROTOCOL)" '
-	test_hook -C "$upstream" --clobber proc-receive <<-\EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-\EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
 		-r "ok refs/for/main/topic"

--- a/t/t5411/test-0025-report-unknown-ref--porcelain.sh
+++ b/t/t5411/test-0025-report-unknown-ref--porcelain.sh
@@ -1,5 +1,5 @@
 test_expect_success "setup proc-receive hook (unexpected ref, $PROTOCOL/porcelain)" '
-	test_hook -C "$upstream" --clobber proc-receive <<-\EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-\EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
 		-r "ok refs/for/main/topic"

--- a/t/t5411/test-0025-report-unknown-ref--porcelain.sh
+++ b/t/t5411/test-0025-report-unknown-ref--porcelain.sh
@@ -27,7 +27,7 @@ test_expect_success "proc-receive: report unknown reference ($PROTOCOL/porcelain
 	EOF
 	test_cmp expect actual &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-A> refs/heads/main
 	EOF
 '

--- a/t/t5411/test-0026-push-options.sh
+++ b/t/t5411/test-0026-push-options.sh
@@ -1,5 +1,5 @@
 test_expect_success "setup proc-receive hook and disable push-options ($PROTOCOL)" '
-	git -C "$upstream" config receive.advertisePushOptions false &&
+	git --git-dir="$upstream" config receive.advertisePushOptions false &&
 	test_hook --git-dir "$upstream" --clobber proc-receive <<-\EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
@@ -27,7 +27,7 @@ test_expect_success "proc-receive: not support push options ($PROTOCOL)" '
 '
 
 test_expect_success "enable push options ($PROTOCOL)" '
-	git -C "$upstream" config receive.advertisePushOptions true
+	git --git-dir="$upstream" config receive.advertisePushOptions true
 '
 
 test_expect_success "setup version=0 for proc-receive hook ($PROTOCOL)" '
@@ -85,7 +85,7 @@ test_expect_success "restore proc-receive hook ($PROTOCOL)" '
 # Refs of upstream : main(A)             next(A)
 # Refs of workbench: main(A)  tags/v123
 test_expect_success "cleanup ($PROTOCOL)" '
-	git -C "$upstream" update-ref -d refs/heads/next
+	git --git-dir="$upstream" update-ref -d refs/heads/next
 '
 
 # Refs of upstream : main(A)
@@ -129,5 +129,5 @@ test_expect_success "proc-receive: push with options ($PROTOCOL)" '
 # Refs of upstream : main(A)             next(A)
 # Refs of workbench: main(A)  tags/v123
 test_expect_success "cleanup ($PROTOCOL)" '
-	git -C "$upstream" update-ref -d refs/heads/next
+	git --git-dir="$upstream" update-ref -d refs/heads/next
 '

--- a/t/t5411/test-0026-push-options.sh
+++ b/t/t5411/test-0026-push-options.sh
@@ -1,6 +1,6 @@
 test_expect_success "setup proc-receive hook and disable push-options ($PROTOCOL)" '
 	git -C "$upstream" config receive.advertisePushOptions false &&
-	test_hook -C "$upstream" --clobber proc-receive <<-\EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-\EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
 		-r "ok refs/for/main/topic"
@@ -31,7 +31,7 @@ test_expect_success "enable push options ($PROTOCOL)" '
 '
 
 test_expect_success "setup version=0 for proc-receive hook ($PROTOCOL)" '
-	test_hook -C "$upstream" --clobber proc-receive <<-\EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-\EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
 		--version 0 \
@@ -75,7 +75,7 @@ test_expect_success "proc-receive: ignore push-options for version 0 ($PROTOCOL)
 '
 
 test_expect_success "restore proc-receive hook ($PROTOCOL)" '
-	test_hook -C "$upstream" --clobber proc-receive <<-\EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-\EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
 		-r "ok refs/for/main/topic"

--- a/t/t5411/test-0026-push-options.sh
+++ b/t/t5411/test-0026-push-options.sh
@@ -21,7 +21,7 @@ test_expect_success "proc-receive: not support push options ($PROTOCOL)" '
 	test_grep "fatal: the receiving end does not support push options" \
 		actual &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-A> refs/heads/main
 	EOF
 '
@@ -68,7 +68,7 @@ test_expect_success "proc-receive: ignore push-options for version 0 ($PROTOCOL)
 	EOF
 	test_cmp expect actual &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-A> refs/heads/main
 	<COMMIT-A> refs/heads/next
 	EOF
@@ -120,7 +120,7 @@ test_expect_success "proc-receive: push with options ($PROTOCOL)" '
 	EOF
 	test_cmp expect actual &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-A> refs/heads/main
 	<COMMIT-A> refs/heads/next
 	EOF

--- a/t/t5411/test-0027-push-options--porcelain.sh
+++ b/t/t5411/test-0027-push-options--porcelain.sh
@@ -1,6 +1,6 @@
 test_expect_success "setup proc-receive hook and disable push-options ($PROTOCOL/porcelain)" '
 	git -C "$upstream" config receive.advertisePushOptions false &&
-	test_hook -C "$upstream" --clobber proc-receive <<-\EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-\EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
 		-r "ok refs/for/main/topic"
@@ -32,7 +32,7 @@ test_expect_success "enable push options ($PROTOCOL/porcelain)" '
 '
 
 test_expect_success "setup version=0 for proc-receive hook ($PROTOCOL/porcelain)" '
-	test_hook -C "$upstream" --clobber proc-receive <<-\EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-\EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
 		--version 0 \
@@ -78,7 +78,7 @@ test_expect_success "proc-receive: ignore push-options for version 0 ($PROTOCOL/
 '
 
 test_expect_success "restore proc-receive hook ($PROTOCOL/porcelain)" '
-	test_hook -C "$upstream" --clobber proc-receive <<-\EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-\EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
 		-r "ok refs/for/main/topic"

--- a/t/t5411/test-0027-push-options--porcelain.sh
+++ b/t/t5411/test-0027-push-options--porcelain.sh
@@ -22,7 +22,7 @@ test_expect_success "proc-receive: not support push options ($PROTOCOL/porcelain
 	test_grep "fatal: the receiving end does not support push options" \
 		actual &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-A> refs/heads/main
 	EOF
 '
@@ -71,7 +71,7 @@ test_expect_success "proc-receive: ignore push-options for version 0 ($PROTOCOL/
 	EOF
 	test_cmp expect actual &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-A> refs/heads/main
 	<COMMIT-A> refs/heads/next
 	EOF
@@ -125,7 +125,7 @@ test_expect_success "proc-receive: push with options ($PROTOCOL/porcelain)" '
 	EOF
 	test_cmp expect actual &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-A> refs/heads/main
 	<COMMIT-A> refs/heads/next
 	EOF

--- a/t/t5411/test-0027-push-options--porcelain.sh
+++ b/t/t5411/test-0027-push-options--porcelain.sh
@@ -1,5 +1,5 @@
 test_expect_success "setup proc-receive hook and disable push-options ($PROTOCOL/porcelain)" '
-	git -C "$upstream" config receive.advertisePushOptions false &&
+	git --git-dir="$upstream" config receive.advertisePushOptions false &&
 	test_hook --git-dir "$upstream" --clobber proc-receive <<-\EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
@@ -28,7 +28,7 @@ test_expect_success "proc-receive: not support push options ($PROTOCOL/porcelain
 '
 
 test_expect_success "enable push options ($PROTOCOL/porcelain)" '
-	git -C "$upstream" config receive.advertisePushOptions true
+	git --git-dir="$upstream" config receive.advertisePushOptions true
 '
 
 test_expect_success "setup version=0 for proc-receive hook ($PROTOCOL/porcelain)" '
@@ -88,7 +88,7 @@ test_expect_success "restore proc-receive hook ($PROTOCOL/porcelain)" '
 # Refs of upstream : main(A)             next(A)
 # Refs of workbench: main(A)  tags/v123
 test_expect_success "cleanup ($PROTOCOL/porcelain)" '
-	git -C "$upstream" update-ref -d refs/heads/next
+	git --git-dir="$upstream" update-ref -d refs/heads/next
 '
 
 # Refs of upstream : main(A)
@@ -134,5 +134,5 @@ test_expect_success "proc-receive: push with options ($PROTOCOL/porcelain)" '
 # Refs of upstream : main(A)             next(A)
 # Refs of workbench: main(A)  tags/v123
 test_expect_success "cleanup ($PROTOCOL/porcelain)" '
-	git -C "$upstream" update-ref -d refs/heads/next
+	git --git-dir="$upstream" update-ref -d refs/heads/next
 '

--- a/t/t5411/test-0030-report-ok.sh
+++ b/t/t5411/test-0030-report-ok.sh
@@ -1,5 +1,5 @@
 test_expect_success "setup proc-receive hook (ok, $PROTOCOL)" '
-	test_hook -C "$upstream" --clobber proc-receive <<-\EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-\EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
 		-r "ok refs/for/main/topic"

--- a/t/t5411/test-0030-report-ok.sh
+++ b/t/t5411/test-0030-report-ok.sh
@@ -27,7 +27,7 @@ test_expect_success "proc-receive: ok ($PROTOCOL)" '
 	EOF
 	test_cmp expect actual &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-A> refs/heads/main
 	EOF
 '

--- a/t/t5411/test-0031-report-ok--porcelain.sh
+++ b/t/t5411/test-0031-report-ok--porcelain.sh
@@ -1,5 +1,5 @@
 test_expect_success "setup proc-receive hook (ok, $PROTOCOL/porcelain)" '
-	test_hook -C "$upstream" --clobber proc-receive <<-\EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-\EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
 		-r "ok refs/for/main/topic"

--- a/t/t5411/test-0031-report-ok--porcelain.sh
+++ b/t/t5411/test-0031-report-ok--porcelain.sh
@@ -28,7 +28,7 @@ test_expect_success "proc-receive: ok ($PROTOCOL/porcelain)" '
 	EOF
 	test_cmp expect actual &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-A> refs/heads/main
 	EOF
 '

--- a/t/t5411/test-0032-report-with-options.sh
+++ b/t/t5411/test-0032-report-with-options.sh
@@ -247,7 +247,7 @@ test_expect_success "proc-receive: report with multiple rewrites ($PROTOCOL)" '
 	EOF
 	test_cmp expect actual &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-A> refs/heads/main
 	EOF
 '

--- a/t/t5411/test-0032-report-with-options.sh
+++ b/t/t5411/test-0032-report-with-options.sh
@@ -1,5 +1,5 @@
 test_expect_success "setup proc-receive hook (option without matching ok, $PROTOCOL)" '
-	test_hook -C "$upstream" --clobber proc-receive <<-EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
 		-r "option refname refs/pull/123/head" \
@@ -30,7 +30,7 @@ test_expect_success "proc-receive: report option without matching ok ($PROTOCOL)
 '
 
 test_expect_success "setup proc-receive hook (option refname, $PROTOCOL)" '
-	test_hook -C "$upstream" --clobber proc-receive <<-\EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-\EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
 		-r "ok refs/for/main/topic" \
@@ -62,7 +62,7 @@ test_expect_success "proc-receive: report option refname ($PROTOCOL)" '
 '
 
 test_expect_success "setup proc-receive hook (option refname and forced-update, $PROTOCOL)" '
-	test_hook -C "$upstream" --clobber proc-receive <<-\EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-\EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
 		-r "ok refs/for/main/topic" \
@@ -95,7 +95,7 @@ test_expect_success "proc-receive: report option refname and forced-update ($PRO
 '
 
 test_expect_success "setup proc-receive hook (option refname and old-oid, $PROTOCOL)" '
-	test_hook -C "$upstream" --clobber proc-receive <<-EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
 		-r "ok refs/for/main/topic" \
@@ -129,7 +129,7 @@ test_expect_success "proc-receive: report option refname and old-oid ($PROTOCOL)
 '
 
 test_expect_success "setup proc-receive hook (option old-oid, $PROTOCOL)" '
-	test_hook -C "$upstream" --clobber proc-receive <<-EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
 		-r "ok refs/for/main/topic" \
@@ -161,7 +161,7 @@ test_expect_success "proc-receive: report option old-oid ($PROTOCOL)" '
 '
 
 test_expect_success "setup proc-receive hook (option old-oid and new-oid, $PROTOCOL)" '
-	test_hook -C "$upstream" --clobber proc-receive <<-EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
 		-r "ok refs/for/main/topic" \
@@ -195,7 +195,7 @@ test_expect_success "proc-receive: report option old-oid and new-oid ($PROTOCOL)
 '
 
 test_expect_success "setup proc-receive hook (report with multiple rewrites, $PROTOCOL)" '
-	test_hook -C "$upstream" --clobber proc-receive <<-EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
 		-r "ok refs/for/a/b/c/topic" \

--- a/t/t5411/test-0033-report-with-options--porcelain.sh
+++ b/t/t5411/test-0033-report-with-options--porcelain.sh
@@ -1,5 +1,5 @@
 test_expect_success "setup proc-receive hook (option without matching ok, $PROTOCOL/porcelain)" '
-	test_hook -C "$upstream" --clobber proc-receive <<-EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
 		-r "option refname refs/pull/123/head" \
@@ -31,7 +31,7 @@ test_expect_success "proc-receive: report option without matching ok ($PROTOCOL/
 '
 
 test_expect_success "setup proc-receive hook (option refname, $PROTOCOL/porcelain)" '
-	test_hook -C "$upstream" --clobber proc-receive <<-\EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-\EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
 		-r "ok refs/for/main/topic" \
@@ -64,7 +64,7 @@ test_expect_success "proc-receive: report option refname ($PROTOCOL/porcelain)" 
 '
 
 test_expect_success "setup proc-receive hook (option refname and forced-update, $PROTOCOL/porcelain)" '
-	test_hook -C "$upstream" --clobber proc-receive <<-\EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-\EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
 		-r "ok refs/for/main/topic" \
@@ -99,7 +99,7 @@ test_expect_success "proc-receive: report option refname and forced-update ($PRO
 '
 
 test_expect_success "setup proc-receive hook (option refname and old-oid, $PROTOCOL/porcelain)" '
-	test_hook -C "$upstream" --clobber proc-receive <<-EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
 		-r "ok refs/for/main/topic" \
@@ -134,7 +134,7 @@ test_expect_success "proc-receive: report option refname and old-oid ($PROTOCOL/
 '
 
 test_expect_success "setup proc-receive hook (option old-oid, $PROTOCOL/porcelain)" '
-	test_hook -C "$upstream" --clobber proc-receive <<-EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
 		-r "ok refs/for/main/topic" \
@@ -167,7 +167,7 @@ test_expect_success "proc-receive: report option old-oid ($PROTOCOL/porcelain)" 
 '
 
 test_expect_success "setup proc-receive hook (option old-oid and new-oid, $PROTOCOL/porcelain)" '
-	test_hook -C "$upstream" --clobber proc-receive <<-EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
 		-r "ok refs/for/main/topic" \
@@ -202,7 +202,7 @@ test_expect_success "proc-receive: report option old-oid and new-oid ($PROTOCOL/
 '
 
 test_expect_success "setup proc-receive hook (report with multiple rewrites, $PROTOCOL/porcelain)" '
-	test_hook -C "$upstream" --clobber proc-receive <<-EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
 		-r "ok refs/for/a/b/c/topic" \

--- a/t/t5411/test-0033-report-with-options--porcelain.sh
+++ b/t/t5411/test-0033-report-with-options--porcelain.sh
@@ -256,7 +256,7 @@ test_expect_success "proc-receive: report with multiple rewrites ($PROTOCOL/porc
 	EOF
 	test_cmp expect actual &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-A> refs/heads/main
 	EOF
 '

--- a/t/t5411/test-0034-report-ft.sh
+++ b/t/t5411/test-0034-report-ft.sh
@@ -38,5 +38,5 @@ test_expect_success "proc-receive: fall through, let receive-pack to execute ($P
 # Refs of upstream : main(A)             refs/for/main/topic(A)
 # Refs of workbench: main(A)  tags/v123
 test_expect_success "cleanup ($PROTOCOL)" '
-	git -C "$upstream" update-ref -d refs/for/main/topic
+	git --git-dir="$upstream" update-ref -d refs/for/main/topic
 '

--- a/t/t5411/test-0034-report-ft.sh
+++ b/t/t5411/test-0034-report-ft.sh
@@ -1,5 +1,5 @@
 test_expect_success "setup proc-receive hook (ft, $PROTOCOL)" '
-	test_hook -C "$upstream" --clobber proc-receive <<-\EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-\EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
 		-r "ok refs/for/main/topic" \

--- a/t/t5411/test-0034-report-ft.sh
+++ b/t/t5411/test-0034-report-ft.sh
@@ -29,7 +29,7 @@ test_expect_success "proc-receive: fall through, let receive-pack to execute ($P
 	EOF
 	test_cmp expect actual &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-B> refs/for/main/topic
 	<COMMIT-A> refs/heads/main
 	EOF

--- a/t/t5411/test-0035-report-ft--porcelain.sh
+++ b/t/t5411/test-0035-report-ft--porcelain.sh
@@ -30,7 +30,7 @@ test_expect_success "proc-receive: fall through, let receive-pack to execute ($P
 	EOF
 	test_cmp expect actual &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-B> refs/for/main/topic
 	<COMMIT-A> refs/heads/main
 	EOF

--- a/t/t5411/test-0035-report-ft--porcelain.sh
+++ b/t/t5411/test-0035-report-ft--porcelain.sh
@@ -39,5 +39,5 @@ test_expect_success "proc-receive: fall through, let receive-pack to execute ($P
 # Refs of upstream : main(A)             refs/for/main/topic(A)
 # Refs of workbench: main(A)  tags/v123
 test_expect_success "cleanup ($PROTOCOL/porcelain)" '
-	git -C "$upstream" update-ref -d refs/for/main/topic
+	git --git-dir="$upstream" update-ref -d refs/for/main/topic
 '

--- a/t/t5411/test-0035-report-ft--porcelain.sh
+++ b/t/t5411/test-0035-report-ft--porcelain.sh
@@ -1,5 +1,5 @@
 test_expect_success "setup proc-receive hook (fall-through, $PROTOCOL/porcelain)" '
-	test_hook -C "$upstream" --clobber proc-receive <<-\EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-\EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
 		-r "ok refs/for/main/topic" \

--- a/t/t5411/test-0036-report-multi-rewrite-for-one-ref.sh
+++ b/t/t5411/test-0036-report-multi-rewrite-for-one-ref.sh
@@ -14,7 +14,7 @@ test_expect_success "setup git config for remote-tracking of special refs" '
 '
 
 test_expect_success "setup proc-receive hook (multiple rewrites for one ref, no refname for the 1st rewrite, $PROTOCOL)" '
-	test_hook -C "$upstream" --clobber proc-receive <<-EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
 		-r "ok refs/for/main/topic" \
@@ -87,7 +87,7 @@ test_expect_success "proc-receive: check remote-tracking #1 ($PROTOCOL)" '
 '
 
 test_expect_success "setup proc-receive hook (multiple rewrites for one ref, no refname for the 2nd rewrite, $PROTOCOL)" '
-	test_hook -C "$upstream" --clobber proc-receive <<-EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
 		-r "ok refs/for/main/topic" \
@@ -162,7 +162,7 @@ test_expect_success "proc-receive: check remote-tracking #2 ($PROTOCOL)" '
 '
 
 test_expect_success "setup proc-receive hook (multiple rewrites for one ref, $PROTOCOL)" '
-	test_hook -C "$upstream" --clobber proc-receive <<-EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
 		-r "ok refs/for/main/topic" \

--- a/t/t5411/test-0036-report-multi-rewrite-for-one-ref.sh
+++ b/t/t5411/test-0036-report-multi-rewrite-for-one-ref.sh
@@ -66,7 +66,7 @@ test_expect_success "proc-receive: multiple rewrite for one ref, no refname for 
 	EOF
 	test_cmp expect actual &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-A> refs/heads/main
 	EOF
 '
@@ -141,7 +141,7 @@ test_expect_success "proc-receive: multiple rewrites for one ref, no refname for
 	EOF
 	test_cmp expect actual &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-A> refs/heads/main
 	EOF
 '
@@ -202,7 +202,7 @@ test_expect_success "proc-receive: multiple rewrites for one ref ($PROTOCOL)" '
 	EOF
 	test_cmp expect actual &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-A> refs/heads/main
 	EOF
 '

--- a/t/t5411/test-0037-report-multi-rewrite-for-one-ref--porcelain.sh
+++ b/t/t5411/test-0037-report-multi-rewrite-for-one-ref--porcelain.sh
@@ -52,7 +52,7 @@ test_expect_success "proc-receive: multiple rewrite for one ref, no refname for 
 	EOF
 	test_cmp expect actual &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-A> refs/heads/main
 	EOF
 '
@@ -113,7 +113,7 @@ test_expect_success "proc-receive: multiple rewrites for one ref, no refname for
 	EOF
 	test_cmp expect actual &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-A> refs/heads/main
 	EOF
 '
@@ -160,7 +160,7 @@ test_expect_success "proc-receive: multiple rewrites for one ref ($PROTOCOL/porc
 	EOF
 	test_cmp expect actual &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-A> refs/heads/main
 	EOF
 '

--- a/t/t5411/test-0037-report-multi-rewrite-for-one-ref--porcelain.sh
+++ b/t/t5411/test-0037-report-multi-rewrite-for-one-ref--porcelain.sh
@@ -1,5 +1,5 @@
 test_expect_success "setup proc-receive hook (multiple rewrites for one ref, no refname for the 1st rewrite, $PROTOCOL/porcelain)" '
-	test_hook -C "$upstream" --clobber proc-receive <<-EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
 		-r "ok refs/for/main/topic" \
@@ -58,7 +58,7 @@ test_expect_success "proc-receive: multiple rewrite for one ref, no refname for 
 '
 
 test_expect_success "setup proc-receive hook (multiple rewrites for one ref, no refname for the 2nd rewrite, $PROTOCOL/porcelain)" '
-	test_hook -C "$upstream" --clobber proc-receive <<-EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
 		-r "ok refs/for/main/topic" \
@@ -119,7 +119,7 @@ test_expect_success "proc-receive: multiple rewrites for one ref, no refname for
 '
 
 test_expect_success "setup proc-receive hook (multiple rewrites for one ref, $PROTOCOL/porcelain)" '
-	test_hook -C "$upstream" --clobber proc-receive <<-EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
 		-r "ok refs/for/main/topic" \

--- a/t/t5411/test-0038-report-mixed-refs.sh
+++ b/t/t5411/test-0038-report-mixed-refs.sh
@@ -78,7 +78,7 @@ test_expect_success "proc-receive: report update of mixed refs ($PROTOCOL)" '
 # Refs of workbench: main(A)  tags/v123
 test_expect_success "cleanup ($PROTOCOL)" '
 	(
-		cd "$upstream" &&
+		cd "$upstream" && GIT_DIR=. && export GIT_DIR &&
 		git update-ref refs/heads/main $A &&
 		git update-ref -d refs/heads/foo &&
 		git update-ref -d refs/heads/bar &&

--- a/t/t5411/test-0038-report-mixed-refs.sh
+++ b/t/t5411/test-0038-report-mixed-refs.sh
@@ -1,5 +1,5 @@
 test_expect_success "setup proc-receive hook ($PROTOCOL)" '
-	test_hook -C "$upstream" --clobber proc-receive <<-EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
 		-r "ok refs/for/next/topic2" \

--- a/t/t5411/test-0038-report-mixed-refs.sh
+++ b/t/t5411/test-0038-report-mixed-refs.sh
@@ -66,7 +66,7 @@ test_expect_success "proc-receive: report update of mixed refs ($PROTOCOL)" '
 	EOF
 	test_cmp expect actual &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-A> refs/heads/bar
 	<COMMIT-A> refs/heads/baz
 	<COMMIT-A> refs/heads/foo

--- a/t/t5411/test-0039-report-mixed-refs--porcelain.sh
+++ b/t/t5411/test-0039-report-mixed-refs--porcelain.sh
@@ -67,7 +67,7 @@ test_expect_success "proc-receive: report update of mixed refs ($PROTOCOL/porcel
 	EOF
 	test_cmp expect actual &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-A> refs/heads/bar
 	<COMMIT-A> refs/heads/baz
 	<COMMIT-A> refs/heads/foo

--- a/t/t5411/test-0039-report-mixed-refs--porcelain.sh
+++ b/t/t5411/test-0039-report-mixed-refs--porcelain.sh
@@ -1,5 +1,5 @@
 test_expect_success "setup proc-receive hook ($PROTOCOL/porcelain)" '
-	test_hook -C "$upstream" --clobber proc-receive <<-EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
 		-r "ok refs/for/next/topic2" \

--- a/t/t5411/test-0039-report-mixed-refs--porcelain.sh
+++ b/t/t5411/test-0039-report-mixed-refs--porcelain.sh
@@ -79,7 +79,7 @@ test_expect_success "proc-receive: report update of mixed refs ($PROTOCOL/porcel
 # Refs of workbench: main(A)  tags/v123
 test_expect_success "cleanup ($PROTOCOL/porcelain)" '
 	(
-		cd "$upstream" &&
+		cd "$upstream" && GIT_DIR=. && export GIT_DIR &&
 		git update-ref refs/heads/main $A &&
 		git update-ref -d refs/heads/foo &&
 		git update-ref -d refs/heads/bar &&

--- a/t/t5411/test-0040-process-all-refs.sh
+++ b/t/t5411/test-0040-process-all-refs.sh
@@ -7,7 +7,7 @@ test_expect_success "config receive.procReceiveRefs = refs ($PROTOCOL)" '
 # Refs of workbench: main(A)  tags/v123
 test_expect_success "setup upstream branches ($PROTOCOL)" '
 	(
-		cd "$upstream" &&
+		cd "$upstream" && GIT_DIR=. && export GIT_DIR &&
 		git update-ref refs/heads/main $B &&
 		git update-ref refs/heads/foo $A &&
 		git update-ref refs/heads/bar $A &&
@@ -104,7 +104,7 @@ test_expect_success "proc-receive: process all refs ($PROTOCOL)" '
 # Refs of workbench: main(A)  tags/v123
 test_expect_success "cleanup ($PROTOCOL)" '
 	(
-		cd "$upstream" &&
+		cd "$upstream" && GIT_DIR=. && export GIT_DIR &&
 		git update-ref -d refs/heads/bar &&
 		git update-ref -d refs/heads/baz
 	)

--- a/t/t5411/test-0040-process-all-refs.sh
+++ b/t/t5411/test-0040-process-all-refs.sh
@@ -1,6 +1,6 @@
 test_expect_success "config receive.procReceiveRefs = refs ($PROTOCOL)" '
-	git -C "$upstream" config --unset-all receive.procReceiveRefs &&
-	git -C "$upstream" config --add receive.procReceiveRefs refs
+	git --git-dir="$upstream" config --unset-all receive.procReceiveRefs &&
+	git --git-dir="$upstream" config --add receive.procReceiveRefs refs
 '
 
 # Refs of upstream : main(A)

--- a/t/t5411/test-0040-process-all-refs.sh
+++ b/t/t5411/test-0040-process-all-refs.sh
@@ -93,7 +93,7 @@ test_expect_success "proc-receive: process all refs ($PROTOCOL)" '
 	EOF
 	test_cmp expect actual &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-B> refs/heads/bar
 	<COMMIT-A> refs/heads/baz
 	<COMMIT-A> refs/heads/main

--- a/t/t5411/test-0040-process-all-refs.sh
+++ b/t/t5411/test-0040-process-all-refs.sh
@@ -17,7 +17,7 @@ test_expect_success "setup upstream branches ($PROTOCOL)" '
 '
 
 test_expect_success "setup proc-receive hook ($PROTOCOL)" '
-	test_hook -C "$upstream" --clobber proc-receive <<-EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
 		-r "ok refs/heads/main" \

--- a/t/t5411/test-0041-process-all-refs--porcelain.sh
+++ b/t/t5411/test-0041-process-all-refs--porcelain.sh
@@ -1,6 +1,6 @@
 test_expect_success "config receive.procReceiveRefs = refs ($PROTOCOL/porcelain)" '
-	git -C "$upstream" config --unset-all receive.procReceiveRefs &&
-	git -C "$upstream" config --add receive.procReceiveRefs refs
+	git --git-dir="$upstream" config --unset-all receive.procReceiveRefs &&
+	git --git-dir="$upstream" config --add receive.procReceiveRefs refs
 '
 
 # Refs of upstream : main(A)

--- a/t/t5411/test-0041-process-all-refs--porcelain.sh
+++ b/t/t5411/test-0041-process-all-refs--porcelain.sh
@@ -17,7 +17,7 @@ test_expect_success "setup upstream branches ($PROTOCOL/porcelain)" '
 '
 
 test_expect_success "setup proc-receive hook ($PROTOCOL/porcelain)" '
-	test_hook -C "$upstream" --clobber proc-receive <<-EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
 		-r "ok refs/heads/main" \

--- a/t/t5411/test-0041-process-all-refs--porcelain.sh
+++ b/t/t5411/test-0041-process-all-refs--porcelain.sh
@@ -7,7 +7,7 @@ test_expect_success "config receive.procReceiveRefs = refs ($PROTOCOL/porcelain)
 # Refs of workbench: main(A)  tags/v123
 test_expect_success "setup upstream branches ($PROTOCOL/porcelain)" '
 	(
-		cd "$upstream" &&
+		cd "$upstream" && GIT_DIR=. && export GIT_DIR &&
 		git update-ref refs/heads/main $B &&
 		git update-ref refs/heads/foo $A &&
 		git update-ref refs/heads/bar $A &&
@@ -105,7 +105,7 @@ test_expect_success "proc-receive: process all refs ($PROTOCOL/porcelain)" '
 # Refs of workbench: main(A)  tags/v123
 test_expect_success "cleanup ($PROTOCOL/porcelain)" '
 	(
-		cd "$upstream" &&
+		cd "$upstream" && GIT_DIR=. && export GIT_DIR &&
 		git update-ref -d refs/heads/bar &&
 		git update-ref -d refs/heads/baz
 	)

--- a/t/t5411/test-0041-process-all-refs--porcelain.sh
+++ b/t/t5411/test-0041-process-all-refs--porcelain.sh
@@ -94,7 +94,7 @@ test_expect_success "proc-receive: process all refs ($PROTOCOL/porcelain)" '
 	EOF
 	test_cmp expect actual &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-B> refs/heads/bar
 	<COMMIT-A> refs/heads/baz
 	<COMMIT-A> refs/heads/main

--- a/t/t5411/test-0050-proc-receive-refs-with-modifiers.sh
+++ b/t/t5411/test-0050-proc-receive-refs-with-modifiers.sh
@@ -51,7 +51,7 @@ test_expect_success "proc-receive: update branch and new tag ($PROTOCOL)" '
 	EOF
 	test_cmp expect actual &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-A> refs/heads/main
 	EOF
 '
@@ -62,7 +62,7 @@ test_expect_success "setup upstream: create tags/v123 ($PROTOCOL)" '
 	git -C "$upstream" update-ref refs/heads/topic $A &&
 	git -C "$upstream" update-ref refs/tags/v123 $TAG &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-A> refs/heads/main
 	<COMMIT-A> refs/heads/topic
 	<TAG-v123> refs/tags/v123
@@ -122,7 +122,7 @@ test_expect_success "proc-receive: create/delete branch, and delete tag ($PROTOC
 	EOF
 	test_cmp expect actual &&
 
-	test_cmp_refs -C "$upstream" <<-EOF
+	test_cmp_refs --git-dir "$upstream" <<-EOF
 	<COMMIT-A> refs/heads/main
 	<COMMIT-B> refs/heads/topic
 	EOF

--- a/t/t5411/test-0050-proc-receive-refs-with-modifiers.sh
+++ b/t/t5411/test-0050-proc-receive-refs-with-modifiers.sh
@@ -9,7 +9,7 @@ test_expect_success "config receive.procReceiveRefs with modifiers ($PROTOCOL)" 
 '
 
 test_expect_success "setup proc-receive hook ($PROTOCOL)" '
-	test_hook -C "$upstream" --clobber proc-receive <<-EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
 		-r "ok refs/heads/main" \
@@ -70,7 +70,7 @@ test_expect_success "setup upstream: create tags/v123 ($PROTOCOL)" '
 '
 
 test_expect_success "setup proc-receive hook ($PROTOCOL)" '
-	test_hook -C "$upstream" --clobber proc-receive <<-EOF
+	test_hook --git-dir "$upstream" --clobber proc-receive <<-EOF
 	printf >&2 "# proc-receive hook\n"
 	test-tool proc-receive -v \
 		-r "ok refs/heads/main" \

--- a/t/t5411/test-0050-proc-receive-refs-with-modifiers.sh
+++ b/t/t5411/test-0050-proc-receive-refs-with-modifiers.sh
@@ -1,6 +1,6 @@
 test_expect_success "config receive.procReceiveRefs with modifiers ($PROTOCOL)" '
 	(
-		cd "$upstream" &&
+		cd "$upstream" && GIT_DIR=. && export GIT_DIR &&
 		git config --unset-all receive.procReceiveRefs &&
 		git config --add receive.procReceiveRefs m:refs/heads/main &&
 		git config --add receive.procReceiveRefs ad:refs/heads &&

--- a/t/t5411/test-0050-proc-receive-refs-with-modifiers.sh
+++ b/t/t5411/test-0050-proc-receive-refs-with-modifiers.sh
@@ -59,8 +59,8 @@ test_expect_success "proc-receive: update branch and new tag ($PROTOCOL)" '
 # Refs of upstream : main(A)
 # Refs of workbench: main(A)  tags/v123
 test_expect_success "setup upstream: create tags/v123 ($PROTOCOL)" '
-	git -C "$upstream" update-ref refs/heads/topic $A &&
-	git -C "$upstream" update-ref refs/tags/v123 $TAG &&
+	git --git-dir="$upstream" update-ref refs/heads/topic $A &&
+	git --git-dir="$upstream" update-ref refs/tags/v123 $TAG &&
 
 	test_cmp_refs -C "$upstream" <<-EOF
 	<COMMIT-A> refs/heads/main

--- a/t/t5500-fetch-pack.sh
+++ b/t/t5500-fetch-pack.sh
@@ -975,8 +975,8 @@ test_expect_success 'fetching deepen beyond merged branch' '
 		git merge --no-ff branch &&
 		cd - &&
 		git clone --bare --depth 3 "file://$(pwd)/shallow-deepen-merged" deepen.git &&
-		git -C deepen.git fetch origin --deepen=1 &&
-		git -C deepen.git rev-list --all >actual &&
+		git --git-dir=deepen.git fetch origin --deepen=1 &&
+		git --git-dir=deepen.git rev-list --all >actual &&
 		for commit in $(sed "/^$/d" deepen.git/shallow)
 		do
 			test_grep "$commit" actual || exit 1

--- a/t/t5500-fetch-pack.sh
+++ b/t/t5500-fetch-pack.sh
@@ -454,11 +454,11 @@ test_expect_success 'fetch in shallow repo unreachable shallow objects' '
 	(
 		git clone --bare --branch B --single-branch "file://$(pwd)/." no-reflog &&
 		git clone --depth 1 "file://$(pwd)/no-reflog" shallow9 &&
-		cd no-reflog &&
+		cd no-reflog && GIT_DIR=. && export GIT_DIR &&
 		git tag -d TAGB1 TAGB2 &&
 		git update-ref refs/heads/B B~~ &&
 		git gc --prune=now &&
-		cd ../shallow9 &&
+		cd ../shallow9 && sane_unset GIT_DIR &&
 		git fetch origin &&
 		git fsck --no-dangling
 	)

--- a/t/t5503-tagfollow.sh
+++ b/t/t5503-tagfollow.sh
@@ -168,16 +168,13 @@ test_expect_success 'new clone fetch main and tags' '
 
 test_expect_success 'fetch specific OID with tag following' '
 	git init --bare clone3.git &&
-	(
-		cd clone3.git &&
-		git remote add origin .. &&
-		git fetch origin $B:refs/heads/main &&
+	git --git-dir=clone3.git remote add origin "$PWD" &&
+	git --git-dir=clone3.git fetch origin $B:refs/heads/main &&
 
-		git -C .. for-each-ref >expect &&
-		git for-each-ref >actual &&
+	git for-each-ref >expect &&
+	git --git-dir=clone3.git for-each-ref >actual &&
 
-		test_cmp expect actual
-	)
+	test_cmp expect actual
 '
 
 test_done

--- a/t/t5504-fetch-receive-strict.sh
+++ b/t/t5504-fetch-receive-strict.sh
@@ -372,7 +372,7 @@ test_expect_success PERL_TEST_HELPERS 'badFilemode is not a strict error' '
 	git init --bare dst.git &&
 	git -C dst.git config transfer.fsckObjects true &&
 
-	git -C badmode.git push ../dst.git $tree:refs/tags/tree 2>err &&
+	git --git-dir=badmode.git push dst.git $tree:refs/tags/tree 2>err &&
 	grep "$tree: badFilemode" err
 '
 

--- a/t/t5504-fetch-receive-strict.sh
+++ b/t/t5504-fetch-receive-strict.sh
@@ -362,7 +362,7 @@ test_expect_success \
 test_expect_success PERL_TEST_HELPERS 'badFilemode is not a strict error' '
 	git init --bare badmode.git &&
 	tree=$(
-		cd badmode.git &&
+		cd badmode.git && GIT_DIR=. && export GIT_DIR &&
 		blob=$(echo blob | git hash-object -w --stdin | hex2oct) &&
 		printf "123456 foo\0${blob}" |
 		git hash-object -t tree --stdin -w --literally

--- a/t/t5504-fetch-receive-strict.sh
+++ b/t/t5504-fetch-receive-strict.sh
@@ -370,7 +370,7 @@ test_expect_success PERL_TEST_HELPERS 'badFilemode is not a strict error' '
 
 	rm -rf dst.git &&
 	git init --bare dst.git &&
-	git -C dst.git config transfer.fsckObjects true &&
+	git --git-dir=dst.git config transfer.fsckObjects true &&
 
 	git --git-dir=badmode.git push dst.git $tree:refs/tags/tree 2>err &&
 	grep "$tree: badFilemode" err

--- a/t/t5505-remote.sh
+++ b/t/t5505-remote.sh
@@ -569,7 +569,7 @@ test_expect_success 'add --mirror && prune' '
 		git branch -m side2 side
 	) &&
 	(
-		cd mirror &&
+		cd mirror && GIT_DIR=. && export GIT_DIR &&
 		git rev-parse --verify refs/heads/side2 &&
 		test_must_fail git rev-parse --verify refs/heads/side &&
 		git fetch origin &&
@@ -593,7 +593,7 @@ test_expect_success 'non-mirror fetch does not interfere with mirror' '
 	test_when_finished rm -rf headnotmain &&
 	(
 		git init --bare -b notmain headnotmain &&
-		cd headnotmain &&
+		cd headnotmain && GIT_DIR=. && export GIT_DIR &&
 		git remote add -f other ../two &&
 		test "$(git symbolic-ref HEAD)" = "refs/heads/notmain"
 	)
@@ -608,7 +608,7 @@ test_expect_success 'add --mirror=fetch' '
 	) &&
 	git init --bare mirror-fetch/child &&
 	(
-		cd mirror-fetch/child &&
+		cd mirror-fetch/child && GIT_DIR=. && export GIT_DIR &&
 		git remote add --mirror=fetch -f parent ../parent
 	)
 '
@@ -620,7 +620,7 @@ test_expect_success 'fetch mirrors act as mirrors during fetch' '
 		git branch -m main renamed
 	) &&
 	(
-		cd mirror-fetch/child &&
+		cd mirror-fetch/child && GIT_DIR=. && export GIT_DIR &&
 		git fetch parent &&
 		git rev-parse --verify refs/heads/new &&
 		git rev-parse --verify refs/heads/renamed
@@ -629,7 +629,7 @@ test_expect_success 'fetch mirrors act as mirrors during fetch' '
 
 test_expect_success 'fetch mirrors can prune' '
 	(
-		cd mirror-fetch/child &&
+		cd mirror-fetch/child && GIT_DIR=. && export GIT_DIR &&
 		git remote prune parent &&
 		test_must_fail git rev-parse --verify refs/heads/main
 	)
@@ -641,7 +641,7 @@ test_expect_success 'fetch mirrors do not act as mirrors during push' '
 		git checkout HEAD^0
 	) &&
 	(
-		cd mirror-fetch/child &&
+		cd mirror-fetch/child && GIT_DIR=. && export GIT_DIR &&
 		git branch -m renamed renamed2 &&
 		git push parent :
 	) &&
@@ -655,14 +655,14 @@ test_expect_success 'fetch mirrors do not act as mirrors during push' '
 test_expect_success 'add fetch mirror with specific branches' '
 	git init --bare mirror-fetch/track &&
 	(
-		cd mirror-fetch/track &&
+		cd mirror-fetch/track && GIT_DIR=. && export GIT_DIR &&
 		git remote add --mirror=fetch -t heads/new parent ../parent
 	)
 '
 
 test_expect_success 'fetch mirror respects specific branches' '
 	(
-		cd mirror-fetch/track &&
+		cd mirror-fetch/track && GIT_DIR=. && export GIT_DIR &&
 		git fetch parent &&
 		git rev-parse --verify refs/heads/new &&
 		test_must_fail git rev-parse --verify refs/heads/renamed
@@ -697,7 +697,7 @@ test_expect_success 'push mirrors act as mirrors during push' '
 
 test_expect_success 'push mirrors do not act as mirrors during fetch' '
 	(
-		cd mirror-push/public &&
+		cd mirror-push/public && GIT_DIR=. && export GIT_DIR &&
 		git branch -m renamed renamed2 &&
 		git symbolic-ref HEAD refs/heads/renamed2
 	) &&
@@ -1292,7 +1292,7 @@ test_expect_success 'remote set-branches with --mirror' '
 	echo "+refs/heads/main:refs/heads/main" >expect.replace &&
 	git clone --mirror .git/ setbranches-mirror &&
 	(
-		cd setbranches-mirror &&
+		cd setbranches-mirror && GIT_DIR=. && export GIT_DIR &&
 		git remote rename origin scratch &&
 		git config --get-all remote.scratch.fetch >../actual.initial &&
 

--- a/t/t5505-remote.sh
+++ b/t/t5505-remote.sh
@@ -83,8 +83,8 @@ test_expect_success 'add another remote' '
 
 test_expect_success 'setup bare clone for server' '
 	git clone --bare "file://$(pwd)/one" srv.bare &&
-	git -C srv.bare config --local uploadpack.allowfilter 1 &&
-	git -C srv.bare config --local uploadpack.allowanysha1inwant 1
+	git --git-dir=srv.bare config --local uploadpack.allowfilter 1 &&
+	git --git-dir=srv.bare config --local uploadpack.allowanysha1inwant 1
 '
 
 test_expect_success 'filters for promisor remotes are listed by git remote -v' '
@@ -1022,10 +1022,10 @@ test_expect_success 'rename handles remote without fetch refspec' '
 	git clone --bare one no-refspec.git &&
 	# confirm assumption that bare clone does not create refspec
 	test_expect_code 5 \
-		git -C no-refspec.git config --unset-all remote.origin.fetch &&
-	git -C no-refspec.git config remote.origin.url >expect &&
-	git -C no-refspec.git remote rename origin foo &&
-	git -C no-refspec.git config remote.foo.url >actual &&
+		git --git-dir=no-refspec.git config --unset-all remote.origin.fetch &&
+	git --git-dir=no-refspec.git config remote.origin.url >expect &&
+	git --git-dir=no-refspec.git remote rename origin foo &&
+	git --git-dir=no-refspec.git config remote.foo.url >actual &&
 	test_cmp expect actual
 '
 

--- a/t/t5505-remote.sh
+++ b/t/t5505-remote.sh
@@ -561,7 +561,7 @@ test_expect_success 'add --mirror && prune' '
 	mkdir mirror &&
 	(
 		cd mirror &&
-		git init --bare &&
+		git init --bare && GIT_DIR=. && export GIT_DIR &&
 		git remote add --mirror -f origin ../one
 	) &&
 	(
@@ -583,7 +583,7 @@ test_expect_success 'add --mirror setting HEAD' '
 	mkdir headmirror &&
 	(
 		cd headmirror &&
-		git init --bare -b notmain &&
+		git init --bare -b notmain && GIT_DIR=. && export GIT_DIR &&
 		git remote add --mirror -f origin ../one &&
 		test "$(git symbolic-ref HEAD)" = "refs/heads/main"
 	)

--- a/t/t5509-fetch-push-namespaces.sh
+++ b/t/t5509-fetch-push-namespaces.sh
@@ -77,7 +77,7 @@ test_expect_success 'pulling from a repository using a ref namespace' '
 test_expect_success 'mirroring a repository using a ref namespace' '
 	git clone --mirror pushee mirror &&
 	(
-		cd mirror &&
+		cd mirror && GIT_DIR=. && export GIT_DIR &&
 		git for-each-ref refs/ >actual &&
 		printf "$commit1 commit\trefs/namespaces/namespace/refs/heads/main\n" >expected &&
 		printf "$commit0 commit\trefs/namespaces/namespace/refs/tags/0\n" >>expected &&

--- a/t/t5509-fetch-push-namespaces.sh
+++ b/t/t5509-fetch-push-namespaces.sh
@@ -88,7 +88,7 @@ test_expect_success 'mirroring a repository using a ref namespace' '
 
 test_expect_success 'hide namespaced refs with transfer.hideRefs' '
 	GIT_NAMESPACE=namespace \
-		git -C pushee -c transfer.hideRefs=refs/tags \
+		git -C pushee --git-dir=. -c transfer.hideRefs=refs/tags \
 		ls-remote "ext::git %s ." >actual &&
 	printf "$commit1\trefs/heads/main\n" >expected &&
 	test_cmp expected actual
@@ -97,7 +97,7 @@ test_expect_success 'hide namespaced refs with transfer.hideRefs' '
 test_expect_success 'check that transfer.hideRefs does not match unstripped refs' '
 	git -C pushee pack-refs --all &&
 	GIT_NAMESPACE=namespace \
-		git -C pushee -c transfer.hideRefs=refs/namespaces/namespace/refs/tags \
+		git -C pushee --git-dir=. -c transfer.hideRefs=refs/namespaces/namespace/refs/tags \
 		ls-remote "ext::git %s ." >actual &&
 	printf "$commit1\trefs/heads/main\n" >expected &&
 	printf "$commit0\trefs/tags/0\n" >>expected &&
@@ -107,7 +107,7 @@ test_expect_success 'check that transfer.hideRefs does not match unstripped refs
 
 test_expect_success 'hide full refs with transfer.hideRefs' '
 	GIT_NAMESPACE=namespace \
-		git -C pushee -c transfer.hideRefs="^refs/namespaces/namespace/refs/tags" \
+		git -C pushee --git-dir=. -c transfer.hideRefs="^refs/namespaces/namespace/refs/tags" \
 		ls-remote "ext::git %s ." >actual &&
 	printf "$commit1\trefs/heads/main\n" >expected &&
 	test_cmp expected actual

--- a/t/t5509-fetch-push-namespaces.sh
+++ b/t/t5509-fetch-push-namespaces.sh
@@ -114,25 +114,25 @@ test_expect_success 'hide full refs with transfer.hideRefs' '
 '
 
 test_expect_success 'try to update a hidden ref' '
-	test_config -C pushee transfer.hideRefs refs/heads/main &&
+	test_config --git-dir pushee transfer.hideRefs refs/heads/main &&
 	test_must_fail git -C original push pushee-namespaced main
 '
 
 test_expect_success 'try to update a ref that is not hidden' '
-	test_config -C pushee transfer.hideRefs refs/namespaces/namespace/refs/heads/main &&
+	test_config --git-dir pushee transfer.hideRefs refs/namespaces/namespace/refs/heads/main &&
 	git -C original push pushee-namespaced main
 '
 
 test_expect_success 'git-receive-pack(1) with transfer.hideRefs does not match unstripped refs during advertisement' '
 	git -C pushee update-ref refs/namespaces/namespace/refs/heads/foo/1 refs/namespaces/namespace/refs/heads/main &&
 	git -C pushee pack-refs --all &&
-	test_config -C pushee transfer.hideRefs refs/namespaces/namespace/refs/heads/foo &&
+	test_config --git-dir pushee transfer.hideRefs refs/namespaces/namespace/refs/heads/foo &&
 	GIT_TRACE_PACKET="$(pwd)/trace" git -C original push pushee-namespaced main &&
 	test_grep refs/heads/foo/1 trace
 '
 
 test_expect_success 'try to update a hidden full ref' '
-	test_config -C pushee transfer.hideRefs "^refs/namespaces/namespace/refs/heads/main" &&
+	test_config --git-dir pushee transfer.hideRefs "^refs/namespaces/namespace/refs/heads/main" &&
 	test_must_fail git -C original push pushee-namespaced main
 '
 

--- a/t/t5509-fetch-push-namespaces.sh
+++ b/t/t5509-fetch-push-namespaces.sh
@@ -95,7 +95,7 @@ test_expect_success 'hide namespaced refs with transfer.hideRefs' '
 '
 
 test_expect_success 'check that transfer.hideRefs does not match unstripped refs' '
-	git -C pushee pack-refs --all &&
+	git --git-dir=pushee pack-refs --all &&
 	GIT_NAMESPACE=namespace \
 		git -C pushee --git-dir=. -c transfer.hideRefs=refs/namespaces/namespace/refs/tags \
 		ls-remote "ext::git %s ." >actual &&
@@ -124,8 +124,8 @@ test_expect_success 'try to update a ref that is not hidden' '
 '
 
 test_expect_success 'git-receive-pack(1) with transfer.hideRefs does not match unstripped refs during advertisement' '
-	git -C pushee update-ref refs/namespaces/namespace/refs/heads/foo/1 refs/namespaces/namespace/refs/heads/main &&
-	git -C pushee pack-refs --all &&
+	git --git-dir=pushee update-ref refs/namespaces/namespace/refs/heads/foo/1 refs/namespaces/namespace/refs/heads/main &&
+	git --git-dir=pushee pack-refs --all &&
 	test_config --git-dir pushee transfer.hideRefs refs/namespaces/namespace/refs/heads/foo &&
 	GIT_TRACE_PACKET="$(pwd)/trace" git -C original push pushee-namespaced main &&
 	test_grep refs/heads/foo/1 trace

--- a/t/t5510-fetch.sh
+++ b/t/t5510-fetch.sh
@@ -112,7 +112,7 @@ test_expect_success "fetch test remote HEAD in bare repository" '
 	test_when_finished rm -rf barerepo &&
 	(
 		git init --bare barerepo &&
-		cd barerepo &&
+		cd barerepo && GIT_DIR=. && export GIT_DIR &&
 		git remote add upstream ../two &&
 		git fetch upstream &&
 		git rev-parse --verify refs/remotes/upstream/HEAD &&
@@ -1493,7 +1493,7 @@ test_expect_success CASE_INSENSITIVE_FS,REFFILES 'existing references in a case 
 	test_when_finished rm -rf case_insensitive &&
 	(
 		git init --bare case_insensitive &&
-		cd case_insensitive &&
+		cd case_insensitive && GIT_DIR=. && export GIT_DIR &&
 		git remote add origin -- ../case_sensitive &&
 		test_must_fail git fetch -f origin "refs/heads/*:refs/heads/*" 2>err &&
 		test_grep "You${SQ}re on a case-insensitive filesystem" err &&
@@ -1518,7 +1518,7 @@ test_expect_success REFFILES 'existing reference lock in repo' '
 		cd .. &&
 
 		git init --ref-format=files --bare repo &&
-		cd repo &&
+		cd repo && GIT_DIR=. && export GIT_DIR &&
 		git remote add origin ../base &&
 		touch refs/heads/foo.lock &&
 		test_must_fail git fetch -f origin "refs/heads/*:refs/heads/*" 2>err &&
@@ -1533,7 +1533,7 @@ test_expect_success CASE_INSENSITIVE_FS,REFFILES 'F/D conflict on case insensiti
 	test_when_finished rm -rf case_insensitive &&
 	(
 		git init --bare case_insensitive &&
-		cd case_insensitive &&
+		cd case_insensitive && GIT_DIR=. && export GIT_DIR &&
 		git remote add origin -- ../case_sensitive_fd &&
 		test_must_fail git fetch -f origin "refs/heads/*:refs/heads/*" 2>err &&
 		test_grep "cannot process ${SQ}refs/remotes/origin/foo${SQ} and ${SQ}refs/remotes/origin/foo/bar${SQ} at the same time" err &&
@@ -1547,7 +1547,7 @@ test_expect_success CASE_INSENSITIVE_FS,REFFILES 'D/F conflict on case insensiti
 	test_when_finished rm -rf case_insensitive &&
 	(
 		git init --bare case_insensitive &&
-		cd case_insensitive &&
+		cd case_insensitive && GIT_DIR=. && export GIT_DIR &&
 		git remote add origin -- ../case_sensitive_df &&
 		test_must_fail git fetch -f origin "refs/heads/*:refs/heads/*" 2>err &&
 		test_grep "cannot lock ref ${SQ}refs/remotes/origin/foo${SQ}: there is a non-empty directory ${SQ}./refs/remotes/origin/foo${SQ} blocking reference ${SQ}refs/remotes/origin/foo${SQ}" err &&
@@ -1572,7 +1572,7 @@ test_expect_success REFFILES 'D/F conflict on case sensitive filesystem with loc
 		cd .. &&
 
 		git init --ref-format=files --bare repo &&
-		cd repo &&
+		cd repo && GIT_DIR=. && export GIT_DIR &&
 		git remote add origin ../base &&
 		mkdir refs/heads/foo &&
 		touch refs/heads/foo/random.lock &&
@@ -1659,7 +1659,7 @@ test_expect_success REFFILES "FETCH_HEAD is updated even if ref updates fail" '
 
 	git init --bare repo &&
 	(
-		cd repo &&
+		cd repo && GIT_DIR=. && export GIT_DIR &&
 		rm -f FETCH_HEAD &&
 		git remote add origin ../base &&
 		>refs/heads/foo.lock &&
@@ -1678,7 +1678,7 @@ test_expect_success "upstream tracking info is added with --set-upstream" '
 
 	git init --bare --initial-branch=main repo &&
 	(
-		cd repo &&
+		cd repo && GIT_DIR=. && export GIT_DIR &&
 		git remote add origin ../base &&
 		git fetch origin --set-upstream main &&
 		git config get branch.main.remote >actual &&
@@ -1695,7 +1695,7 @@ test_expect_success REFFILES "upstream tracking info is added even with conflict
 
 	git init --bare --initial-branch=main repo &&
 	(
-		cd repo &&
+		cd repo && GIT_DIR=. && export GIT_DIR &&
 		git remote add origin ../base &&
 		test_must_fail git config get branch.main.remote &&
 
@@ -1722,7 +1722,7 @@ test_expect_success REFFILES "HEAD is updated even with conflicts" '
 
 	git init --bare repo &&
 	(
-		cd repo &&
+		cd repo && GIT_DIR=. && export GIT_DIR &&
 		git remote add origin ../base &&
 
 		test_path_is_missing refs/remotes/origin/HEAD &&

--- a/t/t5510-fetch.sh
+++ b/t/t5510-fetch.sh
@@ -1354,7 +1354,7 @@ test_expect_success 'prepare source branch' '
 '
 
 validate_store_type () {
-	git -C dest count-objects -v >actual &&
+	git --git-dir=dest count-objects -v >actual &&
 	case "$store_type" in
 	packed)
 		grep "^count: 0$" actual ;;
@@ -1378,8 +1378,8 @@ test_unpack_limit () {
 	test_expect_success "fetch trumps transfer limit" '
 		rm -fr dest &&
 		git --bare init dest &&
-		git -C dest config fetch.unpacklimit $fetch_limit &&
-		git -C dest config transfer.unpacklimit $transfer_limit &&
+		git --git-dir=dest config fetch.unpacklimit $fetch_limit &&
+		git --git-dir=dest config transfer.unpacklimit $transfer_limit &&
 		git --git-dir=dest fetch . onebranch &&
 		validate_store_type
 	'
@@ -1593,10 +1593,10 @@ test_expect_success 'fetch --tags fetches existing tags' '
 	git clone --bare base repo &&
 
 	git -C base tag tag-1 &&
-	git -C repo for-each-ref >out &&
+	git --git-dir=repo for-each-ref >out &&
 	test_grep ! "tag-1" out &&
-	git -C repo fetch --tags &&
-	git -C repo for-each-ref >out &&
+	git --git-dir=repo fetch --tags &&
+	git --git-dir=repo for-each-ref >out &&
 	test_grep "tag-1" out
 '
 
@@ -1610,15 +1610,15 @@ test_expect_success 'fetch --tags fetches non-conflicting tags' '
 	git clone --bare base repo &&
 
 	git -C base tag tag-2 &&
-	git -C repo for-each-ref >out &&
+	git --git-dir=repo for-each-ref >out &&
 	test_grep ! "tag-2" out &&
 
 	git -C base commit --allow-empty -m "second empty-commit" &&
 	git -C base tag -f tag-1 &&
 
-	test_must_fail git -C repo fetch --tags 2>out &&
+	test_must_fail git --git-dir=repo fetch --tags 2>out &&
 	test_grep "tag-1  (would clobber existing tag)" out &&
-	git -C repo for-each-ref >out &&
+	git --git-dir=repo for-each-ref >out &&
 	test_grep "tag-2" out
 '
 

--- a/t/t5510-fetch.sh
+++ b/t/t5510-fetch.sh
@@ -515,7 +515,7 @@ test_expect_success 'fetch --atomic aborts all reference updates if hook aborts'
 	EOF
 
 	rm -f atomic/actual &&
-	test_hook -C atomic/.git reference-transaction <<-\EOF &&
+	test_hook --git-dir atomic/.git reference-transaction <<-\EOF &&
 		( echo "$*" && cat ) >>actual
 		exit 1
 	EOF

--- a/t/t5510-fetch.sh
+++ b/t/t5510-fetch.sh
@@ -1380,7 +1380,7 @@ test_unpack_limit () {
 		git --bare init dest &&
 		git -C dest config fetch.unpacklimit $fetch_limit &&
 		git -C dest config transfer.unpacklimit $transfer_limit &&
-		git -C dest fetch .. onebranch &&
+		git --git-dir=dest fetch . onebranch &&
 		validate_store_type
 	'
 }

--- a/t/t5516-fetch-push.sh
+++ b/t/t5516-fetch-push.sh
@@ -1534,18 +1534,18 @@ test_expect_success 'pushing a tag pushes the tagged object' '
 test_expect_success 'push into bare respects core.logallrefupdates' '
 	test_when_finished "rm -rf dst.git" &&
 	git init --bare dst.git &&
-	git -C dst.git config core.logallrefupdates true &&
+	git --git-dir=dst.git config core.logallrefupdates true &&
 
 	# double push to test both with and without
 	# the actual pack transfer
 	git push dst.git main:one &&
 	echo "one@{0} push" >expect &&
-	git -C dst.git log -g --format="%gd %gs" one >actual &&
+	git --git-dir=dst.git log -g --format="%gd %gs" one >actual &&
 	test_cmp expect actual &&
 
 	git push dst.git main:two &&
 	echo "two@{0} push" >expect &&
-	git -C dst.git log -g --format="%gd %gs" two >actual &&
+	git --git-dir=dst.git log -g --format="%gd %gs" two >actual &&
 	test_cmp expect actual
 '
 
@@ -1808,9 +1808,9 @@ test_expect_success 'denyCurrentBranch and bare repository worktrees' '
 	git clone --bare . bare.git &&
 	git --git-dir=bare.git worktree add bare.git/wt &&
 	test_commit grape &&
-	git -C bare.git config receive.denyCurrentBranch refuse &&
+	git --git-dir=bare.git config receive.denyCurrentBranch refuse &&
 	test_must_fail git push bare.git HEAD:wt &&
-	git -C bare.git config receive.denyCurrentBranch updateInstead &&
+	git --git-dir=bare.git config receive.denyCurrentBranch updateInstead &&
 	git push bare.git HEAD:wt &&
 	test_path_exists bare.git/wt/grape.t &&
 	test_must_fail git push --delete bare.git wt

--- a/t/t5516-fetch-push.sh
+++ b/t/t5516-fetch-push.sh
@@ -1392,7 +1392,7 @@ test_expect_success 'pushing a specific ref applies remote.$name.push as refmap'
 		sed -e "s|refs/heads/|refs/remotes/src/|" >../dst/expect
 	) &&
 	(
-		cd dst &&
+		cd dst && GIT_DIR=. && export GIT_DIR &&
 		test_must_fail git show-ref refs/heads/next &&
 		test_must_fail git show-ref refs/heads/main &&
 		git show-ref refs/remotes/src/main >actual
@@ -1416,7 +1416,7 @@ test_expect_success 'with no remote.$name.push, it is not used as refmap' '
 		git show-ref refs/heads/main >../dst/expect
 	) &&
 	(
-		cd dst &&
+		cd dst && GIT_DIR=. && export GIT_DIR &&
 		test_must_fail git show-ref refs/heads/next &&
 		git show-ref refs/heads/main >actual
 	) &&
@@ -1445,7 +1445,7 @@ test_expect_success 'with no remote.$name.push, upstream mapping is used' '
 		sed -e "s|refs/heads/main|refs/heads/trunk|" >../dst/expect
 	) &&
 	(
-		cd dst &&
+		cd dst && GIT_DIR=. && export GIT_DIR &&
 		test_must_fail git show-ref refs/heads/main &&
 		test_must_fail git show-ref refs/heads/next &&
 		git show-ref refs/heads/trunk >actual
@@ -1471,7 +1471,7 @@ test_expect_success 'push does not follow tags by default' '
 		git push ../dst main
 	) &&
 	(
-		cd dst &&
+		cd dst && GIT_DIR=. && export GIT_DIR &&
 		git for-each-ref >../actual
 	) &&
 	test_cmp expect actual
@@ -1495,7 +1495,7 @@ test_expect_success 'push --follow-tags only pushes relevant tags' '
 		git push --follow-tags ../dst main
 	) &&
 	(
-		cd dst &&
+		cd dst && GIT_DIR=. && export GIT_DIR &&
 		git for-each-ref >../actual
 	) &&
 	test_cmp expect actual
@@ -1553,7 +1553,7 @@ test_expect_success 'fetch into bare respects core.logallrefupdates' '
 	test_when_finished "rm -rf dst.git" &&
 	git init --bare dst.git &&
 	(
-		cd dst.git &&
+		cd dst.git && GIT_DIR=. && export GIT_DIR &&
 		git config core.logallrefupdates true &&
 
 		# as above, we double-fetch to test both

--- a/t/t5516-fetch-push.sh
+++ b/t/t5516-fetch-push.sh
@@ -1806,7 +1806,7 @@ test_expect_success 'denyCurrentBranch and worktrees' '
 test_expect_success 'denyCurrentBranch and bare repository worktrees' '
 	test_when_finished "rm -fr bare.git" &&
 	git clone --bare . bare.git &&
-	git -C bare.git worktree add wt &&
+	git --git-dir=bare.git worktree add bare.git/wt &&
 	test_commit grape &&
 	git -C bare.git config receive.denyCurrentBranch refuse &&
 	test_must_fail git push bare.git HEAD:wt &&
@@ -1827,7 +1827,7 @@ test_expect_success 'refuse fetch to current branch of worktree' '
 test_expect_success 'refuse fetch to current branch of bare repository worktree' '
 	test_when_finished "rm -fr bare.git" &&
 	git clone --bare . bare.git &&
-	git -C bare.git worktree add wt &&
+	git --git-dir=bare.git worktree add bare.git/wt &&
 	test_commit banana &&
 	test_must_fail git -C bare.git fetch .. HEAD:wt &&
 	git -C bare.git fetch -u .. HEAD:wt

--- a/t/t5516-fetch-push.sh
+++ b/t/t5516-fetch-push.sh
@@ -1829,8 +1829,8 @@ test_expect_success 'refuse fetch to current branch of bare repository worktree'
 	git clone --bare . bare.git &&
 	git --git-dir=bare.git worktree add bare.git/wt &&
 	test_commit banana &&
-	test_must_fail git -C bare.git fetch .. HEAD:wt &&
-	git -C bare.git fetch -u .. HEAD:wt
+	test_must_fail git --git-dir=bare.git fetch . HEAD:wt &&
+	git --git-dir=bare.git fetch -u . HEAD:wt
 '
 
 test_expect_success 'refuse to push a hidden ref, and make sure do not pollute the repository' '

--- a/t/t5519-push-alternates.sh
+++ b/t/t5519-push-alternates.sh
@@ -66,7 +66,7 @@ test_expect_success 'bob fetches from alice, works and pushes' '
 	# Check that the second commit by Alice is not sent
 	# to ../bob-pub
 	(
-		cd bob-pub &&
+		cd bob-pub && GIT_DIR=. && export GIT_DIR &&
 		second=$(git rev-parse HEAD^) &&
 		rm -f objects/info/alternates &&
 		test_must_fail git cat-file -t $second &&
@@ -124,7 +124,7 @@ test_expect_success 'alice works and pushes yet again' '
 
 test_expect_success 'bob works and pushes again' '
 	(
-		cd alice-pub &&
+		cd alice-pub && GIT_DIR=. && export GIT_DIR &&
 		git cat-file commit main >../bob-work/commit
 	) &&
 	(

--- a/t/t5525-fetch-tagopt.sh
+++ b/t/t5525-fetch-tagopt.sh
@@ -7,7 +7,7 @@ test_description='tagopt variable affects "git fetch" and is overridden by comma
 setup_clone () {
 	git clone --mirror . $1 &&
 	git remote add remote_$1 $1 &&
-	(cd $1 &&
+	(cd $1 && GIT_DIR=. && export GIT_DIR &&
 	git tag tag_$1 &&
 	git branch branch_$1)
 }
@@ -28,7 +28,7 @@ test_expect_success "fetch with tagopt=--no-tags does not get tag" '
 
 test_expect_success "fetch --tags with tagopt=--no-tags gets tag" '
 	(
-		cd one &&
+		cd one && GIT_DIR=. && export GIT_DIR &&
 		git branch second_branch_one
 	) &&
 	git fetch --tags remote_one &&
@@ -44,7 +44,7 @@ test_expect_success "fetch --no-tags with tagopt=--tags does not get tag" '
 
 test_expect_success "fetch with tagopt=--tags gets tag" '
 	(
-		cd two &&
+		cd two && GIT_DIR=. && export GIT_DIR &&
 		git branch second_branch_two
 	) &&
 	git fetch remote_two &&

--- a/t/t5531-deep-submodule-push.sh
+++ b/t/t5531-deep-submodule-push.sh
@@ -485,8 +485,8 @@ test_expect_success 'push --dry-run does not recursively update submodules' '
 		git commit -m "Ninth commit for gar/bage" &&
 		git push --dry-run --recurse-submodules=on-demand ../pub.git main
 	) &&
-	git -C submodule.git rev-parse main >actual_submodule &&
-	git -C pub.git rev-parse main >actual_pub &&
+	git --git-dir=submodule.git rev-parse main >actual_submodule &&
+	git --git-dir=pub.git rev-parse main >actual_pub &&
 	test_cmp expected_pub actual_pub &&
 	test_cmp expected_submodule actual_submodule
 '
@@ -494,20 +494,20 @@ test_expect_success 'push --dry-run does not recursively update submodules' '
 test_expect_success 'push --dry-run does not recursively update submodules' '
 	git -C work push --dry-run --recurse-submodules=only ../pub.git main &&
 
-	git -C submodule.git rev-parse main >actual_submodule &&
-	git -C pub.git rev-parse main >actual_pub &&
+	git --git-dir=submodule.git rev-parse main >actual_submodule &&
+	git --git-dir=pub.git rev-parse main >actual_pub &&
 	test_cmp expected_pub actual_pub &&
 	test_cmp expected_submodule actual_submodule
 '
 
 test_expect_success 'push only unpushed submodules recursively' '
 	git -C work/gar/bage rev-parse main >expected_submodule &&
-	git -C pub.git rev-parse main >expected_pub &&
+	git --git-dir=pub.git rev-parse main >expected_pub &&
 
 	git -C work push --recurse-submodules=only ../pub.git main &&
 
-	git -C submodule.git rev-parse main >actual_submodule &&
-	git -C pub.git rev-parse main >actual_pub &&
+	git --git-dir=submodule.git rev-parse main >actual_submodule &&
+	git --git-dir=pub.git rev-parse main >actual_pub &&
 	test_cmp expected_submodule actual_submodule &&
 	test_cmp expected_pub actual_pub
 '
@@ -577,8 +577,8 @@ test_expect_success 'push propagating the remotes name to a submodule' '
 	# Succeeds when submodules has matching remote and refspec
 	git -C work push --recurse-submodules=on-demand origin main &&
 
-	git -C submodule.git rev-parse main >actual_submodule &&
-	git -C pub.git rev-parse main >actual_pub &&
+	git --git-dir=submodule.git rev-parse main >actual_submodule &&
+	git --git-dir=pub.git rev-parse main >actual_pub &&
 	git -C work/gar/bage rev-parse main >expected_submodule &&
 	git -C work rev-parse main >expected_pub &&
 	test_cmp expected_submodule actual_submodule &&
@@ -607,8 +607,8 @@ test_expect_success 'push propagating refspec to a submodule' '
 	git -C work/gar/bage branch branch2 main &&
 	git -C work push --recurse-submodules=on-demand origin branch2 &&
 
-	git -C submodule.git rev-parse branch2 >actual_submodule &&
-	git -C pub.git rev-parse branch2 >actual_pub &&
+	git --git-dir=submodule.git rev-parse branch2 >actual_submodule &&
+	git --git-dir=pub.git rev-parse branch2 >actual_pub &&
 	git -C work/gar/bage rev-parse branch2 >expected_submodule &&
 	git -C work rev-parse branch2 >expected_pub &&
 	test_cmp expected_submodule actual_submodule &&
@@ -629,8 +629,8 @@ test_expect_success 'push propagating HEAD refspec to a submodule' '
 	git -C work push --recurse-submodules=on-demand origin \
 		HEAD:refs/heads/branch2 &&
 
-	git -C submodule.git rev-parse branch2 >actual_submodule &&
-	git -C pub.git rev-parse branch2 >actual_pub &&
+	git --git-dir=submodule.git rev-parse branch2 >actual_submodule &&
+	git --git-dir=pub.git rev-parse branch2 >actual_pub &&
 	git -C work/gar/bage rev-parse branch2 >expected_submodule &&
 	git -C work rev-parse branch2 >expected_pub &&
 	test_cmp expected_submodule actual_submodule &&

--- a/t/t5531-deep-submodule-push.sh
+++ b/t/t5531-deep-submodule-push.sh
@@ -391,7 +391,7 @@ test_expect_success 'push unpushed submodules when not needed' '
 		git push --recurse-submodules=on-demand ../pub.git main
 	) &&
 	(
-		cd submodule.git &&
+		cd submodule.git && GIT_DIR=. && export GIT_DIR &&
 		git rev-parse main >../actual
 	) &&
 	test_cmp expected actual
@@ -399,7 +399,7 @@ test_expect_success 'push unpushed submodules when not needed' '
 
 test_expect_success 'push unpushed submodules when not needed 2' '
 	(
-		cd submodule.git &&
+		cd submodule.git && GIT_DIR=. && export GIT_DIR &&
 		git rev-parse main >../expected
 	) &&
 	(
@@ -416,7 +416,7 @@ test_expect_success 'push unpushed submodules when not needed 2' '
 		git push --recurse-submodules=on-demand ../pub.git main
 	) &&
 	(
-		cd submodule.git &&
+		cd submodule.git && GIT_DIR=. && export GIT_DIR &&
 		git rev-parse main >../actual
 	) &&
 	test_cmp expected actual
@@ -439,7 +439,7 @@ test_expect_success 'push unpushed submodules recursively' '
 		git push --recurse-submodules=on-demand ../pub.git main
 	) &&
 	(
-		cd submodule.git &&
+		cd submodule.git && GIT_DIR=. && export GIT_DIR &&
 		git rev-parse main >../actual
 	) &&
 	test_cmp expected actual
@@ -461,7 +461,7 @@ test_expect_success 'push unpushable submodule recursively fails' '
 		test_must_fail git push --recurse-submodules=on-demand ../pub.git main
 	) &&
 	(
-		cd submodule.git &&
+		cd submodule.git && GIT_DIR=. && export GIT_DIR &&
 		git rev-parse main >../actual
 	) &&
 	test_when_finished git -C work reset --hard main^ &&

--- a/t/t5540-http-push-webdav.sh
+++ b/t/t5540-http-push-webdav.sh
@@ -139,7 +139,7 @@ test_expect_success 'create and delete remote branch' '
 
 test_expect_success 'non-force push fails if not up to date' '
 	git init --bare "$HTTPD_DOCUMENT_ROOT_PATH"/test_repo_conflict.git &&
-	git -C "$HTTPD_DOCUMENT_ROOT_PATH"/test_repo_conflict.git update-server-info &&
+	git --git-dir="$HTTPD_DOCUMENT_ROOT_PATH"/test_repo_conflict.git update-server-info &&
 	git clone $HTTPD_URL/dumb/test_repo_conflict.git "$ROOT_PATH"/c1 &&
 	git clone $HTTPD_URL/dumb/test_repo_conflict.git "$ROOT_PATH"/c2 &&
 	test_commit -C "$ROOT_PATH/c1" path1 &&

--- a/t/t5540-http-push-webdav.sh
+++ b/t/t5540-http-push-webdav.sh
@@ -71,7 +71,7 @@ test_expect_success 'push to remote repository with packed refs' '
 	git commit -m path2 &&
 	HEAD=$(git rev-parse --verify HEAD) &&
 	git push &&
-	(cd "$HTTPD_DOCUMENT_ROOT_PATH"/test_repo.git &&
+	(cd "$HTTPD_DOCUMENT_ROOT_PATH"/test_repo.git && GIT_DIR=. && export GIT_DIR &&
 	 test $HEAD = $(git rev-parse --verify HEAD))
 '
 
@@ -80,12 +80,12 @@ test_expect_success 'push already up-to-date' '
 '
 
 test_expect_success 'push to remote repository with unpacked refs' '
-	(cd "$HTTPD_DOCUMENT_ROOT_PATH"/test_repo.git &&
+	(cd "$HTTPD_DOCUMENT_ROOT_PATH"/test_repo.git && GIT_DIR=. && export GIT_DIR &&
 	 rm packed-refs &&
 	 git update-ref refs/heads/main $ORIG_HEAD &&
 	 git --bare update-server-info) &&
 	git push &&
-	(cd "$HTTPD_DOCUMENT_ROOT_PATH"/test_repo.git &&
+	(cd "$HTTPD_DOCUMENT_ROOT_PATH"/test_repo.git && GIT_DIR=. && export GIT_DIR &&
 	 test $HEAD = $(git rev-parse --verify HEAD))
 '
 
@@ -112,7 +112,7 @@ test_expect_success 'http-push fetches packed objects' '
 	git clone $HTTPD_URL/dumb/test_repo_packed.git \
 		"$ROOT_PATH"/test_repo_clone_packed &&
 
-	(cd "$HTTPD_DOCUMENT_ROOT_PATH"/test_repo_packed.git &&
+	(cd "$HTTPD_DOCUMENT_ROOT_PATH"/test_repo_packed.git && GIT_DIR=. && export GIT_DIR &&
 	 git --bare repack &&
 	 git --bare prune-packed) &&
 

--- a/t/t5540-http-push-webdav.sh
+++ b/t/t5540-http-push-webdav.sh
@@ -40,13 +40,13 @@ test_expect_success 'setup remote repository' '
 	git commit -m initial &&
 	cd - &&
 	git clone --bare test_repo test_repo.git &&
-	cd test_repo.git &&
+	cd test_repo.git && GIT_DIR=. && export GIT_DIR &&
 	git --bare update-server-info &&
 	test_hook --setup post-update <<-\EOF &&
 	exec git update-server-info
 	EOF
 	ORIG_HEAD=$(git rev-parse --verify HEAD) &&
-	cd - &&
+	cd - && sane_unset GIT_DIR &&
 	mv test_repo.git "$HTTPD_DOCUMENT_ROOT_PATH"
 '
 

--- a/t/t5541-http-push-smart.sh
+++ b/t/t5541-http-push-smart.sh
@@ -58,7 +58,7 @@ test_expect_success 'push to remote repository (standard)' '
 	GIT_TRACE_CURL=true git push -v -v 2>err &&
 	! grep "Expect: 100-continue" err &&
 	grep "POST git-receive-pack ([0-9]* bytes)" err &&
-	(cd "$HTTPD_DOCUMENT_ROOT_PATH"/test_repo.git &&
+	(cd "$HTTPD_DOCUMENT_ROOT_PATH"/test_repo.git && GIT_DIR=. && export GIT_DIR &&
 	 test $HEAD = $(git rev-parse --verify HEAD))
 '
 
@@ -164,7 +164,7 @@ test_expect_success 'push (chunked)' '
 	test_config http.postbuffer 4 &&
 	git push -v -v origin $BRANCH 2>err &&
 	grep "POST git-receive-pack (chunked)" err &&
-	(cd "$HTTPD_DOCUMENT_ROOT_PATH"/test_repo.git &&
+	(cd "$HTTPD_DOCUMENT_ROOT_PATH"/test_repo.git && GIT_DIR=. && export GIT_DIR &&
 	 test $HEAD = $(git rev-parse --verify HEAD))
 '
 
@@ -416,7 +416,7 @@ test_expect_success GPG 'push with post-receive to inspect certificate' '
 		E_O_F
 	EOF
 	(
-		cd "$HTTPD_DOCUMENT_ROOT_PATH"/test_repo.git &&
+		cd "$HTTPD_DOCUMENT_ROOT_PATH"/test_repo.git && GIT_DIR=. && export GIT_DIR &&
 		git config receive.certnonceseed sekrit &&
 		git config receive.certnonceslop 30
 	) &&

--- a/t/t5541-http-push-smart.sh
+++ b/t/t5541-http-push-smart.sh
@@ -107,7 +107,7 @@ test_expect_success 'create and delete remote branch' '
 '
 
 test_expect_success 'setup rejected update hook' '
-	test_hook --setup -C "$HTTPD_DOCUMENT_ROOT_PATH/test_repo.git" update <<-\EOF &&
+	test_hook --setup --git-dir "$HTTPD_DOCUMENT_ROOT_PATH/test_repo.git" update <<-\EOF &&
 	exit 1
 	EOF
 
@@ -175,7 +175,7 @@ test_expect_success 'push --atomic also prevents branch creation, reports collat
 	# Setup upstream repo - empty for now
 	d=$HTTPD_DOCUMENT_ROOT_PATH/atomic-branches.git &&
 	git init --bare "$d" &&
-	test_config -C "$d" http.receivepack true &&
+	test_config --git-dir "$d" http.receivepack true &&
 	up="$HTTPD_URL"/smart/atomic-branches.git &&
 
 	# Tell "$up" about three branches for now
@@ -229,7 +229,7 @@ test_expect_success 'push --atomic also prevents branch creation, reports collat
 test_expect_success 'push --atomic fails on server-side errors' '
 	# Use previously set up repository
 	d=$HTTPD_DOCUMENT_ROOT_PATH/atomic-branches.git &&
-	test_config -C "$d" http.receivepack true &&
+	test_config --git-dir "$d" http.receivepack true &&
 	up="$HTTPD_URL"/smart/atomic-branches.git &&
 
 	# Create d/f conflict to break ref updates for other on the remote site.
@@ -399,7 +399,7 @@ test_expect_success CMDLINE_LIMIT 'push 2000 tags over http' '
 '
 
 test_expect_success GPG 'push with post-receive to inspect certificate' '
-	test_hook -C "$HTTPD_DOCUMENT_ROOT_PATH"/test_repo.git post-receive <<-\EOF &&
+	test_hook --git-dir "$HTTPD_DOCUMENT_ROOT_PATH"/test_repo.git post-receive <<-\EOF &&
 		# discard the update list
 		cat >/dev/null
 		# record the push certificate

--- a/t/t5541-http-push-smart.sh
+++ b/t/t5541-http-push-smart.sh
@@ -26,11 +26,11 @@ test_expect_success 'setup remote repository' '
 	git commit -m initial &&
 	cd - &&
 	git clone --bare test_repo test_repo.git &&
-	cd test_repo.git &&
+	cd test_repo.git && GIT_DIR=. && export GIT_DIR &&
 	git config http.receivepack true &&
 	git config core.logallrefupdates true &&
 	ORIG_HEAD=$(git rev-parse --verify HEAD) &&
-	cd - &&
+	cd - && sane_unset GIT_DIR &&
 	mv test_repo.git "$HTTPD_DOCUMENT_ROOT_PATH"
 '
 

--- a/t/t5541-http-push-smart.sh
+++ b/t/t5541-http-push-smart.sh
@@ -202,16 +202,16 @@ test_expect_success 'push --atomic also prevents branch creation, reports collat
 	test_must_fail git push --atomic "$up" main atomic collateral 2>output &&
 
 	# the new branch should not have been created upstream
-	test_must_fail git -C "$d" show-ref --verify refs/heads/atomic &&
+	test_must_fail git --git-dir="$d" show-ref --verify refs/heads/atomic &&
 
 	# upstream should still reflect atomic2, the last thing we pushed
 	# successfully
 	git rev-parse atomic2 >expected &&
 	# on main...
-	git -C "$d" rev-parse refs/heads/main >actual &&
+	git --git-dir="$d" rev-parse refs/heads/main >actual &&
 	test_cmp expected actual &&
 	# ...and collateral.
-	git -C "$d" rev-parse refs/heads/collateral >actual &&
+	git --git-dir="$d" rev-parse refs/heads/collateral >actual &&
 	test_cmp expected actual &&
 
 	# the failed refs should be indicated to the user
@@ -233,8 +233,8 @@ test_expect_success 'push --atomic fails on server-side errors' '
 	up="$HTTPD_URL"/smart/atomic-branches.git &&
 
 	# Create d/f conflict to break ref updates for other on the remote site.
-	git -C "$d" update-ref -d refs/heads/other &&
-	git -C "$d" update-ref refs/heads/other/conflict HEAD &&
+	git --git-dir="$d" update-ref -d refs/heads/other &&
+	git --git-dir="$d" update-ref refs/heads/other/conflict HEAD &&
 
 	# add the new commit to other
 	git branch -f other collateral &&
@@ -243,8 +243,8 @@ test_expect_success 'push --atomic fails on server-side errors' '
 	test_must_fail git push --atomic "$up" atomic other 2>output  &&
 
 	# The atomic and other branches should not be created upstream.
-	test_must_fail git -C "$d" show-ref --verify refs/heads/atomic &&
-	test_must_fail git -C "$d" show-ref --verify refs/heads/other &&
+	test_must_fail git --git-dir="$d" show-ref --verify refs/heads/atomic &&
+	test_must_fail git --git-dir="$d" show-ref --verify refs/heads/other &&
 
 	# the failed refs should be indicated to the user
 	grep "^ ! .*rejected.* other -> other .*atomic transaction failed" output &&

--- a/t/t5542-push-http-shallow.sh
+++ b/t/t5542-push-http-shallow.sh
@@ -48,7 +48,7 @@ EOF
 test_expect_success 'push to shallow repo via http' '
 	git clone --bare --no-local shallow "$HTTPD_DOCUMENT_ROOT_PATH/repo.git" &&
 	(
-	cd "$HTTPD_DOCUMENT_ROOT_PATH/repo.git" &&
+	cd "$HTTPD_DOCUMENT_ROOT_PATH/repo.git" && GIT_DIR=. && export GIT_DIR &&
 	git config http.receivepack true
 	) &&
 	(
@@ -57,7 +57,7 @@ test_expect_success 'push to shallow repo via http' '
 	git push $HTTPD_URL/smart/repo.git +main:refs/remotes/top/main
 	) &&
 	(
-	cd "$HTTPD_DOCUMENT_ROOT_PATH/repo.git" &&
+	cd "$HTTPD_DOCUMENT_ROOT_PATH/repo.git" && GIT_DIR=. && export GIT_DIR &&
 	git fsck &&
 	git log --format=%s top/main >actual &&
 	cat <<EOF >expect &&
@@ -73,13 +73,13 @@ test_expect_success 'push from shallow repo via http' '
 	mv "$HTTPD_DOCUMENT_ROOT_PATH/repo.git" shallow-upstream.git &&
 	git clone --bare --no-local full "$HTTPD_DOCUMENT_ROOT_PATH/repo.git" &&
 	(
-	cd "$HTTPD_DOCUMENT_ROOT_PATH/repo.git" &&
+	cd "$HTTPD_DOCUMENT_ROOT_PATH/repo.git" && GIT_DIR=. && export GIT_DIR &&
 	git config http.receivepack true
 	) &&
 	commit 10 &&
 	git push $HTTPD_URL/smart/repo.git +main:refs/remotes/top/main &&
 	(
-	cd "$HTTPD_DOCUMENT_ROOT_PATH/repo.git" &&
+	cd "$HTTPD_DOCUMENT_ROOT_PATH/repo.git" && GIT_DIR=. && export GIT_DIR &&
 	git fsck &&
 	git log --format=%s top/main >actual &&
 	cat <<EOF >expect &&

--- a/t/t5544-pack-objects-hook.sh
+++ b/t/t5544-pack-objects-hook.sh
@@ -70,8 +70,8 @@ test_expect_success 'hook works with partial clone' '
 	test_config_global uploadpack.packObjectsHook ./hook &&
 	test_config_global uploadpack.allowFilter true &&
 	git clone --bare --no-local --filter=blob:none . dst.git &&
-	git -C dst.git rev-list --objects --missing=allow-any --no-object-names --all >objects &&
-	git -C dst.git cat-file --batch-check="%(objecttype)" <objects >types &&
+	git --git-dir=dst.git rev-list --objects --missing=allow-any --no-object-names --all >objects &&
+	git --git-dir=dst.git cat-file --batch-check="%(objecttype)" <objects >types &&
 	! grep blob types
 '
 

--- a/t/t5545-push-options.sh
+++ b/t/t5545-push-options.sh
@@ -261,7 +261,7 @@ test_expect_success 'push options work properly across http' '
 
 	test_commit -C test_http_clone one &&
 	git -C test_http_clone push origin main &&
-	git -C "$HTTPD_DOCUMENT_ROOT_PATH"/upstream.git rev-parse --verify main >expect &&
+	git --git-dir="$HTTPD_DOCUMENT_ROOT_PATH"/upstream.git rev-parse --verify main >expect &&
 	git -C test_http_clone rev-parse --verify main >actual &&
 	test_cmp expect actual &&
 
@@ -271,7 +271,7 @@ test_expect_success 'push options work properly across http' '
 	test_cmp expect "$HTTPD_DOCUMENT_ROOT_PATH"/upstream.git/hooks/pre-receive.push_options &&
 	test_cmp expect "$HTTPD_DOCUMENT_ROOT_PATH"/upstream.git/hooks/post-receive.push_options &&
 
-	git -C "$HTTPD_DOCUMENT_ROOT_PATH"/upstream.git rev-parse --verify main >expect &&
+	git --git-dir="$HTTPD_DOCUMENT_ROOT_PATH"/upstream.git rev-parse --verify main >expect &&
 	git -C test_http_clone rev-parse --verify main >actual &&
 	test_cmp expect actual
 '

--- a/t/t5546-receive-limits.sh
+++ b/t/t5546-receive-limits.sh
@@ -9,7 +9,7 @@ test_description='check receive input limits'
 # When the limit is 10000, `git receive-pack` will call `git unpack-objects`.
 
 validate_store_type () {
-	git -C dest count-objects -v >actual &&
+	git --git-dir=dest count-objects -v >actual &&
 	case "$store_type" in
 	index)
 		grep "^count: 0$" actual ;;

--- a/t/t5547-push-quarantine.sh
+++ b/t/t5547-push-quarantine.sh
@@ -67,7 +67,7 @@ test_expect_success 'updating a ref from quarantine is forbidden' '
 	exit 1
 	EOF
 	test_must_fail git push update.git HEAD &&
-	git -C update.git fsck
+	git --git-dir=update.git fsck
 '
 
 test_done

--- a/t/t5547-push-quarantine.sh
+++ b/t/t5547-push-quarantine.sh
@@ -6,7 +6,7 @@ test_description='check quarantine of objects during push'
 
 test_expect_success 'create picky dest repo' '
 	git init --bare dest.git &&
-	test_hook --setup -C dest.git pre-receive <<-\EOF
+	test_hook --setup --git-dir dest.git pre-receive <<-\EOF
 	while read old new ref; do
 		test "$(git log -1 --format=%s $new)" = reject && exit 1
 	done
@@ -61,7 +61,7 @@ test_expect_success 'push to repo path with path separator (colon)' '
 
 test_expect_success 'updating a ref from quarantine is forbidden' '
 	git init --bare update.git &&
-	test_hook -C update.git pre-receive <<-\EOF &&
+	test_hook --git-dir update.git pre-receive <<-\EOF &&
 	read old new refname
 	git update-ref refs/heads/unrelated $new
 	exit 1

--- a/t/t5548-push-porcelain.sh
+++ b/t/t5548-push-porcelain.sh
@@ -83,7 +83,7 @@ setup_upstream () {
 	# The upstream repository provides services using the HTTP protocol.
 	if ! test "$1" = "upstream.git"
 	then
-		git -C "$1" config http.receivepack true
+		git --git-dir="$1" config http.receivepack true
 	fi
 }
 
@@ -153,7 +153,7 @@ run_git_push_porcelain_output_test() {
 		EOF
 		test_cmp expect actual &&
 
-		git -C "$upstream" show-ref >out &&
+		git --git-dir="$upstream" show-ref >out &&
 		make_user_friendly_and_stable_output <out >actual &&
 		cat >expect <<-EOF &&
 		<COMMIT-B> refs/heads/bar
@@ -187,7 +187,7 @@ run_git_push_porcelain_output_test() {
 		EOF
 		test_cmp expect actual &&
 
-		git -C "$upstream" show-ref >out &&
+		git --git-dir="$upstream" show-ref >out &&
 		make_user_friendly_and_stable_output <out >actual &&
 		cat >expect <<-EOF &&
 		<COMMIT-B> refs/heads/bar
@@ -221,7 +221,7 @@ run_git_push_porcelain_output_test() {
 		EOF
 		test_cmp expect actual &&
 
-		git -C "$upstream" show-ref >out &&
+		git --git-dir="$upstream" show-ref >out &&
 		make_user_friendly_and_stable_output <out >actual &&
 		cat >expect <<-EOF &&
 		<COMMIT-A> refs/heads/bar
@@ -259,7 +259,7 @@ run_git_push_porcelain_output_test() {
 		EOF
 		test_cmp expect actual &&
 
-		git -C "$upstream" show-ref >out &&
+		git --git-dir="$upstream" show-ref >out &&
 		make_user_friendly_and_stable_output <out >actual &&
 		cat >expect <<-EOF &&
 		<COMMIT-A> refs/heads/bar
@@ -290,7 +290,7 @@ run_git_push_porcelain_output_test() {
 		EOF
 		test_cmp expect actual &&
 
-		git -C "$upstream" show-ref >out &&
+		git --git-dir="$upstream" show-ref >out &&
 		make_user_friendly_and_stable_output <out >actual &&
 		cat >expect <<-EOF &&
 		<COMMIT-A> refs/heads/bar
@@ -324,7 +324,7 @@ run_git_push_porcelain_output_test() {
 		EOF
 		test_cmp expect actual &&
 
-		git -C "$upstream" show-ref >out &&
+		git --git-dir="$upstream" show-ref >out &&
 		make_user_friendly_and_stable_output <out >actual &&
 		cat >expect <<-EOF &&
 		<COMMIT-B> refs/heads/bar
@@ -370,7 +370,7 @@ run_git_push_dry_run_porcelain_output_test() {
 		EOF
 		test_cmp expect actual &&
 
-		git -C "$upstream" show-ref >out &&
+		git --git-dir="$upstream" show-ref >out &&
 		make_user_friendly_and_stable_output <out >actual &&
 		cat >expect <<-EOF &&
 		<COMMIT-A> refs/heads/bar
@@ -403,7 +403,7 @@ run_git_push_dry_run_porcelain_output_test() {
 		EOF
 		test_cmp expect actual &&
 
-		git -C "$upstream" show-ref >out &&
+		git --git-dir="$upstream" show-ref >out &&
 		make_user_friendly_and_stable_output <out >actual &&
 		cat >expect <<-EOF &&
 		<COMMIT-A> refs/heads/bar
@@ -436,7 +436,7 @@ run_git_push_dry_run_porcelain_output_test() {
 		EOF
 		test_cmp expect actual &&
 
-		git -C "$upstream" show-ref >out &&
+		git --git-dir="$upstream" show-ref >out &&
 		make_user_friendly_and_stable_output <out >actual &&
 		cat >expect <<-EOF &&
 		<COMMIT-A> refs/heads/bar
@@ -469,7 +469,7 @@ run_git_push_dry_run_porcelain_output_test() {
 		EOF
 		test_cmp expect actual &&
 
-		git -C "$upstream" show-ref >out &&
+		git --git-dir="$upstream" show-ref >out &&
 		make_user_friendly_and_stable_output <out >actual &&
 		cat >expect <<-EOF &&
 		<COMMIT-A> refs/heads/bar

--- a/t/t5548-push-porcelain.sh
+++ b/t/t5548-push-porcelain.sh
@@ -238,7 +238,7 @@ run_git_push_porcelain_output_test() {
 	test_expect_success ".. pre-receive hook declined ($PROTOCOL)" '
 		test_when_finished "rm -f \"$upstream/hooks/pre-receive\" &&
 			setup_upstream \"$upstream\"" &&
-		test_hook --setup -C "$upstream" pre-receive <<-EOF &&
+		test_hook --setup --git-dir "$upstream" pre-receive <<-EOF &&
 			exit 1
 		EOF
 		test_must_fail git -C workbench push --porcelain --force origin \

--- a/t/t5550-http-fetch-dumb.sh
+++ b/t/t5550-http-fetch-dumb.sh
@@ -32,7 +32,7 @@ test_expect_success 'packfile without repository does not crash' '
 '
 
 setup_post_update_server_info_hook () {
-	test_hook --setup -C "$1" post-update <<-\EOF &&
+	test_hook --setup --git-dir "$1" post-update <<-\EOF &&
 	exec git update-server-info
 	EOF
 	git -C "$1" update-server-info

--- a/t/t5550-http-fetch-dumb.sh
+++ b/t/t5550-http-fetch-dumb.sh
@@ -35,12 +35,12 @@ setup_post_update_server_info_hook () {
 	test_hook --setup --git-dir "$1" post-update <<-\EOF &&
 	exec git update-server-info
 	EOF
-	git -C "$1" update-server-info
+	git --git-dir="$1" update-server-info
 }
 
 test_expect_success 'create http-accessible bare repository with loose objects' '
 	cp -R .git "$HTTPD_DOCUMENT_ROOT_PATH/repo.git" &&
-	git -C "$HTTPD_DOCUMENT_ROOT_PATH/repo.git" config core.bare true &&
+	git --git-dir="$HTTPD_DOCUMENT_ROOT_PATH/repo.git" config core.bare true &&
 	setup_post_update_server_info_hook "$HTTPD_DOCUMENT_ROOT_PATH/repo.git" &&
 	git remote add public "$HTTPD_DOCUMENT_ROOT_PATH/repo.git" &&
 	git push public main:main
@@ -65,9 +65,9 @@ test_expect_success 'list refs from outside any repository' '
 test_expect_success 'list detached HEAD from outside any repository' '
 	git clone --mirror "$HTTPD_DOCUMENT_ROOT_PATH/repo.git" \
 		"$HTTPD_DOCUMENT_ROOT_PATH/repo-detached.git" &&
-	git -C "$HTTPD_DOCUMENT_ROOT_PATH/repo-detached.git" \
+	git --git-dir="$HTTPD_DOCUMENT_ROOT_PATH/repo-detached.git" \
 		update-ref --no-deref HEAD refs/heads/main &&
-	git -C "$HTTPD_DOCUMENT_ROOT_PATH/repo-detached.git" update-server-info &&
+	git --git-dir="$HTTPD_DOCUMENT_ROOT_PATH/repo-detached.git" update-server-info &&
 	cat >expect <<-EOF &&
 	$(git rev-parse main)	HEAD
 	$(git rev-parse main)	refs/heads/main
@@ -271,7 +271,7 @@ test_expect_success 'fetch packed objects' '
 test_expect_success 'http-fetch --packfile' '
 	# Arbitrary hash. Use rev-parse so that we get one of the correct
 	# length.
-	ARBITRARY=$(git -C "$HTTPD_DOCUMENT_ROOT_PATH"/repo_pack.git rev-parse HEAD) &&
+	ARBITRARY=$(git --git-dir="$HTTPD_DOCUMENT_ROOT_PATH"/repo_pack.git rev-parse HEAD) &&
 
 	git init packfileclient &&
 	p=$(cd "$HTTPD_DOCUMENT_ROOT_PATH"/repo_pack.git && ls objects/pack/pack-*.pack) &&
@@ -289,7 +289,7 @@ test_expect_success 'http-fetch --packfile' '
 	test -e "packfileclient/.git/objects/pack/pack-$(cat packhash).keep" &&
 
 	# Ensure that it has the HEAD of repo_pack, at least
-	HASH=$(git -C "$HTTPD_DOCUMENT_ROOT_PATH"/repo_pack.git rev-parse HEAD) &&
+	HASH=$(git --git-dir="$HTTPD_DOCUMENT_ROOT_PATH"/repo_pack.git rev-parse HEAD) &&
 	git -C packfileclient cat-file -e "$HASH"
 '
 
@@ -476,10 +476,10 @@ test_expect_success 'http.followRedirects defaults to "initial"' '
 test_expect_success 'set up evil alternates scheme' '
 	victim=$HTTPD_DOCUMENT_ROOT_PATH/victim.git &&
 	git init --bare "$victim" &&
-	git -C "$victim" --work-tree=. commit --allow-empty -m secret &&
-	git -C "$victim" repack -ad &&
-	git -C "$victim" update-server-info &&
-	sha1=$(git -C "$victim" rev-parse HEAD) &&
+	git --git-dir="$victim" --work-tree=. commit --allow-empty -m secret &&
+	git --git-dir="$victim" repack -ad &&
+	git --git-dir="$victim" update-server-info &&
+	sha1=$(git --git-dir="$victim" rev-parse HEAD) &&
 
 	evil=$HTTPD_DOCUMENT_ROOT_PATH/evil.git &&
 	git init --template= --bare "$evil" &&
@@ -532,15 +532,15 @@ test_expect_success 'print HTTP error when any intermediate redirect throws erro
 test_expect_success 'fetching via http alternates works' '
 	parent=$HTTPD_DOCUMENT_ROOT_PATH/alt-parent.git &&
 	git init --bare "$parent" &&
-	git -C "$parent" --work-tree=. commit --allow-empty -m foo &&
-	git -C "$parent" update-server-info &&
-	commit=$(git -C "$parent" rev-parse HEAD) &&
+	git --git-dir="$parent" --work-tree=. commit --allow-empty -m foo &&
+	git --git-dir="$parent" update-server-info &&
+	commit=$(git --git-dir="$parent" rev-parse HEAD) &&
 
 	child=$HTTPD_DOCUMENT_ROOT_PATH/alt-child.git &&
 	git init --bare "$child" &&
 	echo "../../alt-parent.git/objects" >"$child/objects/info/alternates" &&
-	git -C "$child" update-ref HEAD $commit &&
-	git -C "$child" update-server-info &&
+	git --git-dir="$child" update-ref HEAD $commit &&
+	git --git-dir="$child" update-server-info &&
 
 	git -c http.followredirects=true clone "$HTTPD_URL/dumb/alt-child.git"
 '
@@ -548,8 +548,8 @@ test_expect_success 'fetching via http alternates works' '
 test_expect_success 'dumb http can fetch index v1' '
 	server=$HTTPD_DOCUMENT_ROOT_PATH/idx-v1.git &&
 	git init --bare "$server" &&
-	git -C "$server" --work-tree=. commit --allow-empty -m foo &&
-	git -C "$server" -c pack.indexVersion=1 gc &&
+	git --git-dir="$server" --work-tree=. commit --allow-empty -m foo &&
+	git --git-dir="$server" -c pack.indexVersion=1 gc &&
 
 	git clone "$HTTPD_URL/dumb/idx-v1.git" &&
 	git -C idx-v1 fsck

--- a/t/t5550-http-fetch-dumb.sh
+++ b/t/t5550-http-fetch-dumb.sh
@@ -262,7 +262,7 @@ test_expect_success 'http remote detects correct HEAD' '
 
 test_expect_success 'fetch packed objects' '
 	cp -R "$HTTPD_DOCUMENT_ROOT_PATH"/repo.git "$HTTPD_DOCUMENT_ROOT_PATH"/repo_pack.git &&
-	(cd "$HTTPD_DOCUMENT_ROOT_PATH"/repo_pack.git &&
+	(cd "$HTTPD_DOCUMENT_ROOT_PATH"/repo_pack.git && GIT_DIR=. && export GIT_DIR &&
 	 git --bare repack -a -d
 	) &&
 	git clone $HTTPD_URL/dumb/repo_pack.git
@@ -301,7 +301,7 @@ test_expect_success 'fetch notices corrupt pack' '
 	 printf %0256d 0 | dd of=$p bs=256 count=1 seek=1 conv=notrunc
 	) &&
 	mkdir repo_bad1.git &&
-	(cd repo_bad1.git &&
+	(cd repo_bad1.git && GIT_DIR=. && export GIT_DIR &&
 	 git --bare init &&
 	 test_must_fail git --bare fetch $HTTPD_URL/dumb/repo_bad1.git &&
 	 test 0 = $(ls objects/pack/pack-*.pack | wc -l)
@@ -324,7 +324,7 @@ test_expect_success 'fetch notices corrupt idx' '
 	 printf %0256d 0 | dd of=$p bs=256 count=1 seek=1 conv=notrunc
 	) &&
 	mkdir repo_bad2.git &&
-	(cd repo_bad2.git &&
+	(cd repo_bad2.git && GIT_DIR=. && export GIT_DIR &&
 	 git --bare init &&
 	 test_must_fail git --bare fetch $HTTPD_URL/dumb/repo_bad2.git &&
 	 test 0 = $(ls objects/pack | wc -l)

--- a/t/t5551-http-fetch-smart.sh
+++ b/t/t5551-http-fetch-smart.sh
@@ -365,8 +365,8 @@ test_expect_success 'transfer.hiderefs works over smart-http' '
 	git --git-dir="$HTTPD_DOCUMENT_ROOT_PATH/repo.git" \
 		config transfer.hiderefs refs/heads/a &&
 	git clone --bare "$HTTPD_URL/smart/repo.git" hidden.git &&
-	test_must_fail git -C hidden.git rev-parse --verify a &&
-	git -C hidden.git rev-parse --verify b
+	test_must_fail git --git-dir=hidden.git rev-parse --verify a &&
+	git --git-dir=hidden.git rev-parse --verify b
 '
 
 # create an arbitrary number of tags, numbered from tag-$1 to tag-$2
@@ -425,12 +425,12 @@ test_expect_success 'large fetch-pack requests can be sent using chunked encodin
 test_expect_success 'test allowreachablesha1inwant' '
 	test_when_finished "rm -rf test_reachable.git" &&
 	server="$HTTPD_DOCUMENT_ROOT_PATH/repo.git" &&
-	main_sha=$(git -C "$server" rev-parse refs/heads/main) &&
-	git -C "$server" config uploadpack.allowreachablesha1inwant 1 &&
+	main_sha=$(git --git-dir="$server" rev-parse refs/heads/main) &&
+	git --git-dir="$server" config uploadpack.allowreachablesha1inwant 1 &&
 
 	git init --bare test_reachable.git &&
-	git -C test_reachable.git remote add origin "$HTTPD_URL/smart/repo.git" &&
-	git -C test_reachable.git fetch origin "$main_sha"
+	git --git-dir=test_reachable.git remote add origin "$HTTPD_URL/smart/repo.git" &&
+	git --git-dir=test_reachable.git fetch origin "$main_sha"
 '
 
 test_expect_success 'test allowreachablesha1inwant with unreachable' '
@@ -444,15 +444,15 @@ test_expect_success 'test allowreachablesha1inwant with unreachable' '
 	git push public :refs/heads/doomed &&
 
 	server="$HTTPD_DOCUMENT_ROOT_PATH/repo.git" &&
-	main_sha=$(git -C "$server" rev-parse refs/heads/main) &&
-	git -C "$server" config uploadpack.allowreachablesha1inwant 1 &&
+	main_sha=$(git --git-dir="$server" rev-parse refs/heads/main) &&
+	git --git-dir="$server" config uploadpack.allowreachablesha1inwant 1 &&
 
 	git init --bare test_reachable.git &&
-	git -C test_reachable.git remote add origin "$HTTPD_URL/smart/repo.git" &&
+	git --git-dir=test_reachable.git remote add origin "$HTTPD_URL/smart/repo.git" &&
 	# Some protocol versions (e.g. 2) support fetching
 	# unadvertised objects, so restrict this test to v0.
 	test_must_fail env GIT_TEST_PROTOCOL_VERSION=0 \
-		git -C test_reachable.git fetch origin "$(git rev-parse HEAD)"
+		git --git-dir=test_reachable.git fetch origin "$(git rev-parse HEAD)"
 '
 
 test_expect_success 'test allowanysha1inwant with unreachable' '
@@ -466,18 +466,18 @@ test_expect_success 'test allowanysha1inwant with unreachable' '
 	git push public :refs/heads/doomed &&
 
 	server="$HTTPD_DOCUMENT_ROOT_PATH/repo.git" &&
-	main_sha=$(git -C "$server" rev-parse refs/heads/main) &&
-	git -C "$server" config uploadpack.allowreachablesha1inwant 1 &&
+	main_sha=$(git --git-dir="$server" rev-parse refs/heads/main) &&
+	git --git-dir="$server" config uploadpack.allowreachablesha1inwant 1 &&
 
 	git init --bare test_reachable.git &&
-	git -C test_reachable.git remote add origin "$HTTPD_URL/smart/repo.git" &&
+	git --git-dir=test_reachable.git remote add origin "$HTTPD_URL/smart/repo.git" &&
 	# Some protocol versions (e.g. 2) support fetching
 	# unadvertised objects, so restrict this test to v0.
 	test_must_fail env GIT_TEST_PROTOCOL_VERSION=0 \
-		git -C test_reachable.git fetch origin "$(git rev-parse HEAD)" &&
+		git --git-dir=test_reachable.git fetch origin "$(git rev-parse HEAD)" &&
 
-	git -C "$server" config uploadpack.allowanysha1inwant 1 &&
-	git -C test_reachable.git fetch origin "$(git rev-parse HEAD)"
+	git --git-dir="$server" config uploadpack.allowanysha1inwant 1 &&
+	git --git-dir=test_reachable.git fetch origin "$(git rev-parse HEAD)"
 '
 
 test_expect_success EXPENSIVE 'http can handle enormous ref negotiation' '

--- a/t/t5551-http-fetch-smart.sh
+++ b/t/t5551-http-fetch-smart.sh
@@ -30,7 +30,7 @@ test_expect_success 'setup repository' '
 
 test_expect_success 'create http-accessible bare repository' '
 	mkdir "$HTTPD_DOCUMENT_ROOT_PATH/repo.git" &&
-	(cd "$HTTPD_DOCUMENT_ROOT_PATH/repo.git" &&
+	(cd "$HTTPD_DOCUMENT_ROOT_PATH/repo.git" && GIT_DIR=. && export GIT_DIR &&
 	 git --bare init
 	) &&
 	git remote add public "$HTTPD_DOCUMENT_ROOT_PATH/repo.git" &&
@@ -398,7 +398,7 @@ create_tags () {
 
 test_expect_success 'create 2,000 tags in the repo' '
 	(
-		cd "$HTTPD_DOCUMENT_ROOT_PATH/repo.git" &&
+		cd "$HTTPD_DOCUMENT_ROOT_PATH/repo.git" && GIT_DIR=. && export GIT_DIR &&
 		create_tags 1 2000
 	)
 '
@@ -482,12 +482,12 @@ test_expect_success 'test allowanysha1inwant with unreachable' '
 
 test_expect_success EXPENSIVE 'http can handle enormous ref negotiation' '
 	(
-		cd "$HTTPD_DOCUMENT_ROOT_PATH/repo.git" &&
+		cd "$HTTPD_DOCUMENT_ROOT_PATH/repo.git" && GIT_DIR=. && export GIT_DIR &&
 		create_tags 2001 50000
 	) &&
 	git -C too-many-refs fetch -q --tags &&
 	(
-		cd "$HTTPD_DOCUMENT_ROOT_PATH/repo.git" &&
+		cd "$HTTPD_DOCUMENT_ROOT_PATH/repo.git" && GIT_DIR=. && export GIT_DIR &&
 		create_tags 50001 100000
 	) &&
 	git -C too-many-refs fetch -q --tags &&
@@ -647,7 +647,7 @@ test_expect_success 'client falls back from v2 to v0 to match server' '
 
 test_expect_success 'create empty http-accessible SHA-256 repository' '
 	mkdir "$HTTPD_DOCUMENT_ROOT_PATH/sha256.git" &&
-	(cd "$HTTPD_DOCUMENT_ROOT_PATH/sha256.git" &&
+	(cd "$HTTPD_DOCUMENT_ROOT_PATH/sha256.git" && GIT_DIR=. && export GIT_DIR &&
 	 git --bare init --object-format=sha256
 	)
 '

--- a/t/t5558-clone-bundle-uri.sh
+++ b/t/t5558-clone-bundle-uri.sh
@@ -1035,7 +1035,7 @@ test_expect_success 'expand incremental bundle list' '
 
 		cp bundle-*.bundle "$HTTPD_DOCUMENT_ROOT_PATH/"
 	) &&
-	git -C "$HTTPD_DOCUMENT_ROOT_PATH/fetch.git" fetch origin +refs/heads/*:refs/heads/*
+	git --git-dir="$HTTPD_DOCUMENT_ROOT_PATH/fetch.git" fetch origin +refs/heads/*:refs/heads/*
 '
 
 test_expect_success 'creationToken heuristic with failed downloads (fetch)' '

--- a/t/t556x_common
+++ b/t/t556x_common
@@ -24,7 +24,7 @@ test_expect_success 'setup repository' '
 	git remote add public "$HTTPD_DOCUMENT_ROOT_PATH/repo.git" &&
 	git push public main:main &&
 
-	(cd "$HTTPD_DOCUMENT_ROOT_PATH/repo.git" &&
+	(cd "$HTTPD_DOCUMENT_ROOT_PATH/repo.git" && GIT_DIR=. && export GIT_DIR &&
 	 git repack -a -d
 	) &&
 

--- a/t/t5570-git-daemon.sh
+++ b/t/t5570-git-daemon.sh
@@ -228,7 +228,7 @@ test_expect_success FAKENC 'hostname interpolation works after LF-stripping' '
 	# just pick out the value of main, which avoids any protocol
 	# particulars
 	perl -lne "print \$1 if m{^(\\S+) refs/heads/main}" <output.raw >actual &&
-	git -C "$repo" rev-parse main >expect &&
+	git --git-dir="$repo" rev-parse main >expect &&
 	test_cmp expect actual
 '
 

--- a/t/t5583-push-branches.sh
+++ b/t/t5583-push-branches.sh
@@ -15,12 +15,12 @@ delete_refs() {
 	do
 		echo "delete ${arg}" >>deletes
 	done
-	git -C $dir update-ref --stdin < deletes
+	git --git-dir=$dir update-ref --stdin < deletes
 }
 
 test_expect_success 'setup bare remote' '
 	git init --bare remote-1 &&
-	git -C remote-1 config gc.auto 0 &&
+	git --git-dir=remote-1 config gc.auto 0 &&
 	test_commit one &&
 	git push remote-1 HEAD
 '
@@ -48,10 +48,10 @@ test_expect_success '--all and --branches have the same behavior' '
 	$commit refs/heads/main
 	EOF
 
-	git -C remote-1 show-ref --heads >actual.all &&
+	git --git-dir=remote-1 show-ref --heads >actual.all &&
 	delete_refs remote-1 refs/heads/branch-1 refs/heads/branch-2 &&
 	git push remote-1 --branches &&
-	git -C remote-1 show-ref --heads >actual.branches &&
+	git --git-dir=remote-1 show-ref --heads >actual.branches &&
 	test_cmp actual.all actual.branches &&
 	test_cmp expect actual.all
 '
@@ -92,7 +92,7 @@ test_expect_success '--all or --branches combines with --follow-tags have same b
 			   refs/tags/annotated-1 \
 			   refs/tags/annotated-2" &&
 	git push remote-1 --all --follow-tags &&
-	git -C remote-1 show-ref > actual.all &&
+	git --git-dir=remote-1 show-ref > actual.all &&
 	cat >expect <<-EOF &&
 	$commit refs/heads/branch-1
 	$commit refs/heads/branch-2
@@ -107,7 +107,7 @@ test_expect_success '--all or --branches combines with --follow-tags have same b
 		    refs/tags/annotated-1 \
 		    refs/tags/annotated-2 &&
 	git push remote-1 --branches --follow-tags &&
-	git -C remote-1 show-ref >actual.branches &&
+	git --git-dir=remote-1 show-ref >actual.branches &&
 	test_cmp actual.all actual.branches &&
 	test_cmp expect actual.all
 '

--- a/t/t5601-clone.sh
+++ b/t/t5601-clone.sh
@@ -168,7 +168,7 @@ test_expect_success 'clone with files ref format' '
 	test_when_finished "rm -rf ref-storage" &&
 	git clone --ref-format=files --mirror src ref-storage &&
 	echo files >expect &&
-	git -C ref-storage rev-parse --show-ref-format >actual &&
+	git --git-dir=ref-storage rev-parse --show-ref-format >actual &&
 	test_cmp expect actual
 '
 
@@ -646,7 +646,7 @@ test_expect_success 'GIT_TRACE_PACKFILE produces a usable pack' '
 	rm -rf dst.git &&
 	GIT_TRACE_PACKFILE=$PWD/tmp.pack git clone --no-local --bare src dst.git &&
 	git init --bare replay.git &&
-	git -C replay.git index-pack -v --stdin <tmp.pack
+	git --git-dir=replay.git index-pack -v --stdin <tmp.pack
 '
 
 test_expect_success PERL_TEST_HELPERS 'clone on case-insensitive fs' '
@@ -839,13 +839,13 @@ test_expect_success 'auto-discover bundle URI from HTTP clone' '
 	git -C src bundle create "$HTTPD_DOCUMENT_ROOT_PATH/everything.bundle" --all &&
 	git clone --bare --no-local src "$HTTPD_DOCUMENT_ROOT_PATH/repo2.git" &&
 
-	git -C "$HTTPD_DOCUMENT_ROOT_PATH/repo2.git" config \
+	git --git-dir="$HTTPD_DOCUMENT_ROOT_PATH/repo2.git" config \
 		uploadpack.advertiseBundleURIs true &&
-	git -C "$HTTPD_DOCUMENT_ROOT_PATH/repo2.git" config \
+	git --git-dir="$HTTPD_DOCUMENT_ROOT_PATH/repo2.git" config \
 		bundle.version 1 &&
-	git -C "$HTTPD_DOCUMENT_ROOT_PATH/repo2.git" config \
+	git --git-dir="$HTTPD_DOCUMENT_ROOT_PATH/repo2.git" config \
 		bundle.mode all &&
-	git -C "$HTTPD_DOCUMENT_ROOT_PATH/repo2.git" config \
+	git --git-dir="$HTTPD_DOCUMENT_ROOT_PATH/repo2.git" config \
 		bundle.everything.uri "$HTTPD_URL/everything.bundle" &&
 
 	GIT_TRACE2_EVENT="$(pwd)/trace.txt" \
@@ -865,16 +865,16 @@ test_expect_success 'auto-discover multiple bundles from HTTP clone' '
 	git -C src bundle create "$HTTPD_DOCUMENT_ROOT_PATH/new.bundle" HEAD~1..HEAD &&
 	git clone --bare --no-local src "$HTTPD_DOCUMENT_ROOT_PATH/repo3.git" &&
 
-	git -C "$HTTPD_DOCUMENT_ROOT_PATH/repo3.git" config \
+	git --git-dir="$HTTPD_DOCUMENT_ROOT_PATH/repo3.git" config \
 		uploadpack.advertiseBundleURIs true &&
-	git -C "$HTTPD_DOCUMENT_ROOT_PATH/repo3.git" config \
+	git --git-dir="$HTTPD_DOCUMENT_ROOT_PATH/repo3.git" config \
 		bundle.version 1 &&
-	git -C "$HTTPD_DOCUMENT_ROOT_PATH/repo3.git" config \
+	git --git-dir="$HTTPD_DOCUMENT_ROOT_PATH/repo3.git" config \
 		bundle.mode all &&
 
-	git -C "$HTTPD_DOCUMENT_ROOT_PATH/repo3.git" config \
+	git --git-dir="$HTTPD_DOCUMENT_ROOT_PATH/repo3.git" config \
 		bundle.everything.uri "$HTTPD_URL/everything.bundle" &&
-	git -C "$HTTPD_DOCUMENT_ROOT_PATH/repo3.git" config \
+	git --git-dir="$HTTPD_DOCUMENT_ROOT_PATH/repo3.git" config \
 		bundle.new.uri "$HTTPD_URL/new.bundle" &&
 
 	GIT_TRACE2_EVENT="$(pwd)/trace.txt" \

--- a/t/t5601-clone.sh
+++ b/t/t5601-clone.sh
@@ -118,9 +118,9 @@ test_expect_success 'clone --mirror' '
 	git clone --mirror src mirror &&
 	test -f mirror/HEAD &&
 	test ! -f mirror/file &&
-	FETCH="$(cd mirror && git config remote.origin.fetch)" &&
+	FETCH="$(cd mirror && GIT_DIR=. && export GIT_DIR && git config remote.origin.fetch)" &&
 	test "+refs/*:refs/*" = "$FETCH" &&
-	MIRROR="$(cd mirror && git config --bool remote.origin.mirror)" &&
+	MIRROR="$(cd mirror && GIT_DIR=. && export GIT_DIR && git config --bool remote.origin.mirror)" &&
 	test "$MIRROR" = true
 
 '
@@ -157,7 +157,7 @@ test_expect_success 'clone --mirror does not repeat tags' '
 	(cd src &&
 	 git tag some-tag HEAD) &&
 	git clone --mirror src mirror2 &&
-	(cd mirror2 &&
+	(cd mirror2 && GIT_DIR=. && export GIT_DIR &&
 	 git show-ref 2> clone.err > clone.out) &&
 	! grep Duplicate mirror2/clone.err &&
 	grep some-tag mirror2/clone.out

--- a/t/t5605-clone-local.sh
+++ b/t/t5605-clone-local.sh
@@ -16,10 +16,10 @@ test_expect_success 'preparing origin repository' '
 	git clone --bare . a.git &&
 	git clone --bare . x &&
 	echo true >expect &&
-	git -C a.git config --bool core.bare >actual &&
+	git --git-dir=a.git config --bool core.bare >actual &&
 	test_cmp expect actual &&
 	echo true >expect &&
-	git -C x config --bool core.bare >actual &&
+	git --git-dir=x config --bool core.bare >actual &&
 	test_cmp expect actual &&
 	git bundle create b1.bundle --all &&
 	git bundle create b2.bundle main &&
@@ -65,7 +65,7 @@ test_expect_success 'Even without -l, local will make a hardlink' '
 '
 
 test_expect_success 'local clone of repo with nonexistent ref in HEAD' '
-	git -C a.git symbolic-ref HEAD refs/heads/nonexistent &&
+	git --git-dir=a.git symbolic-ref HEAD refs/heads/nonexistent &&
 	git clone a d &&
 	(cd d &&
 	git fetch &&

--- a/t/t5606-clone-options.sh
+++ b/t/t5606-clone-options.sh
@@ -46,7 +46,7 @@ test_expect_success 'clone --bare -o' '
 
 	git clone -o foo --bare parent clone-bare-o &&
 	(cd parent && pwd) >expect &&
-	git -C clone-bare-o config remote.foo.url >actual &&
+	git --git-dir=clone-bare-o config remote.foo.url >actual &&
 	test_cmp expect actual
 
 '
@@ -164,7 +164,7 @@ test_expect_success 'clone does not segfault with --bare and core.bare=false' '
 	test_config_global core.bare false &&
 	git clone --bare parent clone-bare &&
 	echo true >expect &&
-	git -C clone-bare rev-parse --is-bare-repository >actual &&
+	git --git-dir=clone-bare rev-parse --is-bare-repository >actual &&
 	test_cmp expect actual
 '
 
@@ -190,7 +190,7 @@ test_expect_success 'guesses initial branch name correctly' '
 	GIT_TEST_DEFAULT_INITIAL_BRANCH_NAME= \
 	git clone no-head is-it2 &&
 	test_must_fail git -C is-it2 symbolic-ref refs/remotes/origin/HEAD &&
-	git -C no-head update-ref --no-deref HEAD refs/heads/guess &&
+	git --git-dir=no-head update-ref --no-deref HEAD refs/heads/guess &&
 	GIT_TEST_DEFAULT_INITIAL_BRANCH_NAME= \
 	git -c init.defaultBranch=guess clone no-head is-it3 &&
 	test refs/remotes/origin/guess = \

--- a/t/t5606-clone-options.sh
+++ b/t/t5606-clone-options.sh
@@ -171,7 +171,7 @@ test_expect_success 'clone does not segfault with --bare and core.bare=false' '
 test_expect_success 'chooses correct default initial branch name' '
 	GIT_TEST_DEFAULT_INITIAL_BRANCH_NAME= \
 	git -c init.defaultBranch=foo init --bare empty &&
-	test_config -C empty lsrefs.unborn advertise &&
+	test_config --git-dir empty lsrefs.unborn advertise &&
 	GIT_TEST_DEFAULT_INITIAL_BRANCH_NAME= \
 	git -c init.defaultBranch=up -c protocol.version=2 clone empty whats-up &&
 	test refs/heads/foo = $(git -C whats-up symbolic-ref HEAD) &&

--- a/t/t5612-clone-refspec.sh
+++ b/t/t5612-clone-refspec.sh
@@ -205,7 +205,7 @@ test_expect_success '--single-branch with explicit --branch with tag fetches upd
 
 test_expect_success '--single-branch with --mirror' '
 	(
-		cd dir_mirror &&
+		cd dir_mirror && GIT_DIR=. && export GIT_DIR &&
 		git fetch &&
 		git for-each-ref refs > ../actual
 	) &&
@@ -215,7 +215,7 @@ test_expect_success '--single-branch with --mirror' '
 
 test_expect_success '--single-branch with explicit --branch and --mirror' '
 	(
-		cd dir_mirror_side &&
+		cd dir_mirror_side && GIT_DIR=. && export GIT_DIR &&
 		git fetch &&
 		git for-each-ref refs > ../actual
 	) &&

--- a/t/t5613-info-alternate.sh
+++ b/t/t5613-info-alternate.sh
@@ -115,7 +115,7 @@ test_expect_success 'relative duplicates are eliminated' '
 	alternate: $(pwd)/B/.git/objects
 	alternate: $(pwd)/A/.git/objects
 	EOF
-	git -C deep/subdir/duplicate.git count-objects -v >actual &&
+	git --git-dir=deep/subdir/duplicate.git count-objects -v >actual &&
 	grep ^alternate: actual >actual.alternates &&
 	test_cmp expect actual.alternates
 '
@@ -132,7 +132,7 @@ test_expect_success CASE_INSENSITIVE_FS 'dup finding can be case-insensitive' '
 	alternate: $(pwd)/B/.git/objects
 	alternate: $(pwd)/A/.git/objects
 	EOF
-	git -C insensitive.git count-objects -v >actual &&
+	git --git-dir=insensitive.git count-objects -v >actual &&
 	grep ^alternate: actual >actual.alternates &&
 	test_cmp expect actual.alternates
 '

--- a/t/t5615-alternate-env.sh
+++ b/t/t5615-alternate-env.sh
@@ -19,9 +19,9 @@ check_obj () {
 
 test_expect_success 'create alternate repositories' '
 	git init --bare one.git &&
-	one=$(echo one | git -C one.git hash-object -w --stdin) &&
+	one=$(echo one | git --git-dir=one.git hash-object -w --stdin) &&
 	git init --bare two.git &&
-	two=$(echo two | git -C two.git hash-object -w --stdin)
+	two=$(echo two | git --git-dir=two.git hash-object -w --stdin)
 '
 
 test_expect_success 'objects inaccessible without alternates' '

--- a/t/t5615-alternate-env.sh
+++ b/t/t5615-alternate-env.sh
@@ -48,9 +48,12 @@ test_expect_success 'access multiple alternates' '
 # bare paths are relative from $GIT_DIR
 test_expect_success 'access alternate via relative path (bare)' '
 	git init --bare bare.git &&
-	check_obj "../one.git/objects" -C bare.git <<-EOF
-	$one blob
-	EOF
+	(
+		cd bare.git && GIT_DIR=. && export GIT_DIR &&
+		check_obj "../one.git/objects" <<-EOF
+		$one blob
+		EOF
+	)
 '
 
 # non-bare paths are relative to top of worktree

--- a/t/t5616-partial-clone.sh
+++ b/t/t5616-partial-clone.sh
@@ -28,8 +28,8 @@ test_expect_success 'setup normal src repo' '
 # bare clone "src" giving "srv.bare" for use as our server.
 test_expect_success 'setup bare clone for server' '
 	git clone --bare "file://$(pwd)/src" srv.bare &&
-	git -C srv.bare config --local uploadpack.allowfilter 1 &&
-	git -C srv.bare config --local uploadpack.allowanysha1inwant 1
+	git --git-dir=srv.bare config --local uploadpack.allowfilter 1 &&
+	git --git-dir=srv.bare config --local uploadpack.allowanysha1inwant 1
 '
 
 # do basic partial clone from "srv.bare"
@@ -59,7 +59,7 @@ test_expect_success 'rev-list --missing=allow-promisor on partial clone' '
 test_expect_success 'verify that .promisor file contains refs fetched' '
 	ls pc1/.git/objects/pack/pack-*.promisor >promisorlist &&
 	test_line_count = 1 promisorlist &&
-	git -C srv.bare rev-parse --verify HEAD >headhash &&
+	git --git-dir=srv.bare rev-parse --verify HEAD >headhash &&
 	grep "$(cat headhash) HEAD" $(cat promisorlist) &&
 	grep "$(cat headhash) refs/heads/main" $(cat promisorlist)
 '
@@ -335,14 +335,14 @@ test_expect_success 'implicitly construct combine: filter with repeated flags' '
 		"file://$(pwd)/srv.bare" pc2 &&
 	grep "trace:.* git pack-objects .*--filter=combine:blob:none+tree:1" \
 		trace &&
-	git -C pc2 rev-list --objects --missing=allow-any HEAD >objects &&
+	git --git-dir=pc2 rev-list --objects --missing=allow-any HEAD >objects &&
 
 	# We should have gotten some root trees.
 	grep " $" objects &&
 	# Should not have gotten any non-root trees or blobs.
 	! grep " ." objects &&
 
-	xargs -n 1 git -C pc2 cat-file -t <objects >types &&
+	xargs -n 1 git --git-dir=pc2 cat-file -t <objects >types &&
 	sort -u types >unique_types.actual &&
 	test_write_lines commit tree >unique_types.expected &&
 	test_cmp unique_types.expected unique_types.actual
@@ -423,10 +423,10 @@ test_expect_success 'fetch what is specified on CLI even if already promised' '
 	git hash-object --stdin <src/foo.t >blob &&
 
 	git clone --bare --filter=blob:none "file://$(pwd)/src" dst.git &&
-	git -C dst.git rev-list --objects --quiet --missing=print HEAD >missing_before &&
+	git --git-dir=dst.git rev-list --objects --quiet --missing=print HEAD >missing_before &&
 	grep "?$(cat blob)" missing_before &&
-	git -C dst.git fetch origin $(cat blob) &&
-	git -C dst.git rev-list --objects --quiet --missing=print HEAD >missing_after &&
+	git --git-dir=dst.git fetch origin $(cat blob) &&
+	git --git-dir=dst.git rev-list --objects --quiet --missing=print HEAD >missing_after &&
 	! grep "?$(cat blob)" missing_after
 '
 
@@ -501,7 +501,7 @@ setup_triangle () {
 	# for this tree or blob.
 	test_commit -C promisor-remote one && # so that ref advertisement is not empty
 	git -C promisor-remote config --local uploadpack.allowanysha1inwant 1 &&
-	git -C client remote set-url origin "file://$(pwd)/promisor-remote"
+	git --git-dir=client remote set-url origin "file://$(pwd)/promisor-remote"
 }
 
 # NEEDSWORK: The tests beginning with "fetch lazy-fetches" below only
@@ -515,7 +515,7 @@ test_expect_success 'fetch lazy-fetches only to resolve deltas' '
 	# Exercise to make sure it works. Git will not fetch anything from the
 	# promisor remote other than for the big tree (because it needs to
 	# resolve the delta).
-	GIT_TRACE_PACKET="$(pwd)/trace" git -C client \
+	GIT_TRACE_PACKET="$(pwd)/trace" git --git-dir=client \
 		fetch "file://$(pwd)/server" main &&
 
 	# Verify the assumption that the client needed to fetch the delta base
@@ -528,13 +528,13 @@ test_expect_success 'fetch lazy-fetches only to resolve deltas, protocol v2' '
 	setup_triangle &&
 
 	git -C server config --local protocol.version 2 &&
-	git -C client config --local protocol.version 2 &&
+	git --git-dir=client config --local protocol.version 2 &&
 	git -C promisor-remote config --local protocol.version 2 &&
 
 	# Exercise to make sure it works. Git will not fetch anything from the
 	# promisor remote other than for the big blob (because it needs to
 	# resolve the delta).
-	GIT_TRACE_PACKET="$(pwd)/trace" git -C client \
+	GIT_TRACE_PACKET="$(pwd)/trace" git --git-dir=client \
 		fetch "file://$(pwd)/server" main &&
 
 	# Verify that protocol version 2 was used.
@@ -577,7 +577,7 @@ test_expect_success 'verify fetch succeeds when asking for new tags' '
 		test_commit -C src $i &&
 		git -C src branch $i || return 1
 	done &&
-	git -C srv.bare fetch --tags origin +refs/heads/*:refs/heads/* &&
+	git --git-dir=srv.bare fetch --tags origin +refs/heads/*:refs/heads/* &&
 	git -C tag-test -c protocol.version=2 fetch --tags origin
 '
 
@@ -591,7 +591,7 @@ test_expect_success 'verify fetch downloads only one pack when updating refs' '
 		test_commit -C src $i &&
 		git -C src branch $i || return 1
 	done &&
-	git -C srv.bare fetch origin +refs/heads/*:refs/heads/* &&
+	git --git-dir=srv.bare fetch origin +refs/heads/*:refs/heads/* &&
 	git -C pack-test fetch origin &&
 	ls pack-test/.git/objects/pack/*pack >pack-list &&
 	test_line_count = 3 pack-list
@@ -647,7 +647,7 @@ test_expect_success 'repack does not loosen promisor objects' '
 	rm -rf client trace &&
 	git clone --bare --filter=blob:none "file://$(pwd)/srv.bare" client &&
 	test_when_finished "rm -rf client trace" &&
-	GIT_TRACE2_PERF="$(pwd)/trace" git -C client repack -A -d &&
+	GIT_TRACE2_PERF="$(pwd)/trace" git --git-dir=client repack -A -d &&
 	grep "loosen_unused_packed_objects/loosened:0" trace
 '
 

--- a/t/t5616-partial-clone.sh
+++ b/t/t5616-partial-clone.sh
@@ -357,40 +357,40 @@ test_expect_success 'upload-pack complains of bogus filter config' '
 '
 
 test_expect_success 'upload-pack fails banned object filters' '
-	test_config -C srv.bare uploadpackfilter.blob:none.allow false &&
+	test_config --git-dir srv.bare uploadpackfilter.blob:none.allow false &&
 	test_must_fail ok=sigpipe git clone --no-checkout --filter=blob:none \
 		"file://$(pwd)/srv.bare" pc3 2>err &&
 	test_grep "filter '\''blob:none'\'' not supported" err
 '
 
 test_expect_success 'upload-pack fails banned combine object filters' '
-	test_config -C srv.bare uploadpackfilter.allow false &&
-	test_config -C srv.bare uploadpackfilter.combine.allow true &&
-	test_config -C srv.bare uploadpackfilter.tree.allow true &&
-	test_config -C srv.bare uploadpackfilter.blob:none.allow false &&
+	test_config --git-dir srv.bare uploadpackfilter.allow false &&
+	test_config --git-dir srv.bare uploadpackfilter.combine.allow true &&
+	test_config --git-dir srv.bare uploadpackfilter.tree.allow true &&
+	test_config --git-dir srv.bare uploadpackfilter.blob:none.allow false &&
 	test_must_fail ok=sigpipe git clone --no-checkout --filter=tree:1 \
 		--filter=blob:none "file://$(pwd)/srv.bare" pc3 2>err &&
 	test_grep "filter '\''blob:none'\'' not supported" err
 '
 
 test_expect_success 'upload-pack fails banned object filters with fallback' '
-	test_config -C srv.bare uploadpackfilter.allow false &&
+	test_config --git-dir srv.bare uploadpackfilter.allow false &&
 	test_must_fail ok=sigpipe git clone --no-checkout --filter=blob:none \
 		"file://$(pwd)/srv.bare" pc3 2>err &&
 	test_grep "filter '\''blob:none'\'' not supported" err
 '
 
 test_expect_success 'upload-pack limits tree depth filters' '
-	test_config -C srv.bare uploadpackfilter.allow false &&
-	test_config -C srv.bare uploadpackfilter.tree.allow true &&
-	test_config -C srv.bare uploadpackfilter.tree.maxDepth 0 &&
+	test_config --git-dir srv.bare uploadpackfilter.allow false &&
+	test_config --git-dir srv.bare uploadpackfilter.tree.allow true &&
+	test_config --git-dir srv.bare uploadpackfilter.tree.maxDepth 0 &&
 	test_must_fail ok=sigpipe git clone --no-checkout --filter=tree:1 \
 		"file://$(pwd)/srv.bare" pc3 2>err &&
 	test_grep "tree filter allows max depth 0, but got 1" err &&
 
 	git clone --no-checkout --filter=tree:0 "file://$(pwd)/srv.bare" pc4 &&
 
-	test_config -C srv.bare uploadpackfilter.tree.maxDepth 5 &&
+	test_config --git-dir srv.bare uploadpackfilter.tree.maxDepth 5 &&
 	git clone --no-checkout --filter=tree:5 "file://$(pwd)/srv.bare" pc5 &&
 	test_must_fail ok=sigpipe git clone --no-checkout --filter=tree:6 \
 		"file://$(pwd)/srv.bare" pc6 2>err &&

--- a/t/t5616-partial-clone.sh
+++ b/t/t5616-partial-clone.sh
@@ -447,7 +447,7 @@ test_expect_success 'partial clone with sparse filter succeeds' '
 		  --filter=sparse:oid=main:only-one \
 		  sparse-src dst.git &&
 	(
-		cd dst.git &&
+		cd dst.git && GIT_DIR=. && export GIT_DIR &&
 		git rev-list --objects --missing=print HEAD >out &&
 		grep "^$(git rev-parse HEAD:one.t)" out &&
 		grep "^?$(git rev-parse HEAD:two.t)" out

--- a/t/t5617-clone-submodules-remote.sh
+++ b/t/t5617-clone-submodules-remote.sh
@@ -32,8 +32,8 @@ test_expect_success 'setup' '
 # bare clone giving "srv.bare" for use as our server.
 test_expect_success 'setup bare clone for server' '
 	git clone --bare "file://$(pwd)/." srv.bare &&
-	git -C srv.bare config --local uploadpack.allowfilter 1 &&
-	git -C srv.bare config --local uploadpack.allowanysha1inwant 1
+	git --git-dir=srv.bare config --local uploadpack.allowfilter 1 &&
+	git --git-dir=srv.bare config --local uploadpack.allowanysha1inwant 1
 '
 
 test_expect_success 'clone with --no-remote-submodules' '

--- a/t/t5619-clone-local-ambiguous-transport.sh
+++ b/t/t5619-clone-local-ambiguous-transport.sh
@@ -23,8 +23,8 @@ test_expect_success 'setup' '
 	git init --bare "$REPO" &&
 	(GIT_DIR="$REPO" && export GIT_DIR && test_commit_bulk --ref=main 1) &&
 
-	git -C "$REPO" update-ref HEAD main &&
-	git -C "$REPO" update-server-info &&
+	git --git-dir="$REPO" update-ref HEAD main &&
+	git --git-dir="$REPO" update-server-info &&
 
 	git init malicious &&
 	(
@@ -48,9 +48,9 @@ test_expect_success 'setup' '
 	# avoid the client attempting to checkout any objects (which
 	# will be missing, and thus will cause the clone to fail before
 	# we can trigger the exploit).
-	git -C "$REPO" for-each-ref --format="delete %(refname)" >in &&
-	git -C "$REPO" update-ref --stdin <in &&
-	git -C "$REPO" update-server-info
+	git --git-dir="$REPO" for-each-ref --format="delete %(refname)" >in &&
+	git --git-dir="$REPO" update-ref --stdin <in &&
+	git --git-dir="$REPO" update-server-info
 '
 
 test_expect_success 'ambiguous transport does not lead to arbitrary file-inclusion' '

--- a/t/t5619-clone-local-ambiguous-transport.sh
+++ b/t/t5619-clone-local-ambiguous-transport.sh
@@ -21,7 +21,7 @@ test_expect_success 'setup' '
 	echo "secret" >sensitive/secret &&
 
 	git init --bare "$REPO" &&
-	test_commit_bulk -C "$REPO" --ref=main 1 &&
+	(GIT_DIR="$REPO" && export GIT_DIR && test_commit_bulk --ref=main 1) &&
 
 	git -C "$REPO" update-ref HEAD main &&
 	git -C "$REPO" update-server-info &&

--- a/t/t5620-backfill.sh
+++ b/t/t5620-backfill.sh
@@ -37,8 +37,8 @@ test_expect_success 'setup repo for object creation' '
 # server for the partial clone.
 test_expect_success 'setup bare clone for server' '
 	git clone --bare "file://$(pwd)/src" srv.bare &&
-	git -C srv.bare config --local uploadpack.allowfilter 1 &&
-	git -C srv.bare config --local uploadpack.allowanysha1inwant 1
+	git --git-dir=srv.bare config --local uploadpack.allowfilter 1 &&
+	git --git-dir=srv.bare config --local uploadpack.allowanysha1inwant 1
 '
 
 # do basic partial clone from "srv.bare"

--- a/t/t5620-backfill.sh
+++ b/t/t5620-backfill.sh
@@ -183,8 +183,8 @@ test_expect_success 'create a partial clone over HTTP' '
 	SERVER="$HTTPD_DOCUMENT_ROOT_PATH/server" &&
 	rm -rf "$SERVER" repo &&
 	git clone --bare "file://$(pwd)/src" "$SERVER" &&
-	test_config -C "$SERVER" uploadpack.allowfilter 1 &&
-	test_config -C "$SERVER" uploadpack.allowanysha1inwant 1 &&
+	test_config --git-dir "$SERVER" uploadpack.allowfilter 1 &&
+	test_config --git-dir "$SERVER" uploadpack.allowanysha1inwant 1 &&
 
 	git clone --no-checkout --filter=blob:none \
 		"$HTTPD_URL/smart/server" backfill-http

--- a/t/t5621-clone-revision.sh
+++ b/t/t5621-clone-revision.sh
@@ -82,12 +82,12 @@ test_expect_success 'clone with --revision and --bare' '
 	test_when_finished "rm -rf dst" &&
 	git clone --revision=refs/heads/main --bare . dst &&
 	oid=$(git rev-parse refs/heads/main) &&
-	git -C dst cat-file -t $oid >actual &&
+	git --git-dir=dst cat-file -t $oid >actual &&
 	echo "commit" >expect &&
 	test_cmp expect actual &&
-	git -C dst for-each-ref refs >expect &&
+	git --git-dir=dst for-each-ref refs >expect &&
 	test_must_be_empty expect &&
-	test_must_fail git -C dst config remote.origin.fetch
+	test_must_fail git --git-dir=dst config remote.origin.fetch
 '
 
 test_expect_success 'clone with --revision being a short raw commit hash' '

--- a/t/t5702-protocol-v2.sh
+++ b/t/t5702-protocol-v2.sh
@@ -289,7 +289,7 @@ test_expect_success 'bare clone propagates empty default branch' '
 		clone --bare \
 		"file://$(pwd)/file_empty_parent" file_empty_child.git &&
 	echo "refs/heads/mydefaultbranch" >expect &&
-	git -C file_empty_child.git symbolic-ref HEAD >actual &&
+	git --git-dir=file_empty_child.git symbolic-ref HEAD >actual &&
 	test_cmp expect actual
 '
 
@@ -341,7 +341,7 @@ test_expect_success 'bare clone propagates unborn HEAD from non-empty repo' '
 		clone --bare "file://$(pwd)/file_unborn_parent" \
 		file_unborn_child.git 2>stderr &&
 	echo "refs/heads/mydefaultbranch" >expect &&
-	git -C file_unborn_child.git symbolic-ref HEAD >actual &&
+	git --git-dir=file_unborn_child.git symbolic-ref HEAD >actual &&
 	test_cmp expect actual &&
 	! grep "warning:" stderr
 '

--- a/t/t5710-promisor-remote-capability.sh
+++ b/t/t5710-promisor-remote-capability.sh
@@ -30,11 +30,11 @@ test_expect_success 'setup: create bare "server" repository' '
 	git clone --bare --no-local template server &&
 	mv server/objects/pack/pack-* . &&
 	packfile=$(ls pack-*.pack) &&
-	git -C server unpack-objects --strict <"$packfile"
+	git --git-dir=server unpack-objects --strict <"$packfile"
 '
 
 check_missing_objects () {
-	git -C "$1" rev-list --objects --all --missing=print > all.txt &&
+	git --git-dir="$1" rev-list --objects --all --missing=print > all.txt &&
 	perl -ne 'print if s/^[?]//' all.txt >missing.txt &&
 	test_line_count = "$2" missing.txt &&
 	if test "$2" -lt 2
@@ -53,13 +53,13 @@ initialize_server () {
 	missing_oids="$2"
 
 	# Repack everything first
-	git -C server -c repack.writebitmaps=false repack -a -d &&
+	git --git-dir=server -c repack.writebitmaps=false repack -a -d &&
 
 	# Remove promisor file in case they exist, useful when reinitializing
 	rm -rf server/objects/pack/*.promisor &&
 
 	# Repack without the largest object and create a promisor pack on server
-	git -C server -c repack.writebitmaps=false repack -a -d \
+	git --git-dir=server -c repack.writebitmaps=false repack -a -d \
 	    --filter=blob:limit=5k --filter-to="$(pwd)/pack" &&
 	promisor_file=$(ls server/objects/pack/*.pack | sed "s/\.pack/.promisor/") &&
 	>"$promisor_file" &&
@@ -82,23 +82,23 @@ test_expect_success "setup for testing promisor remote advertisement" '
 
 	# Copy the largest object from server to lop
 	obj="HEAD:foo" &&
-	oid="$(git -C server rev-parse $obj)" &&
+	oid="$(git --git-dir=server rev-parse $obj)" &&
 	copy_to_lop "$oid" &&
 
 	initialize_server 1 "$oid" &&
 
 	# Configure lop as promisor remote for server
-	git -C server remote add lop "file://$(pwd)/lop" &&
-	git -C server config remote.lop.promisor true &&
+	git --git-dir=server remote add lop "file://$(pwd)/lop" &&
+	git --git-dir=server config remote.lop.promisor true &&
 
-	git -C lop config uploadpack.allowFilter true &&
-	git -C lop config uploadpack.allowAnySHA1InWant true &&
-	git -C server config uploadpack.allowFilter true &&
-	git -C server config uploadpack.allowAnySHA1InWant true
+	git --git-dir=lop config uploadpack.allowFilter true &&
+	git --git-dir=lop config uploadpack.allowAnySHA1InWant true &&
+	git --git-dir=server config uploadpack.allowFilter true &&
+	git --git-dir=server config uploadpack.allowAnySHA1InWant true
 '
 
 test_expect_success "clone with promisor.advertise set to 'true'" '
-	git -C server config promisor.advertise true &&
+	git --git-dir=server config promisor.advertise true &&
 	test_when_finished "rm -rf client" &&
 
 	# Clone from server to create a client
@@ -113,7 +113,7 @@ test_expect_success "clone with promisor.advertise set to 'true'" '
 '
 
 test_expect_success "clone with promisor.advertise set to 'false'" '
-	git -C server config promisor.advertise false &&
+	git --git-dir=server config promisor.advertise false &&
 	test_when_finished "rm -rf client" &&
 
 	# Clone from server to create a client
@@ -131,7 +131,7 @@ test_expect_success "clone with promisor.advertise set to 'false'" '
 '
 
 test_expect_success "clone with promisor.acceptfromserver set to 'None'" '
-	git -C server config promisor.advertise true &&
+	git --git-dir=server config promisor.advertise true &&
 	test_when_finished "rm -rf client" &&
 
 	# Clone from server to create a client
@@ -149,7 +149,7 @@ test_expect_success "clone with promisor.acceptfromserver set to 'None'" '
 '
 
 test_expect_success "init + fetch with promisor.advertise set to 'true'" '
-	git -C server config promisor.advertise true &&
+	git --git-dir=server config promisor.advertise true &&
 	test_when_finished "rm -rf client" &&
 
 	mkdir client &&
@@ -167,7 +167,7 @@ test_expect_success "init + fetch with promisor.advertise set to 'true'" '
 '
 
 test_expect_success "clone with promisor.acceptfromserver set to 'KnownName'" '
-	git -C server config promisor.advertise true &&
+	git --git-dir=server config promisor.advertise true &&
 	test_when_finished "rm -rf client" &&
 
 	# Clone from server to create a client
@@ -182,7 +182,7 @@ test_expect_success "clone with promisor.acceptfromserver set to 'KnownName'" '
 '
 
 test_expect_success "clone with 'KnownName' and different remote names" '
-	git -C server config promisor.advertise true &&
+	git --git-dir=server config promisor.advertise true &&
 	test_when_finished "rm -rf client" &&
 
 	# Clone from server to create a client
@@ -200,7 +200,7 @@ test_expect_success "clone with 'KnownName' and different remote names" '
 '
 
 test_expect_success "clone with 'KnownName' and missing URL in the config" '
-	git -C server config promisor.advertise true &&
+	git --git-dir=server config promisor.advertise true &&
 	test_when_finished "rm -rf client" &&
 
 	# Clone from server to create a client
@@ -219,7 +219,7 @@ test_expect_success "clone with 'KnownName' and missing URL in the config" '
 '
 
 test_expect_success "clone with promisor.acceptfromserver set to 'KnownUrl'" '
-	git -C server config promisor.advertise true &&
+	git --git-dir=server config promisor.advertise true &&
 	test_when_finished "rm -rf client" &&
 
 	# Clone from server to create a client
@@ -236,7 +236,7 @@ test_expect_success "clone with promisor.acceptfromserver set to 'KnownUrl'" '
 test_expect_success "clone with 'KnownUrl' and different remote urls" '
 	ln -s lop serverTwo &&
 
-	git -C server config promisor.advertise true &&
+	git --git-dir=server config promisor.advertise true &&
 	test_when_finished "rm -rf client" &&
 
 	# Clone from server to create a client
@@ -254,11 +254,11 @@ test_expect_success "clone with 'KnownUrl' and different remote urls" '
 '
 
 test_expect_success "clone with 'KnownUrl' and url not configured on the server" '
-	git -C server config promisor.advertise true &&
+	git --git-dir=server config promisor.advertise true &&
 	test_when_finished "rm -rf client" &&
 
-	test_when_finished "git -C server config set remote.lop.url \"file://$(pwd)/lop\"" &&
-	git -C server config unset remote.lop.url &&
+	test_when_finished "git --git-dir=server config set remote.lop.url \"file://$(pwd)/lop\"" &&
+	git --git-dir=server config unset remote.lop.url &&
 
 	# Clone from server to create a client
 	# It should fail because the client will reject the LOP as URLs are
@@ -275,11 +275,11 @@ test_expect_success "clone with 'KnownUrl' and url not configured on the server"
 '
 
 test_expect_success "clone with 'KnownUrl' and empty url, so not advertised" '
-	git -C server config promisor.advertise true &&
+	git --git-dir=server config promisor.advertise true &&
 	test_when_finished "rm -rf client" &&
 
-	test_when_finished "git -C server config set remote.lop.url \"file://$(pwd)/lop\"" &&
-	git -C server config set remote.lop.url "" &&
+	test_when_finished "git --git-dir=server config set remote.lop.url \"file://$(pwd)/lop\"" &&
+	git --git-dir=server config set remote.lop.url "" &&
 
 	# Clone from server to create a client
 	# It should fail because the client will reject the LOP as an empty URL is
@@ -296,14 +296,14 @@ test_expect_success "clone with 'KnownUrl' and empty url, so not advertised" '
 '
 
 test_expect_success "clone with promisor.sendFields" '
-	git -C server config promisor.advertise true &&
+	git --git-dir=server config promisor.advertise true &&
 	test_when_finished "rm -rf client" &&
 
-	git -C server remote add otherLop "https://invalid.invalid"  &&
-	git -C server config remote.otherLop.token "fooBar" &&
-	git -C server config remote.otherLop.stuff "baz" &&
-	git -C server config remote.otherLop.partialCloneFilter "blob:limit=10k" &&
-	test_when_finished "git -C server remote remove otherLop" &&
+	git --git-dir=server remote add otherLop "https://invalid.invalid"  &&
+	git --git-dir=server config remote.otherLop.token "fooBar" &&
+	git --git-dir=server config remote.otherLop.stuff "baz" &&
+	git --git-dir=server config remote.otherLop.partialCloneFilter "blob:limit=10k" &&
+	test_when_finished "git --git-dir=server remote remove otherLop" &&
 	test_config --git-dir server promisor.sendFields "partialCloneFilter, token" &&
 	test_when_finished "rm trace" &&
 
@@ -327,14 +327,14 @@ test_expect_success "clone with promisor.sendFields" '
 '
 
 test_expect_success "clone with promisor.checkFields" '
-	git -C server config promisor.advertise true &&
+	git --git-dir=server config promisor.advertise true &&
 	test_when_finished "rm -rf client" &&
 
-	git -C server remote add otherLop "https://invalid.invalid"  &&
-	git -C server config remote.otherLop.token "fooBar" &&
-	git -C server config remote.otherLop.stuff "baz" &&
-	git -C server config remote.otherLop.partialCloneFilter "blob:limit=10k" &&
-	test_when_finished "git -C server remote remove otherLop" &&
+	git --git-dir=server remote add otherLop "https://invalid.invalid"  &&
+	git --git-dir=server config remote.otherLop.token "fooBar" &&
+	git --git-dir=server config remote.otherLop.stuff "baz" &&
+	git --git-dir=server config remote.otherLop.partialCloneFilter "blob:limit=10k" &&
+	test_when_finished "git --git-dir=server remote remove otherLop" &&
 	test_config --git-dir server promisor.sendFields "partialCloneFilter, token" &&
 	test_when_finished "rm trace" &&
 
@@ -361,17 +361,17 @@ test_expect_success "clone with promisor.checkFields" '
 '
 
 test_expect_success "clone with promisor.storeFields=partialCloneFilter" '
-	git -C server config promisor.advertise true &&
+	git --git-dir=server config promisor.advertise true &&
 	test_when_finished "rm -rf client" &&
 
-	git -C server remote add otherLop "https://invalid.invalid"  &&
-	git -C server config remote.otherLop.token "fooBar" &&
-	git -C server config remote.otherLop.stuff "baz" &&
-	git -C server config remote.otherLop.partialCloneFilter "blob:limit=10k" &&
-	test_when_finished "git -C server remote remove otherLop" &&
+	git --git-dir=server remote add otherLop "https://invalid.invalid"  &&
+	git --git-dir=server config remote.otherLop.token "fooBar" &&
+	git --git-dir=server config remote.otherLop.stuff "baz" &&
+	git --git-dir=server config remote.otherLop.partialCloneFilter "blob:limit=10k" &&
+	test_when_finished "git --git-dir=server remote remove otherLop" &&
 
-	git -C server config remote.lop.token "fooXXX" &&
-	git -C server config remote.lop.partialCloneFilter "blob:limit=8k" &&
+	git --git-dir=server config remote.lop.token "fooXXX" &&
+	git --git-dir=server config remote.lop.partialCloneFilter "blob:limit=8k" &&
 
 	test_config --git-dir server promisor.sendFields "partialCloneFilter, token" &&
 	test_when_finished "rm trace" &&
@@ -409,7 +409,7 @@ test_expect_success "clone with promisor.storeFields=partialCloneFilter" '
 	check_missing_objects server 1 "$oid" &&
 
 	# Change the configuration on the server and fetch from the client
-	git -C server config remote.lop.partialCloneFilter "blob:limit=7k" &&
+	git --git-dir=server config remote.lop.partialCloneFilter "blob:limit=7k" &&
 	GIT_NO_LAZY_FETCH=0 git -C client fetch \
 		--filter="blob:limit=5k" ../server 2>err &&
 
@@ -424,10 +424,10 @@ test_expect_success "clone with promisor.storeFields=partialCloneFilter" '
 '
 
 test_expect_success "clone and fetch with --filter=auto" '
-	git -C server config promisor.advertise true &&
+	git --git-dir=server config promisor.advertise true &&
 	test_when_finished "rm -rf client trace" &&
 
-	git -C server config remote.lop.partialCloneFilter "blob:limit=9500" &&
+	git --git-dir=server config remote.lop.partialCloneFilter "blob:limit=9500" &&
 	test_config --git-dir server promisor.sendFields "partialCloneFilter" &&
 
 	GIT_TRACE_PACKET="$(pwd)/trace" GIT_NO_LAZY_FETCH=0 git clone \
@@ -448,7 +448,7 @@ test_expect_success "clone and fetch with --filter=auto" '
 	check_missing_objects server 1 "$oid" &&
 
 	# Now change the filter on the server
-	git -C server config remote.lop.partialCloneFilter "blob:limit=5678" &&
+	git --git-dir=server config remote.lop.partialCloneFilter "blob:limit=5678" &&
 
 	# Get a new commit on the server to ensure "git fetch" actually runs fetch-pack
 	test_commit -C template new-commit &&
@@ -465,7 +465,7 @@ test_expect_success "clone and fetch with --filter=auto" '
 	check_missing_objects server 1 "$oid" &&
 
 	# Change the filter on the server again
-	git -C server config remote.lop.partialCloneFilter "blob:limit=5432" &&
+	git --git-dir=server config remote.lop.partialCloneFilter "blob:limit=5432" &&
 
 	# Get yet a new commit on the server to ensure fetch-pack runs
 	test_commit -C template yet-a-new-commit &&
@@ -484,7 +484,7 @@ test_expect_success "clone and fetch with --filter=auto" '
 '
 
 test_expect_success "clone with promisor.advertise set to 'true' but don't delete the client" '
-	git -C server config promisor.advertise true &&
+	git --git-dir=server config promisor.advertise true &&
 
 	# Clone from server to create a client
 	GIT_NO_LAZY_FETCH=0 git clone -c remote.lop.promisor=true \
@@ -504,9 +504,9 @@ test_expect_success "setup for subsequent fetches" '
 	git -C template commit -m bar &&
 
 	# Fetch new commit with large blob
-	git -C server fetch origin &&
-	git -C server update-ref HEAD FETCH_HEAD &&
-	git -C server rev-parse HEAD >expected_head &&
+	git --git-dir=server fetch origin &&
+	git --git-dir=server update-ref HEAD FETCH_HEAD &&
+	git --git-dir=server rev-parse HEAD >expected_head &&
 
 	# Repack everything twice and remove .promisor files before
 	# each repack. This makes sure everything gets repacked
@@ -515,19 +515,19 @@ test_expect_success "setup for subsequent fetches" '
 	# packfile and its associated .promisor file.
 
 	rm -f server/objects/pack/*.promisor &&
-	git -C server -c repack.writebitmaps=false repack -a -d &&
+	git --git-dir=server -c repack.writebitmaps=false repack -a -d &&
 	rm -f server/objects/pack/*.promisor &&
-	git -C server -c repack.writebitmaps=false repack -a -d &&
+	git --git-dir=server -c repack.writebitmaps=false repack -a -d &&
 
 	# Unpack everything
 	rm pack-* &&
 	mv server/objects/pack/pack-* . &&
 	packfile=$(ls pack-*.pack) &&
-	git -C server unpack-objects --strict <"$packfile" &&
+	git --git-dir=server unpack-objects --strict <"$packfile" &&
 
 	# Copy new large object to lop
 	obj_bar="HEAD:bar" &&
-	oid_bar="$(git -C server rev-parse $obj_bar)" &&
+	oid_bar="$(git --git-dir=server rev-parse $obj_bar)" &&
 	copy_to_lop "$oid_bar" &&
 
 	# Reinitialize server so that the 2 largest objects are missing
@@ -539,7 +539,7 @@ test_expect_success "setup for subsequent fetches" '
 '
 
 test_expect_success "subsequent fetch from a client when promisor.advertise is true" '
-	git -C server config promisor.advertise true &&
+	git --git-dir=server config promisor.advertise true &&
 
 	GIT_NO_LAZY_FETCH=0 git -C client pull origin &&
 
@@ -552,7 +552,7 @@ test_expect_success "subsequent fetch from a client when promisor.advertise is t
 '
 
 test_expect_success "subsequent fetch from a client when promisor.advertise is false" '
-	git -C server config promisor.advertise false &&
+	git --git-dir=server config promisor.advertise false &&
 
 	GIT_NO_LAZY_FETCH=0 git -C client2 pull origin &&
 

--- a/t/t5710-promisor-remote-capability.sh
+++ b/t/t5710-promisor-remote-capability.sh
@@ -304,7 +304,7 @@ test_expect_success "clone with promisor.sendFields" '
 	git -C server config remote.otherLop.stuff "baz" &&
 	git -C server config remote.otherLop.partialCloneFilter "blob:limit=10k" &&
 	test_when_finished "git -C server remote remove otherLop" &&
-	test_config -C server promisor.sendFields "partialCloneFilter, token" &&
+	test_config --git-dir server promisor.sendFields "partialCloneFilter, token" &&
 	test_when_finished "rm trace" &&
 
 	# Clone from server to create a client
@@ -335,7 +335,7 @@ test_expect_success "clone with promisor.checkFields" '
 	git -C server config remote.otherLop.stuff "baz" &&
 	git -C server config remote.otherLop.partialCloneFilter "blob:limit=10k" &&
 	test_when_finished "git -C server remote remove otherLop" &&
-	test_config -C server promisor.sendFields "partialCloneFilter, token" &&
+	test_config --git-dir server promisor.sendFields "partialCloneFilter, token" &&
 	test_when_finished "rm trace" &&
 
 	# Clone from server to create a client
@@ -373,7 +373,7 @@ test_expect_success "clone with promisor.storeFields=partialCloneFilter" '
 	git -C server config remote.lop.token "fooXXX" &&
 	git -C server config remote.lop.partialCloneFilter "blob:limit=8k" &&
 
-	test_config -C server promisor.sendFields "partialCloneFilter, token" &&
+	test_config --git-dir server promisor.sendFields "partialCloneFilter, token" &&
 	test_when_finished "rm trace" &&
 
 	# Clone from server to create a client
@@ -428,7 +428,7 @@ test_expect_success "clone and fetch with --filter=auto" '
 	test_when_finished "rm -rf client trace" &&
 
 	git -C server config remote.lop.partialCloneFilter "blob:limit=9500" &&
-	test_config -C server promisor.sendFields "partialCloneFilter" &&
+	test_config --git-dir server promisor.sendFields "partialCloneFilter" &&
 
 	GIT_TRACE_PACKET="$(pwd)/trace" GIT_NO_LAZY_FETCH=0 git clone \
 		-c remote.lop.promisor=true \

--- a/t/t5811-proto-disable-git.sh
+++ b/t/t5811-proto-disable-git.sh
@@ -13,7 +13,7 @@ test_expect_success 'create git-accessible repo' '
 	git --bare init "$bare" &&
 	git push "$bare" HEAD &&
 	>"$bare/git-daemon-export-ok" &&
-	git -C "$bare" config daemon.receivepack true
+	git --git-dir="$bare" config daemon.receivepack true
 '
 
 test_proto "git://" git "$GIT_DAEMON_URL/repo.git"

--- a/t/t5812-proto-disable-http.sh
+++ b/t/t5812-proto-disable-http.sh
@@ -12,7 +12,7 @@ test_expect_success 'create git-accessible repo' '
 	test_commit one &&
 	git --bare init "$bare" &&
 	git push "$bare" HEAD &&
-	git -C "$bare" config http.receivepack true
+	git --git-dir="$bare" config http.receivepack true
 '
 
 test_proto "smart http" http "$HTTPD_URL/smart/repo.git"

--- a/t/t5900-repo-selection.sh
+++ b/t/t5900-repo-selection.sh
@@ -15,7 +15,7 @@ make_tree() {
 
 make_bare() {
 	git init --bare "$1" &&
-	(cd "$1" &&
+	(cd "$1" && GIT_DIR=. && export GIT_DIR &&
 	 tree=$(git hash-object -w -t tree /dev/null) &&
 	 commit=$(echo "$1" | git commit-tree $tree) &&
 	 git update-ref HEAD $commit
@@ -24,13 +24,13 @@ make_bare() {
 
 get() {
 	git init --bare fetch &&
-	(cd fetch && git fetch "../$1") &&
+	(cd fetch && GIT_DIR=. && export GIT_DIR && git fetch "../$1") &&
 	git clone "$1" clone
 }
 
 check() {
 	echo "$1" >expect &&
-	(cd fetch && git log -1 --format=%s FETCH_HEAD) >actual.fetch &&
+	(cd fetch && GIT_DIR=. && export GIT_DIR && git log -1 --format=%s FETCH_HEAD) >actual.fetch &&
 	(cd clone && git log -1 --format=%s HEAD) >actual.clone &&
 	test_cmp expect actual.fetch &&
 	test_cmp expect actual.clone

--- a/t/t6020-bundle-misc.sh
+++ b/t/t6020-bundle-misc.sh
@@ -594,9 +594,9 @@ do
 		reflist=$(git for-each-ref --format="%(objectname)") &&
 		git rev-list --objects --filter=$filter --missing=allow-any \
 			$reflist >expect &&
-		for repo in cloned unbundled
+		for opt in "--git-dir cloned" "-C unbundled"
 		do
-			git -C $repo rev-list --objects --missing=allow-any \
+			git $opt rev-list --objects --missing=allow-any \
 				$reflist >actual &&
 			test_cmp expect actual || return 1
 		done

--- a/t/t6020-bundle-misc.sh
+++ b/t/t6020-bundle-misc.sh
@@ -452,7 +452,7 @@ test_expect_success 'create bundle 4 - with tags' '
 
 test_expect_success 'clone from bundle' '
 	git clone --mirror 1.bdl mirror.git &&
-	git -C mirror.git show-ref |
+	git --git-dir=mirror.git show-ref |
 		make_user_friendly_and_stable_output >actual &&
 	cat >expect <<-\EOF &&
 	<COMMIT-D> refs/heads/topic/1
@@ -461,7 +461,7 @@ test_expect_success 'clone from bundle' '
 	test_cmp expect actual &&
 
 	git --git-dir=mirror.git fetch 2.bdl "+refs/*:refs/*" &&
-	git -C mirror.git show-ref |
+	git --git-dir=mirror.git show-ref |
 		make_user_friendly_and_stable_output >actual &&
 	cat >expect <<-\EOF &&
 	<COMMIT-N> refs/heads/release
@@ -471,7 +471,7 @@ test_expect_success 'clone from bundle' '
 	test_cmp expect actual &&
 
 	git --git-dir=mirror.git fetch 3.bdl "+refs/*:refs/*" &&
-	git -C mirror.git show-ref |
+	git --git-dir=mirror.git show-ref |
 		make_user_friendly_and_stable_output >actual &&
 	cat >expect <<-\EOF &&
 	<COMMIT-P> refs/heads/main
@@ -482,7 +482,7 @@ test_expect_success 'clone from bundle' '
 	test_cmp expect actual &&
 
 	git --git-dir=mirror.git fetch 4.bdl "+refs/*:refs/*" &&
-	git -C mirror.git show-ref |
+	git --git-dir=mirror.git show-ref |
 		make_user_friendly_and_stable_output >actual &&
 	cat >expect <<-\EOF &&
 	<COMMIT-P> refs/heads/main
@@ -526,7 +526,7 @@ test_expect_success 'full bundle upto annotated tag' '
 
 test_expect_success 'clone from full bundle upto annotated tag' '
 	git clone --mirror v2.bdl tag-clone.git &&
-	git -C tag-clone.git show-ref |
+	git --git-dir=tag-clone.git show-ref |
 		make_user_friendly_and_stable_output >actual &&
 	cat >expect <<-\EOF &&
 	<TAG-2> refs/tags/v2

--- a/t/t6020-bundle-misc.sh
+++ b/t/t6020-bundle-misc.sh
@@ -358,11 +358,11 @@ test_expect_success 'fail to verify bundle without prerequisites' '
 	error: <COMMIT-G> Z
 	EOF
 
-	test_must_fail git -C test1.git bundle verify ../2.bdl 2>&1 |
+	test_must_fail git --git-dir=test1.git bundle verify 2.bdl 2>&1 |
 		make_user_friendly_and_stable_output >actual &&
 	test_cmp expect actual &&
 
-	test_must_fail git -C test1.git bundle verify ../stdin-2.bdl 2>&1 |
+	test_must_fail git --git-dir=test1.git bundle verify stdin-2.bdl 2>&1 |
 		make_user_friendly_and_stable_output >actual &&
 	test_cmp expect actual
 '
@@ -460,7 +460,7 @@ test_expect_success 'clone from bundle' '
 	EOF
 	test_cmp expect actual &&
 
-	git -C mirror.git fetch ../2.bdl "+refs/*:refs/*" &&
+	git --git-dir=mirror.git fetch 2.bdl "+refs/*:refs/*" &&
 	git -C mirror.git show-ref |
 		make_user_friendly_and_stable_output >actual &&
 	cat >expect <<-\EOF &&
@@ -470,7 +470,7 @@ test_expect_success 'clone from bundle' '
 	EOF
 	test_cmp expect actual &&
 
-	git -C mirror.git fetch ../3.bdl "+refs/*:refs/*" &&
+	git --git-dir=mirror.git fetch 3.bdl "+refs/*:refs/*" &&
 	git -C mirror.git show-ref |
 		make_user_friendly_and_stable_output >actual &&
 	cat >expect <<-\EOF &&
@@ -481,7 +481,7 @@ test_expect_success 'clone from bundle' '
 	EOF
 	test_cmp expect actual &&
 
-	git -C mirror.git fetch ../4.bdl "+refs/*:refs/*" &&
+	git --git-dir=mirror.git fetch 4.bdl "+refs/*:refs/*" &&
 	git -C mirror.git show-ref |
 		make_user_friendly_and_stable_output >actual &&
 	cat >expect <<-\EOF &&

--- a/t/t6030-bisect-porcelain.sh
+++ b/t/t6030-bisect-porcelain.sh
@@ -818,7 +818,7 @@ test_expect_success 'erroring out when using bad path arguments' '
 test_expect_success 'test bisection on bare repo - --no-checkout specified' '
 	git clone --bare . bare.nocheckout &&
 	(
-		cd bare.nocheckout &&
+		cd bare.nocheckout && GIT_DIR=. && export GIT_DIR &&
 		git bisect start --no-checkout &&
 		git bisect good $HASH1 &&
 		git bisect bad $HASH4 &&
@@ -833,7 +833,7 @@ test_expect_success 'test bisection on bare repo - --no-checkout specified' '
 test_expect_success 'test bisection on bare repo - --no-checkout defaulted' '
 	git clone --bare . bare.defaulted &&
 	(
-		cd bare.defaulted &&
+		cd bare.defaulted && GIT_DIR=. && export GIT_DIR &&
 		git bisect start &&
 		git bisect good $HASH1 &&
 		git bisect bad $HASH4 &&

--- a/t/t6060-merge-index.sh
+++ b/t/t6060-merge-index.sh
@@ -51,7 +51,7 @@ test_expect_success 'git merge-index git-merge-one-file resolves' '
 
 test_expect_success 'setup bare merge' '
 	git clone --bare . bare.git &&
-	(cd bare.git &&
+	(cd bare.git && GIT_DIR=. && export GIT_DIR &&
 	 GIT_INDEX_FILE=$PWD/merge.index &&
 	 export GIT_INDEX_FILE &&
 	 git read-tree -i -m base ten two
@@ -59,7 +59,7 @@ test_expect_success 'setup bare merge' '
 '
 
 test_expect_success 'merge-one-file fails without a work tree' '
-	(cd bare.git &&
+	(cd bare.git && GIT_DIR=. && export GIT_DIR &&
 	 GIT_INDEX_FILE=$PWD/merge.index &&
 	 export GIT_INDEX_FILE &&
 	 test_must_fail git merge-index git-merge-one-file -a
@@ -67,7 +67,7 @@ test_expect_success 'merge-one-file fails without a work tree' '
 '
 
 test_expect_success 'merge-one-file respects GIT_WORK_TREE' '
-	(cd bare.git &&
+	(cd bare.git && GIT_DIR=. && export GIT_DIR &&
 	 mkdir work &&
 	 GIT_WORK_TREE=$PWD/work &&
 	 export GIT_WORK_TREE &&

--- a/t/t6136-pathspec-in-bare.sh
+++ b/t/t6136-pathspec-in-bare.sh
@@ -11,7 +11,7 @@ test_expect_success 'setup a bare and non-bare repository' '
 
 test_expect_success 'log and ls-files in a bare repository' '
 	(
-		cd bare &&
+		cd bare && GIT_DIR=. && export GIT_DIR &&
 		test_must_fail git log -- .. >out 2>err &&
 		test_must_be_empty out &&
 		test_grep "outside repository" err &&
@@ -24,7 +24,7 @@ test_expect_success 'log and ls-files in a bare repository' '
 
 test_expect_success 'log and ls-files in .git directory' '
 	(
-		cd .git &&
+		cd .git && GIT_DIR=. && export GIT_DIR &&
 		test_must_fail git log -- .. >out 2>err &&
 		test_must_be_empty out &&
 		test_grep "outside repository" err &&

--- a/t/t6500-gc.sh
+++ b/t/t6500-gc.sh
@@ -190,10 +190,10 @@ test_expect_success 'one of gc.reflogExpire{Unreachable,}=never does not skip "e
 test_expect_success 'gc.repackFilter launches repack with a filter' '
 	git clone --no-local --bare . bare.git &&
 
-	git -C bare.git -c gc.cruftPacks=false gc &&
+	git --git-dir=bare.git -c gc.cruftPacks=false gc &&
 	test_stdout_line_count = 1 ls bare.git/objects/pack/*.pack &&
 
-	GIT_TRACE=$(pwd)/trace.out git -C bare.git -c gc.repackFilter=blob:none \
+	GIT_TRACE=$(pwd)/trace.out git --git-dir=bare.git -c gc.repackFilter=blob:none \
 		-c repack.writeBitmaps=false -c gc.cruftPacks=false gc &&
 	test_stdout_line_count = 2 ls bare.git/objects/pack/*.pack &&
 	grep -E "^trace: (built-in|exec|run_command): git repack .* --filter=blob:none ?.*" trace.out

--- a/t/t6500-gc.sh
+++ b/t/t6500-gc.sh
@@ -203,8 +203,8 @@ test_expect_success 'gc.repackFilterTo store filtered out objects' '
 	test_when_finished "rm -rf bare.git filtered.git" &&
 
 	git init --bare filtered.git &&
-	git -C bare.git -c gc.repackFilter=blob:none \
-		-c gc.repackFilterTo=../filtered.git/objects/pack/pack \
+	git --git-dir=bare.git -c gc.repackFilter=blob:none \
+		-c gc.repackFilterTo=filtered.git/objects/pack/pack \
 		-c repack.writeBitmaps=false -c gc.cruftPacks=false gc &&
 
 	test_stdout_line_count = 1 ls bare.git/objects/pack/*.pack &&

--- a/t/t7103-reset-bare.sh
+++ b/t/t7103-reset-bare.sh
@@ -43,7 +43,7 @@ test_expect_success 'hard reset works with GIT_WORK_TREE' '
 
 test_expect_success 'setup bare' '
 	git clone --bare . bare.git &&
-	cd bare.git
+	cd bare.git && GIT_DIR=. && export GIT_DIR
 '
 
 test_expect_success '"hard" reset is not allowed in bare' '

--- a/t/t7103-reset-bare.sh
+++ b/t/t7103-reset-bare.sh
@@ -13,26 +13,26 @@ test_expect_success 'setup non-bare' '
 '
 
 test_expect_success '"hard" reset requires a worktree' '
-	(cd .git &&
+	(cd .git && GIT_CONFIG_PARAMETERS="${SQ}safe.bareRepository=all${SQ}" && export GIT_CONFIG_PARAMETERS &&
 	 test_must_fail git reset --hard)
 '
 
 test_expect_success '"merge" reset requires a worktree' '
-	(cd .git &&
+	(cd .git && GIT_CONFIG_PARAMETERS="${SQ}safe.bareRepository=all${SQ}" && export GIT_CONFIG_PARAMETERS &&
 	 test_must_fail git reset --merge)
 '
 
 test_expect_success '"keep" reset requires a worktree' '
-	(cd .git &&
+	(cd .git && GIT_CONFIG_PARAMETERS="${SQ}safe.bareRepository=all${SQ}" && export GIT_CONFIG_PARAMETERS &&
 	 test_must_fail git reset --keep)
 '
 
 test_expect_success '"mixed" reset is ok' '
-	(cd .git && git reset)
+	(cd .git && GIT_CONFIG_PARAMETERS="${SQ}safe.bareRepository=all${SQ}" && export GIT_CONFIG_PARAMETERS && git reset)
 '
 
 test_expect_success '"soft" reset is ok' '
-	(cd .git && git reset --soft)
+	(cd .git && GIT_CONFIG_PARAMETERS="${SQ}safe.bareRepository=all${SQ}" && export GIT_CONFIG_PARAMETERS && git reset --soft)
 '
 
 test_expect_success 'hard reset works with GIT_WORK_TREE' '

--- a/t/t7412-submodule-absorbgitdirs.sh
+++ b/t/t7412-submodule-absorbgitdirs.sh
@@ -122,7 +122,7 @@ test_expect_success 'absorb the git dir outside of primary worktree' '
 	test_when_finished "rm -rf repo-bare.git" &&
 	git clone --bare . repo-bare.git &&
 	test_when_finished "rm -rf repo-wt" &&
-	git -C repo-bare.git worktree add ../repo-wt &&
+	git --git-dir=repo-bare.git worktree add repo-wt &&
 
 	test_when_finished "rm -f .gitconfig" &&
 	test_config_global protocol.file.allow always &&

--- a/t/t7416-submodule-dash-url.sh
+++ b/t/t7416-submodule-dash-url.sh
@@ -28,7 +28,7 @@ test_expect_success 'clone can recurse submodule' '
 test_expect_success 'fsck accepts protected dash' '
 	test_when_finished "rm -rf dst" &&
 	git init --bare dst &&
-	git -C dst config transfer.fsckObjects true &&
+	git --git-dir=dst config transfer.fsckObjects true &&
 	git push dst HEAD
 '
 
@@ -47,7 +47,7 @@ test_expect_success 'clone rejects unprotected dash' '
 test_expect_success 'fsck rejects unprotected dash' '
 	test_when_finished "rm -rf dst" &&
 	git init --bare dst &&
-	git -C dst config transfer.fsckObjects true &&
+	git --git-dir=dst config transfer.fsckObjects true &&
 	test_must_fail git push dst HEAD 2>err &&
 	grep gitmodulesUrl err
 '
@@ -77,7 +77,7 @@ test_expect_success 'fsck rejects missing URL scheme' '
 	git commit -m "gitmodules with missing URL scheme" &&
 	test_when_finished "rm -rf dst" &&
 	git init --bare dst &&
-	git -C dst config transfer.fsckObjects true &&
+	git --git-dir=dst config transfer.fsckObjects true &&
 	test_must_fail git push dst HEAD 2>err &&
 	grep gitmodulesUrl err
 '
@@ -93,7 +93,7 @@ test_expect_success 'fsck rejects relative URL resolving to missing scheme' '
 	git commit -m "gitmodules with relative URL that strips off scheme" &&
 	test_when_finished "rm -rf dst" &&
 	git init --bare dst &&
-	git -C dst config transfer.fsckObjects true &&
+	git --git-dir=dst config transfer.fsckObjects true &&
 	test_must_fail git push dst HEAD 2>err &&
 	grep gitmodulesUrl err
 '
@@ -109,7 +109,7 @@ test_expect_success 'fsck rejects empty URL scheme' '
 	git commit -m "gitmodules with empty URL scheme" &&
 	test_when_finished "rm -rf dst" &&
 	git init --bare dst &&
-	git -C dst config transfer.fsckObjects true &&
+	git --git-dir=dst config transfer.fsckObjects true &&
 	test_must_fail git push dst HEAD 2>err &&
 	grep gitmodulesUrl err
 '
@@ -125,7 +125,7 @@ test_expect_success 'fsck rejects relative URL resolving to empty scheme' '
 	git commit -m "relative gitmodules URL resolving to empty scheme" &&
 	test_when_finished "rm -rf dst" &&
 	git init --bare dst &&
-	git -C dst config transfer.fsckObjects true &&
+	git --git-dir=dst config transfer.fsckObjects true &&
 	test_must_fail git push dst HEAD 2>err &&
 	grep gitmodulesUrl err
 '
@@ -141,7 +141,7 @@ test_expect_success 'fsck rejects empty hostname' '
 	git commit -m "gitmodules with extra slashes" &&
 	test_when_finished "rm -rf dst" &&
 	git init --bare dst &&
-	git -C dst config transfer.fsckObjects true &&
+	git --git-dir=dst config transfer.fsckObjects true &&
 	test_must_fail git push dst HEAD 2>err &&
 	grep gitmodulesUrl err
 '
@@ -157,7 +157,7 @@ test_expect_success 'fsck rejects relative url that produced empty hostname' '
 	git commit -m "gitmodules abusing relative_path" &&
 	test_when_finished "rm -rf dst" &&
 	git init --bare dst &&
-	git -C dst config transfer.fsckObjects true &&
+	git --git-dir=dst config transfer.fsckObjects true &&
 	test_must_fail git push dst HEAD 2>err &&
 	grep gitmodulesUrl err
 '
@@ -172,7 +172,7 @@ test_expect_success 'fsck permits embedded newline with unrecognized scheme' '
 	git commit -m "gitmodules with unrecognized scheme" &&
 	test_when_finished "rm -rf dst" &&
 	git init --bare dst &&
-	git -C dst config transfer.fsckObjects true &&
+	git --git-dir=dst config transfer.fsckObjects true &&
 	git push dst HEAD
 '
 
@@ -187,7 +187,7 @@ test_expect_success 'fsck rejects embedded newline in url' '
 	git commit -m "gitmodules with newline" &&
 	test_when_finished "rm -rf dst" &&
 	git init --bare dst &&
-	git -C dst config transfer.fsckObjects true &&
+	git --git-dir=dst config transfer.fsckObjects true &&
 	test_must_fail git push dst HEAD 2>err &&
 	grep gitmodulesUrl err
 '
@@ -202,7 +202,7 @@ test_expect_success 'fsck rejects embedded newline in relative url' '
 	git commit -m "relative url with newline" &&
 	test_when_finished "rm -rf dst" &&
 	git init --bare dst &&
-	git -C dst config transfer.fsckObjects true &&
+	git --git-dir=dst config transfer.fsckObjects true &&
 	test_must_fail git push dst HEAD 2>err &&
 	grep gitmodulesUrl err
 '
@@ -217,7 +217,7 @@ test_expect_success 'fsck rejects embedded newline in git url' '
 	git commit -m "git url with newline" &&
 	test_when_finished "rm -rf dst" &&
 	git init --bare dst &&
-	git -C dst config transfer.fsckObjects true &&
+	git --git-dir=dst config transfer.fsckObjects true &&
 	test_must_fail git push dst HEAD 2>err &&
 	grep gitmodulesUrl err
 '

--- a/t/t7417-submodule-path-url.sh
+++ b/t/t7417-submodule-path-url.sh
@@ -27,7 +27,7 @@ test_expect_success 'clone rejects unprotected dash' '
 test_expect_success 'fsck rejects unprotected dash' '
 	test_when_finished "rm -rf dst" &&
 	git init --bare dst &&
-	git -C dst config transfer.fsckObjects true &&
+	git --git-dir=dst config transfer.fsckObjects true &&
 	test_must_fail git push dst HEAD 2>err &&
 	grep gitmodulesPath err
 '

--- a/t/t7450-bad-git-dotfiles.sh
+++ b/t/t7450-bad-git-dotfiles.sh
@@ -119,15 +119,15 @@ test_expect_success 'fsck detects evil superproject' '
 test_expect_success 'transfer.fsckObjects detects evil superproject (unpack)' '
 	rm -rf dst.git &&
 	git init --bare dst.git &&
-	git -C dst.git config transfer.fsckObjects true &&
+	git --git-dir=dst.git config transfer.fsckObjects true &&
 	test_must_fail git push dst.git HEAD
 '
 
 test_expect_success 'transfer.fsckObjects detects evil superproject (index)' '
 	rm -rf dst.git &&
 	git init --bare dst.git &&
-	git -C dst.git config transfer.fsckObjects true &&
-	git -C dst.git config transfer.unpackLimit 1 &&
+	git --git-dir=dst.git config transfer.fsckObjects true &&
+	git --git-dir=dst.git config transfer.unpackLimit 1 &&
 	test_must_fail git push dst.git HEAD
 '
 
@@ -151,20 +151,20 @@ test_expect_success 'create oddly ordered pack' '
 test_expect_success 'transfer.fsckObjects handles odd pack (unpack)' '
 	rm -rf dst.git &&
 	git init --bare dst.git &&
-	test_must_fail git -C dst.git unpack-objects --strict <odd.pack
+	test_must_fail git --git-dir=dst.git unpack-objects --strict <odd.pack
 '
 
 test_expect_success 'transfer.fsckObjects handles odd pack (index)' '
 	rm -rf dst.git &&
 	git init --bare dst.git &&
-	test_must_fail git -C dst.git index-pack --strict --stdin <odd.pack
+	test_must_fail git --git-dir=dst.git index-pack --strict --stdin <odd.pack
 '
 
 test_expect_success 'index-pack --strict works for non-repo pack' '
 	rm -rf dst.git &&
 	git init --bare dst.git &&
 	cp odd.pack dst.git &&
-	test_must_fail git -C dst.git index-pack --strict odd.pack 2>output &&
+	test_must_fail git --git-dir=dst.git index-pack --strict odd.pack 2>output &&
 	# Make sure we fail due to bad gitmodules content, not because we
 	# could not read the blob in the first place.
 	grep gitmodulesName output

--- a/t/t7519-status-fsmonitor.sh
+++ b/t/t7519-status-fsmonitor.sh
@@ -61,12 +61,12 @@ test_expect_success 'incompatible bare repo' '
 	git init --bare bare-clone &&
 
 	test_must_fail \
-		git -C ./bare-clone -c core.fsmonitor=foo \
+		git --git-dir=./bare-clone -c core.fsmonitor=foo \
 			update-index --fsmonitor 2>actual &&
 	grep "bare repository .* is incompatible with fsmonitor" actual &&
 
 	test_must_fail \
-		git -C ./bare-clone -c core.fsmonitor=true \
+		git --git-dir=./bare-clone -c core.fsmonitor=true \
 			update-index --fsmonitor 2>actual &&
 	grep "bare repository .* is incompatible with fsmonitor" actual
 '
@@ -74,7 +74,7 @@ test_expect_success 'incompatible bare repo' '
 test_expect_success FSMONITOR_DAEMON 'run fsmonitor-daemon in bare repo' '
 	test_when_finished "rm -rf ./bare-clone actual" &&
 	git init --bare bare-clone &&
-	test_must_fail git -C ./bare-clone fsmonitor--daemon run 2>actual &&
+	test_must_fail git --git-dir=./bare-clone fsmonitor--daemon run 2>actual &&
 	grep "bare repository .* is incompatible with fsmonitor" actual
 '
 

--- a/t/t7700-repack.sh
+++ b/t/t7700-repack.sh
@@ -362,7 +362,7 @@ test_expect_success 'repacking with two filters works' '
 	) &&
 	git clone --no-local --bare two-filters two-filters.git &&
 	(
-		cd two-filters.git &&
+		cd two-filters.git && GIT_DIR=. && export GIT_DIR &&
 		test_stdout_line_count = 1 ls objects/pack/*.pack &&
 		git -c repack.writebitmaps=false repack -a -d \
 			--filter=blob:none --filter=tree:1 &&
@@ -389,7 +389,7 @@ prepare_for_keep_packs () {
 	) &&
 	git clone --no-local --bare keep-packs keep-packs.git &&
 	(
-		cd keep-packs.git &&
+		cd keep-packs.git && GIT_DIR=. && export GIT_DIR &&
 
 		# Create two packs
 		# The first pack will contain all of the objects except one blob
@@ -408,7 +408,7 @@ prepare_for_keep_packs () {
 test_expect_success '--filter works with .keep packs' '
 	prepare_for_keep_packs &&
 	(
-		cd keep-packs.git &&
+		cd keep-packs.git && GIT_DIR=. && export GIT_DIR &&
 
 		foo_pack=$(test-tool find-pack -c 1 HEAD:foo.t) &&
 		bar_pack=$(test-tool find-pack -c 1 HEAD:bar.t) &&
@@ -438,7 +438,7 @@ test_expect_success '--filter works with --pack-kept-objects and .keep packs' '
 	rm -rf keep-packs keep-packs.git &&
 	prepare_for_keep_packs &&
 	(
-		cd keep-packs.git &&
+		cd keep-packs.git && GIT_DIR=. && export GIT_DIR &&
 
 		foo_pack=$(test-tool find-pack -c 1 HEAD:foo.t) &&
 		bar_pack=$(test-tool find-pack -c 1 HEAD:bar.t) &&
@@ -506,7 +506,7 @@ test_expect_success '--filter works with --max-pack-size' '
 	) &&
 	git clone --no-local --bare max-pack-size max-pack-size.git &&
 	(
-		cd max-pack-size.git &&
+		cd max-pack-size.git && GIT_DIR=. && export GIT_DIR &&
 		git -c repack.writebitmaps=false repack -a -d --filter=blob:none \
 			--max-pack-size=1M \
 			--filter-to=../filtered.git/objects/pack/pack &&

--- a/t/t7700-repack.sh
+++ b/t/t7700-repack.sh
@@ -471,9 +471,9 @@ test_expect_success '--filter-to stores filtered out objects' '
 	test_stdout_line_count = 1 ls bare.git/objects/pack/*.pack &&
 
 	git init --bare filtered.git &&
-	git -C bare.git -c repack.writebitmaps=false repack -a -d \
+	git --git-dir=bare.git -c repack.writebitmaps=false repack -a -d \
 		--filter=blob:none \
-		--filter-to=../filtered.git/objects/pack/pack &&
+		--filter-to=filtered.git/objects/pack/pack &&
 	test_stdout_line_count = 1 ls bare.git/objects/pack/pack-*.pack &&
 	test_stdout_line_count = 1 ls filtered.git/objects/pack/pack-*.pack &&
 

--- a/t/t7700-repack.sh
+++ b/t/t7700-repack.sh
@@ -320,7 +320,7 @@ test_expect_success 'no bitmaps created if .keep files present' '
 '
 
 test_expect_success 'auto-bitmaps do not complain if unavailable' '
-	test_config -C bare.git pack.packSizeLimit 1M &&
+	test_config --git-dir bare.git pack.packSizeLimit 1M &&
 	blob=$(test-tool genrandom big 1m |
 	       git -C bare.git hash-object -w --stdin) &&
 	git -C bare.git update-ref refs/tags/big $blob &&

--- a/t/t7700-repack.sh
+++ b/t/t7700-repack.sh
@@ -288,18 +288,18 @@ test_expect_success 'repacking fails when missing .pack actually means missing o
 test_expect_success 'bitmaps are created by default in bare repos' '
 	git clone --bare .git bare.git &&
 	rm -f bare.git/objects/pack/*.bitmap &&
-	git -C bare.git repack -ad &&
+	git --git-dir=bare.git repack -ad &&
 	bitmap=$(ls bare.git/objects/pack/*.bitmap) &&
 	test_path_is_file "$bitmap"
 '
 
 test_expect_success 'incremental repack does not complain' '
-	git -C bare.git repack -q 2>repack.err &&
+	git --git-dir=bare.git repack -q 2>repack.err &&
 	test_must_be_empty repack.err
 '
 
 test_expect_success 'bitmaps can be disabled on bare repos' '
-	git -c repack.writeBitmaps=false -C bare.git repack -ad &&
+	git -c repack.writeBitmaps=false --git-dir=bare.git repack -ad &&
 	bitmap=$(ls bare.git/objects/pack/*.bitmap || :) &&
 	test -z "$bitmap"
 '
@@ -313,7 +313,7 @@ test_expect_success 'no bitmaps created if .keep files present' '
 
 	# Disable --name-hash-version test due to stderr comparison.
 	GIT_TEST_NAME_HASH_VERSION=1 \
-		git -C bare.git repack -ad 2>stderr &&
+		git --git-dir=bare.git repack -ad 2>stderr &&
 	test_must_be_empty stderr &&
 	find bare.git/objects/pack/ -type f -name "*.bitmap" >actual &&
 	test_must_be_empty actual
@@ -322,33 +322,33 @@ test_expect_success 'no bitmaps created if .keep files present' '
 test_expect_success 'auto-bitmaps do not complain if unavailable' '
 	test_config --git-dir bare.git pack.packSizeLimit 1M &&
 	blob=$(test-tool genrandom big 1m |
-	       git -C bare.git hash-object -w --stdin) &&
-	git -C bare.git update-ref refs/tags/big $blob &&
+	       git --git-dir=bare.git hash-object -w --stdin) &&
+	git --git-dir=bare.git update-ref refs/tags/big $blob &&
 
 	# Disable --name-hash-version test due to stderr comparison.
 	GIT_TEST_NAME_HASH_VERSION=1 \
-		git -C bare.git repack -ad 2>stderr &&
+		git --git-dir=bare.git repack -ad 2>stderr &&
 	test_must_be_empty stderr &&
 	find bare.git/objects/pack -type f -name "*.bitmap" >actual &&
 	test_must_be_empty actual
 '
 
 test_expect_success 'repacking with a filter works' '
-	git -C bare.git repack -a -d &&
+	git --git-dir=bare.git repack -a -d &&
 	test_stdout_line_count = 1 ls bare.git/objects/pack/*.pack &&
-	git -C bare.git -c repack.writebitmaps=false repack -a -d --filter=blob:none &&
+	git --git-dir=bare.git -c repack.writebitmaps=false repack -a -d --filter=blob:none &&
 	test_stdout_line_count = 2 ls bare.git/objects/pack/*.pack &&
-	commit_pack=$(test-tool -C bare.git find-pack -c 1 HEAD) &&
-	blob_pack=$(test-tool -C bare.git find-pack -c 1 HEAD:file1) &&
+	commit_pack=$(test-tool --git-dir=bare.git find-pack -c 1 HEAD) &&
+	blob_pack=$(test-tool --git-dir=bare.git find-pack -c 1 HEAD:file1) &&
 	test "$commit_pack" != "$blob_pack" &&
-	tree_pack=$(test-tool -C bare.git find-pack -c 1 HEAD^{tree}) &&
+	tree_pack=$(test-tool --git-dir=bare.git find-pack -c 1 HEAD^{tree}) &&
 	test "$tree_pack" = "$commit_pack" &&
-	blob_pack2=$(test-tool -C bare.git find-pack -c 1 HEAD:file2) &&
+	blob_pack2=$(test-tool --git-dir=bare.git find-pack -c 1 HEAD:file2) &&
 	test "$blob_pack2" = "$blob_pack"
 '
 
 test_expect_success '--filter fails with --write-bitmap-index' '
-	test_must_fail git -C bare.git repack -a -d --write-bitmap-index --filter=blob:none
+	test_must_fail git --git-dir=bare.git repack -a -d --write-bitmap-index --filter=blob:none
 '
 
 test_expect_success 'repacking with two filters works' '
@@ -467,7 +467,7 @@ test_expect_success '--filter works with --pack-kept-objects and .keep packs' '
 '
 
 test_expect_success '--filter-to stores filtered out objects' '
-	git -C bare.git repack -a -d &&
+	git --git-dir=bare.git repack -a -d &&
 	test_stdout_line_count = 1 ls bare.git/objects/pack/*.pack &&
 
 	git init --bare filtered.git &&
@@ -477,15 +477,15 @@ test_expect_success '--filter-to stores filtered out objects' '
 	test_stdout_line_count = 1 ls bare.git/objects/pack/pack-*.pack &&
 	test_stdout_line_count = 1 ls filtered.git/objects/pack/pack-*.pack &&
 
-	commit_pack=$(test-tool -C bare.git find-pack -c 1 HEAD) &&
-	blob_pack=$(test-tool -C bare.git find-pack -c 0 HEAD:file1) &&
-	blob_hash=$(git -C bare.git rev-parse HEAD:file1) &&
+	commit_pack=$(test-tool --git-dir=bare.git find-pack -c 1 HEAD) &&
+	blob_pack=$(test-tool --git-dir=bare.git find-pack -c 0 HEAD:file1) &&
+	blob_hash=$(git --git-dir=bare.git rev-parse HEAD:file1) &&
 	test -n "$blob_hash" &&
-	blob_pack=$(test-tool -C filtered.git find-pack -c 1 $blob_hash) &&
+	blob_pack=$(test-tool --git-dir=filtered.git find-pack -c 1 $blob_hash) &&
 
 	echo $(pwd)/filtered.git/objects >bare.git/objects/info/alternates &&
-	blob_pack=$(test-tool -C bare.git find-pack -c 1 HEAD:file1) &&
-	blob_content=$(git -C bare.git show $blob_hash) &&
+	blob_pack=$(test-tool --git-dir=bare.git find-pack -c 1 HEAD:file1) &&
+	blob_content=$(git --git-dir=bare.git show $blob_hash) &&
 	test "$blob_content" = "content1"
 '
 

--- a/t/t7704-repack-cruft.sh
+++ b/t/t7704-repack-cruft.sh
@@ -109,7 +109,7 @@ test_expect_success '--expire-to stores pruned objects (5.minutes.ago)' '
 		test_cmp expect actual &&
 
 		(
-			cd expired.git &&
+			cd expired.git && GIT_DIR=. && export GIT_DIR &&
 
 			expired="$(ls objects/pack/pack-*.mtimes)" &&
 			test-tool pack-mtimes $(basename $expired) >out &&

--- a/t/t7900-maintenance.sh
+++ b/t/t7900-maintenance.sh
@@ -1397,7 +1397,7 @@ test_expect_success 'register and unregister bare repo' '
 	test_might_fail git config --global --unset-all maintenance.repo &&
 	git init --bare barerepo &&
 	(
-		cd barerepo &&
+		cd barerepo && GIT_DIR=. && export GIT_DIR &&
 		git maintenance register &&
 		git config --get --global --fixed-value maintenance.repo "$(pwd)" &&
 		git maintenance unregister &&

--- a/t/t9003-help-autocorrect.sh
+++ b/t/t9003-help-autocorrect.sh
@@ -66,7 +66,7 @@ test_expect_success 'autocorrect can be declined altogether' '
 
 test_expect_success 'autocorrect works in work tree created from bare repo' '
 	git clone --bare . bare.git &&
-	git -C bare.git worktree add ../worktree &&
+	git --git-dir=bare.git worktree add worktree &&
 	git -C worktree -c help.autocorrect=immediate status
 '
 

--- a/t/t9100-git-svn-basic.sh
+++ b/t/t9100-git-svn-basic.sh
@@ -315,7 +315,7 @@ test_expect_success 'able to set-tree to a subdirectory' '
 
 test_expect_success 'git-svn works in a bare repository' '
 	mkdir bare-repo &&
-	( cd bare-repo &&
+	( cd bare-repo && GIT_DIR=. && export GIT_DIR &&
 	git init --bare &&
 	GIT_DIR=. git svn init "$svnrepo" &&
 	git svn fetch ) &&

--- a/t/t9210-scalar.sh
+++ b/t/t9210-scalar.sh
@@ -88,7 +88,7 @@ test_expect_success 'scalar enlistments need a worktree' '
 	test_when_finished rm -rf bare test &&
 
 	git init --bare bare/src &&
-	! scalar register bare/src 2>err &&
+	! scalar -c safe.bareRepository=all register bare/src 2>err &&
 	grep "Scalar enlistments require a worktree" err &&
 
 	git init test/src &&

--- a/t/t9700-perl-git.sh
+++ b/t/t9700-perl-git.sh
@@ -45,7 +45,7 @@ test_expect_success 'set up test repository' '
 
 test_expect_success 'set up bare repository' '
 	git init --bare bare.git &&
-	git -C bare.git --work-tree=. commit --allow-empty -m "bare commit"
+	git --git-dir=bare.git --work-tree=. commit --allow-empty -m "bare commit"
 '
 
 test_expect_success 'use t9700/test.pl to test Git.pm' '

--- a/t/t9700/test.pl
+++ b/t/t9700/test.pl
@@ -153,9 +153,12 @@ unlink $tmpfile3;
 chdir($abs_repo_dir);
 
 # open alternate bare repo
-my $r4 = Git->repository(Directory => "$abs_repo_dir/bare.git");
-is($r4->command_oneline(qw(log --format=%s)), "bare commit",
-	"log of bare repo works");
+{
+	local $ENV{GIT_DIR} = "$abs_repo_dir/bare.git";
+	my $r4 = Git->repository(Directory => "$abs_repo_dir/bare.git");
+	is($r4->command_oneline(qw(log --format=%s)), "bare commit",
+		"log of bare repo works");
+}
 
 # unquoting paths
 is(Git::unquote_path('abc'), 'abc', 'unquote unquoted path');

--- a/t/t9800-git-p4-basic.sh
+++ b/t/t9800-git-p4-basic.sh
@@ -321,7 +321,7 @@ test_expect_success 'clone --bare should make a bare repository' '
 	git p4 clone --dest="$git" --bare //depot &&
 	test_when_finished cleanup_git &&
 	(
-		cd "$git" &&
+		cd "$git" && GIT_DIR=. && export GIT_DIR &&
 		test_path_is_missing .git &&
 		git config --get --bool core.bare true &&
 		git rev-parse --verify refs/remotes/p4/master &&

--- a/t/t9903-bash-prompt.sh
+++ b/t/t9903-bash-prompt.sh
@@ -135,7 +135,7 @@ test_expect_success 'prompt - describe detached head - default' '
 test_expect_success 'prompt - inside .git directory' '
 	printf " (GIT_DIR!)" >expected &&
 	(
-		cd .git &&
+		cd .git && GIT_CONFIG_PARAMETERS="${SQ}safe.bareRepository=all${SQ}" && export GIT_CONFIG_PARAMETERS &&
 		__git_ps1 >"$actual"
 	) &&
 	test_cmp expected "$actual"
@@ -155,7 +155,7 @@ test_expect_success 'prompt - inside bare repository' '
 	git init --bare bare.git &&
 	test_when_finished "rm -rf bare.git" &&
 	(
-		cd bare.git &&
+		cd bare.git && GIT_CONFIG_PARAMETERS="${SQ}safe.bareRepository=all${SQ}" && export GIT_CONFIG_PARAMETERS &&
 		__git_ps1 >"$actual"
 	) &&
 	test_cmp expected "$actual"
@@ -374,7 +374,7 @@ test_expect_success 'prompt - dirty status indicator - not shown inside .git dir
 	test_when_finished "git reset --hard" &&
 	(
 		GIT_PS1_SHOWDIRTYSTATE=y &&
-		cd .git &&
+		cd .git && GIT_CONFIG_PARAMETERS="${SQ}safe.bareRepository=all${SQ}" && export GIT_CONFIG_PARAMETERS &&
 		__git_ps1 >"$actual"
 	) &&
 	test_cmp expected "$actual"
@@ -409,7 +409,7 @@ test_expect_success 'prompt - stash status indicator - not shown inside .git dir
 	test_when_finished "git stash drop" &&
 	(
 		GIT_PS1_SHOWSTASHSTATE=y &&
-		cd .git &&
+		cd .git && GIT_CONFIG_PARAMETERS="${SQ}safe.bareRepository=all${SQ}" && export GIT_CONFIG_PARAMETERS &&
 		__git_ps1 >"$actual"
 	) &&
 	test_cmp expected "$actual"
@@ -514,7 +514,7 @@ test_expect_success 'prompt - untracked files status indicator - not shown insid
 	printf " (GIT_DIR!)" >expected &&
 	(
 		GIT_PS1_SHOWUNTRACKEDFILES=y &&
-		cd .git &&
+		cd .git && GIT_CONFIG_PARAMETERS="${SQ}safe.bareRepository=all${SQ}" && export GIT_CONFIG_PARAMETERS &&
 		__git_ps1 >"$actual"
 	) &&
 	test_cmp expected "$actual"
@@ -619,7 +619,7 @@ test_expect_success 'prompt - bash color pc mode - inside .git directory' '
 	(
 		GIT_PS1_SHOWDIRTYSTATE=y &&
 		GIT_PS1_SHOWCOLORHINTS=y &&
-		cd .git &&
+		cd .git && GIT_CONFIG_PARAMETERS="${SQ}safe.bareRepository=all${SQ}" && export GIT_CONFIG_PARAMETERS &&
 		__git_ps1 "BEFORE:" ":AFTER" &&
 		printf "%s\\n%s" "$PS1" "${__git_ps1_branch_name}" >"$actual"
 	) &&
@@ -749,7 +749,7 @@ test_expect_success 'prompt - hide if pwd ignored - inside gitdir' '
 	printf " (GIT_DIR!)" >expected &&
 	(
 		GIT_PS1_HIDE_IF_PWD_IGNORED=y &&
-		cd .git &&
+		cd .git && GIT_CONFIG_PARAMETERS="${SQ}safe.bareRepository=all${SQ}" && export GIT_CONFIG_PARAMETERS &&
 		__git_ps1 >"$actual"
 	) &&
 	test_cmp expected "$actual"

--- a/t/test-lib-functions.sh
+++ b/t/test-lib-functions.sh
@@ -637,6 +637,8 @@ write_script () {
 #
 #   -C <dir>:
 #	Run all git commands in directory <dir>
+#   --git-dir <dir>:
+#	Use <dir> as the git directory (for bare repositories)
 #   --setup
 #	Setup a hook for subsequent tests, i.e. don't remove it in a
 #	"test_when_finished"
@@ -654,11 +656,16 @@ test_hook () {
 	disable= &&
 	remove= &&
 	indir= &&
+	gitdir= &&
 	while test $# != 0
 	do
 		case "$1" in
 		-C)
 			indir="$2" &&
+			shift
+			;;
+		--git-dir)
+			gitdir="$2" &&
 			shift
 			;;
 		--setup)
@@ -683,7 +690,8 @@ test_hook () {
 		shift
 	done &&
 
-	git_dir=$(git -C "$indir" rev-parse --absolute-git-dir) &&
+	git_dir=$(git ${indir:+-C "$indir"} ${gitdir:+--git-dir="$gitdir"} \
+		rev-parse --absolute-git-dir) &&
 	hook_dir="$git_dir/hooks" &&
 	hook_file="$hook_dir/$1" &&
 	if test -n "$disable$remove"

--- a/t/test-lib-functions.sh
+++ b/t/test-lib-functions.sh
@@ -582,13 +582,20 @@ test_modebits () {
 # Unset a configuration variable, but don't fail if it doesn't exist.
 test_unconfig () {
 	config_dir=
+	config_git_dir=
 	if test "$1" = -C
 	then
 		shift
 		config_dir=$1
 		shift
+	elif test "$1" = --git-dir
+	then
+		shift
+		config_git_dir=$1
+		shift
 	fi
-	git ${config_dir:+-C "$config_dir"} config --unset-all "$@"
+	git ${config_git_dir:+--git-dir="$config_git_dir"} \
+		${config_dir:+-C "$config_dir"} config --unset-all "$@"
 	config_status=$?
 	case "$config_status" in
 	5) # ok, nothing to unset
@@ -601,10 +608,16 @@ test_unconfig () {
 # Set git config, automatically unsetting it after the test is over.
 test_config () {
 	config_dir=
+	config_git_dir=
 	if test "$1" = -C
 	then
 		shift
 		config_dir=$1
+		shift
+	elif test "$1" = --git-dir
+	then
+		shift
+		config_git_dir=$1
 		shift
 	fi
 
@@ -616,8 +629,10 @@ test_config () {
 		shift
 	fi
 
-	test_when_finished "test_unconfig ${config_dir:+-C '$config_dir'} ${is_worktree:+--worktree} '$1'" &&
-	git ${config_dir:+-C "$config_dir"} config ${is_worktree:+--worktree} "$@"
+	test_when_finished "test_unconfig ${config_git_dir:+--git-dir '$config_git_dir'} \
+		${config_dir:+-C '$config_dir'} ${is_worktree:+--worktree} '$1'" &&
+	git ${config_git_dir:+--git-dir="$config_git_dir"} \
+		${config_dir:+-C "$config_dir"} config ${is_worktree:+--worktree} "$@"
 }
 
 test_config_global () {


### PR DESCRIPTION
In one of my projects, I work exclusively on bare repositories. During one of the tests, I noticed that [`safe.bareRepository`](https://git-scm.com/docs/git-config#Documentation/git-config.txt-safebareRepository) is not yet enabled by default. This strikes me as undesirable, and I deem Git v3.0 the most logical opportunity to change the default.

Cc: Patrick Steinhardt <ps@pks.im>