### PR TITLE
rebase: handle --update-refs branch symrefs

### DIFF
--- a/sequencer.c
+++ b/sequencer.c
@@ -6546,28 +6546,50 @@ static int add_decorations_to_list(const struct commit *commit,
 				   struct todo_add_branch_context *ctx)
 {
 	const struct name_decoration *decoration = get_name_decoration(&commit->object);
-	const char *head_ref = refs_resolve_ref_unsafe(get_main_ref_store(the_repository),
-						       "HEAD",
-						       RESOLVE_REF_READING,
-						       NULL,
-						       NULL);
+	struct ref_store *refs = get_main_ref_store(the_repository);
+	char *head_ref = refs_resolve_refdup(refs, "HEAD",
+					     RESOLVE_REF_READING,
+					     NULL, NULL);
 
 	while (decoration) {
 		struct todo_item *item;
 		const char *path;
+		char *resolved_ref;
+		int flags = 0;
 		size_t base_offset = ctx->buf->len;
 
 		/*
-		 * If the branch is the current HEAD, then it will be
-		 * updated by the default rebase behavior.
-		 * Exclude it from the list of refs to update,
-		 * as well as any non-branch decorations.
 		 * Non-branch decorations may be present if the pretty format
 		 * includes "%d", which would have loaded all refs
 		 * into the global decoration table.
 		 */
-		if ((head_ref && !strcmp(head_ref, decoration->name)) ||
-		    (decoration->type != DECORATION_REF_LOCAL)) {
+		if (decoration->type != DECORATION_REF_LOCAL) {
+			decoration = decoration->next;
+			continue;
+		}
+
+		/*
+		 * A symref to another local branch is only an alias. The
+		 * target branch has its own decoration, so only queue the
+		 * concrete branch.
+		 */
+		resolved_ref = refs_resolve_refdup(refs, decoration->name,
+						      RESOLVE_REF_READING,
+						      NULL, &flags);
+		if (resolved_ref && (flags & REF_ISSYMREF) &&
+		    starts_with(resolved_ref, "refs/heads/")) {
+			free(resolved_ref);
+			decoration = decoration->next;
+			continue;
+		}
+
+		/*
+		 * If the branch or its referent is the current HEAD, then it
+		 * will be updated by the default rebase behavior.
+		 */
+		if (head_ref && resolved_ref &&
+		    !strcmp(head_ref, resolved_ref)) {
+			free(resolved_ref);
 			decoration = decoration->next;
 			continue;
 		}
@@ -6599,9 +6621,11 @@ static int add_decorations_to_list(const struct commit *commit,
 		item->arg_len = ctx->buf->len - base_offset;
 		ctx->items_nr++;
 
+		free(resolved_ref);
 		decoration = decoration->next;
 	}
 
+	free(head_ref);
 	return 0;
 }
 

--- a/t/t3400-rebase.sh
+++ b/t/t3400-rebase.sh
@@ -483,7 +483,7 @@ test_expect_success 'git rebase --update-ref with core.commentChar and branch on
 	GIT_SEQUENCE_EDITOR="cat >actual" git -c core.commentChar=% \
 		 rebase -i --update-refs base &&
 	test_grep "% Ref refs/heads/wt-topic checked out at" actual &&
-	test_grep "% Ref refs/heads/topic2 checked out at" actual
+	test_grep ! "% Ref refs/heads/topic2 checked out at" actual
 '
 
 test_done

--- a/t/t3404-rebase-interactive.sh
+++ b/t/t3404-rebase-interactive.sh
@@ -1990,11 +1990,18 @@ test_expect_success '--update-refs ignores non-branch decorations' '
 '
 
 test_expect_success '--update-refs updates refs correctly' '
+	test_when_finished "
+		test_might_fail git symbolic-ref -d refs/heads/no-conflict-branch-alias &&
+		test_might_fail git symbolic-ref -d refs/heads/second-alias
+	" &&
 	git checkout -B update-refs no-conflict-branch &&
 	git branch -f base HEAD~4 &&
 	git branch -f first HEAD~3 &&
 	git branch -f second HEAD~3 &&
 	git branch -f third HEAD~1 &&
+	git symbolic-ref refs/heads/no-conflict-branch-alias \
+		refs/heads/no-conflict-branch &&
+	git symbolic-ref refs/heads/second-alias refs/heads/second &&
 	test_commit extra2 fileX &&
 	git commit --amend --fixup=L &&
 
@@ -2002,8 +2009,16 @@ test_expect_success '--update-refs updates refs correctly' '
 
 	test_cmp_rev HEAD~3 refs/heads/first &&
 	test_cmp_rev HEAD~3 refs/heads/second &&
+	test_cmp_rev HEAD~3 refs/heads/second-alias &&
 	test_cmp_rev HEAD~1 refs/heads/third &&
 	test_cmp_rev HEAD refs/heads/no-conflict-branch &&
+	test_cmp_rev HEAD refs/heads/no-conflict-branch-alias &&
+	test_write_lines refs/heads/no-conflict-branch >expect &&
+	git symbolic-ref refs/heads/no-conflict-branch-alias >actual &&
+	test_cmp expect actual &&
+	test_write_lines refs/heads/second >expect &&
+	git symbolic-ref refs/heads/second-alias >actual &&
+	test_cmp expect actual &&
 
 	q_to_tab >expect <<-\EOF &&
 	Successfully rebased and updated refs/heads/update-refs.
@@ -2017,6 +2032,31 @@ test_expect_success '--update-refs updates refs correctly' '
 	# Clear "Rebasing (X/Y)" progress lines and drop leading tabs.
 	sed "s/Rebasing.*Successfully/Successfully/g" <err >err.trimmed &&
 	test_cmp expect err.trimmed
+'
+
+test_expect_success '--update-refs skips symref to current non-branch target' '
+	test_create_repo current-non-branch-target &&
+	test_commit -C current-non-branch-target one &&
+	test_commit -C current-non-branch-target two &&
+	test_commit -C current-non-branch-target three &&
+	git -C current-non-branch-target update-ref \
+		refs/tags/current-non-branch-target HEAD &&
+	git -C current-non-branch-target symbolic-ref \
+		refs/heads/current-non-branch-alias \
+		refs/tags/current-non-branch-target &&
+	git -C current-non-branch-target symbolic-ref HEAD \
+		refs/heads/current-non-branch-alias &&
+	(
+		cd current-non-branch-target &&
+		GIT_SEQUENCE_EDITOR="cat >todo" \
+			git rebase -i --force-rebase --update-refs HEAD~2 &&
+
+		test_grep ! "refs/heads/current-non-branch-alias" todo &&
+		test_cmp_rev HEAD refs/heads/current-non-branch-alias &&
+		test_write_lines refs/tags/current-non-branch-target >expect &&
+		git symbolic-ref refs/heads/current-non-branch-alias >actual &&
+		test_cmp expect actual
+	)
 '
 
 test_expect_success 'respect user edits to update-ref steps' '


### PR DESCRIPTION
git rebase --update-refs can finish rewriting the current branch and
then fail while updating a local branch that is a symbolic ref. This can
happen during a default-branch rename where refs/heads/main points at
refs/heads/master while users migrate. The failure leaves refs partially
updated even though the main rebase has succeeded.

Resolve local branch decorations before adding update-ref commands. The
first patch skips aliases whose targets are other branches and preserves
the existing handling of the current branch. The second patch keeps
aliases to non-branch refs supported while preventing duplicate and
cross-worktree updates to their resolved targets.

Changes since v3:

- Compare the resolved decoration against the resolved HEAD, covering
  HEAD reaching a non-branch target through a local branch alias.
- Add a focused full-todo regression test using the valid indirect
  `HEAD -> refs/heads/alias -> refs/tags/target` symref chain.
- Centralize checked-out ref recording so worktree HEAD, active rebase
  or bisect state, and update-refs state reserve both the literal symref
  and its resolved target.
- Preserve full refnames from rebase and bisect state instead of
  prefixing non-branch refs with `refs/heads/`.
- Deduplicate non-branch aliases by their resolved target.
- Trim redundant alias fixtures and assertions while retaining distinct
  coverage for current, checked-out, duplicate, and reserved targets.

The focused t2407, t3400, and t3404 test suites pass with both the files
and reftable backends.

cc: "Kristoffer Haugsbakk" <kristofferhaugsbakk@fastmail.com>
cc: Phillip Wood <phillip.wood123@gmail.com>
cc: Erik Cervin-Edin <erik@cervined.in>
