### PR TITLE
index-pack: retain child bases in delta cache

### DIFF
--- a/builtin/index-pack.c
+++ b/builtin/index-pack.c
@@ -1212,7 +1212,6 @@ static void *threaded_second_pass(void *data)
 			list_add(&child->list, &work_head);
 			base_cache_used += child->size;
 			prune_base_data(NULL);
-			free_base_data(child);
 		} else if (child) {
 			/*
 			 * This child does not have its own children. It may be


### PR DESCRIPTION
Speed up the local `index-pack` phase used by clone/fetch for large
delta-compressed packs.

When `index-pack` reconstructs a child base and queues it for resolving
descendant deltas, it currently frees that data immediately. This can force
the same base to be reconstructed again. This patch keeps the data in the
existing delta base cache instead of immediately freeing it.

This does not add a new cache or increase the cache limit. The object data is
already accounted in `base_cache_used`, and `prune_base_data()` is already
called at this point. Existing cache pruning and cleanup paths remain
responsible for releasing the data.

Changes since v3:

- Returned to the simpler v2 implementation after review discussion found no
  measurable benefit from the additional proactive-release bookkeeping.
- Retained the expanded benchmark and test context in the commit message.

Changes since v1:

- Added benchmark results and leak-safety context to the commit message.
- Included standard `p5302-pack-index.sh` perf-suite results.

Correctness:

- `t/t5302-pack-index.sh` passed.
- GitGitGadget's `linux-leaks` CI exercises `t5302-pack-index.sh` under
  `SANITIZE=leak`.

Benchmarks on a quiet Ubuntu 24.04 VM, 16 vCPU, 32 GiB RAM, local SSD:

Standard `p5302-pack-index.sh` perf-suite results using
`GIT_PERF_LARGE_REPO=<repo> ./run HEAD~1 HEAD -- p5302-pack-index.sh`:

| repo | HEAD~1 | HEAD | wall-time change |
| --- | ---: | ---: | ---: |
| libgit2 | 3.17(11.42+0.61) | 2.69(10.49+0.32) | 15.1% faster |
| redis | 5.88(15.77+0.63) | 4.98(14.08+0.39) | 15.3% faster |
| git.git | 11.22(38.31+1.29) | 9.69(35.36+0.64) | 13.6% faster |
| cpython | 32.64(117.70+4.39) | 28.70(109.90+1.98) | 12.1% faster |
| linux | 276.95(793.14+39.51) | 234.75(722.33+18.01) | 15.2% faster |

The linux `p5302` row is from a single repeat; the others use the default
three repeats. These timings isolate the `index-pack` phase affected by this
patch.

End-to-end local full-clone spot checks also showed wins, though these timings
include both server-side `pack-objects` and client-side `index-pack` running
concurrently over a local `file://` transport, so they are not isolated
`index-pack` timings.

These runs used `git clone --bare --no-local`, dropped page cache before each
clone, and used the matching build's `bin-wrappers/git` as the client plus the
matching `bin-wrappers/git-upload-pack` via `--upload-pack`.

| repo | baseline | patched | wall-time change |
| --- | ---: | ---: | ---: |
| libgit2 | 4.99s | 4.50s | 9.8% faster |
| redis | 8.71s | 7.90s | 9.3% faster |
| git.git | 24.89s | 23.57s | 5.3% faster |
| cpython | 58.77s | 53.84s | 8.4% faster |
| linux | 549.21s | 515.52s | 6.1% faster |

CC: Ævar Arnfjörð Bjarmason <avarab@gmail.com>, Junio C Hamano <gitster@pobox.com>, Derrick Stolee <stolee@gmail.com>, Jeff King <peff@peff.net>
