### PR TITLE
tests: access bare repositories explicitly

### DIFF
--- a/git-p4.py
+++ b/git-p4.py
@@ -4360,6 +4360,7 @@ class P4Clone(P4Sync):
         init_cmd = ["git", "init"]
         if self.cloneBare:
             init_cmd.append("--bare")
+            os.environ["GIT_DIR"] = os.getcwd()
         retcode = subprocess.call(init_cmd)
         if retcode:
             raise subprocess.CalledProcessError(retcode, init_cmd)

--- a/t/lib-httpd.sh
+++ b/t/lib-httpd.sh
@@ -259,7 +259,7 @@ test_http_push_nonff () {
 
 	test_expect_success 'non-fast-forward push fails' '
 		cd "$REMOTE_REPO" &&
-		HEAD=$(git rev-parse --verify HEAD) &&
+		HEAD=$(git --git-dir=. rev-parse --verify HEAD) &&
 
 		cd "$LOCAL_REPO" &&
 		git checkout $BRANCH &&
@@ -270,7 +270,7 @@ test_http_push_nonff () {
 		(
 			cd "$REMOTE_REPO" &&
 			echo "$HEAD" >expect &&
-			git rev-parse --verify HEAD >actual &&
+			git --git-dir=. rev-parse --verify HEAD >actual &&
 			test_cmp expect actual
 		)
 	'
@@ -284,18 +284,16 @@ test_http_push_nonff () {
 	'
 
 	test_expect_${EXPECT_CAS_RESULT} 'force with lease aka cas' '
-		HEAD=$(	cd "$REMOTE_REPO" && git rev-parse --verify HEAD ) &&
+		HEAD=$(git --git-dir="$REMOTE_REPO" rev-parse --verify HEAD) &&
 		test_when_finished '\''
-			(cd "$REMOTE_REPO" && git update-ref HEAD "$HEAD")
+			git --git-dir="$REMOTE_REPO" update-ref HEAD "$HEAD"
 		'\'' &&
 		(
 			cd "$LOCAL_REPO" &&
 			git push -v --force-with-lease=$BRANCH:$HEAD origin
 		) &&
 		git rev-parse --verify "$BRANCH" >expect &&
-		(
-			cd "$REMOTE_REPO" && git rev-parse --verify HEAD
-		) >actual &&
+		git --git-dir="$REMOTE_REPO" rev-parse --verify HEAD >actual &&
 		test_cmp expect actual
 	'
 }

--- a/t/t0001-init.sh
+++ b/t/t0001-init.sh
@@ -20,8 +20,8 @@ check_config () {
 		return 1
 	fi
 
-	bare=$(cd "$1" && git config --bool core.bare)
-	worktree=$(cd "$1" && git config core.worktree) ||
+	bare=$(git --git-dir="$1" config --bool core.bare)
+	worktree=$(git --git-dir="$1" config core.worktree) ||
 	worktree=unset
 
 	test "$bare" = "$2" && test "$worktree" = "$3" || {

--- a/t/t0001-init.sh
+++ b/t/t0001-init.sh
@@ -77,6 +77,7 @@ test_expect_success 'plain nested through aliased command' '
 '
 
 test_expect_success 'plain nested in bare through aliased command' '
+	test_config_global safe.bareRepository all &&
 	(
 		git init --bare bare-ancestor-aliased.git &&
 		cd bare-ancestor-aliased.git &&

--- a/t/t0003-attributes.sh
+++ b/t/t0003-attributes.sh
@@ -346,17 +346,14 @@ test_expect_success 'setup bare' '
 
 test_expect_success 'bare repository: check that .gitattribute is ignored' '
 	(
-		cd bare.git &&
-		(
-			echo "f	test=f" &&
-			echo "a/i test=a/i"
-		) >.gitattributes &&
-		attr_check f unspecified &&
-		attr_check a/f unspecified &&
-		attr_check a/c/f unspecified &&
-		attr_check a/i unspecified &&
-		attr_check subdir/a/i unspecified
-	)
+		echo "f	test=f" &&
+		echo "a/i test=a/i"
+	) >bare.git/.gitattributes &&
+	attr_check f unspecified --git-dir=bare.git &&
+	attr_check a/f unspecified --git-dir=bare.git &&
+	attr_check a/c/f unspecified --git-dir=bare.git &&
+	attr_check a/i unspecified --git-dir=bare.git &&
+	attr_check subdir/a/i unspecified --git-dir=bare.git
 '
 
 bad_attr_source_err="fatal: bad --attr-source or GIT_ATTR_SOURCE"
@@ -449,41 +446,32 @@ test_expect_success 'diff without repository with attr source' '
 '
 
 test_expect_success 'bare repository: with --source' '
-	(
-		cd bare.git &&
-		attr_check_source foo/bar/f f tag-1 &&
-		attr_check_source foo/bar/a/i n tag-1 &&
-		attr_check_source foo/bar/f unspecified tag-2 &&
-		attr_check_source foo/bar/a/i m tag-2 &&
-		attr_check_source foo/bar/g g tag-2 &&
-		attr_check_source foo/bar/g unspecified tag-1
-	)
+	attr_check_source foo/bar/f f tag-1 --git-dir=bare.git &&
+	attr_check_source foo/bar/a/i n tag-1 --git-dir=bare.git &&
+	attr_check_source foo/bar/f unspecified tag-2 --git-dir=bare.git &&
+	attr_check_source foo/bar/a/i m tag-2 --git-dir=bare.git &&
+	attr_check_source foo/bar/g g tag-2 --git-dir=bare.git &&
+	attr_check_source foo/bar/g unspecified tag-1 --git-dir=bare.git
 '
 
 test_expect_success 'bare repository: check that --cached honors index' '
-	(
-		cd bare.git &&
-		GIT_INDEX_FILE=../.git/index \
-		git check-attr --cached --stdin --all <../stdin-all |
-		sort >actual &&
-		test_cmp ../specified-all actual
-	)
+	GIT_INDEX_FILE=.git/index \
+	git --git-dir=bare.git check-attr --cached --stdin --all <stdin-all |
+	sort >actual &&
+	test_cmp specified-all actual
 '
 
 test_expect_success 'bare repository: test info/attributes' '
+	mkdir -p bare.git/info &&
 	(
-		cd bare.git &&
-		mkdir info &&
-		(
-			echo "f	test=f" &&
-			echo "a/i test=a/i"
-		) >info/attributes &&
-		attr_check f f &&
-		attr_check a/f f &&
-		attr_check a/c/f f &&
-		attr_check a/i a/i &&
-		attr_check subdir/a/i unspecified
-	)
+		echo "f	test=f" &&
+		echo "a/i test=a/i"
+	) >bare.git/info/attributes &&
+	attr_check f f --git-dir=bare.git &&
+	attr_check a/f f --git-dir=bare.git &&
+	attr_check a/c/f f --git-dir=bare.git &&
+	attr_check a/i a/i --git-dir=bare.git &&
+	attr_check subdir/a/i unspecified --git-dir=bare.git
 '
 
 test_expect_success 'binary macro expanded by -a' '

--- a/t/t0056-git-C.sh
+++ b/t/t0056-git-C.sh
@@ -57,11 +57,13 @@ test_expect_success 'Order should not matter: "--git-dir=a.git -C c" is equivale
 test_expect_success 'Effect on --work-tree option: "-C c/a.git --work-tree=../a"  is equivalent to "--work-tree=c/a --git-dir=c/a.git"' '
 	rm c/a/a.txt &&
 	git --git-dir=c/a.git --work-tree=c/a status >expected &&
+	test_config_global safe.bareRepository all &&
 	git -C c/a.git --work-tree=../a status >actual &&
 	test_cmp expected actual
 '
 
 test_expect_success 'Order should not matter: "--work-tree=../a -C c/a.git" is equivalent to "-C c/a.git --work-tree=../a"' '
+	test_config_global safe.bareRepository all &&
 	git -C c/a.git --work-tree=../a status >expected &&
 	git --work-tree=../a -C c/a.git status >actual &&
 	test_cmp expected actual

--- a/t/t1020-subdirectory.sh
+++ b/t/t1020-subdirectory.sh
@@ -177,10 +177,7 @@ test_expect_success 'no file/rev ambiguity check inside a bare repo (explicit GI
 test_expect_success 'no file/rev ambiguity check inside a bare repo' '
 	test_when_finished "rm -fr foo.git" &&
 	git clone -s --bare .git foo.git &&
-	(
-		cd foo.git &&
-		git show -s HEAD
-	)
+	git --git-dir=foo.git show -s HEAD
 '
 
 test_expect_success SYMLINKS 'detection should not be fooled by a symlink' '

--- a/t/t1900-repo-info.sh
+++ b/t/t1900-repo-info.sh
@@ -20,6 +20,7 @@ test_repo_info () {
 	repo_name=$3
 	key=$4
 	expected_value=$5
+	repo_flag=${6:--C}
 
 	test_expect_success "setup: $label" '
 		eval "$init_command $repo_name"
@@ -27,13 +28,13 @@ test_repo_info () {
 
 	test_expect_success "lines: $label" '
 		echo "$key=$expected_value" > expect &&
-		git -C "$repo_name" repo info "$key" >actual &&
+		git $repo_flag "$repo_name" repo info "$key" >actual &&
 		test_cmp expect actual
 	'
 
 	test_expect_success "nul: $label" '
 		printf "%s\n%s\0" "$key" "$expected_value" >expect &&
-		git -C "$repo_name" repo info --format=nul "$key" >actual &&
+		git $repo_flag "$repo_name" repo info --format=nul "$key" >actual &&
 		test_cmp_bin expect actual
 	'
 }
@@ -48,7 +49,7 @@ test_repo_info 'bare repository = false is retrieved correctly' \
 	'git init' 'nonbare' 'layout.bare' 'false'
 
 test_repo_info 'bare repository = true is retrieved correctly' \
-	'git init --bare' 'bare' 'layout.bare' 'true'
+	'git init --bare' 'bare' 'layout.bare' 'true' '--git-dir'
 
 test_repo_info 'shallow repository = false is retrieved correctly' \
 	'git init' 'nonshallow' 'layout.shallow' 'false'

--- a/t/t2400-worktree-add.sh
+++ b/t/t2400-worktree-add.sh
@@ -171,11 +171,8 @@ test_expect_success 'not die on re-checking out current branch' '
 '
 
 test_expect_success '"add" from a bare repo' '
-	(
-		git clone --bare . bare &&
-		cd bare &&
-		git worktree add -b bare-main ../there2 main
-	)
+	git clone --bare . bare &&
+	git -C bare --git-dir=. worktree add -b bare-main ../there2 main
 '
 
 test_expect_success 'checkout from a bare repo without "add"' '
@@ -186,15 +183,11 @@ test_expect_success 'checkout from a bare repo without "add"' '
 '
 
 test_expect_success '"add" default branch of a bare repo' '
-	(
-		git clone --bare . bare2 &&
-		cd bare2 &&
-		git worktree add ../there3 main &&
-		cd ../there3 &&
-		# Simple check that a Git command does not
-		# immediately fail with the current setup
-		git status
-	) &&
+	git clone --bare . bare2 &&
+	git -C bare2 --git-dir=. worktree add ../there3 main &&
+	# Simple check that a Git command does not
+	# immediately fail with the current setup
+	git status &&
 	cat >expect <<-EOF &&
 	init.t
 	EOF

--- a/t/t2406-worktree-repair.sh
+++ b/t/t2406-worktree-repair.sh
@@ -84,7 +84,7 @@ test_expect_success 'repair .git file from bare.git' '
 	git -C bare.git worktree add --detach ../corrupt &&
 	git -C corrupt rev-parse --absolute-git-dir >expect &&
 	rm -f corrupt/.git &&
-	git -C bare.git worktree repair &&
+	git -C bare.git --git-dir=. worktree repair &&
 	git -C corrupt rev-parse --absolute-git-dir >actual &&
 	test_cmp expect actual
 '

--- a/t/t5503-tagfollow.sh
+++ b/t/t5503-tagfollow.sh
@@ -168,16 +168,13 @@ test_expect_success 'new clone fetch main and tags' '
 
 test_expect_success 'fetch specific OID with tag following' '
 	git init --bare clone3.git &&
-	(
-		cd clone3.git &&
-		git remote add origin .. &&
-		git fetch origin $B:refs/heads/main &&
+	git --git-dir=clone3.git remote add origin "$PWD" &&
+	git --git-dir=clone3.git fetch origin $B:refs/heads/main &&
 
-		git -C .. for-each-ref >expect &&
-		git for-each-ref >actual &&
+	git for-each-ref >expect &&
+	git --git-dir=clone3.git for-each-ref >actual &&
 
-		test_cmp expect actual
-	)
+	test_cmp expect actual
 '
 
 test_done

--- a/t/t5505-remote.sh
+++ b/t/t5505-remote.sh
@@ -561,7 +561,7 @@ test_expect_success 'add --mirror && prune' '
 	mkdir mirror &&
 	(
 		cd mirror &&
-		git init --bare &&
+		git init --bare && GIT_DIR=. && export GIT_DIR &&
 		git remote add --mirror -f origin ../one
 	) &&
 	(
@@ -583,7 +583,7 @@ test_expect_success 'add --mirror setting HEAD' '
 	mkdir headmirror &&
 	(
 		cd headmirror &&
-		git init --bare -b notmain &&
+		git init --bare -b notmain && GIT_DIR=. && export GIT_DIR &&
 		git remote add --mirror -f origin ../one &&
 		test "$(git symbolic-ref HEAD)" = "refs/heads/main"
 	)

--- a/t/t5509-fetch-push-namespaces.sh
+++ b/t/t5509-fetch-push-namespaces.sh
@@ -88,7 +88,7 @@ test_expect_success 'mirroring a repository using a ref namespace' '
 
 test_expect_success 'hide namespaced refs with transfer.hideRefs' '
 	GIT_NAMESPACE=namespace \
-		git -C pushee -c transfer.hideRefs=refs/tags \
+		git -C pushee --git-dir=. -c transfer.hideRefs=refs/tags \
 		ls-remote "ext::git %s ." >actual &&
 	printf "$commit1\trefs/heads/main\n" >expected &&
 	test_cmp expected actual
@@ -97,7 +97,7 @@ test_expect_success 'hide namespaced refs with transfer.hideRefs' '
 test_expect_success 'check that transfer.hideRefs does not match unstripped refs' '
 	git -C pushee pack-refs --all &&
 	GIT_NAMESPACE=namespace \
-		git -C pushee -c transfer.hideRefs=refs/namespaces/namespace/refs/tags \
+		git -C pushee --git-dir=. -c transfer.hideRefs=refs/namespaces/namespace/refs/tags \
 		ls-remote "ext::git %s ." >actual &&
 	printf "$commit1\trefs/heads/main\n" >expected &&
 	printf "$commit0\trefs/tags/0\n" >>expected &&
@@ -107,7 +107,7 @@ test_expect_success 'check that transfer.hideRefs does not match unstripped refs
 
 test_expect_success 'hide full refs with transfer.hideRefs' '
 	GIT_NAMESPACE=namespace \
-		git -C pushee -c transfer.hideRefs="^refs/namespaces/namespace/refs/tags" \
+		git -C pushee --git-dir=. -c transfer.hideRefs="^refs/namespaces/namespace/refs/tags" \
 		ls-remote "ext::git %s ." >actual &&
 	printf "$commit1\trefs/heads/main\n" >expected &&
 	test_cmp expected actual

--- a/t/t5619-clone-local-ambiguous-transport.sh
+++ b/t/t5619-clone-local-ambiguous-transport.sh
@@ -21,7 +21,7 @@ test_expect_success 'setup' '
 	echo "secret" >sensitive/secret &&
 
 	git init --bare "$REPO" &&
-	test_commit_bulk -C "$REPO" --ref=main 1 &&
+	(GIT_DIR="$REPO" && export GIT_DIR && test_commit_bulk --ref=main 1) &&
 
 	git -C "$REPO" update-ref HEAD main &&
 	git -C "$REPO" update-server-info &&

--- a/t/t6020-bundle-misc.sh
+++ b/t/t6020-bundle-misc.sh
@@ -594,9 +594,9 @@ do
 		reflist=$(git for-each-ref --format="%(objectname)") &&
 		git rev-list --objects --filter=$filter --missing=allow-any \
 			$reflist >expect &&
-		for repo in cloned unbundled
+		for opt in "--git-dir cloned" "-C unbundled"
 		do
-			git -C $repo rev-list --objects --missing=allow-any \
+			git $opt rev-list --objects --missing=allow-any \
 				$reflist >actual &&
 			test_cmp expect actual || return 1
 		done

--- a/t/t9210-scalar.sh
+++ b/t/t9210-scalar.sh
@@ -88,7 +88,7 @@ test_expect_success 'scalar enlistments need a worktree' '
 	test_when_finished rm -rf bare test &&
 
 	git init --bare bare/src &&
-	! scalar register bare/src 2>err &&
+	! scalar -c safe.bareRepository=all register bare/src 2>err &&
 	grep "Scalar enlistments require a worktree" err &&
 
 	git init test/src &&

--- a/t/t9700/test.pl
+++ b/t/t9700/test.pl
@@ -153,9 +153,12 @@ unlink $tmpfile3;
 chdir($abs_repo_dir);
 
 # open alternate bare repo
-my $r4 = Git->repository(Directory => "$abs_repo_dir/bare.git");
-is($r4->command_oneline(qw(log --format=%s)), "bare commit",
-	"log of bare repo works");
+{
+	local $ENV{GIT_DIR} = "$abs_repo_dir/bare.git";
+	my $r4 = Git->repository(Directory => "$abs_repo_dir/bare.git");
+	is($r4->command_oneline(qw(log --format=%s)), "bare commit",
+		"log of bare repo works");
+}
 
 # unquoting paths
 is(Git::unquote_path('abc'), 'abc', 'unquote unquoted path');


### PR DESCRIPTION
The `safe.bareRepository` configuration variable (introduced in
8d1a7448206e) allows restricting implicit bare repository discovery.
Its default may well change to "explicit" in Git v3.0, at which point
any test that relies on implicit discovery of a bare repository would
break, even if the test subject has nothing to do with bare
repositories.

This series adjusts 16 test scripts and git-p4 so that they access
bare repositories explicitly. The techniques used are:

  - Replace `git -C <bare-repo> ...` with `git --git-dir=<bare-repo> ...`
  - Export `GIT_DIR=.` after `cd`-ing into a bare repository
  - Wrap commands in `(GIT_DIR=<path> && export GIT_DIR && ...)`
  - Add `test_config_global safe.bareRepository all` in the few tests
    where implicit discovery is genuinely part of what is being tested

Each commit is a self-contained fix to one test file (or a small
related group).

This patch series is part of https://github.com/gitgitgadget/git/pull/2072.

Changes since v1:
- Dramatically simplified the patch "t5509: specify bare repository path explicitly"