### PR TITLE
fetch: pass transport to post-fetch connectivity check

### DIFF
--- a/builtin/fetch.c
+++ b/builtin/fetch.c
@@ -1213,6 +1213,7 @@ N_("it took %.2f seconds to check forced updates; you can use\n"
    "to avoid this check\n");
 
 static int store_updated_refs(struct display_state *display_state,
+			      struct transport *transport,
 			      int connectivity_checked,
 			      struct ref_transaction *transaction, struct ref *ref_map,
 			      struct fetch_head *fetch_head,
@@ -1228,6 +1229,7 @@ static int store_updated_refs(struct display_state *display_state,
 	if (!connectivity_checked) {
 		struct check_connected_options opt = CHECK_CONNECTED_INIT;
 
+		opt.transport = transport;
 		opt.exclude_hidden_refs_section = "fetch";
 		rm = ref_map;
 		if (check_connected(iterate_ref_map, &rm, &opt)) {
@@ -1432,7 +1434,7 @@ static int fetch_and_consume_refs(struct display_state *display_state,
 	}
 
 	trace2_region_enter("fetch", "consume_refs", the_repository);
-	ret = store_updated_refs(display_state, connectivity_checked,
+	ret = store_updated_refs(display_state, transport, connectivity_checked,
 				 transaction, ref_map, fetch_head, config,
 				 display_array);
 	trace2_region_leave("fetch", "consume_refs", the_repository);


### PR DESCRIPTION
We're working on reducing `git fetch` times on a large monorepo (2.4M
commits, 374K files, 10.9K local refs). Profiling showed the post-fetch
connectivity check (`rev-list --objects --stdin --not --all`) dominating
wall time when there are new objects.

While investigating, I noticed that `check_connected()` already has a
fast path for self-contained packs — it uses `find_pack_entry_one()` to
skip refs whose objects are in the new pack. `builtin/clone.c` passes
the transport to enable this, but `store_updated_refs()` in
`builtin/fetch.c` does not, making the optimization dead code for
fetches.

The fix is a three-line change to thread the transport through.

cc: Kristofer Karlsson <krka@spotify.com>
cc: Jeff King <peff@peff.net>