### PR TITLE
config: mark as sparse-index compatible

### DIFF
--- a/builtin/config.c
+++ b/builtin/config.c
@@ -1618,6 +1618,12 @@ int cmd_config(int argc,
 	 */
 	argc = parse_options(argc, argv, prefix, subcommand_opts, builtin_config_usage,
 			     PARSE_OPT_SUBCOMMAND_OPTIONAL|PARSE_OPT_KEEP_ARGV0|PARSE_OPT_KEEP_UNKNOWN_OPT);
+	if (startup_info->have_repository) {
+		repo_config(repo, git_default_config, NULL);
+		prepare_repo_settings(repo);
+		repo->settings.command_requires_full_index = 0;
+	}
+
 	if (subcommand) {
 		argc = parse_options(argc, argv, prefix, subcommand_opts, builtin_config_usage,
 		       PARSE_OPT_SUBCOMMAND_OPTIONAL|PARSE_OPT_KEEP_UNKNOWN_OPT);

--- a/t/t1092-sparse-checkout-compatibility.sh
+++ b/t/t1092-sparse-checkout-compatibility.sh
@@ -2573,4 +2573,67 @@ test_expect_success 'sparse-index is not expanded: merge-ours' '
 	ensure_not_expanded merge -s ours merge-right
 '
 
+test_expect_success 'sparse-index is not expanded: config --blob with index path' '
+	init_repos &&
+
+	# Stage valid config blobs at in-cone locations.
+	for repo in full-checkout sparse-checkout sparse-index
+	do
+		test_write_lines "[test]" "value = root" \
+			>"$repo/test-config" &&
+		git -C "$repo" add test-config &&
+		test_write_lines "[test]" "value = deep" \
+			>"$repo/deep/test-config" &&
+		git -C "$repo" add deep/test-config || return 1
+	done &&
+
+	# Nonexistent file: must not expand.
+	rm -f trace2.txt &&
+	GIT_TRACE2_EVENT="$(pwd)/trace2.txt" GIT_TRACE2_EVENT_NESTING=10 \
+		test_must_fail \
+		git -C sparse-index config --blob ":.lfsconfig" -l &&
+	test_region ! index ensure_full_index trace2.txt &&
+
+	# Root-level file (always in-cone): must not expand, and must
+	# successfully parse the config values.
+	rm -f trace2.txt &&
+	GIT_TRACE2_EVENT="$(pwd)/trace2.txt" GIT_TRACE2_EVENT_NESTING=10 \
+		git -C sparse-index config --blob ":test-config" -l >actual &&
+	echo "test.value=root" >expect &&
+	test_cmp expect actual &&
+	test_region ! index ensure_full_index trace2.txt &&
+
+	# File inside sparse cone (deep/): must not expand.
+	rm -f trace2.txt &&
+	GIT_TRACE2_EVENT="$(pwd)/trace2.txt" GIT_TRACE2_EVENT_NESTING=10 \
+		git -C sparse-index config --blob ":deep/test-config" -l >actual &&
+	echo "test.value=deep" >expect &&
+	test_cmp expect actual &&
+	test_region ! index ensure_full_index trace2.txt &&
+
+	# File outside sparse cone (folder1/a): must expand because
+	# it is behind a sparse directory entry. The blob contains
+	# "a\n" from the initial setup, which git config parses as
+	# a valueless key.
+	rm -f trace2.txt &&
+	GIT_TRACE2_EVENT="$(pwd)/trace2.txt" GIT_TRACE2_EVENT_NESTING=10 \
+		git -C sparse-index config --blob ":folder1/a" -l &&
+	test_region index ensure_full_index trace2.txt
+'
+
+test_expect_success 'config --file and --blob do not expand sparse index' '
+	init_repos &&
+
+	test_write_lines "[test]" "value = external" >external-config &&
+
+	# --file reads an external config file; the sparse index
+	# should not be read or expanded.
+	rm -f trace2.txt &&
+	GIT_TRACE2_EVENT="$(pwd)/trace2.txt" GIT_TRACE2_EVENT_NESTING=10 \
+		git -C sparse-index config --file ../external-config -l >actual &&
+	echo "test.value=external" >expect &&
+	test_cmp expect actual &&
+	test_region ! index ensure_full_index trace2.txt
+'
+
 test_done


### PR DESCRIPTION
## Summary

`git config --blob :.lfsconfig` (and similar `:path` lookups) triggers
`ensure_full_index()` in sparse checkouts, expanding the entire sparse
index to a full index. On large repositories this takes seconds even
though the command only needs to look up a single path.

This is because `git config` was never added to the list of commands
that are sparse-index compatible. The fix follows the same pattern used
by ~30 other commands: set `command_requires_full_index = 0`.

The one wrinkle is that `git config` uses `RUN_SETUP_GENTLY`, which
does not call the default config callbacks that populate the sparse
checkout globals (`core.sparseCheckout`, `core.sparseCheckoutCone`).
Without those globals, `is_sparse_index_allowed()` returns false and
the index is expanded on read. Adding a `repo_config()` call (guarded
by `startup_info->have_repository`) fixes this. The call is cached and
free when config is already loaded.

### Benchmark (388K-file monorepo, 7K sparse index entries)

| Operation | Before | After | Speedup |
|-----------|--------|-------|---------|
| `git config --blob :.lfsconfig` | 3.36s | 0.01s | 336x |
| `git lfs post-checkout` (calls the above) | 3.35s | 0.06s | 56x |

This matters in practice because git-lfs runs
`git config --blob :.lfsconfig` during every `post-checkout` hook
invocation, making sparse-checkout rebase/switch/checkout pay a
multi-second penalty on every operation.

## Test plan

- New test in t1092 verifies four cases:
  - Nonexistent root-level file: no expansion
  - Valid config at root: no expansion, values readable
  - Valid config inside sparse cone: no expansion, values readable
  - File outside sparse cone: expansion required (on-demand via `index_name_pos`)
- Test fails without the fix, passes with it
- All 498 t1300 (config) tests pass
- All 105 t1092 (sparse-checkout-compatibility) tests pass