### PR TITLE
t5608, t7508: require LONG_IS_64BIT for >4GB tests

### DIFF
--- a/t/t5608-clone-2gb.sh
+++ b/t/t5608-clone-2gb.sh
@@ -49,7 +49,7 @@ test_expect_success 'clone - with worktree, file:// protocol' '
 
 '
 
-test_expect_success SIZE_T_IS_64BIT,EXPENSIVE 'set up repo with >4GB object' '
+test_expect_success SIZE_T_IS_64BIT,LONG_IS_64BIT,EXPENSIVE 'set up repo with >4GB object' '
 	large_blob_size=$((4*1024*1024*1024+1)) &&
 	git init --bare 4gb-repo &&
 	head_oid=$(test-tool synthesize pack \
@@ -60,7 +60,7 @@ test_expect_success SIZE_T_IS_64BIT,EXPENSIVE 'set up repo with >4GB object' '
 	git -C 4gb-repo symbolic-ref HEAD refs/heads/main
 '
 
-test_expect_success SIZE_T_IS_64BIT,EXPENSIVE 'clone >4GB object via unpack-objects' '
+test_expect_success SIZE_T_IS_64BIT,LONG_IS_64BIT,EXPENSIVE 'clone >4GB object via unpack-objects' '
 	# The synthesized pack has five objects, so a large unpack limit keeps
 	# fetch-pack on the unpack-objects path.
 	git -c fetch.unpackLimit=100 clone --bare \
@@ -76,7 +76,7 @@ test_expect_success SIZE_T_IS_64BIT,EXPENSIVE 'clone >4GB object via unpack-obje
 	test "$source_blob" = "$clone_blob"
 '
 
-test_expect_success SIZE_T_IS_64BIT,EXPENSIVE 'clone with >4GB object via index-pack' '
+test_expect_success SIZE_T_IS_64BIT,LONG_IS_64BIT,EXPENSIVE 'clone with >4GB object via index-pack' '
 	# Force fetch-pack to hand the pack to index-pack instead.
 	git -c fetch.unpackLimit=1 clone --bare \
 		"file://$(pwd)/4gb-repo" 4gb-clone-index &&

--- a/t/t7508-status.sh
+++ b/t/t7508-status.sh
@@ -1773,7 +1773,7 @@ test_expect_success 'slow status advice when core.untrackedCache true, and fsmon
 	)
 '
 
-test_expect_success EXPENSIVE 'status does not re-read unchanged 4 or 8 GiB file' '
+test_expect_success LONG_IS_64BIT,EXPENSIVE 'status does not re-read unchanged 4 or 8 GiB file' '
 	(
 		mkdir large-file &&
 		cd large-file &&


### PR DESCRIPTION
The >4GB clone tests in t5608 and the large-file status test in t7508
fail on Windows x86_64 where `unsigned long` is 32 bits.

**t5608 (tests 5-6):** The server-side pack-objects still uses
`unsigned long` for object sizes, so `cast_size_t_to_ulong()` dies
when it encounters a 4294967297-byte object. The streaming/odb side
was widened to `size_t` in js/objects-larger-than-4gb-on-windows, but
pack-objects was deliberately left as a stop-gap.

**t7508 (test 126):** `ftruncate` is implemented via `_chsize` on
MSVC, which takes a `long` parameter — overflowing at 2 GiB. The
subsequent `git add` / `git diff-index` also route through
`object_info.sizep` (`unsigned long`), which would truncate.

Add `LONG_IS_64BIT` prerequisite so these tests skip on Windows
until the remaining `unsigned long` → `size_t` widening lands.

cc: @dscho