### PR TITLE
Maintenance inception

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,6 +119,7 @@
 /git-name-rev
 /git-notes
 /git-p4
+/git-pack-aggregate
 /git-pack-redundant
 /git-pack-objects
 /git-pack-refs

--- a/Documentation/config/pack.adoc
+++ b/Documentation/config/pack.adoc
@@ -43,6 +43,10 @@ pack.aggregateMaxObjects::
 	Default for linkgit:git-pack-aggregate[1]'s `--max-objects`
 	option.  Defaults to `100000`; see that option for details.
 
+pack.aggregateMaxLooseObjects::
+	Default for linkgit:git-pack-aggregate[1]'s `--max-loose-objects`
+	option.  Defaults to `100000`; see that option for details.
+
 pack.island::
 	An extended regular expression configuring a set of delta
 	islands. See "DELTA ISLANDS" in linkgit:git-pack-objects[1]

--- a/Documentation/config/pack.adoc
+++ b/Documentation/config/pack.adoc
@@ -39,11 +39,14 @@ is set to "multi", reuse parts of just the bitmapped packfile. This
 can reduce memory and CPU usage to serve fetches, but might result in
 sending a slightly larger pack. Defaults to true.
 
+pack.aggregateMaxObjects::
+	Default for linkgit:git-pack-aggregate[1]'s `--max-objects`
+	option.  Defaults to `100000`; see that option for details.
+
 pack.island::
 	An extended regular expression configuring a set of delta
 	islands. See "DELTA ISLANDS" in linkgit:git-pack-objects[1]
 	for details.
-
 pack.islandCore::
 	Specify an island name which gets to have its objects be
 	packed first. This creates a kind of pseudo-pack at the front

--- a/Documentation/config/pack.adoc
+++ b/Documentation/config/pack.adoc
@@ -47,6 +47,10 @@ pack.aggregateMaxLooseObjects::
 	Default for linkgit:git-pack-aggregate[1]'s `--max-loose-objects`
 	option.  Defaults to `100000`; see that option for details.
 
+pack.aggregateMaxPacks::
+	Default for linkgit:git-pack-aggregate[1]'s `--max-packs`
+	option.  Defaults to `10000`; see that option for details.
+
 pack.island::
 	An extended regular expression configuring a set of delta
 	islands. See "DELTA ISLANDS" in linkgit:git-pack-objects[1]

--- a/Documentation/config/repack.adoc
+++ b/Documentation/config/repack.adoc
@@ -64,3 +64,13 @@ repack.midxNewLayerThreshold::
 When the tip layer has fewer packs than this threshold, those packs are
 excluded from the geometric repack entirely, and are thus left
 unmodified. Must be at least 1. Defaults to 8.
+
+repack.aggregate::
+	If set to true, linkgit:git-repack[1] will spawn a background
+	linkgit:git-pack-aggregate[1] for the duration of its main
+	pack-objects run.  The aggregator rolls up small packs and
+	loose objects that arrive after pack-objects has enumerated
+	its inputs, preventing them from accumulating in
+	`objects/pack/` and slowing other Git operations on busy
+	servers.  Defaults to false.  Can be overridden on the
+	command line with `--aggregate` or `--no-aggregate`.

--- a/Documentation/config/repack.adoc
+++ b/Documentation/config/repack.adoc
@@ -64,3 +64,11 @@ repack.midxNewLayerThreshold::
 When the tip layer has fewer packs than this threshold, those packs are
 excluded from the geometric repack entirely, and are thus left
 unmodified. Must be at least 1. Defaults to 8.
+
+repack.aggregateOnce::
+	If set to true, linkgit:git-repack[1] will run
+	linkgit:git-pack-aggregate[1] once before inspecting the packs
+	and loose objects to repack.  This can quickly reduce a large
+	number of files before the more thorough repack begins.
+	Defaults to false.  Can be overridden on the command line with
+	`--aggregate-once` or `--no-aggregate-once`.

--- a/Documentation/config/repack.adoc
+++ b/Documentation/config/repack.adoc
@@ -72,3 +72,13 @@ repack.aggregateOnce::
 	number of files before the more thorough repack begins.
 	Defaults to false.  Can be overridden on the command line with
 	`--aggregate-once` or `--no-aggregate-once`.
+
+repack.aggregateLoop::
+	If set to true, linkgit:git-repack[1] will spawn a background
+	linkgit:git-pack-aggregate[1] for the duration of its main
+	pack-objects run.  The aggregator rolls up small packs and
+	loose objects that arrive after pack-objects has enumerated
+	its inputs, preventing them from accumulating in
+	`objects/pack/` and slowing other Git operations on busy
+	servers.  Defaults to false.  Can be overridden on the
+	command line with `--aggregate-loop` or `--no-aggregate-loop`.

--- a/Documentation/git-pack-aggregate.adoc
+++ b/Documentation/git-pack-aggregate.adoc
@@ -1,0 +1,115 @@
+git-pack-aggregate(1)
+=====================
+
+NAME
+----
+git-pack-aggregate - Periodically roll up loose objects and small packs
+into a single pack without doing any delta compression or search
+
+SYNOPSIS
+--------
+[verse]
+'git pack-aggregate' (--once | --loop) [--interval=<seconds>]
+                   [--min-loose=<n>] [--min-packs=<n>]
+                   [--exclude-pack-file=<path>]
+                   [--exclude-loose-file=<path>]
+                   [--parent-pipe-fd=<n>]
+
+DESCRIPTION
+-----------
+
+`git pack-aggregate` watches `$GIT_DIR/objects` for loose objects and
+small packfiles that have accumulated since the last cycle, and
+periodically rolls them up into a single new pack.  Each cycle has two
+steps:
+
+1. Bundle local loose objects (minus any listed in
+   `--exclude-loose-file`) into a new pack and unlink the loose copies.
+2. Aggregate small local packs (minus any listed in
+   `--exclude-pack-file`, or those referenced by the multi-pack-index,
+   or those carrying a `.keep`, `.promisor`, `.mtimes`, or `.bitmap`
+   sidecar) into another new pack and unlink the source packs.  The
+   pack written in step 1 is naturally a candidate here and will
+   normally be folded into the step-2 output.
+
+No delta search is performed, no bitmaps or commit-graphs are updated,
+and no objects are recompressed; the existing on-disk representation
+of each object is copied through unchanged.  Both new packs are
+written with `pack-objects --window=0 --mark-bad-deltas`, so each one
+ships with a `.baddeltas` sidecar (see linkgit:gitformat-pack[5]).  A
+subsequent thorough repack (linkgit:git-repack[1]) honors that marker
+and reconsiders intra-pack deltas at that time.
+
+The purpose of this command is to keep `objects/` from accumulating
+large numbers of loose objects or small packs while a long-running
+repack is in flight, so unrelated `git` operations are not slowed down
+by readdir cost in a sprawling object directory.  Used together with
+`repack.aggregate` (see linkgit:git-repack[1]), `git repack` will spawn
+this command for the duration of its own work.
+
+`git pack-aggregate` takes no locks of its own.  It mirrors
+linkgit:git-repack[1] in this regard: callers that need serialization
+must arrange it themselves (for example by running under `git gc`).
+The exclusion files supplied via `--exclude-pack-file` and
+`--exclude-loose-file` are the only mechanism by which a concurrent
+`pack-objects` or `git repack` declares "do not touch these inputs".
+
+OPTIONS
+-------
+
+--once::
+	Run a single cycle and exit.  Exactly one of `--once` or
+	`--loop` is required.
+
+--loop::
+	Run cycles forever, sleeping `--interval` seconds between
+	cycles.  Stops on `SIGTERM`, `SIGHUP`, or `SIGINT`.
+
+--interval=<seconds>::
+	Number of seconds to sleep between the end of one cycle and the
+	start of the next.  Defaults to 60.  Only meaningful with
+	`--loop`.
+
+--min-loose=<n>::
+	Skip step 1 if fewer than `<n>` loose objects (after applying
+	`--exclude-loose-file`) are present.  Defaults to 5.
+
+--min-packs=<n>::
+	Skip step 2 if fewer than `<n>` aggregatable packs (after
+	applying all exclusions) are present.  Defaults to 5.
+
+--exclude-pack-file=<path>::
+	Read a list of pack basenames (one per line) from `<path>` and
+	never touch any of those packs.  Lines may name a basename with
+	or without a `.pack` or `.idx` suffix; the suffix is stripped.
+	Blank lines and lines beginning with `#` are ignored.  When
+	`git pack-aggregate` is spawned by a long-running `git repack`,
+	this file is populated by that `pack-objects` itself via
+	`--emit-input-packs`, and may contain a conservative superset
+	of the packs it will actually consume (such as in `--geometric`
+	mode).
+
+--exclude-loose-file=<path>::
+	Read a list of loose object IDs (one per line) from `<path>`
+	and never pack or unlink any of those loose objects.  Blank
+	lines and lines beginning with `#` are ignored.  When `git
+	pack-aggregate` is spawned by a long-running `git repack`, this
+	file is populated by that `pack-objects` itself via
+	`--emit-input-loose`.
+
+--parent-pipe-fd=<n>::
+	An inherited pipe file descriptor whose write end the parent
+	process holds open.  When the parent exits the pipe is closed
+	and `git pack-aggregate` exits at the next cycle boundary,
+	without waiting out the remainder of `--interval`.  This is an
+	internal plumbing option used by `git repack` to keep its
+	companion aggregator from outliving it.
+
+SEE ALSO
+--------
+linkgit:git-repack[1], linkgit:git-pack-objects[1],
+linkgit:gitformat-pack[5]
+
+GIT
+---
+Part of the linkgit:git[1] suite

--- a/Documentation/git-pack-aggregate.adoc
+++ b/Documentation/git-pack-aggregate.adoc
@@ -10,7 +10,7 @@ SYNOPSIS
 --------
 [verse]
 'git pack-aggregate' --once [--min-loose=<n>] [--min-packs=<n>]
-                   [--max-objects=<n>]
+                   [--max-loose-objects=<n>] [--max-objects=<n>]
 
 DESCRIPTION
 -----------
@@ -55,6 +55,17 @@ OPTIONS
 	Skip aggregation of small packfiles if fewer than `<n>` aggregatable
 	packs are present.
 	Defaults to 5.
+
+--max-loose-objects=<n>::
+	Pack at most `<n>` loose objects into each output pack.  Each pack
+	is installed and its loose copies are removed before the next
+	tranche begins, so repository performance can improve incrementally
+	during recovery from an extreme backlog.  Loose objects created
+	after the cycle starts are left for the next cycle.
+	If multiple tranches are needed, their output packs are left for a
+	later aggregation cycle instead of being copied again immediately.
+	Defaults to the `pack.aggregateMaxLooseObjects` configuration value,
+	or 100000 if that is unset.  A value of `0` disables the limit.
 
 --max-objects=<n>::
 	Skip any pack that contains more than `<n>` objects, leaving it

--- a/Documentation/git-pack-aggregate.adoc
+++ b/Documentation/git-pack-aggregate.adoc
@@ -10,6 +10,7 @@ SYNOPSIS
 --------
 [verse]
 'git pack-aggregate' --once [--min-loose=<n>] [--min-packs=<n>]
+                   [--max-objects=<n>]
 
 DESCRIPTION
 -----------
@@ -54,6 +55,19 @@ OPTIONS
 	Skip aggregation of small packfiles if fewer than `<n>` aggregatable
 	packs are present.
 	Defaults to 5.
+
+--max-objects=<n>::
+	Skip any pack that contains more than `<n>` objects, leaving it
+	untouched by step 2.  The object count is estimated cheaply from
+	the size of the pack's `.idx` file rather than by opening it.
+	This keeps `git pack-aggregate` focused on rolling up the small
+	packs it is meant for, instead of repacking a large base pack
+	(which would amount to a near-full repack).  Defaults to the
+	`pack.aggregateMaxObjects` configuration value, or 100000 if that
+	is unset.  A value of `0` disables the limit.  Note that packs
+	already referenced by the multi-pack-index are excluded
+	regardless of this setting, so on a normally-maintained
+	repository the large base pack is skipped anyway.
 
 SEE ALSO
 --------

--- a/Documentation/git-pack-aggregate.adoc
+++ b/Documentation/git-pack-aggregate.adoc
@@ -10,7 +10,8 @@ SYNOPSIS
 --------
 [verse]
 'git pack-aggregate' --once [--min-loose=<n>] [--min-packs=<n>]
-                   [--max-loose-objects=<n>] [--max-objects=<n>]
+                   [--max-loose-objects=<n>]
+                   [--max-objects=<n>] [--max-packs=<n>]
 
 DESCRIPTION
 -----------
@@ -80,6 +81,24 @@ OPTIONS
 	regardless of this setting, so on a normally-maintained
 	repository the large base pack is skipped anyway.
 
+--max-packs=<n>::
+	Fold at most `<n>` packs into each output pack.  When more than
+	`<n>` aggregatable packs are present, they are split into several
+	evenly-sized batches and each batch is rolled up into its own
+	output pack, rather than combining everything into a single pack.
+	This bounds how many packs any single `pack-objects` run (and any
+	later reader) must keep open at once, which matters on repositories
+	with such an extreme number of packs that per-process limits on
+	memory mappings or open files would otherwise be exceeded.  Note
+	that a pack in use costs roughly three such resources -- its
+	`.idx`, `.pack`, and `.rev` files -- so a batch of `<n>` packs
+	holds on the order of `3 * <n>` at peak; leave headroom below the
+	relevant limit when choosing `<n>`.  Splitting happens on whole-pack
+	boundaries, so each batch reuses the packs' existing deltas as-is
+	(a delta and its base always share a pack).  Defaults to the
+	`pack.aggregateMaxPacks` configuration value, or `10000` if that is
+	unset.  A value of `0` disables the limit and folds everything into
+	one pack.
 SEE ALSO
 --------
 linkgit:git-repack[1], linkgit:git-pack-objects[1],

--- a/Documentation/git-pack-aggregate.adoc
+++ b/Documentation/git-pack-aggregate.adoc
@@ -48,9 +48,9 @@ objects or small packs.  With `--loop`, it keeps new material under
 control while a long-running repack is in flight.  Both reduce the
 number of files that unrelated Git operations must scan, while leaving
 a later thorough linkgit:git-repack[1] to optimize deltas and pack
-layout.  The `repack.aggregateOnce` configuration variable (see
-linkgit:git-repack[1]) lets `git repack` request the one-shot cleanup
-before beginning that more expensive work.
+layout.  The `repack.aggregateOnce` and `repack.aggregateLoop`
+configuration variables (see linkgit:git-repack[1]) let `git repack`
+request either behavior independently.
 
 Like linkgit:git-repack[1], `git pack-aggregate` takes no locks of its
 own.  Callers that need serialization must arrange it themselves (for
@@ -58,6 +58,15 @@ example by running under `git gc`).
 The exclusion files supplied via `--exclude-pack-file` and
 `--exclude-loose-file` are the only mechanism by which a concurrent
 `pack-objects` or `git repack` declares "do not touch these inputs".
+When spawned by `git repack`, protection across the parent's MIDX update
+is layered: each aggregation cycle skips packs already named by the
+current MIDX and packs with protective sidecars; `--emit-input-packs`
+protects every local pack visible when the parent's `pack-objects`
+prepares its inputs; and temporary `.keep` files protect the parent's new
+packs before their indexes become visible and remain until after its MIDX
+write.  The parent's explicit MIDX include list is drawn from those
+protected existing and newly-written packs, so the aggregator cannot
+retire a pack that the parent is about to reference.
 
 OPTIONS
 -------

--- a/Documentation/git-pack-aggregate.adoc
+++ b/Documentation/git-pack-aggregate.adoc
@@ -1,0 +1,65 @@
+git-pack-aggregate(1)
+=====================
+
+NAME
+----
+git-pack-aggregate - Quickly roll up loose objects and small packs
+without doing any delta compression or search
+
+SYNOPSIS
+--------
+[verse]
+'git pack-aggregate' --once [--min-loose=<n>] [--min-packs=<n>]
+
+DESCRIPTION
+-----------
+
+`git pack-aggregate` rolls accumulated loose objects and small
+packfiles into a new pack in two steps:
+
+1. Bundle local loose objects into a new pack and unlink the loose copies.
+2. Aggregate small local packs (minus those referenced by the
+   multi-pack-index or carrying a `.keep`, `.promisor`, `.mtimes`, or
+   `.bitmap` sidecar) into another new pack and unlink the source packs.
+   The pack written in step 1 is naturally a candidate here and will
+   normally be folded into the step-2 output.
+
+No delta search is performed, no bitmaps or commit-graphs are updated,
+and no objects are recompressed; the existing on-disk representation
+of each object is copied through unchanged.  Both new packs are
+written with `pack-objects --window=0 --mark-bad-deltas`, so each one
+ships with a `.baddeltas` sidecar (see linkgit:gitformat-pack[5]).  A
+subsequent thorough repack (linkgit:git-repack[1]) honors that marker
+and reconsiders intra-pack deltas at that time.
+
+This command provides a quick recovery step for a repository that has
+accumulated many loose objects or small packs.  It reduces the number
+of files that unrelated `git` operations must scan, while leaving a
+later thorough linkgit:git-repack[1] to optimize deltas and pack layout.
+
+Like `git repack`, `git pack-aggregate` takes no locks of its own.  Do
+not run it concurrently with other pack-rewriting maintenance.
+
+OPTIONS
+-------
+
+--once::
+	Run one aggregation pass and exit.  This option is required.
+
+--min-loose=<n>::
+	Skip aggregation of loose objects if fewer than `<n>` are present.
+	Defaults to 5.
+
+--min-packs=<n>::
+	Skip aggregation of small packfiles if fewer than `<n>` aggregatable
+	packs are present.
+	Defaults to 5.
+
+SEE ALSO
+--------
+linkgit:git-repack[1], linkgit:git-pack-objects[1],
+linkgit:gitformat-pack[5]
+
+GIT
+---
+Part of the linkgit:git[1] suite

--- a/Documentation/git-pack-aggregate.adoc
+++ b/Documentation/git-pack-aggregate.adoc
@@ -38,6 +38,9 @@ This command provides a quick recovery step for a repository that has
 accumulated many loose objects or small packs.  It reduces the number
 of files that unrelated `git` operations must scan, while leaving a
 later thorough linkgit:git-repack[1] to optimize deltas and pack layout.
+The `repack.aggregateOnce` configuration variable (see
+linkgit:git-repack[1]) lets `git repack` request this cleanup before
+beginning that more expensive work.
 
 Like `git repack`, `git pack-aggregate` takes no locks of its own.  Do
 not run it concurrently with other pack-rewriting maintenance.

--- a/Documentation/git-pack-aggregate.adoc
+++ b/Documentation/git-pack-aggregate.adoc
@@ -9,21 +9,29 @@ without doing any delta compression or search
 SYNOPSIS
 --------
 [verse]
-'git pack-aggregate' --once [--min-loose=<n>] [--min-packs=<n>]
+'git pack-aggregate' (--once | --loop) [--interval=<seconds>]
+                   [--min-loose=<n>] [--min-packs=<n>]
                    [--max-loose-objects=<n>]
                    [--max-objects=<n>] [--max-packs=<n>]
+                   [--exclude-pack-file=<path>]
+                   [--exclude-loose-file=<path>]
+                   [--parent-pipe-fd=<n>]
 
 DESCRIPTION
 -----------
 
 `git pack-aggregate` rolls accumulated loose objects and small
-packfiles into a new pack in two steps:
+packfiles into new packs.  It can run one cycle as a quick recovery
+step, or run cycles periodically to keep new material under control
+while longer-running maintenance proceeds.  Each cycle has two steps:
 
-1. Bundle local loose objects into a new pack and unlink the loose copies.
-2. Aggregate small local packs (minus those referenced by the
-   multi-pack-index or carrying a `.keep`, `.promisor`, `.mtimes`, or
-   `.bitmap` sidecar) into another new pack and unlink the source packs.
-   The pack written in step 1 is naturally a candidate here and will
+1. Bundle local loose objects (minus any listed in
+   `--exclude-loose-file`) into a new pack and unlink the loose copies.
+2. Aggregate small local packs (minus any listed in
+   `--exclude-pack-file`, or those referenced by the multi-pack-index,
+   or those carrying a `.keep`, `.promisor`, `.mtimes`, or `.bitmap`
+   sidecar) into another new pack and unlink the source packs.  The
+   pack written in step 1 is naturally a candidate here and will
    normally be folded into the step-2 output.
 
 No delta search is performed, no bitmaps or commit-graphs are updated,
@@ -34,31 +42,74 @@ ships with a `.baddeltas` sidecar (see linkgit:gitformat-pack[5]).  A
 subsequent thorough repack (linkgit:git-repack[1]) honors that marker
 and reconsiders intra-pack deltas at that time.
 
-This command provides a quick recovery step for a repository that has
-accumulated many loose objects or small packs.  It reduces the number
-of files that unrelated `git` operations must scan, while leaving a
-later thorough linkgit:git-repack[1] to optimize deltas and pack layout.
-The `repack.aggregateOnce` configuration variable (see
-linkgit:git-repack[1]) lets `git repack` request this cleanup before
-beginning that more expensive work.
+This command serves two related purposes.  With `--once`, it provides a
+quick recovery step for a repository that has accumulated many loose
+objects or small packs.  With `--loop`, it keeps new material under
+control while a long-running repack is in flight.  Both reduce the
+number of files that unrelated Git operations must scan, while leaving
+a later thorough linkgit:git-repack[1] to optimize deltas and pack
+layout.  The `repack.aggregateOnce` configuration variable (see
+linkgit:git-repack[1]) lets `git repack` request the one-shot cleanup
+before beginning that more expensive work.
 
-Like `git repack`, `git pack-aggregate` takes no locks of its own.  Do
-not run it concurrently with other pack-rewriting maintenance.
+Like linkgit:git-repack[1], `git pack-aggregate` takes no locks of its
+own.  Callers that need serialization must arrange it themselves (for
+example by running under `git gc`).
+The exclusion files supplied via `--exclude-pack-file` and
+`--exclude-loose-file` are the only mechanism by which a concurrent
+`pack-objects` or `git repack` declares "do not touch these inputs".
 
 OPTIONS
 -------
 
 --once::
-	Run one aggregation pass and exit.  This option is required.
+	Run a single cycle and exit.  Exactly one of `--once` or
+	`--loop` is required.
+
+--loop::
+	Run cycles forever, sleeping `--interval` seconds between
+	cycles.  Stops on `SIGTERM`, `SIGHUP`, or `SIGINT`.
+
+--interval=<seconds>::
+	Number of seconds to sleep between the end of one cycle and the
+	start of the next.  Defaults to 60.  Only meaningful with
+	`--loop`.
 
 --min-loose=<n>::
-	Skip aggregation of loose objects if fewer than `<n>` are present.
-	Defaults to 5.
+	Skip aggregation of loose objects if fewer than `<n>` remain
+	after applying `--exclude-loose-file`.  Defaults to 5.
 
 --min-packs=<n>::
-	Skip aggregation of small packfiles if fewer than `<n>` aggregatable
-	packs are present.
-	Defaults to 5.
+	Skip aggregation of small packfiles if fewer than `<n>`
+	aggregatable packs remain after applying all exclusions.  Defaults
+	to 5.
+
+--exclude-pack-file=<path>::
+	Read a list of pack basenames (one per line) from `<path>` and
+	never touch any of those packs.  Lines may name a basename with
+	or without a `.pack` or `.idx` suffix; the suffix is stripped.
+	Blank lines and lines beginning with `#` are ignored.  When
+	`git pack-aggregate` is spawned by a long-running `git repack`,
+	this file is populated by that `pack-objects` itself via
+	`--emit-input-packs`, and may contain a conservative superset
+	of the packs it will actually consume (such as in `--geometric`
+	mode).
+
+--exclude-loose-file=<path>::
+	Read a list of loose object IDs (one per line) from `<path>`
+	and never pack or unlink any of those loose objects.  Blank
+	lines and lines beginning with `#` are ignored.  When `git
+	pack-aggregate` is spawned by a long-running `git repack`, this
+	file is populated by that `pack-objects` itself via
+	`--emit-input-loose`.
+
+--parent-pipe-fd=<n>::
+	An inherited pipe file descriptor whose write end the parent
+	process holds open.  When the parent exits the pipe is closed
+	and `git pack-aggregate` exits at the next cycle boundary,
+	without waiting out the remainder of `--interval`.  This is an
+	internal plumbing option used by `git repack` to keep its
+	companion aggregator from outliving it.
 
 --max-loose-objects=<n>::
 	Pack at most `<n>` loose objects into each output pack.  Each pack
@@ -102,6 +153,7 @@ OPTIONS
 	`pack.aggregateMaxPacks` configuration value, or `10000` if that is
 	unset.  A value of `0` disables the limit and folds everything into
 	one pack.
+
 SEE ALSO
 --------
 linkgit:git-repack[1], linkgit:git-pack-objects[1],

--- a/Documentation/git-pack-objects.adoc
+++ b/Documentation/git-pack-objects.adoc
@@ -143,6 +143,14 @@ options which imply `--revs`.
 	have an mtime older than `<approxidate>`. If unspecified (and
 	given `--cruft`), then no objects are eliminated.
 
+--mark-bad-deltas::
+	Write a `.baddeltas` marker file alongside each output pack.  The
+	marker signals that objects within the pack have not been fully
+	delta-searched against other objects within the same pack and
+	that future repacking should consider them.  Any deltas that do
+	exist within this pack can still be reused, however.
+	Incompatible with `--stdout`.
+
 --window=<n>::
 --depth=<n>::
 	These two options affect how the objects contained in

--- a/Documentation/git-pack-objects.adoc
+++ b/Documentation/git-pack-objects.adoc
@@ -254,6 +254,13 @@ depth is 4095.
 	wholesale enforcement of a different compression level on the
 	packed data is desired.
 
+--prefer-reused-deltas::
+	Only meaningful with `--stdin-packs`.  When the same object is
+	present as a base in one included pack and a delta in another,
+	record the delta copy rather than the base.  This costs a
+	cheap object-header read per duplicate, and has no effect
+	under `--no-reuse-delta`.
+
 --compression=<n>::
 	Specifies compression level for newly-compressed data in the
 	generated pack.  If not specified,  pack compression level is

--- a/Documentation/git-repack.adoc
+++ b/Documentation/git-repack.adoc
@@ -12,6 +12,7 @@ SYNOPSIS
 'git repack' [-a] [-A] [-d] [-f] [-F] [-l] [-n] [-q] [-b] [-m]
 	[--window=<n>] [--depth=<n>] [--threads=<n>] [--keep-pack=<pack-name>]
 	[--write-midx[=<mode>]] [--name-hash-version=<n>] [--path-walk]
+	[--[no-]aggregate]
 
 DESCRIPTION
 -----------
@@ -300,6 +301,16 @@ created for any new pack(s) without disturbing the existing chain.
 	Pass the `--path-walk` option to the underlying `git pack-objects`
 	process. See linkgit:git-pack-objects[1] for full details.
 
+--aggregate::
+--no-aggregate::
+	Spawn a background linkgit:git-pack-aggregate[1] for the
+	duration of the main pack-objects run.  The aggregator rolls
+	up small packs and loose objects that arrive after
+	pack-objects has enumerated its inputs, preventing them from
+	accumulating in `objects/pack/` and slowing other Git
+	operations on busy servers.  Overrides the
+	`repack.aggregate` configuration variable.  Off by default.
+
 CONFIGURATION
 -------------
 
@@ -324,6 +335,7 @@ SEE ALSO
 --------
 linkgit:git-pack-objects[1]
 linkgit:git-prune-packed[1]
+linkgit:git-pack-aggregate[1]
 
 GIT
 ---

--- a/Documentation/git-repack.adoc
+++ b/Documentation/git-repack.adoc
@@ -13,7 +13,7 @@ SYNOPSIS
 	[--window=<n>] [--depth=<n>] [--threads=<n>] [--keep-pack=<pack-name>]
 	[--write-midx[=<mode>]] [--name-hash-version=<n>] [--path-walk]
 	[--filter=<filter-spec>] [--drop-filtered [--dry-run]]
-	[--[no-]aggregate-once]
+	[--[no-]aggregate-once] [--[no-]aggregate-loop]
 
 DESCRIPTION
 -----------
@@ -346,6 +346,17 @@ created for any new pack(s) without disturbing the existing chain.
 	Overrides the `repack.aggregateOnce` configuration variable.
 	Off by default.
 
+--aggregate-loop::
+--no-aggregate-loop::
+	Spawn a background linkgit:git-pack-aggregate[1] for the
+	duration of the main pack-objects run.  The aggregator rolls
+	up small packs and loose objects that arrive after
+	pack-objects has enumerated its inputs, preventing them from
+	accumulating in `objects/pack/` and slowing other Git
+	operations on busy servers.  Overrides the
+	`repack.aggregateLoop` configuration variable.  Off by
+	default.
+
 CONFIGURATION
 -------------
 
@@ -370,6 +381,7 @@ SEE ALSO
 --------
 linkgit:git-pack-objects[1]
 linkgit:git-prune-packed[1]
+linkgit:git-pack-aggregate[1]
 
 GIT
 ---

--- a/Documentation/git-repack.adoc
+++ b/Documentation/git-repack.adoc
@@ -13,6 +13,7 @@ SYNOPSIS
 	[--window=<n>] [--depth=<n>] [--threads=<n>] [--keep-pack=<pack-name>]
 	[--write-midx[=<mode>]] [--name-hash-version=<n>] [--path-walk]
 	[--filter=<filter-spec>] [--drop-filtered [--dry-run]]
+	[--[no-]aggregate-once]
 
 DESCRIPTION
 -----------
@@ -336,6 +337,14 @@ created for any new pack(s) without disturbing the existing chain.
 --path-walk::
 	Pass the `--path-walk` option to the underlying `git pack-objects`
 	process. See linkgit:git-pack-objects[1] for full details.
+
+--aggregate-once::
+--no-aggregate-once::
+	Run linkgit:git-pack-aggregate[1] once before inspecting the
+	packs and loose objects to repack.  This can quickly reduce a
+	large number of files before the more thorough repack begins.
+	Overrides the `repack.aggregateOnce` configuration variable.
+	Off by default.
 
 CONFIGURATION
 -------------

--- a/Documentation/gitformat-pack.adoc
+++ b/Documentation/gitformat-pack.adoc
@@ -12,6 +12,7 @@ SYNOPSIS
 $GIT_DIR/objects/pack/pack-*.{pack,idx}
 $GIT_DIR/objects/pack/pack-*.rev
 $GIT_DIR/objects/pack/pack-*.mtimes
+$GIT_DIR/objects/pack/pack-*.baddeltas
 $GIT_DIR/objects/pack/multi-pack-index
 
 DESCRIPTION
@@ -356,6 +357,32 @@ All 4-byte numbers are in network byte order.
   - A trailer, containing a checksum of the corresponding packfile,
     and a checksum of all of the above (each having length according
     to the specified hash function).
+
+== pack-*.baddeltas files
+
+The optional `.baddeltas` file is an empty marker sitting alongside a
+`pack-*.pack` (and its `.idx`).  It signals to `git pack-objects` that
+the delta layout of the pack should not be trusted: even when two
+objects appear together in the same pack and neither is stored as a
+delta, the next packing run should still call out to its delta search
+routine for the pair instead of assuming a prior pack-objects already
+considered (and rejected) the pair.
+
+This is intended for producers that intentionally skip delta search
+when writing a pack (for example, processes that bulk-import objects
+or aggregate multiple existing packs without recomputing deltas).
+Without this marker, the same-pack delta skip in `git pack-objects`
+would silently inherit those producers' lack of delta search into
+future repacks.
+
+The contents of the file are currently ignored.  Producers should
+write an empty file; consumers must tolerate (and ignore) any
+content.
+
+The marker only affects whether `git pack-objects` will attempt to
+compute new deltas for object pairs that share the marked pack.  It
+does not disable reuse of existing on-disk deltas, nor does it affect
+multi-pack-index, bitmap, or pack reuse for transfer.
 
 == multi-pack-index (MIDX) files have the following format:
 

--- a/Documentation/meson.build
+++ b/Documentation/meson.build
@@ -99,6 +99,7 @@ manpages = {
   'git-name-rev.adoc' : 1,
   'git-notes.adoc' : 1,
   'git-p4.adoc' : 1,
+  'git-pack-aggregate.adoc' : 1,
   'git-pack-objects.adoc' : 1,
   'git-pack-refs.adoc' : 1,
   'git-patch-id.adoc' : 1,

--- a/Makefile
+++ b/Makefile
@@ -1450,6 +1450,7 @@ BUILTIN_OBJS += builtin/multi-pack-index.o
 BUILTIN_OBJS += builtin/mv.o
 BUILTIN_OBJS += builtin/name-rev.o
 BUILTIN_OBJS += builtin/notes.o
+BUILTIN_OBJS += builtin/pack-aggregate.o
 BUILTIN_OBJS += builtin/pack-objects.o
 ifndef WITH_BREAKING_CHANGES
 BUILTIN_OBJS += builtin/pack-redundant.o

--- a/Makefile
+++ b/Makefile
@@ -1465,6 +1465,7 @@ BUILTIN_OBJS += builtin/multi-pack-index.o
 BUILTIN_OBJS += builtin/mv.o
 BUILTIN_OBJS += builtin/name-rev.o
 BUILTIN_OBJS += builtin/notes.o
+BUILTIN_OBJS += builtin/pack-aggregate.o
 BUILTIN_OBJS += builtin/pack-objects.o
 ifndef WITH_BREAKING_CHANGES
 BUILTIN_OBJS += builtin/pack-redundant.o

--- a/builtin.h
+++ b/builtin.h
@@ -224,6 +224,7 @@ int cmd_multi_pack_index(int argc, const char **argv, const char *prefix, struct
 int cmd_mv(int argc, const char **argv, const char *prefix, struct repository *repo);
 int cmd_name_rev(int argc, const char **argv, const char *prefix, struct repository *repo);
 int cmd_notes(int argc, const char **argv, const char *prefix, struct repository *repo);
+int cmd_pack_aggregate(int argc, const char **argv, const char *prefix, struct repository *repo);
 int cmd_pack_objects(int argc, const char **argv, const char *prefix, struct repository *repo);
 int cmd_pack_redundant(int argc, const char **argv, const char *prefix, struct repository *repo);
 int cmd_patch_id(int argc, const char **argv, const char *prefix, struct repository *repo);

--- a/builtin/cat-file.c
+++ b/builtin/cat-file.c
@@ -1008,10 +1008,10 @@ static int batch_one_object_oi(const struct object_id *oid,
 	return payload->callback(oid, NULL, 0, payload->payload);
 }
 
-static void batch_each_object(struct batch_options *opt,
-			      for_each_object_fn callback,
-			      unsigned flags,
-			      void *_payload)
+static int batch_each_object(struct batch_options *opt,
+			     for_each_object_fn callback,
+			     unsigned flags,
+			     void *_payload)
 {
 	struct for_each_object_payload payload = {
 		.callback = callback,
@@ -1026,8 +1026,8 @@ static void batch_each_object(struct batch_options *opt,
 		.filter = &opt->objects_filter,
 	};
 
-	odb_for_each_object_ext(the_repository->objects, &oi,
-				batch_one_object_oi, &payload, &opts);
+	return odb_for_each_object_ext(the_repository->objects, &oi,
+				       batch_one_object_oi, &payload, &opts);
 }
 
 static int batch_objects(struct batch_options *opt)
@@ -1084,20 +1084,24 @@ static int batch_objects(struct batch_options *opt)
 
 			cb.seen = &seen;
 
-			batch_each_object(opt, batch_unordered_object,
-					  ODB_FOR_EACH_OBJECT_PACK_ORDER, &cb);
+			retval = batch_each_object(opt, batch_unordered_object,
+						   ODB_FOR_EACH_OBJECT_PACK_ORDER, &cb);
 
 			oidset_clear(&seen);
 		} else {
 			struct oid_array sa = OID_ARRAY_INIT;
 
-			batch_each_object(opt, collect_object, 0, &sa);
+			retval = batch_each_object(opt, collect_object, 0, &sa);
 			oid_array_for_each_unique(&sa, batch_object_cb, &cb);
 
 			oid_array_clear(&sa);
 		}
 
 		strbuf_release(&output);
+		if (retval)
+			return error(_("object enumeration ended early; "
+				       "a pack may have been removed by "
+				       "concurrent repacking"));
 		return 0;
 	}
 

--- a/builtin/cat-file.c
+++ b/builtin/cat-file.c
@@ -1017,6 +1017,21 @@ static int batch_one_object_oi(const struct object_id *oid,
 	return payload->callback(oid, NULL, 0, payload->payload);
 }
 
+/*
+ * Open every pack index up front so the enumeration's object set is
+ * fixed: an index mmap survives unlink() of the .idx and pack fd
+ * pressure (close_one_pack() closes only the pack fd).  This narrows
+ * the race with concurrent repacks, like f6b262581a88 (fsck: snapshot
+ * default refs before object walk, 2026-01-09).
+ */
+static void snapshot_pack_indexes(void)
+{
+	struct packed_git *p;
+
+	repo_for_each_pack(the_repository, p)
+		open_pack_index(p);
+}
+
 static int batch_each_object(struct batch_options *opt,
 			     for_each_object_fn callback,
 			     unsigned flags,
@@ -1083,6 +1098,8 @@ static int batch_objects(struct batch_options *opt)
 			warning("This repository uses promisor remotes. Some objects may not be loaded.");
 
 		disable_replace_refs();
+
+		snapshot_pack_indexes();
 
 		cb.opt = opt;
 		cb.expand = &data;

--- a/builtin/cat-file.c
+++ b/builtin/cat-file.c
@@ -543,6 +543,15 @@ static void batch_object_write(const char *obj_name,
 		if (opt->objects_filter.choice == LOFC_BLOB_LIMIT)
 			data->info.sizep = &data->size;
 
+		/*
+		 * With "--batch-all-objects --unordered" we read straight
+		 * from the pack the walk handed us.  If a concurrent repack
+		 * removed it, fall back to a normal lookup; is_pack_valid()
+		 * pins the pack's fd, so a passing check stays valid even if
+		 * the pack is unlinked right after.
+		 */
+		if (pack && !is_pack_valid(pack))
+			pack = NULL;
 		if (pack)
 			ret = packed_object_info(NULL, pack, offset, &data->info);
 		else

--- a/builtin/fsck.c
+++ b/builtin/fsck.c
@@ -937,7 +937,13 @@ static int check_pack_rev_indexes(struct repository *r, int show_progress)
 		int load_error = load_pack_revindex_from_disk(p);
 
 		if (load_error < 0) {
-			error(_("unable to load rev-index for pack '%s'"), p->pack_name);
+			if (access(p->pack_name, F_OK) < 0 && errno == ENOENT)
+				error(_("pack '%s' disappeared while fsck was "
+					"running; retry after concurrent "
+					"maintenance completes"), p->pack_name);
+			else
+				error(_("unable to load rev-index for pack '%s'"),
+				      p->pack_name);
 			res = ERROR_PACK_REV_INDEX;
 		} else if (!load_error &&
 			   !load_pack_revindex(r, p) &&

--- a/builtin/pack-aggregate.c
+++ b/builtin/pack-aggregate.c
@@ -1,0 +1,636 @@
+#define USE_THE_REPOSITORY_VARIABLE
+
+#include "builtin.h"
+#include "gettext.h"
+#include "hash.h"
+#include "hex.h"
+#include "midx.h"
+#include "object-file.h"
+#include "odb.h"
+#include "oid-array.h"
+#include "packfile.h"
+#include "parse-options.h"
+#include "path.h"
+#include "repository.h"
+#include "run-command.h"
+#include "sigchain.h"
+#include "strbuf.h"
+#include "string-list.h"
+#include "strmap.h"
+#include "strvec.h"
+#include "wrapper.h"
+
+static const char *const pack_aggregate_usage[] = {
+	N_("git pack-aggregate (--once | --loop) [--interval=<seconds>]\n"
+	   "                  [--min-loose=<n>] [--min-packs=<n>]\n"
+	   "                  [--exclude-pack-file=<path>]\n"
+	   "                  [--exclude-loose-file=<path>]\n"
+	   "                  [--parent-pipe-fd=<n>]"),
+	NULL
+};
+
+static volatile sig_atomic_t stop_signaled;
+static volatile sig_atomic_t active_child_pid;
+static int parent_pipe_fd = -1;
+
+static void term_handler(int sig)
+{
+	stop_signaled = 1;
+	/*
+	 * Best-effort forward to an in-flight pack-objects so it
+	 * doesn't keep running after we have been asked to stop.
+	 * The check-and-signal is racy with finish_command() in the
+	 * main thread; the worst case is signaling a pid we no longer
+	 * own (kill() returns ESRCH and we ignore it).
+	 */
+	if (active_child_pid > 0)
+		kill(active_child_pid, sig);
+}
+
+static int is_hex(const char *s, size_t len)
+{
+	while (len--)
+		if (!isxdigit(*s++))
+			return 0;
+	return 1;
+}
+
+static int looks_like_pack_basename(const char *name, size_t hexsz)
+{
+	static const char prefix[] = "pack-";
+	size_t plen = strlen(prefix);
+	size_t nlen = strlen(name);
+
+	/* Does this look like "pack-<hex>" with no extension? */
+	if (nlen != plen + hexsz || strncmp(name, prefix, plen))
+		return 0;
+	return is_hex(name + plen, hexsz);
+}
+
+static int has_sidecar(const char *packdir, const char *basename,
+		       const char *ext)
+{
+	struct strbuf buf = STRBUF_INIT;
+	struct stat st;
+	int ret;
+
+	strbuf_addf(&buf, "%s/%s.%s", packdir, basename, ext);
+	ret = !lstat(buf.buf, &st);
+	strbuf_release(&buf);
+	return ret;
+}
+
+static int has_protective_sidecar(const char *packdir, const char *basename)
+{
+	/*
+	 * Ignore packs with sidecars that mean "don't touch me". .baddeltas
+	 * is intentionally absent: rolling those up is the point.
+	 */
+	static const char *exts[] = {
+		"keep", "promisor", "mtimes", "bitmap", NULL
+	};
+	int i;
+
+	for (i = 0; exts[i]; i++)
+		if (has_sidecar(packdir, basename, exts[i]))
+			return 1;
+	return 0;
+}
+
+static int has_idx(const char *packdir, const char *basename)
+{
+	return has_sidecar(packdir, basename, "idx");
+}
+
+static void load_exclusions_from_file(const char *path, struct strset *set)
+{
+	FILE *fp;
+	struct strbuf line = STRBUF_INIT;
+
+	fp = fopen(path, "r");
+	if (!fp)
+		die_errno(_("could not open exclude file '%s'"), path);
+
+	while (strbuf_getline_lf(&line, fp) != EOF) {
+		strbuf_trim(&line);
+		if (!line.len || line.buf[0] == '#')
+			continue;
+		strbuf_strip_suffix(&line, ".pack");
+		strbuf_strip_suffix(&line, ".idx");
+		strset_add(set, line.buf);
+	}
+	strbuf_release(&line);
+	fclose(fp);
+}
+
+/*
+ * Re-read the multi-pack-index (and any incremental layers) and
+ * populate `set` with the basenames of every referenced pack.  The
+ * strset is cleared first so this is safe to call once per cycle.
+ */
+static int refresh_midx_exclusions(struct repository *repo,
+				   struct strset *set)
+{
+	struct multi_pack_index *m;
+	int had_midx = 0;
+
+	strset_clear(set);
+
+	odb_reprepare(repo->objects);
+	m = get_multi_pack_index(repo->objects->sources);
+	for (; m; m = m->base_midx) {
+		uint32_t i;
+		had_midx = 1;
+		for (i = 0; i < m->num_packs; i++) {
+			struct strbuf base = STRBUF_INIT;
+			strbuf_addstr(&base, m->pack_names[i]);
+			strbuf_strip_suffix(&base, ".idx");
+			strbuf_strip_suffix(&base, ".pack");
+			strset_add(set, base.buf);
+			strbuf_release(&base);
+		}
+	}
+	return had_midx;
+}
+
+/* ---------- loose-object pre-pass ---------- */
+
+struct loose_scan {
+	struct strset *exclude;
+	struct oid_array *oids;
+	struct string_list *paths;
+};
+
+static int loose_scan_cb(const struct object_id *oid, const char *path,
+			 void *cb_data)
+{
+	struct loose_scan *data = cb_data;
+
+	if (strset_contains(data->exclude, oid_to_hex(oid)))
+		return 0;
+	oid_array_append(data->oids, oid);
+	string_list_append(data->paths, path);
+	return 0;
+}
+
+static int run_pack_objects_loose(const char *packtmp, struct oid_array *oids,
+				  struct strbuf *out_hash)
+{
+	struct child_process cmd = CHILD_PROCESS_INIT;
+	struct strbuf line = STRBUF_INIT;
+	FILE *in, *out;
+	size_t i;
+	int ret;
+
+	strvec_pushl(&cmd.args,
+		     "pack-objects",
+		     "--window=0",
+		     "--mark-bad-deltas",
+		     "--delta-base-offset",
+		     "--no-write-bitmap-index",
+		     "--quiet",
+		     packtmp,
+		     NULL);
+	cmd.git_cmd = 1;
+	cmd.in = -1;
+	cmd.out = -1;
+
+	if (start_command(&cmd))
+		return -1;
+	active_child_pid = cmd.pid;
+
+	/*
+	 * The order is "write all stdin, then read all stdout".  This
+	 * is only safe because --quiet bounds pack-objects's stdout to
+	 * a single short pack-hash line, which fits in the pipe buffer;
+	 * pack-objects can therefore drain its stdin without blocking
+	 * on stdout writes back to us.
+	 */
+	in = xfdopen(cmd.in, "w");
+	for (i = 0; i < oids->nr; i++)
+		fprintf(in, "%s\n", oid_to_hex(&oids->oid[i]));
+	if (fclose(in))
+		warning_errno(_("could not close pack-objects input"));
+
+	/*
+	 * Capture the first line as the pack hash, then drain to EOF so
+	 * pack-objects observes a clean close on its stdout and we never
+	 * end up in finish_command() with bytes left in the pipe.
+	 */
+	out = xfdopen(cmd.out, "r");
+	while (strbuf_getline_lf(&line, out) != EOF) {
+		if (!out_hash->len)
+			strbuf_addbuf(out_hash, &line);
+	}
+	fclose(out);
+
+	ret = finish_command(&cmd);
+	active_child_pid = 0;
+	strbuf_release(&line);
+	return ret;
+}
+
+static void unlink_loose_paths(const struct string_list *paths)
+{
+	size_t i;
+
+	for (i = 0; i < paths->nr; i++) {
+		const char *p = paths->items[i].string;
+		if (unlink(p) < 0 && errno != ENOENT)
+			warning_errno(_("could not unlink loose object '%s'"),
+				      p);
+	}
+}
+
+/* ---------- pack aggregation ---------- */
+
+struct pack_scan {
+	const char *packdir;
+	struct strset *file_exclude;
+	struct strset *midx_exclude;
+	struct string_list *candidates;
+	size_t hexsz;
+};
+
+static void pack_scan_cb(const char *full_path UNUSED,
+			 size_t full_path_len UNUSED,
+			 const char *file_name, void *cb_data)
+{
+	struct pack_scan *data = cb_data;
+	struct strbuf base = STRBUF_INIT;
+
+	if (!ends_with(file_name, ".pack"))
+		return;
+	strbuf_addstr(&base, file_name);
+	strbuf_setlen(&base, base.len - strlen(".pack"));
+
+	if (!looks_like_pack_basename(base.buf, data->hexsz))
+		goto out;
+	if (strset_contains(data->file_exclude, base.buf))
+		goto out;
+	if (strset_contains(data->midx_exclude, base.buf))
+		goto out;
+	if (has_protective_sidecar(data->packdir, base.buf))
+		goto out;
+	if (!has_idx(data->packdir, base.buf))
+		goto out;
+
+	string_list_append(data->candidates, base.buf);
+out:
+	strbuf_release(&base);
+}
+
+static int run_pack_objects_packs(const char *packtmp,
+				  const struct string_list *bases,
+				  struct strbuf *out_hash)
+{
+	struct child_process cmd = CHILD_PROCESS_INIT;
+	struct strbuf line = STRBUF_INIT;
+	FILE *in, *out;
+	size_t i;
+	int ret;
+
+	strvec_pushl(&cmd.args,
+		     "pack-objects",
+		     "--stdin-packs",
+		     "--window=0",
+		     "--mark-bad-deltas",
+		     "--delta-base-offset",
+		     "--no-write-bitmap-index",
+		     "--quiet",
+		     packtmp,
+		     NULL);
+	cmd.git_cmd = 1;
+	cmd.in = -1;
+	cmd.out = -1;
+
+	if (start_command(&cmd))
+		return -1;
+	active_child_pid = cmd.pid;
+
+	/* See run_pack_objects_loose() for why write-then-read is safe. */
+	in = xfdopen(cmd.in, "w");
+	for (i = 0; i < bases->nr; i++)
+		fprintf(in, "%s.pack\n", bases->items[i].string);
+	if (fclose(in))
+		warning_errno(_("could not close pack-objects input"));
+
+	out = xfdopen(cmd.out, "r");
+	while (strbuf_getline_lf(&line, out) != EOF) {
+		if (!out_hash->len)
+			strbuf_addbuf(out_hash, &line);
+	}
+	fclose(out);
+
+	ret = finish_command(&cmd);
+	active_child_pid = 0;
+	strbuf_release(&line);
+	return ret;
+}
+
+/*
+ * pack-objects writes its output as <packtmp>-<hash>.<ext>; rename it
+ * into place as <packdir>/pack-<hash>.<ext>.  .idx is renamed last so
+ * a concurrent reader scanning the pack directory never sees a .idx
+ * without its companion .pack.
+ */
+static void install_pack(const char *packtmp, const char *packdir,
+			 const char *hash)
+{
+	static const char *exts[] = {
+		".pack", ".rev", ".baddeltas", ".idx"
+	};
+	size_t i;
+
+	for (i = 0; i < ARRAY_SIZE(exts); i++) {
+		struct strbuf src = STRBUF_INIT;
+		struct strbuf dst = STRBUF_INIT;
+		struct stat st;
+
+		strbuf_addf(&src, "%s-%s%s", packtmp, hash, exts[i]);
+		strbuf_addf(&dst, "%s/pack-%s%s", packdir, hash, exts[i]);
+
+		if (!stat(src.buf, &st)) {
+			if (chmod(src.buf, st.st_mode & ~(S_IWUSR | S_IWGRP | S_IWOTH)))
+				warning_errno(_("could not make '%s' read-only"),
+					      src.buf);
+			if (rename(src.buf, dst.buf))
+				die_errno(_("renaming '%s' to '%s' failed"),
+					  src.buf, dst.buf);
+		} else if (errno != ENOENT) {
+			die_errno(_("could not stat '%s'"), src.buf);
+		}
+		strbuf_release(&src);
+		strbuf_release(&dst);
+	}
+}
+
+static void unlink_consumed_packs(const char *packdir,
+				  const struct string_list *bases,
+				  const char *keep_basename)
+{
+	static const char *exts[] = {
+		"pack", "idx", "rev", "baddeltas", NULL
+	};
+	size_t i;
+
+	for (i = 0; i < bases->nr; i++) {
+		const char *base = bases->items[i].string;
+		int j;
+
+		/*
+		 * Recheck protective sidecars: a .keep (or similar) may
+		 * have appeared between scan and now, in which case the
+		 * pack must stay.
+		 */
+		if (has_protective_sidecar(packdir, base))
+			continue;
+		/*
+		 * Never unlink the pack we just installed.  Aggregating
+		 * packs whose union equals one of the inputs (e.g. one
+		 * input is a strict superset of the others) can yield a
+		 * byte-identical output, which lands at the same final
+		 * name as that input.  In that case, we do not want the
+		 * file serving as both input and output to be deleted.
+		 */
+		if (keep_basename && !strcmp(base, keep_basename))
+			continue;
+
+		for (j = 0; exts[j]; j++) {
+			struct strbuf fname = STRBUF_INIT;
+			strbuf_addf(&fname, "%s/%s.%s", packdir, base,
+				    exts[j]);
+			if (unlink(fname.buf) < 0 && errno != ENOENT)
+				warning_errno(_("could not unlink '%s'"),
+					      fname.buf);
+			strbuf_release(&fname);
+		}
+	}
+}
+
+static int do_one_cycle(struct repository *repo, const char *packdir,
+			struct strset *pack_exclude,
+			struct strset *loose_exclude,
+			struct strset *midx_exclude,
+			int min_loose, int min_packs)
+{
+	struct oid_array loose_oids = OID_ARRAY_INIT;
+	struct string_list loose_paths = STRING_LIST_INIT_DUP;
+	struct loose_scan loose_data = {
+		.exclude = loose_exclude,
+		.oids = &loose_oids,
+		.paths = &loose_paths,
+	};
+	struct string_list candidates = STRING_LIST_INIT_DUP;
+	struct pack_scan pack_data = {
+		.packdir = packdir,
+		.file_exclude = pack_exclude,
+		.midx_exclude = midx_exclude,
+		.candidates = &candidates,
+		.hexsz = repo->hash_algo->hexsz,
+	};
+	struct strbuf loose_hash = STRBUF_INIT;
+	struct strbuf packs_hash = STRBUF_INIT;
+	char *packtmp_loose = NULL;
+	char *packtmp_packs = NULL;
+	int ret = 0;
+
+	/*
+	 * Step 1: bundle local loose objects (minus excluded ones) into
+	 * a single new pack and remove the on-disk loose copies.  The
+	 * resulting pack picks up a .baddeltas marker thanks to
+	 * --mark-bad-deltas, and is in turn a candidate for the pack
+	 * aggregation step below.
+	 */
+	for_each_loose_file_in_source(repo->objects->sources,
+				      loose_scan_cb, NULL, NULL, &loose_data);
+	if ((int)loose_oids.nr >= min_loose && !stop_signaled) {
+		packtmp_loose = mkpathdup("%s/.tmp-%d-loose-pack",
+					  packdir, (int)getpid());
+		if (run_pack_objects_loose(packtmp_loose, &loose_oids,
+					   &loose_hash)) {
+			ret = error(_("pack-objects failed during "
+				      "loose-object rollup"));
+			goto out;
+		}
+		if (loose_hash.len) {
+			install_pack(packtmp_loose, packdir, loose_hash.buf);
+			unlink_loose_paths(&loose_paths);
+		}
+	}
+
+	if (stop_signaled)
+		goto out;
+
+	/*
+	 * Step 2: aggregate small packs into a single bigger pack.  The
+	 * freshly-installed loose-rollup pack from step 1 is picked up
+	 * naturally by the directory scan below (it has no protective
+	 * sidecars and isn't in any exclusion set).  Re-read the MIDX
+	 * just before scanning so a pack added to a MIDX between cycles
+	 * is honored.
+	 */
+	refresh_midx_exclusions(repo, midx_exclude);
+	for_each_file_in_pack_dir(repo_get_object_directory(repo),
+				  pack_scan_cb, &pack_data);
+
+	if ((int)candidates.nr < min_packs)
+		goto out;
+
+	packtmp_packs = mkpathdup("%s/.tmp-%d-pack",
+				  packdir, (int)getpid());
+	if (run_pack_objects_packs(packtmp_packs, &candidates,
+				   &packs_hash)) {
+		ret = error(_("pack-objects failed during "
+			      "pack aggregation"));
+		goto out;
+	}
+	if (packs_hash.len) {
+		struct strbuf output_base = STRBUF_INIT;
+		install_pack(packtmp_packs, packdir, packs_hash.buf);
+		strbuf_addf(&output_base, "pack-%s", packs_hash.buf);
+		unlink_consumed_packs(packdir, &candidates, output_base.buf);
+		strbuf_release(&output_base);
+	}
+
+out:
+	free(packtmp_loose);
+	free(packtmp_packs);
+	strbuf_release(&loose_hash);
+	strbuf_release(&packs_hash);
+	string_list_clear(&candidates, 0);
+	oid_array_clear(&loose_oids);
+	string_list_clear(&loose_paths, 0);
+	return ret;
+}
+
+static void interruptible_sleep(unsigned int seconds)
+{
+	struct pollfd pfd;
+	int timeout_ms;
+
+	if (stop_signaled)
+		return;
+
+	if (parent_pipe_fd < 0) {
+		unsigned int remaining = seconds;
+		while (remaining > 0 && !stop_signaled)
+			remaining = sleep(remaining);
+		return;
+	}
+
+	/*
+	 * Watch the parent pipe so we wake immediately if the process
+	 * that spawned us exits.  POLLHUP is reported in revents
+	 * regardless of whether it appears in events, so we leave
+	 * events==0; any of POLLHUP/POLLERR/POLLNVAL/POLLIN means the
+	 * other end of the pipe is gone and we should stop.
+	 */
+	pfd.fd = parent_pipe_fd;
+	pfd.events = 0;
+	timeout_ms = (seconds > INT_MAX / 1000) ? INT_MAX
+					       : (int)(seconds * 1000);
+
+	while (!stop_signaled) {
+		int ret;
+		pfd.revents = 0;
+		ret = poll(&pfd, 1, timeout_ms);
+		if (ret < 0) {
+			if (errno == EINTR)
+				continue;
+			break;
+		}
+		if (ret == 0)
+			break;
+		if (pfd.revents & (POLLHUP | POLLERR | POLLNVAL | POLLIN)) {
+			stop_signaled = 1;
+			break;
+		}
+	}
+}
+
+int cmd_pack_aggregate(int argc, const char **argv,
+		       const char *prefix, struct repository *repo)
+{
+	const char *exclude_pack_file = NULL;
+	const char *exclude_loose_file = NULL;
+	int interval = 60;
+	int min_packs = 5;
+	int min_loose = 5;
+	int once = 0;
+	int loop = 0;
+	struct option options[] = {
+		OPT_BOOL(0, "once", &once,
+			 N_("run a single cycle and exit")),
+		OPT_BOOL(0, "loop", &loop,
+			 N_("loop forever, sleeping --interval seconds "
+			    "between cycles")),
+		OPT_INTEGER(0, "interval", &interval,
+			    N_("seconds to sleep between cycles "
+			       "(default 60)")),
+		OPT_INTEGER(0, "min-loose", &min_loose,
+			    N_("skip loose-object rollup if fewer "
+			       "candidates (default 5)")),
+		OPT_INTEGER(0, "min-packs", &min_packs,
+			    N_("skip pack aggregation if fewer "
+			       "candidates (default 5)")),
+		OPT_STRING(0, "exclude-pack-file", &exclude_pack_file,
+			   N_("file"),
+			   N_("file listing pack basenames never to "
+			      "touch")),
+		OPT_STRING(0, "exclude-loose-file", &exclude_loose_file,
+			   N_("file"),
+			   N_("file listing loose object OIDs never to "
+			      "touch")),
+		OPT_INTEGER(0, "parent-pipe-fd", &parent_pipe_fd,
+			    N_("inherited fd of a pipe whose write end "
+			       "the parent holds; EOF triggers exit")),
+		OPT_END(),
+	};
+	struct strset pack_exclude = STRSET_INIT;
+	struct strset loose_exclude = STRSET_INIT;
+	struct strset midx_exclude = STRSET_INIT;
+	char *packdir;
+	int ret = 0;
+
+	argc = parse_options(argc, argv, prefix, options,
+			     pack_aggregate_usage, 0);
+	if (argc > 0)
+		usage_with_options(pack_aggregate_usage, options);
+	if (once == loop)
+		die(_("exactly one of --once or --loop is required"));
+	if (interval < 1)
+		die(_("--interval must be at least 1"));
+	if (min_loose < 1)
+		die(_("--min-loose must be at least 1"));
+	if (min_packs < 1)
+		die(_("--min-packs must be at least 1"));
+
+	packdir = mkpathdup("%s/pack", repo_get_object_directory(repo));
+
+	if (exclude_pack_file)
+		load_exclusions_from_file(exclude_pack_file, &pack_exclude);
+	if (exclude_loose_file)
+		load_exclusions_from_file(exclude_loose_file, &loose_exclude);
+
+	sigchain_push(SIGTERM, term_handler);
+	sigchain_push(SIGHUP, term_handler);
+	sigchain_push(SIGINT, term_handler);
+
+	do {
+		if (stop_signaled)
+			break;
+		ret = do_one_cycle(repo, packdir, &pack_exclude,
+				   &loose_exclude, &midx_exclude,
+				   min_loose, min_packs);
+		if (ret || once || stop_signaled)
+			break;
+		interruptible_sleep((unsigned int)interval);
+	} while (!stop_signaled);
+
+	strset_clear(&pack_exclude);
+	strset_clear(&loose_exclude);
+	strset_clear(&midx_exclude);
+	free(packdir);
+	return ret ? 1 : 0;
+}

--- a/builtin/pack-aggregate.c
+++ b/builtin/pack-aggregate.c
@@ -23,9 +23,12 @@
 
 static const char *const pack_aggregate_usage[] = {
 	N_("git pack-aggregate --once [--min-loose=<n>] [--min-packs=<n>]\n"
+	   "                         [--max-loose-objects=<n>]\n"
 	   "                         [--max-objects=<n>]"),
 	NULL
 };
+
+#define DEFAULT_MAX_LOOSE_OBJECTS 100000
 
 #define DEFAULT_MAX_OBJECTS 100000
 
@@ -148,17 +151,60 @@ struct loose_scan {
 	struct strset *exclude;
 	struct oid_array *oids;
 	struct string_list *paths;
+	size_t limit;
+	size_t minimum;
+	size_t eligible;
+	time_t cutoff_sec;
+	unsigned int cutoff_nsec;
 };
+
+static void set_loose_scan_cutoff(struct repository *repo,
+				  struct loose_scan *data)
+{
+	struct strbuf template = STRBUF_INIT;
+	struct tempfile *marker;
+	struct stat st;
+
+	strbuf_addf(&template, "%s/.tmp-pack-aggregate-cutoff-XXXXXX",
+		    repo_get_object_directory(repo));
+	marker = xmks_tempfile(template.buf);
+	strbuf_release(&template);
+
+	if (fstat(get_tempfile_fd(marker), &st))
+		die_errno(_("could not stat loose-object cutoff marker"));
+	data->cutoff_sec = st.st_mtime;
+	data->cutoff_nsec = ST_MTIME_NSEC(st);
+	delete_tempfile(&marker);
+}
 
 static int loose_scan_cb(const struct object_id *oid, const char *path,
 			 void *cb_data)
 {
 	struct loose_scan *data = cb_data;
+	struct stat st;
 
 	if (strset_contains(data->exclude, oid_to_hex(oid)))
 		return 0;
-	oid_array_append(data->oids, oid);
-	string_list_append(data->paths, path);
+	if (lstat(path, &st)) {
+		if (errno != ENOENT)
+			warning_errno(_("could not stat loose object '%s'"),
+				      path);
+		return 0;
+	}
+	if (st.st_mtime > data->cutoff_sec ||
+	    (st.st_mtime == data->cutoff_sec &&
+	     ST_MTIME_NSEC(st) >= data->cutoff_nsec))
+		return 0;
+
+	data->eligible++;
+	if (!data->limit || data->oids->nr < data->limit) {
+		oid_array_append(data->oids, oid);
+		string_list_append(data->paths, path);
+	}
+
+	if (data->limit && data->oids->nr >= data->limit &&
+	    data->eligible >= data->minimum)
+		return 1;
 	return 0;
 }
 
@@ -230,6 +276,7 @@ static void unlink_loose_paths(const struct string_list *paths)
 static void collect_pack_candidates(struct repository *repo,
 				    const char *packdir,
 				    struct strset *file_exclude,
+				    struct strset *cycle_exclude,
 				    struct strset *midx_exclude,
 				    struct string_list *candidates,
 				    off_t max_idx_size)
@@ -248,6 +295,8 @@ static void collect_pack_candidates(struct repository *repo,
 			continue;
 
 		if (strset_contains(file_exclude, base.buf))
+			continue;
+		if (strset_contains(cycle_exclude, base.buf))
 			continue;
 		if (strset_contains(midx_exclude, base.buf))
 			continue;
@@ -385,7 +434,8 @@ static int run_aggregation(struct repository *repo, const char *packdir,
 			   struct strset *pack_exclude,
 			   struct strset *loose_exclude,
 			   struct strset *midx_exclude,
-			   int min_loose, int min_packs, int max_objects)
+			   int min_loose, int min_packs,
+			   int max_loose_objects, int max_objects)
 {
 	struct oid_array loose_oids = OID_ARRAY_INIT;
 	struct string_list loose_paths = STRING_LIST_INIT_DUP;
@@ -393,8 +443,12 @@ static int run_aggregation(struct repository *repo, const char *packdir,
 		.exclude = loose_exclude,
 		.oids = &loose_oids,
 		.paths = &loose_paths,
+		.limit = max_loose_objects,
+		.minimum = min_loose,
 	};
+	struct strset loose_rollup_exclude = STRSET_INIT;
 	struct string_list candidates = STRING_LIST_INIT_DUP;
+	struct strbuf first_loose_rollup = STRBUF_INIT;
 	struct strbuf loose_hash = STRBUF_INIT;
 	struct strbuf packs_hash = STRBUF_INIT;
 	char *packtmp_loose = NULL;
@@ -403,23 +457,30 @@ static int run_aggregation(struct repository *repo, const char *packdir,
 
 	/*
 	 * Step 1: bundle local loose objects (minus excluded ones) into
-	 * a single new pack and remove the on-disk loose copies.  The
-	 * resulting pack picks up a .baddeltas marker thanks to
-	 * --mark-bad-deltas, and is in turn a candidate for the pack
-	 * aggregation step below.
+	 * bounded packs and remove the on-disk loose copies after each
+	 * pack is installed.  Ignore objects newer than the cycle-start
+	 * timestamp so concurrent writers cannot keep this cycle running
+	 * indefinitely.
 	 */
+	set_loose_scan_cutoff(repo, &loose_data);
 	for_each_loose_file_in_source(repo->objects->sources,
 				      loose_scan_cb, NULL, NULL, &loose_data);
-	if ((int)loose_oids.nr >= min_loose) {
+	if (loose_data.eligible >= (size_t)min_loose) {
+		size_t loose_pack_count = 0;
+
 		packtmp_loose = mkpathdup("%s/.tmp-%d-loose-pack",
 					  packdir, (int)getpid());
-		if (run_pack_objects_loose(packtmp_loose, &loose_oids,
-					   &loose_hash)) {
-			ret = error(_("pack-objects failed during "
-				      "loose-object rollup"));
-			goto out;
-		}
-		if (loose_hash.len) {
+		while (loose_oids.nr) {
+			strbuf_reset(&loose_hash);
+			if (run_pack_objects_loose(packtmp_loose, &loose_oids,
+						   &loose_hash)) {
+				ret = error(_("pack-objects failed during "
+					      "loose-object rollup"));
+				goto out;
+			}
+			if (!loose_hash.len)
+				break;
+
 			if (loose_hash.len != repo->hash_algo->hexsz) {
 				ret = error(_("pack-objects returned an invalid "
 					      "pack hash"));
@@ -431,20 +492,44 @@ static int run_aggregation(struct repository *repo, const char *packdir,
 				goto out;
 			}
 			unlink_loose_paths(&loose_paths);
+			loose_pack_count++;
+			if (loose_pack_count == 1) {
+				strbuf_addf(&first_loose_rollup, "pack-%s",
+					    loose_hash.buf);
+			} else {
+				struct strbuf base = STRBUF_INIT;
+
+				if (loose_pack_count == 2)
+					strset_add(&loose_rollup_exclude,
+						   first_loose_rollup.buf);
+				strbuf_addf(&base, "pack-%s", loose_hash.buf);
+				strset_add(&loose_rollup_exclude, base.buf);
+				strbuf_release(&base);
+			}
+
+			oid_array_clear(&loose_oids);
+			string_list_clear(&loose_paths, 0);
+
+			/* Once rollup starts, also consume a final partial tranche. */
+			loose_data.minimum = 1;
+			loose_data.eligible = 0;
+			for_each_loose_file_in_source(repo->objects->sources,
+						      loose_scan_cb, NULL, NULL,
+						      &loose_data);
 		}
 	}
 
 	/*
-	 * Step 2: aggregate small packs into a single bigger pack.  The
-	 * freshly-installed loose-rollup pack from step 1 is picked up
-	 * naturally by the directory scan below (it has no protective
-	 * sidecars and isn't in any exclusion set).  Re-read the MIDX
-	 * just before scanning so a pack added to a MIDX between cycles
-	 * is honored.
+	 * Step 2: aggregate small packs into a single bigger pack.  A
+	 * single loose-rollup pack is picked up naturally below.  When
+	 * step 1 needed multiple tranches, leave those outputs alone this
+	 * cycle rather than immediately copying the entire backlog again.
+	 * Re-read the MIDX just before scanning so a pack added to a MIDX
+	 * between cycles is honored.
 	 */
 	refresh_midx_exclusions(repo, midx_exclude);
-	collect_pack_candidates(repo, packdir, pack_exclude, midx_exclude,
-				&candidates,
+	collect_pack_candidates(repo, packdir, pack_exclude,
+				&loose_rollup_exclude, midx_exclude, &candidates,
 				max_objects_to_idx_size(repo->hash_algo,
 							max_objects));
 
@@ -480,8 +565,10 @@ static int run_aggregation(struct repository *repo, const char *packdir,
 out:
 	free(packtmp_loose);
 	free(packtmp_packs);
+	strbuf_release(&first_loose_rollup);
 	strbuf_release(&loose_hash);
 	strbuf_release(&packs_hash);
+	strset_clear(&loose_rollup_exclude);
 	string_list_clear(&candidates, 0);
 	oid_array_clear(&loose_oids);
 	string_list_clear(&loose_paths, 0);
@@ -493,6 +580,7 @@ int cmd_pack_aggregate(int argc, const char **argv,
 {
 	int min_packs = 5;
 	int min_loose = 5;
+	int max_loose_objects = -1;
 	int max_objects = -1;
 	int once = 0;
 	struct option options[] = {
@@ -504,6 +592,9 @@ int cmd_pack_aggregate(int argc, const char **argv,
 		OPT_INTEGER(0, "min-packs", &min_packs,
 			    N_("skip pack aggregation if fewer "
 			       "candidates (default 5)")),
+		OPT_INTEGER(0, "max-loose-objects", &max_loose_objects,
+			    N_("pack at most this many loose objects into "
+			       "each output pack (0 for no limit)")),
 		OPT_INTEGER(0, "max-objects", &max_objects,
 			    N_("skip packs with more than this many "
 			       "objects (0 for no limit)")),
@@ -526,6 +617,13 @@ int cmd_pack_aggregate(int argc, const char **argv,
 	if (min_packs < 1)
 		die(_("--min-packs must be at least 1"));
 
+	if (max_loose_objects < 0 &&
+	    repo_config_get_int(repo, "pack.aggregatemaxlooseobjects",
+				&max_loose_objects))
+		max_loose_objects = DEFAULT_MAX_LOOSE_OBJECTS;
+	if (max_loose_objects < 0)
+		die(_("pack.aggregateMaxLooseObjects cannot be negative"));
+
 	if (max_objects < 0 &&
 	    repo_config_get_int(repo, "pack.aggregatemaxobjects", &max_objects))
 		max_objects = DEFAULT_MAX_OBJECTS;
@@ -536,7 +634,8 @@ int cmd_pack_aggregate(int argc, const char **argv,
 
 	ret = run_aggregation(repo, packdir, &pack_exclude,
 			      &loose_exclude, &midx_exclude,
-			      min_loose, min_packs, max_objects);
+			      min_loose, min_packs,
+			      max_loose_objects, max_objects);
 
 	strset_clear(&pack_exclude);
 	strset_clear(&loose_exclude);

--- a/builtin/pack-aggregate.c
+++ b/builtin/pack-aggregate.c
@@ -20,6 +20,7 @@
 #include "strmap.h"
 #include "strvec.h"
 #include "tempfile.h"
+#include "trace2.h"
 #include "wrapper.h"
 
 static const char *const pack_aggregate_usage[] = {
@@ -738,6 +739,7 @@ int cmd_pack_aggregate(int argc, const char **argv,
 	int max_packs = -1;
 	int once = 0;
 	int loop = 0;
+	uintmax_t cycle_count = 0;
 	struct option options[] = {
 		OPT_BOOL(0, "once", &once,
 			 N_("run a single cycle and exit")),
@@ -827,11 +829,15 @@ int cmd_pack_aggregate(int argc, const char **argv,
 	do {
 		if (stop_signaled)
 			break;
+		trace2_region_enter("pack-aggregate", "cycle", repo);
 		ret = do_one_cycle(repo, packdir, &pack_exclude,
 				   &loose_exclude, &midx_exclude,
 				   min_loose, min_packs,
 				   max_loose_objects, max_objects,
 				   max_packs);
+		trace2_data_intmax("pack-aggregate", repo, "cycle-num",
+				   ++cycle_count);
+		trace2_region_leave("pack-aggregate", "cycle", repo);
 		if (ret || once || stop_signaled)
 			break;
 		interruptible_sleep((unsigned int)interval);

--- a/builtin/pack-aggregate.c
+++ b/builtin/pack-aggregate.c
@@ -309,6 +309,25 @@ static void unlink_loose_paths(const struct string_list *paths)
 
 /* ---------- pack aggregation ---------- */
 
+/*
+ * True only for a durably installed "pack-<hash>" basename.  This
+ * rejects an in-flight ".tmp-<pid>-pack-<hash>" staging file written by
+ * a concurrent repack or pack-aggregate, which the object-store scan
+ * (matching any "*.idx") would otherwise surface as a candidate.
+ */
+static int is_canonical_pack_base(const char *base)
+{
+	const char *hex;
+	size_t i, hexsz = the_hash_algo->hexsz;
+
+	if (!skip_prefix(base, "pack-", &hex))
+		return 0;
+	for (i = 0; i < hexsz; i++)
+		if (!isxdigit(hex[i]))
+			return 0;
+	return hex[hexsz] == '\0';
+}
+
 static void collect_pack_candidates(struct repository *repo,
 				    const char *packdir,
 				    struct strset *file_exclude,
@@ -328,6 +347,9 @@ static void collect_pack_candidates(struct repository *repo,
 		strbuf_reset(&base);
 		strbuf_addstr(&base, pack_basename(p));
 		if (!strbuf_strip_suffix(&base, ".pack"))
+			continue;
+
+		if (!is_canonical_pack_base(base.buf))
 			continue;
 
 		if (strset_contains(file_exclude, base.buf))

--- a/builtin/pack-aggregate.c
+++ b/builtin/pack-aggregate.c
@@ -14,6 +14,7 @@
 #include "path.h"
 #include "repository.h"
 #include "run-command.h"
+#include "sigchain.h"
 #include "strbuf.h"
 #include "string-list.h"
 #include "strmap.h"
@@ -22,9 +23,13 @@
 #include "wrapper.h"
 
 static const char *const pack_aggregate_usage[] = {
-	N_("git pack-aggregate --once [--min-loose=<n>] [--min-packs=<n>]\n"
-	   "                         [--max-loose-objects=<n>]\n"
-	   "                         [--max-objects=<n>] [--max-packs=<n>]"),
+	N_("git pack-aggregate (--once | --loop) [--interval=<seconds>]\n"
+	   "                  [--min-loose=<n>] [--min-packs=<n>]\n"
+	   "                  [--max-loose-objects=<n>]\n"
+	   "                  [--max-objects=<n>] [--max-packs=<n>]\n"
+	   "                  [--exclude-pack-file=<path>]\n"
+	   "                  [--exclude-loose-file=<path>]\n"
+	   "                  [--parent-pipe-fd=<n>]"),
 	NULL
 };
 
@@ -33,6 +38,14 @@ static const char *const pack_aggregate_usage[] = {
 #define DEFAULT_MAX_OBJECTS 100000
 
 #define DEFAULT_MAX_PACKS 10000
+
+static volatile sig_atomic_t stop_signaled;
+static int parent_pipe_fd = -1;
+
+static void term_handler(int sig UNUSED)
+{
+	stop_signaled = 1;
+}
 
 static int has_sidecar(const char *packdir, const char *basename,
 		       const char *ext)
@@ -112,6 +125,27 @@ static off_t max_objects_to_idx_size(const struct git_hash_algo *algo,
 	if (!max_objects)
 		return 0;
 	return 8 + 1024 + 2 * rawsz + (rawsz + 8) * (off_t)max_objects;
+}
+
+static void load_exclusions_from_file(const char *path, struct strset *set)
+{
+	FILE *fp;
+	struct strbuf line = STRBUF_INIT;
+
+	fp = fopen(path, "r");
+	if (!fp)
+		die_errno(_("could not open exclude file '%s'"), path);
+
+	while (strbuf_getline_lf(&line, fp) != EOF) {
+		strbuf_trim(&line);
+		if (!line.len || line.buf[0] == '#')
+			continue;
+		strbuf_strip_suffix(&line, ".pack");
+		strbuf_strip_suffix(&line, ".idx");
+		strset_add(set, line.buf);
+	}
+	strbuf_release(&line);
+	fclose(fp);
 }
 
 /*
@@ -434,13 +468,13 @@ static void unlink_consumed_packs(const char *packdir,
 	}
 }
 
-static int run_aggregation(struct repository *repo, const char *packdir,
-			   struct strset *pack_exclude,
-			   struct strset *loose_exclude,
-			   struct strset *midx_exclude,
-			   int min_loose, int min_packs,
-			   int max_loose_objects, int max_objects,
-			   int max_packs)
+static int do_one_cycle(struct repository *repo, const char *packdir,
+			struct strset *pack_exclude,
+			struct strset *loose_exclude,
+			struct strset *midx_exclude,
+			int min_loose, int min_packs,
+			int max_loose_objects, int max_objects,
+			int max_packs)
 {
 	struct oid_array loose_oids = OID_ARRAY_INIT;
 	struct string_list loose_paths = STRING_LIST_INIT_DUP;
@@ -469,12 +503,12 @@ static int run_aggregation(struct repository *repo, const char *packdir,
 	set_loose_scan_cutoff(repo, &loose_data);
 	for_each_loose_file_in_source(repo->objects->sources,
 				      loose_scan_cb, NULL, NULL, &loose_data);
-	if (loose_data.eligible >= (size_t)min_loose) {
+	if (loose_data.eligible >= (size_t)min_loose && !stop_signaled) {
 		size_t loose_pack_count = 0;
 
 		packtmp_loose = mkpathdup("%s/.tmp-%d-loose-pack",
 					  packdir, (int)getpid());
-		while (loose_oids.nr) {
+		while (loose_oids.nr && !stop_signaled) {
 			strbuf_reset(&loose_hash);
 			if (run_pack_objects_loose(packtmp_loose, &loose_oids,
 						   &loose_hash)) {
@@ -513,6 +547,8 @@ static int run_aggregation(struct repository *repo, const char *packdir,
 
 			oid_array_clear(&loose_oids);
 			string_list_clear(&loose_paths, 0);
+			if (stop_signaled)
+				break;
 
 			/* Once rollup starts, also consume a final partial tranche. */
 			loose_data.minimum = 1;
@@ -522,6 +558,9 @@ static int run_aggregation(struct repository *repo, const char *packdir,
 						      &loose_data);
 		}
 	}
+
+	if (stop_signaled)
+		goto out;
 
 	/*
 	 * Step 2: aggregate small packs into one or more output packs.  A
@@ -564,7 +603,8 @@ static int run_aggregation(struct repository *repo, const char *packdir,
 			batch_size = DIV_ROUND_UP(total, num_batches);
 		}
 
-		for (start = 0; start < total; start += batch_size) {
+		for (start = 0; start < total && !stop_signaled;
+		     start += batch_size) {
 			size_t count = batch_size;
 			struct strbuf batch_hash = STRBUF_INIT;
 
@@ -618,18 +658,73 @@ out:
 	return ret;
 }
 
+static void interruptible_sleep(unsigned int seconds)
+{
+	struct pollfd pfd;
+	int timeout_ms;
+
+	if (stop_signaled)
+		return;
+
+	if (parent_pipe_fd < 0) {
+		unsigned int remaining = seconds;
+		while (remaining > 0 && !stop_signaled)
+			remaining = sleep(remaining);
+		return;
+	}
+
+	/*
+	 * Watch the parent pipe so we wake immediately if the process
+	 * that spawned us exits.  POLLHUP is reported in revents
+	 * regardless of whether it appears in events, so we leave
+	 * events==0; any of POLLHUP/POLLERR/POLLNVAL/POLLIN means the
+	 * other end of the pipe is gone and we should stop.
+	 */
+	pfd.fd = parent_pipe_fd;
+	pfd.events = 0;
+	timeout_ms = (seconds > INT_MAX / 1000) ? INT_MAX
+					       : (int)(seconds * 1000);
+
+	while (!stop_signaled) {
+		int ret;
+		pfd.revents = 0;
+		ret = poll(&pfd, 1, timeout_ms);
+		if (ret < 0) {
+			if (errno == EINTR)
+				continue;
+			break;
+		}
+		if (ret == 0)
+			break;
+		if (pfd.revents & (POLLHUP | POLLERR | POLLNVAL | POLLIN)) {
+			stop_signaled = 1;
+			break;
+		}
+	}
+}
+
 int cmd_pack_aggregate(int argc, const char **argv,
 		       const char *prefix, struct repository *repo)
 {
+	const char *exclude_pack_file = NULL;
+	const char *exclude_loose_file = NULL;
+	int interval = 60;
 	int min_packs = 5;
 	int min_loose = 5;
 	int max_loose_objects = -1;
 	int max_objects = -1;
 	int max_packs = -1;
 	int once = 0;
+	int loop = 0;
 	struct option options[] = {
 		OPT_BOOL(0, "once", &once,
 			 N_("run a single cycle and exit")),
+		OPT_BOOL(0, "loop", &loop,
+			 N_("loop forever, sleeping --interval seconds "
+			    "between cycles")),
+		OPT_INTEGER(0, "interval", &interval,
+			    N_("seconds to sleep between cycles "
+			       "(default 60)")),
 		OPT_INTEGER(0, "min-loose", &min_loose,
 			    N_("skip loose-object rollup if fewer "
 			       "candidates (default 5)")),
@@ -645,6 +740,17 @@ int cmd_pack_aggregate(int argc, const char **argv,
 		OPT_INTEGER(0, "max-packs", &max_packs,
 			    N_("aggregate at most this many packs into "
 			       "each output pack (0 for no limit)")),
+		OPT_STRING(0, "exclude-pack-file", &exclude_pack_file,
+			   N_("file"),
+			   N_("file listing pack basenames never to "
+			      "touch")),
+		OPT_STRING(0, "exclude-loose-file", &exclude_loose_file,
+			   N_("file"),
+			   N_("file listing loose object OIDs never to "
+			      "touch")),
+		OPT_INTEGER(0, "parent-pipe-fd", &parent_pipe_fd,
+			    N_("inherited fd of a pipe whose write end "
+			       "the parent holds; EOF triggers exit")),
 		OPT_END(),
 	};
 	struct strset pack_exclude = STRSET_INIT;
@@ -657,8 +763,10 @@ int cmd_pack_aggregate(int argc, const char **argv,
 			     pack_aggregate_usage, 0);
 	if (argc > 0)
 		usage_with_options(pack_aggregate_usage, options);
-	if (!once)
-		die(_("--once is required"));
+	if (once == loop)
+		die(_("exactly one of --once or --loop is required"));
+	if (interval < 1)
+		die(_("--interval must be at least 1"));
 	if (min_loose < 1)
 		die(_("--min-loose must be at least 1"));
 	if (min_packs < 1)
@@ -685,10 +793,27 @@ int cmd_pack_aggregate(int argc, const char **argv,
 
 	packdir = mkpathdup("%s/pack", repo_get_object_directory(repo));
 
-	ret = run_aggregation(repo, packdir, &pack_exclude,
-			      &loose_exclude, &midx_exclude,
-			      min_loose, min_packs,
-			      max_loose_objects, max_objects, max_packs);
+	if (exclude_pack_file)
+		load_exclusions_from_file(exclude_pack_file, &pack_exclude);
+	if (exclude_loose_file)
+		load_exclusions_from_file(exclude_loose_file, &loose_exclude);
+
+	sigchain_push(SIGTERM, term_handler);
+	sigchain_push(SIGHUP, term_handler);
+	sigchain_push(SIGINT, term_handler);
+
+	do {
+		if (stop_signaled)
+			break;
+		ret = do_one_cycle(repo, packdir, &pack_exclude,
+				   &loose_exclude, &midx_exclude,
+				   min_loose, min_packs,
+				   max_loose_objects, max_objects,
+				   max_packs);
+		if (ret || once || stop_signaled)
+			break;
+		interruptible_sleep((unsigned int)interval);
+	} while (!stop_signaled);
 
 	strset_clear(&pack_exclude);
 	strset_clear(&loose_exclude);

--- a/builtin/pack-aggregate.c
+++ b/builtin/pack-aggregate.c
@@ -24,13 +24,15 @@
 static const char *const pack_aggregate_usage[] = {
 	N_("git pack-aggregate --once [--min-loose=<n>] [--min-packs=<n>]\n"
 	   "                         [--max-loose-objects=<n>]\n"
-	   "                         [--max-objects=<n>]"),
+	   "                         [--max-objects=<n>] [--max-packs=<n>]"),
 	NULL
 };
 
 #define DEFAULT_MAX_LOOSE_OBJECTS 100000
 
 #define DEFAULT_MAX_OBJECTS 100000
+
+#define DEFAULT_MAX_PACKS 10000
 
 static int has_sidecar(const char *packdir, const char *basename,
 		       const char *ext)
@@ -315,13 +317,14 @@ static void collect_pack_candidates(struct repository *repo,
 
 static int run_pack_objects_packs(const char *packtmp,
 				  const struct string_list *bases,
+				  size_t begin, size_t count,
 				  struct strbuf *out_hash)
 {
 	struct strbuf input = STRBUF_INIT;
 	size_t i;
 	int ret;
 
-	for (i = 0; i < bases->nr; i++)
+	for (i = begin; i < begin + count; i++)
 		strbuf_addf(&input, "%s.pack\n", bases->items[i].string);
 	ret = run_pack_objects(packtmp, 1, &input, out_hash);
 	strbuf_release(&input);
@@ -389,6 +392,7 @@ cleanup:
 
 static void unlink_consumed_packs(const char *packdir,
 				  const struct string_list *bases,
+				  size_t begin, size_t count,
 				  const char *keep_basename)
 {
 	static const char *exts[] = {
@@ -396,7 +400,7 @@ static void unlink_consumed_packs(const char *packdir,
 	};
 	size_t i;
 
-	for (i = 0; i < bases->nr; i++) {
+	for (i = begin; i < begin + count; i++) {
 		const char *base = bases->items[i].string;
 		int j;
 
@@ -435,7 +439,8 @@ static int run_aggregation(struct repository *repo, const char *packdir,
 			   struct strset *loose_exclude,
 			   struct strset *midx_exclude,
 			   int min_loose, int min_packs,
-			   int max_loose_objects, int max_objects)
+			   int max_loose_objects, int max_objects,
+			   int max_packs)
 {
 	struct oid_array loose_oids = OID_ARRAY_INIT;
 	struct string_list loose_paths = STRING_LIST_INIT_DUP;
@@ -450,7 +455,6 @@ static int run_aggregation(struct repository *repo, const char *packdir,
 	struct string_list candidates = STRING_LIST_INIT_DUP;
 	struct strbuf first_loose_rollup = STRBUF_INIT;
 	struct strbuf loose_hash = STRBUF_INIT;
-	struct strbuf packs_hash = STRBUF_INIT;
 	char *packtmp_loose = NULL;
 	char *packtmp_packs = NULL;
 	int ret = 0;
@@ -520,7 +524,7 @@ static int run_aggregation(struct repository *repo, const char *packdir,
 	}
 
 	/*
-	 * Step 2: aggregate small packs into a single bigger pack.  A
+	 * Step 2: aggregate small packs into one or more output packs.  A
 	 * single loose-rollup pack is picked up naturally below.  When
 	 * step 1 needed multiple tranches, leave those outputs alone this
 	 * cycle rather than immediately copying the entire backlog again.
@@ -538,28 +542,68 @@ static int run_aggregation(struct repository *repo, const char *packdir,
 
 	packtmp_packs = mkpathdup("%s/.tmp-%d-pack",
 				  packdir, (int)getpid());
-	if (run_pack_objects_packs(packtmp_packs, &candidates,
-				   &packs_hash)) {
-		ret = error(_("pack-objects failed during "
-			      "pack aggregation"));
-		goto out;
-	}
-	if (packs_hash.len) {
-		struct strbuf output_base = STRBUF_INIT;
 
-		if (packs_hash.len != repo->hash_algo->hexsz) {
-			ret = error(_("pack-objects returned an invalid pack hash"));
-			strbuf_release(&output_base);
-			goto out;
+	/*
+	 * Split the candidates into evenly-sized batches of at most
+	 * max_packs and roll each batch up into its own output pack (see
+	 * --max-packs).  Splitting on whole-pack boundaries lets each
+	 * batch reuse the packs' existing deltas as-is: on-disk packs are
+	 * self-contained, so a delta and its base never land in different
+	 * batches.  Size batches as ceil(total / ceil(total / max_packs))
+	 * to avoid a tiny trailing batch; max_packs == 0 means one batch
+	 * holding everything.
+	 */
+	{
+		size_t total = candidates.nr;
+		size_t batch_size = total;
+		size_t start;
+
+		if (max_packs > 0 && total > (size_t)max_packs) {
+			size_t num_batches = DIV_ROUND_UP(total,
+							  (size_t)max_packs);
+			batch_size = DIV_ROUND_UP(total, num_batches);
 		}
-		if (install_pack(repo, packtmp_packs, packdir, packs_hash.buf)) {
-			ret = -1;
-			strbuf_release(&output_base);
-			goto out;
+
+		for (start = 0; start < total; start += batch_size) {
+			size_t count = batch_size;
+			struct strbuf batch_hash = STRBUF_INIT;
+
+			if (start + count > total)
+				count = total - start;
+
+			if (run_pack_objects_packs(packtmp_packs, &candidates,
+						   start, count, &batch_hash)) {
+				ret = error(_("pack-objects failed during "
+					      "pack aggregation"));
+				strbuf_release(&batch_hash);
+				goto out;
+			}
+			if (batch_hash.len) {
+				struct strbuf output_base = STRBUF_INIT;
+
+				if (batch_hash.len != repo->hash_algo->hexsz) {
+					ret = error(_("pack-objects returned an "
+						      "invalid pack hash"));
+					strbuf_release(&batch_hash);
+					strbuf_release(&output_base);
+					goto out;
+				}
+				if (install_pack(repo, packtmp_packs, packdir,
+						 batch_hash.buf)) {
+					ret = -1;
+					strbuf_release(&batch_hash);
+					strbuf_release(&output_base);
+					goto out;
+				}
+				strbuf_addf(&output_base, "pack-%s",
+					    batch_hash.buf);
+				unlink_consumed_packs(packdir, &candidates,
+						      start, count,
+						      output_base.buf);
+				strbuf_release(&output_base);
+			}
+			strbuf_release(&batch_hash);
 		}
-		strbuf_addf(&output_base, "pack-%s", packs_hash.buf);
-		unlink_consumed_packs(packdir, &candidates, output_base.buf);
-		strbuf_release(&output_base);
 	}
 
 out:
@@ -567,7 +611,6 @@ out:
 	free(packtmp_packs);
 	strbuf_release(&first_loose_rollup);
 	strbuf_release(&loose_hash);
-	strbuf_release(&packs_hash);
 	strset_clear(&loose_rollup_exclude);
 	string_list_clear(&candidates, 0);
 	oid_array_clear(&loose_oids);
@@ -582,6 +625,7 @@ int cmd_pack_aggregate(int argc, const char **argv,
 	int min_loose = 5;
 	int max_loose_objects = -1;
 	int max_objects = -1;
+	int max_packs = -1;
 	int once = 0;
 	struct option options[] = {
 		OPT_BOOL(0, "once", &once,
@@ -598,6 +642,9 @@ int cmd_pack_aggregate(int argc, const char **argv,
 		OPT_INTEGER(0, "max-objects", &max_objects,
 			    N_("skip packs with more than this many "
 			       "objects (0 for no limit)")),
+		OPT_INTEGER(0, "max-packs", &max_packs,
+			    N_("aggregate at most this many packs into "
+			       "each output pack (0 for no limit)")),
 		OPT_END(),
 	};
 	struct strset pack_exclude = STRSET_INIT;
@@ -630,12 +677,18 @@ int cmd_pack_aggregate(int argc, const char **argv,
 	if (max_objects < 0)
 		die(_("pack.aggregateMaxObjects cannot be negative"));
 
+	if (max_packs < 0 &&
+	    repo_config_get_int(repo, "pack.aggregatemaxpacks", &max_packs))
+		max_packs = DEFAULT_MAX_PACKS;
+	if (max_packs < 0)
+		die(_("pack.aggregateMaxPacks cannot be negative"));
+
 	packdir = mkpathdup("%s/pack", repo_get_object_directory(repo));
 
 	ret = run_aggregation(repo, packdir, &pack_exclude,
 			      &loose_exclude, &midx_exclude,
 			      min_loose, min_packs,
-			      max_loose_objects, max_objects);
+			      max_loose_objects, max_objects, max_packs);
 
 	strset_clear(&pack_exclude);
 	strset_clear(&loose_exclude);

--- a/builtin/pack-aggregate.c
+++ b/builtin/pack-aggregate.c
@@ -1,6 +1,7 @@
 #define USE_THE_REPOSITORY_VARIABLE
 
 #include "builtin.h"
+#include "config.h"
 #include "gettext.h"
 #include "hash.h"
 #include "hex.h"
@@ -21,9 +22,12 @@
 #include "wrapper.h"
 
 static const char *const pack_aggregate_usage[] = {
-	N_("git pack-aggregate --once [--min-loose=<n>] [--min-packs=<n>]"),
+	N_("git pack-aggregate --once [--min-loose=<n>] [--min-packs=<n>]\n"
+	   "                         [--max-objects=<n>]"),
 	NULL
 };
+
+#define DEFAULT_MAX_OBJECTS 100000
 
 static int has_sidecar(const char *packdir, const char *basename,
 		       const char *ext)
@@ -55,9 +59,54 @@ static int has_protective_sidecar(const char *packdir, const char *basename)
 	return 0;
 }
 
-static int has_idx(const char *packdir, const char *basename)
+static int idx_file_size(const char *packdir, const char *basename,
+			 off_t *size)
 {
-	return has_sidecar(packdir, basename, "idx");
+	struct strbuf buf = STRBUF_INIT;
+	struct stat st;
+	int ret;
+
+	strbuf_addf(&buf, "%s/%s.idx", packdir, basename);
+	ret = !lstat(buf.buf, &st);
+	if (ret)
+		*size = st.st_size;
+	strbuf_release(&buf);
+	return ret;
+}
+
+/*
+ * Gauge pack heft by object count rather than byte size because the work
+ * this gate bounds -- enumerating objects and rebuilding the output index --
+ * scales with object count.  A pack containing a few enormous blobs can
+ * still fall below the cap, but that is uncommon in the target workload and
+ * aggregation copies its existing representation without delta search or
+ * recompression.
+ *
+ * Convert that object-count cap into the maximum size (in bytes) of a v2
+ * pack `.idx`.  The v2 index is linear in the number of objects N:
+ *
+ *   size = 8 (header) + 1024 (fanout) + N*(rawsz + 8) + 2*rawsz (trailer)
+ *
+ * Reusing the lstat() performed by idx_file_size() is much faster than
+ * opening, mapping, and reading each candidate index.  In particular,
+ * p->num_objects is populated only by open_pack_index(), which mmaps the
+ * index; mapping every candidate merely to apply this gate can also exhaust
+ * vm.max_map_count on repositories with an enormous number of packs.
+ *
+ * The format also uses an 8-byte entry per large offset (objects at pack
+ * offset >= 2GiB), which we ignore here.  Ignoring it makes our estimated N
+ * slightly high, i.e. we err on the side of skipping a borderline pack,
+ * which is the safe direction for this "don't touch large packs" gate.  A
+ * cap of 0 disables the limit and is represented by a returned size of 0.
+ */
+static off_t max_objects_to_idx_size(const struct git_hash_algo *algo,
+				     int max_objects)
+{
+	off_t rawsz = algo->rawsz;
+
+	if (!max_objects)
+		return 0;
+	return 8 + 1024 + 2 * rawsz + (rawsz + 8) * (off_t)max_objects;
 }
 
 /*
@@ -182,10 +231,12 @@ static void collect_pack_candidates(struct repository *repo,
 				    const char *packdir,
 				    struct strset *file_exclude,
 				    struct strset *midx_exclude,
-				    struct string_list *candidates)
+				    struct string_list *candidates,
+				    off_t max_idx_size)
 {
 	struct packed_git *p;
 	struct strbuf base = STRBUF_INIT;
+	off_t idx_size = 0;
 
 	repo_for_each_pack(repo, p) {
 		if (!p->pack_local)
@@ -202,7 +253,9 @@ static void collect_pack_candidates(struct repository *repo,
 			continue;
 		if (has_protective_sidecar(packdir, base.buf))
 			continue;
-		if (!has_idx(packdir, base.buf))
+		if (!idx_file_size(packdir, base.buf, &idx_size))
+			continue;
+		if (max_idx_size && idx_size > max_idx_size)
 			continue;
 
 		string_list_append(candidates, base.buf);
@@ -332,7 +385,7 @@ static int run_aggregation(struct repository *repo, const char *packdir,
 			   struct strset *pack_exclude,
 			   struct strset *loose_exclude,
 			   struct strset *midx_exclude,
-			   int min_loose, int min_packs)
+			   int min_loose, int min_packs, int max_objects)
 {
 	struct oid_array loose_oids = OID_ARRAY_INIT;
 	struct string_list loose_paths = STRING_LIST_INIT_DUP;
@@ -391,7 +444,9 @@ static int run_aggregation(struct repository *repo, const char *packdir,
 	 */
 	refresh_midx_exclusions(repo, midx_exclude);
 	collect_pack_candidates(repo, packdir, pack_exclude, midx_exclude,
-				&candidates);
+				&candidates,
+				max_objects_to_idx_size(repo->hash_algo,
+							max_objects));
 
 	if ((int)candidates.nr < min_packs)
 		goto out;
@@ -438,6 +493,7 @@ int cmd_pack_aggregate(int argc, const char **argv,
 {
 	int min_packs = 5;
 	int min_loose = 5;
+	int max_objects = -1;
 	int once = 0;
 	struct option options[] = {
 		OPT_BOOL(0, "once", &once,
@@ -448,6 +504,9 @@ int cmd_pack_aggregate(int argc, const char **argv,
 		OPT_INTEGER(0, "min-packs", &min_packs,
 			    N_("skip pack aggregation if fewer "
 			       "candidates (default 5)")),
+		OPT_INTEGER(0, "max-objects", &max_objects,
+			    N_("skip packs with more than this many "
+			       "objects (0 for no limit)")),
 		OPT_END(),
 	};
 	struct strset pack_exclude = STRSET_INIT;
@@ -467,11 +526,17 @@ int cmd_pack_aggregate(int argc, const char **argv,
 	if (min_packs < 1)
 		die(_("--min-packs must be at least 1"));
 
+	if (max_objects < 0 &&
+	    repo_config_get_int(repo, "pack.aggregatemaxobjects", &max_objects))
+		max_objects = DEFAULT_MAX_OBJECTS;
+	if (max_objects < 0)
+		die(_("pack.aggregateMaxObjects cannot be negative"));
+
 	packdir = mkpathdup("%s/pack", repo_get_object_directory(repo));
 
 	ret = run_aggregation(repo, packdir, &pack_exclude,
 			      &loose_exclude, &midx_exclude,
-			      min_loose, min_packs);
+			      min_loose, min_packs, max_objects);
 
 	strset_clear(&pack_exclude);
 	strset_clear(&loose_exclude);

--- a/builtin/pack-aggregate.c
+++ b/builtin/pack-aggregate.c
@@ -1,0 +1,481 @@
+#define USE_THE_REPOSITORY_VARIABLE
+
+#include "builtin.h"
+#include "gettext.h"
+#include "hash.h"
+#include "hex.h"
+#include "midx.h"
+#include "object-file.h"
+#include "odb.h"
+#include "oid-array.h"
+#include "packfile.h"
+#include "parse-options.h"
+#include "path.h"
+#include "repository.h"
+#include "run-command.h"
+#include "strbuf.h"
+#include "string-list.h"
+#include "strmap.h"
+#include "strvec.h"
+#include "tempfile.h"
+#include "wrapper.h"
+
+static const char *const pack_aggregate_usage[] = {
+	N_("git pack-aggregate --once [--min-loose=<n>] [--min-packs=<n>]"),
+	NULL
+};
+
+static int has_sidecar(const char *packdir, const char *basename,
+		       const char *ext)
+{
+	struct strbuf buf = STRBUF_INIT;
+	struct stat st;
+	int ret;
+
+	strbuf_addf(&buf, "%s/%s.%s", packdir, basename, ext);
+	ret = !lstat(buf.buf, &st);
+	strbuf_release(&buf);
+	return ret;
+}
+
+static int has_protective_sidecar(const char *packdir, const char *basename)
+{
+	/*
+	 * Ignore packs with sidecars that mean "don't touch me". .baddeltas
+	 * is intentionally absent: rolling those up is the point.
+	 */
+	static const char *exts[] = {
+		"keep", "promisor", "mtimes", "bitmap", NULL
+	};
+	int i;
+
+	for (i = 0; exts[i]; i++)
+		if (has_sidecar(packdir, basename, exts[i]))
+			return 1;
+	return 0;
+}
+
+static int has_idx(const char *packdir, const char *basename)
+{
+	return has_sidecar(packdir, basename, "idx");
+}
+
+/*
+ * Re-read the multi-pack-index (and any incremental layers) and
+ * populate `set` with the basenames of every referenced pack.  The
+ * strset is cleared first so this is safe to call once per cycle.
+ */
+static int refresh_midx_exclusions(struct repository *repo,
+				   struct strset *set)
+{
+	struct odb_source *source;
+	int had_midx = 0;
+
+	strset_clear(set);
+
+	odb_reprepare(repo->objects);
+	for (source = repo->objects->sources; source; source = source->next) {
+		struct odb_source_files *files = odb_source_files_downcast(source);
+		struct multi_pack_index *m = get_multi_pack_index(files->packed);
+		for (; m; m = m->base_midx) {
+			uint32_t i;
+			had_midx = 1;
+			for (i = 0; i < m->num_packs; i++) {
+				struct strbuf base = STRBUF_INIT;
+				strbuf_addstr(&base, m->pack_names[i]);
+				strbuf_strip_suffix(&base, ".idx");
+				strbuf_strip_suffix(&base, ".pack");
+				strset_add(set, base.buf);
+				strbuf_release(&base);
+			}
+		}
+	}
+	return had_midx;
+}
+
+/* ---------- loose-object pre-pass ---------- */
+
+struct loose_scan {
+	struct strset *exclude;
+	struct oid_array *oids;
+	struct string_list *paths;
+};
+
+static int loose_scan_cb(const struct object_id *oid, const char *path,
+			 void *cb_data)
+{
+	struct loose_scan *data = cb_data;
+
+	if (strset_contains(data->exclude, oid_to_hex(oid)))
+		return 0;
+	oid_array_append(data->oids, oid);
+	string_list_append(data->paths, path);
+	return 0;
+}
+
+static int run_pack_objects(const char *packtmp, int stdin_packs,
+			    const struct strbuf *input, struct strbuf *out_hash)
+{
+	struct child_process cmd = CHILD_PROCESS_INIT;
+	struct strbuf output = STRBUF_INIT;
+	const char *newline;
+	int ret;
+
+	strvec_push(&cmd.args, "pack-objects");
+	if (stdin_packs)
+		strvec_push(&cmd.args, "--stdin-packs");
+	strvec_pushl(&cmd.args,
+		     "--window=0",
+		     "--mark-bad-deltas",
+		     "--delta-base-offset",
+		     "--no-write-bitmap-index",
+		     "--quiet",
+		     packtmp,
+		     NULL);
+	cmd.git_cmd = 1;
+	cmd.clean_on_exit = 1;
+
+	/*
+	 * pipe_command() pumps stdin and stdout concurrently.  Its
+	 * clean-on-exit handling also terminates the child if we exit
+	 * before it does.
+	 */
+	ret = pipe_command(&cmd, input->buf, input->len, &output, 0, NULL, 0);
+
+	newline = memchr(output.buf, '\n', output.len);
+	strbuf_add(out_hash, output.buf,
+		   newline ? (size_t)(newline - output.buf) : output.len);
+
+	strbuf_release(&output);
+	return ret;
+}
+
+static int run_pack_objects_loose(const char *packtmp, struct oid_array *oids,
+				  struct strbuf *out_hash)
+{
+	struct strbuf input = STRBUF_INIT;
+	size_t i;
+	int ret;
+
+	for (i = 0; i < oids->nr; i++)
+		strbuf_addf(&input, "%s\n", oid_to_hex(&oids->oid[i]));
+	ret = run_pack_objects(packtmp, 0, &input, out_hash);
+	strbuf_release(&input);
+	return ret;
+}
+
+static void unlink_loose_paths(const struct string_list *paths)
+{
+	size_t i;
+
+	for (i = 0; i < paths->nr; i++) {
+		const char *p = paths->items[i].string;
+		if (unlink(p) < 0 && errno != ENOENT)
+			warning_errno(_("could not unlink loose object '%s'"),
+				      p);
+	}
+}
+
+/* ---------- pack aggregation ---------- */
+
+static void collect_pack_candidates(struct repository *repo,
+				    const char *packdir,
+				    struct strset *file_exclude,
+				    struct strset *midx_exclude,
+				    struct string_list *candidates)
+{
+	struct packed_git *p;
+	struct strbuf base = STRBUF_INIT;
+
+	repo_for_each_pack(repo, p) {
+		if (!p->pack_local)
+			continue;
+
+		strbuf_reset(&base);
+		strbuf_addstr(&base, pack_basename(p));
+		if (!strbuf_strip_suffix(&base, ".pack"))
+			continue;
+
+		if (strset_contains(file_exclude, base.buf))
+			continue;
+		if (strset_contains(midx_exclude, base.buf))
+			continue;
+		if (has_protective_sidecar(packdir, base.buf))
+			continue;
+		if (!has_idx(packdir, base.buf))
+			continue;
+
+		string_list_append(candidates, base.buf);
+	}
+
+	strbuf_release(&base);
+}
+
+static int run_pack_objects_packs(const char *packtmp,
+				  const struct string_list *bases,
+				  struct strbuf *out_hash)
+{
+	struct strbuf input = STRBUF_INIT;
+	size_t i;
+	int ret;
+
+	for (i = 0; i < bases->nr; i++)
+		strbuf_addf(&input, "%s.pack\n", bases->items[i].string);
+	ret = run_pack_objects(packtmp, 1, &input, out_hash);
+	strbuf_release(&input);
+	return ret;
+}
+
+/*
+ * pack-objects writes its output as <packtmp>-<hash>.<ext>; rename it
+ * into place as <packdir>/pack-<hash>.<ext>.  .idx is renamed last so
+ * a concurrent reader scanning the pack directory never sees a .idx
+ * without its companion .pack.
+ */
+static int install_pack(struct repository *repo, const char *packtmp,
+			const char *packdir, const char *hash)
+{
+	static const char *exts[] = {
+		".pack", ".rev", ".baddeltas", ".idx"
+	};
+	struct tempfile *files[ARRAY_SIZE(exts)] = { 0 };
+	size_t i;
+
+	for (i = 0; i < ARRAY_SIZE(exts); i++) {
+		struct strbuf src = STRBUF_INIT;
+		struct stat st;
+
+		strbuf_addf(&src, "%s-%s%s", packtmp, hash, exts[i]);
+		if (!stat(src.buf, &st)) {
+			files[i] = register_tempfile(src.buf);
+			if (adjust_shared_perm(repo, src.buf)) {
+				error_errno(_("unable to adjust permissions for '%s'"),
+					    src.buf);
+				strbuf_release(&src);
+				goto cleanup;
+			}
+		} else if (errno != ENOENT) {
+			error_errno(_("could not stat '%s'"), src.buf);
+			strbuf_release(&src);
+			goto cleanup;
+		}
+		strbuf_release(&src);
+	}
+
+	for (i = 0; i < ARRAY_SIZE(exts); i++) {
+		struct strbuf dst = STRBUF_INIT;
+
+		if (!files[i])
+			continue;
+
+		strbuf_addf(&dst, "%s/pack-%s%s", packdir, hash, exts[i]);
+		if (rename_tempfile(&files[i], dst.buf)) {
+			error_errno(_("renaming pack to '%s' failed"), dst.buf);
+			strbuf_release(&dst);
+			goto cleanup;
+		}
+		strbuf_release(&dst);
+	}
+	return 0;
+
+cleanup:
+	for (i = 0; i < ARRAY_SIZE(files); i++)
+		if (files[i])
+			delete_tempfile(&files[i]);
+	return -1;
+}
+
+static void unlink_consumed_packs(const char *packdir,
+				  const struct string_list *bases,
+				  const char *keep_basename)
+{
+	static const char *exts[] = {
+		"pack", "idx", "rev", "baddeltas", NULL
+	};
+	size_t i;
+
+	for (i = 0; i < bases->nr; i++) {
+		const char *base = bases->items[i].string;
+		int j;
+
+		/*
+		 * Recheck protective sidecars: a .keep (or similar) may
+		 * have appeared between scan and now, in which case the
+		 * pack must stay.
+		 */
+		if (has_protective_sidecar(packdir, base))
+			continue;
+		/*
+		 * Never unlink the pack we just installed.  Aggregating
+		 * packs whose union equals one of the inputs (e.g. one
+		 * input is a strict superset of the others) can yield a
+		 * byte-identical output, which lands at the same final
+		 * name as that input.  In that case, we do not want the
+		 * file serving as both input and output to be deleted.
+		 */
+		if (keep_basename && !strcmp(base, keep_basename))
+			continue;
+
+		for (j = 0; exts[j]; j++) {
+			struct strbuf fname = STRBUF_INIT;
+			strbuf_addf(&fname, "%s/%s.%s", packdir, base,
+				    exts[j]);
+			if (unlink(fname.buf) < 0 && errno != ENOENT)
+				warning_errno(_("could not unlink '%s'"),
+					      fname.buf);
+			strbuf_release(&fname);
+		}
+	}
+}
+
+static int run_aggregation(struct repository *repo, const char *packdir,
+			   struct strset *pack_exclude,
+			   struct strset *loose_exclude,
+			   struct strset *midx_exclude,
+			   int min_loose, int min_packs)
+{
+	struct oid_array loose_oids = OID_ARRAY_INIT;
+	struct string_list loose_paths = STRING_LIST_INIT_DUP;
+	struct loose_scan loose_data = {
+		.exclude = loose_exclude,
+		.oids = &loose_oids,
+		.paths = &loose_paths,
+	};
+	struct string_list candidates = STRING_LIST_INIT_DUP;
+	struct strbuf loose_hash = STRBUF_INIT;
+	struct strbuf packs_hash = STRBUF_INIT;
+	char *packtmp_loose = NULL;
+	char *packtmp_packs = NULL;
+	int ret = 0;
+
+	/*
+	 * Step 1: bundle local loose objects (minus excluded ones) into
+	 * a single new pack and remove the on-disk loose copies.  The
+	 * resulting pack picks up a .baddeltas marker thanks to
+	 * --mark-bad-deltas, and is in turn a candidate for the pack
+	 * aggregation step below.
+	 */
+	for_each_loose_file_in_source(repo->objects->sources,
+				      loose_scan_cb, NULL, NULL, &loose_data);
+	if ((int)loose_oids.nr >= min_loose) {
+		packtmp_loose = mkpathdup("%s/.tmp-%d-loose-pack",
+					  packdir, (int)getpid());
+		if (run_pack_objects_loose(packtmp_loose, &loose_oids,
+					   &loose_hash)) {
+			ret = error(_("pack-objects failed during "
+				      "loose-object rollup"));
+			goto out;
+		}
+		if (loose_hash.len) {
+			if (loose_hash.len != repo->hash_algo->hexsz) {
+				ret = error(_("pack-objects returned an invalid "
+					      "pack hash"));
+				goto out;
+			}
+			if (install_pack(repo, packtmp_loose, packdir,
+					 loose_hash.buf)) {
+				ret = -1;
+				goto out;
+			}
+			unlink_loose_paths(&loose_paths);
+		}
+	}
+
+	/*
+	 * Step 2: aggregate small packs into a single bigger pack.  The
+	 * freshly-installed loose-rollup pack from step 1 is picked up
+	 * naturally by the directory scan below (it has no protective
+	 * sidecars and isn't in any exclusion set).  Re-read the MIDX
+	 * just before scanning so a pack added to a MIDX between cycles
+	 * is honored.
+	 */
+	refresh_midx_exclusions(repo, midx_exclude);
+	collect_pack_candidates(repo, packdir, pack_exclude, midx_exclude,
+				&candidates);
+
+	if ((int)candidates.nr < min_packs)
+		goto out;
+
+	packtmp_packs = mkpathdup("%s/.tmp-%d-pack",
+				  packdir, (int)getpid());
+	if (run_pack_objects_packs(packtmp_packs, &candidates,
+				   &packs_hash)) {
+		ret = error(_("pack-objects failed during "
+			      "pack aggregation"));
+		goto out;
+	}
+	if (packs_hash.len) {
+		struct strbuf output_base = STRBUF_INIT;
+
+		if (packs_hash.len != repo->hash_algo->hexsz) {
+			ret = error(_("pack-objects returned an invalid pack hash"));
+			strbuf_release(&output_base);
+			goto out;
+		}
+		if (install_pack(repo, packtmp_packs, packdir, packs_hash.buf)) {
+			ret = -1;
+			strbuf_release(&output_base);
+			goto out;
+		}
+		strbuf_addf(&output_base, "pack-%s", packs_hash.buf);
+		unlink_consumed_packs(packdir, &candidates, output_base.buf);
+		strbuf_release(&output_base);
+	}
+
+out:
+	free(packtmp_loose);
+	free(packtmp_packs);
+	strbuf_release(&loose_hash);
+	strbuf_release(&packs_hash);
+	string_list_clear(&candidates, 0);
+	oid_array_clear(&loose_oids);
+	string_list_clear(&loose_paths, 0);
+	return ret;
+}
+
+int cmd_pack_aggregate(int argc, const char **argv,
+		       const char *prefix, struct repository *repo)
+{
+	int min_packs = 5;
+	int min_loose = 5;
+	int once = 0;
+	struct option options[] = {
+		OPT_BOOL(0, "once", &once,
+			 N_("run a single cycle and exit")),
+		OPT_INTEGER(0, "min-loose", &min_loose,
+			    N_("skip loose-object rollup if fewer "
+			       "candidates (default 5)")),
+		OPT_INTEGER(0, "min-packs", &min_packs,
+			    N_("skip pack aggregation if fewer "
+			       "candidates (default 5)")),
+		OPT_END(),
+	};
+	struct strset pack_exclude = STRSET_INIT;
+	struct strset loose_exclude = STRSET_INIT;
+	struct strset midx_exclude = STRSET_INIT;
+	char *packdir;
+	int ret = 0;
+
+	argc = parse_options(argc, argv, prefix, options,
+			     pack_aggregate_usage, 0);
+	if (argc > 0)
+		usage_with_options(pack_aggregate_usage, options);
+	if (!once)
+		die(_("--once is required"));
+	if (min_loose < 1)
+		die(_("--min-loose must be at least 1"));
+	if (min_packs < 1)
+		die(_("--min-packs must be at least 1"));
+
+	packdir = mkpathdup("%s/pack", repo_get_object_directory(repo));
+
+	ret = run_aggregation(repo, packdir, &pack_exclude,
+			      &loose_exclude, &midx_exclude,
+			      min_loose, min_packs);
+
+	strset_clear(&pack_exclude);
+	strset_clear(&loose_exclude);
+	strset_clear(&midx_exclude);
+	free(packdir);
+	return ret ? 1 : 0;
+}

--- a/builtin/pack-objects.c
+++ b/builtin/pack-objects.c
@@ -43,6 +43,7 @@
 #include "pack-mtimes.h"
 #include "parse-options.h"
 #include "pkt-line.h"
+#include "path.h"
 #include "blob.h"
 #include "tree.h"
 #include "path-walk.h"
@@ -211,6 +212,7 @@ static int keep_unreachable, unpack_unreachable, include_tag;
 static timestamp_t unpack_unreachable_expiration;
 static int pack_loose_unreachable;
 static int cruft;
+static int mark_bad_deltas;
 static int shallow = 0;
 static timestamp_t cruft_expiration;
 static int local;
@@ -1458,6 +1460,23 @@ static void write_pack_file(void)
 					    nr_written, &to_pack,
 					    &pack_idx_opts, hash,
 					    &idx_tmp_name);
+
+			if (mark_bad_deltas) {
+				size_t tmpname_len = tmpname.len;
+				int fd;
+
+				strbuf_addstr(&tmpname, "baddeltas");
+				fd = xopen(tmpname.buf,
+					   O_WRONLY | O_CREAT | O_TRUNC, 0444);
+				if (close(fd))
+					die_errno(_("unable to close '%s'"),
+						  tmpname.buf);
+				if (adjust_shared_perm(the_repository,
+						       tmpname.buf))
+					die_errno(_("unable to make '%s' readable"),
+						  tmpname.buf);
+				strbuf_setlen(&tmpname, tmpname_len);
+			}
 
 			if (write_bitmap_index) {
 				size_t tmpname_len = tmpname.len;
@@ -5091,6 +5110,8 @@ int cmd_pack_objects(int argc,
 		  N_("unpack unreachable objects newer than <time>"),
 		  PARSE_OPT_OPTARG, option_parse_unpack_unreachable),
 		OPT_BOOL(0, "cruft", &cruft, N_("create a cruft pack")),
+		OPT_BOOL(0, "mark-bad-deltas", &mark_bad_deltas,
+			 N_("write a .baddeltas marker alongside the output pack(s)")),
 		OPT_CALLBACK_F(0, "cruft-expiration", NULL, N_("time"),
 		  N_("expire cruft objects older than <time>"),
 		  PARSE_OPT_OPTARG, option_parse_cruft_expiration),
@@ -5283,6 +5304,9 @@ int cmd_pack_objects(int argc,
 
 	if (!pack_to_stdout && thin)
 		die(_("--thin cannot be used to build an indexable pack"));
+
+	die_for_incompatible_opt2(mark_bad_deltas, "--mark-bad-deltas",
+				  pack_to_stdout, "--stdout");
 
 	die_for_incompatible_opt2(keep_unreachable, "--keep-unreachable",
 				  unpack_unreachable, "--unpack-unreachable");

--- a/builtin/pack-objects.c
+++ b/builtin/pack-objects.c
@@ -2794,9 +2794,15 @@ static int try_delta(struct unpacked *trg, struct unpacked *src,
 	 * be considered, as even if we produce a suboptimal delta against
 	 * it, we will still save the transfer cost, as we already know
 	 * the other side has it and we won't send src_entry at all.
+	 *
+	 * If the source pack carries a ".baddeltas" marker, we treat its
+	 * existing delta layout as untrusted: even if the two objects are
+	 * in the same pack and neither is a delta, we have no reason to
+	 * believe a previous packing run actually considered the pair.
 	 */
 	if (reuse_delta && IN_PACK(trg_entry) &&
 	    IN_PACK(trg_entry) == IN_PACK(src_entry) &&
+	    !IN_PACK(trg_entry)->has_bad_deltas &&
 	    !src_entry->preferred_base &&
 	    trg_entry->in_pack_type != OBJ_REF_DELTA &&
 	    trg_entry->in_pack_type != OBJ_OFS_DELTA)

--- a/builtin/pack-objects.c
+++ b/builtin/pack-objects.c
@@ -4082,6 +4082,7 @@ static void read_stdin_packs(enum stdin_packs_mode mode, int rev_list_unpacked)
 {
 	int prev_fetch_if_missing = fetch_if_missing;
 	struct rev_info revs;
+	int need_walk;
 
 	/*
 	 * The revision walk may hit objects that are promised, only. As the
@@ -4099,7 +4100,14 @@ static void read_stdin_packs(enum stdin_packs_mode mode, int rev_list_unpacked)
 	 * That may cause us to avoid populating all of the namehash fields of
 	 * all included objects, but our goal is best-effort, since this is only
 	 * an optimization during delta selection.
+	 *
+	 * However, the walk is only needed for delta selection (which
+	 * consumes the namehash) and for STDIN_PACKS_MODE_FOLLOW (which
+	 * uses the walk to discover additional reachable objects); skip
+	 * it when neither applies.
 	 */
+	need_walk = (window && depth) || mode == STDIN_PACKS_MODE_FOLLOW;
+
 	revs.no_kept_objects = 1;
 	revs.keep_pack_cache_flags |= KEPT_PACK_IN_CORE;
 	revs.blob_objects = 1;
@@ -4122,12 +4130,14 @@ static void read_stdin_packs(enum stdin_packs_mode mode, int rev_list_unpacked)
 	if (rev_list_unpacked)
 		add_unreachable_loose_objects(&revs);
 
-	if (prepare_revision_walk(&revs))
-		die(_("revision walk setup failed"));
-	traverse_commit_list(&revs,
-			     show_commit_pack_hint,
-			     show_object_pack_hint,
-			     &mode);
+	if (need_walk) {
+		if (prepare_revision_walk(&revs))
+			die(_("revision walk setup failed"));
+		traverse_commit_list(&revs,
+				     show_commit_pack_hint,
+				     show_object_pack_hint,
+				     &mode);
+	}
 
 	release_revisions(&revs);
 

--- a/builtin/pack-objects.c
+++ b/builtin/pack-objects.c
@@ -213,6 +213,8 @@ static timestamp_t unpack_unreachable_expiration;
 static int pack_loose_unreachable;
 static int cruft;
 static int mark_bad_deltas;
+static const char *emit_input_packs_path;
+static const char *emit_input_loose_path;
 static int shallow = 0;
 static timestamp_t cruft_expiration;
 static int local;
@@ -5040,6 +5042,62 @@ static int parse_stdin_packs_mode(const struct option *opt, const char *arg,
 	return 0;
 }
 
+static void emit_input_packs_to_file(const char *path)
+{
+	struct strbuf tmp = STRBUF_INIT;
+	struct packed_git *p;
+	FILE *fp;
+
+	strbuf_addf(&tmp, "%s.tmp", path);
+	fp = fopen(tmp.buf, "w");
+	if (!fp)
+		die_errno(_("unable to write '%s'"), tmp.buf);
+	repo_for_each_pack(the_repository, p) {
+		/* Exclude alternates */
+		if (!p->pack_local)
+			continue;
+		fprintf(fp, "%s\n", pack_basename(p));
+	}
+	if (fclose(fp))
+		die_errno(_("unable to write '%s'"), tmp.buf);
+	if (rename(tmp.buf, path))
+		die_errno(_("unable to rename '%s' to '%s'"), tmp.buf, path);
+	strbuf_release(&tmp);
+}
+
+static int emit_input_loose_cb(const struct object_id *oid,
+			       const char *path UNUSED,
+			       void *data)
+{
+	FILE *fp = data;
+	fprintf(fp, "%s\n", oid_to_hex(oid));
+	return 0;
+}
+
+static void emit_input_loose_to_file(const char *path)
+{
+	struct strbuf tmp = STRBUF_INIT;
+	FILE *fp;
+
+	strbuf_addf(&tmp, "%s.tmp", path);
+	fp = fopen(tmp.buf, "w");
+	if (!fp)
+		die_errno(_("unable to write '%s'"), tmp.buf);
+	/*
+	 * Note: for_each_loose_file_in_source() walks only the local
+	 * source (sources->next is skipped), thus excluding
+	 * alternates and matching the "p->pack_local" check in
+	 * emit_input_packs_to_file().
+	 */
+	for_each_loose_file_in_source(the_repository->objects->sources,
+				      emit_input_loose_cb, NULL, NULL, fp);
+	if (fclose(fp))
+		die_errno(_("unable to write '%s'"), tmp.buf);
+	if (rename(tmp.buf, path))
+		die_errno(_("unable to rename '%s' to '%s'"), tmp.buf, path);
+	strbuf_release(&tmp);
+}
+
 int cmd_pack_objects(int argc,
 		     const char **argv,
 		     const char *prefix,
@@ -5137,6 +5195,14 @@ int cmd_pack_objects(int argc,
 			 N_("ignore packs that have companion .keep file")),
 		OPT_STRING_LIST(0, "keep-pack", &keep_pack_list, N_("name"),
 				N_("ignore this pack")),
+		OPT_STRING(0, "emit-input-packs", &emit_input_packs_path,
+			   N_("file"),
+			   N_("write basenames of input packs to <file> "
+			      "(plumbing, undocumented)")),
+		OPT_STRING(0, "emit-input-loose", &emit_input_loose_path,
+			   N_("file"),
+			   N_("write OIDs of input loose objects to <file> "
+			      "(plumbing, undocumented)")),
 		OPT_INTEGER(0, "compression", &pack_compression_level,
 			    N_("pack compression level")),
 		OPT_BOOL(0, "keep-true-parents", &grafts_keep_true_parents,
@@ -5399,6 +5465,11 @@ int cmd_pack_objects(int argc,
 	trace2_region_enter("pack-objects", "enumerate-objects",
 			    the_repository);
 	prepare_packing_data(the_repository, &to_pack);
+
+	if (emit_input_packs_path)
+		emit_input_packs_to_file(emit_input_packs_path);
+	if (emit_input_loose_path)
+		emit_input_loose_to_file(emit_input_loose_path);
 
 	if (progress && !cruft)
 		progress_state = start_progress(the_repository,

--- a/builtin/pack-objects.c
+++ b/builtin/pack-objects.c
@@ -2827,9 +2827,15 @@ static int try_delta(struct unpacked *trg, struct unpacked *src,
 	 * be considered, as even if we produce a suboptimal delta against
 	 * it, we will still save the transfer cost, as we already know
 	 * the other side has it and we won't send src_entry at all.
+	 *
+	 * If the source pack carries a ".baddeltas" marker, we treat its
+	 * existing delta layout as untrusted: even if the two objects are
+	 * in the same pack and neither is a delta, we have no reason to
+	 * believe a previous packing run actually considered the pair.
 	 */
 	if (reuse_delta && IN_PACK(trg_entry) &&
 	    IN_PACK(trg_entry) == IN_PACK(src_entry) &&
+	    !IN_PACK(trg_entry)->has_bad_deltas &&
 	    !src_entry->preferred_base &&
 	    trg_entry->in_pack_type != OBJ_REF_DELTA &&
 	    trg_entry->in_pack_type != OBJ_OFS_DELTA)

--- a/builtin/pack-objects.c
+++ b/builtin/pack-objects.c
@@ -209,6 +209,7 @@ static uint32_t write_layer;
 
 static int non_empty;
 static int reuse_delta = 1, reuse_object = 1;
+static int prefer_reused_deltas;
 static int keep_unreachable, unpack_unreachable, include_tag;
 static timestamp_t unpack_unreachable_expiration;
 static int pack_loose_unreachable;
@@ -3836,6 +3837,60 @@ static int stdin_packs_hints_nr;
  */
 static int stdin_packs_need_walk;
 
+/*
+ * Return 1 if the object stored in pack `p` at byte offset `offset` is
+ * represented as a delta (OFS or REF), 0 otherwise.  Only the object
+ * header is read, so this is cheap.
+ */
+static int pack_entry_is_delta(struct packed_git *p, off_t offset)
+{
+	struct pack_window *w_curs = NULL;
+	unsigned long avail, size;
+	enum object_type type;
+	unsigned char *buf;
+	int is_delta = 0;
+
+	buf = use_pack(p, &w_curs, offset, &avail);
+	if (unpack_object_header_buffer(buf, avail, &type, &size))
+		is_delta = (type == OBJ_OFS_DELTA || type == OBJ_REF_DELTA);
+	unuse_pack(&w_curs);
+	return is_delta;
+}
+
+/*
+ * When an object appears in more than one included pack, the first copy we
+ * saw (packs are visited newest-mtime first) is the one recorded in the
+ * packing list.  If that copy is a plain base but another included pack
+ * stores the object as a delta, point the entry at the delta copy instead,
+ * so this run writes the object as a reused delta rather than as a base.
+ * Preferring the delta at this stage is safe -- if the chosen delta's base
+ * is not itself included, then check_object() will simply fall back and
+ * store this object as a base anyway.
+ */
+static void maybe_prefer_delta_copy(const struct object_id *oid,
+				    struct packed_git *p, uint32_t pos)
+{
+	struct object_entry *entry;
+	off_t ofs;
+
+	if (!reuse_delta)
+		return;
+	entry = packlist_find(&to_pack, oid);
+	if (!entry || entry->preferred_base || !IN_PACK(entry))
+		return;
+
+	/* Only switch a plain base copy over to a delta copy. */
+	if (pack_entry_is_delta(IN_PACK(entry), entry->in_pack_offset))
+		return;
+
+	ofs = nth_packed_object_offset(p, pos);
+	if (!pack_entry_is_delta(p, ofs))
+		return;
+
+	oe_set_in_pack(&to_pack, entry, p);
+	entry->in_pack_offset = ofs;
+}
+
 static int add_object_entry_from_pack(const struct object_id *oid,
 				      struct packed_git *p,
 				      uint32_t pos,
@@ -3847,8 +3902,11 @@ static int add_object_entry_from_pack(const struct object_id *oid,
 
 	display_progress(progress_state, ++nr_seen);
 
-	if (have_duplicate_entry(oid, 0))
+	if (have_duplicate_entry(oid, 0)) {
+		if (prefer_reused_deltas)
+			maybe_prefer_delta_copy(oid, p, pos);
 		return 0;
+	}
 
 	stdin_packs_found_nr++;
 
@@ -5204,6 +5262,9 @@ int cmd_pack_objects(int argc,
 			    N_("maximum length of delta chain allowed in the resulting pack")),
 		OPT_BOOL(0, "reuse-delta", &reuse_delta,
 			 N_("reuse existing deltas")),
+		OPT_BOOL(0, "prefer-reused-deltas", &prefer_reused_deltas,
+			 N_("when an object is in several included packs, "
+			    "prefer a copy stored as a delta")),
 		OPT_BOOL(0, "reuse-object", &reuse_object,
 			 N_("reuse existing objects")),
 		OPT_BOOL(0, "delta-base-offset", &allow_ofs_delta,

--- a/builtin/pack-objects.c
+++ b/builtin/pack-objects.c
@@ -3858,6 +3858,30 @@ static int pack_entry_is_delta(struct packed_git *p, off_t offset)
 }
 
 /*
+ * If the object stored in pack `p` at `offset` is a delta, resolve the
+ * object id of its base into `base_out` and return 1.  Return 0 for a
+ * non-delta or on any parse failure.  The cost is just an object-header
+ * parse, plus a revindex-backed offset lookup for OFS deltas.
+ */
+static int pack_entry_delta_base(struct packed_git *p, off_t offset,
+				 struct object_id *base_out)
+{
+	struct pack_window *w_curs = NULL;
+	off_t curpos = offset;
+	unsigned long size;
+	enum object_type type;
+	int ret = 0;
+
+	type = unpack_object_header(p, &w_curs, &curpos, &size);
+	if ((type == OBJ_OFS_DELTA || type == OBJ_REF_DELTA) &&
+	    !get_delta_base_oid(p, &w_curs, curpos, base_out, type, offset))
+		ret = 1;
+
+	unuse_pack(&w_curs);
+	return ret;
+}
+
+/*
  * When an object appears in more than one included pack, the first copy we
  * saw (packs are visited newest-mtime first) is the one recorded in the
  * packing list.  If that copy is a plain base but another included pack
@@ -3870,7 +3894,8 @@ static int pack_entry_is_delta(struct packed_git *p, off_t offset)
 static void maybe_prefer_delta_copy(const struct object_id *oid,
 				    struct packed_git *p, uint32_t pos)
 {
-	struct object_entry *entry;
+	struct object_entry *entry, *base_entry;
+	struct object_id cand_base, base_of_base;
 	off_t ofs;
 
 	if (!reuse_delta)
@@ -3884,7 +3909,23 @@ static void maybe_prefer_delta_copy(const struct object_id *oid,
 		return;
 
 	ofs = nth_packed_object_offset(p, pos);
-	if (!pack_entry_is_delta(p, ofs))
+	if (!pack_entry_delta_base(p, ofs, &cand_base))
+		return;
+
+	/*
+	 * Switching would make `oid` a delta against `cand_base`.  If
+	 * `cand_base` is itself already recorded as a delta against `oid`,
+	 * the switch forms a two-object cycle that a later
+	 * break_delta_chains() pass would have to cut.  Cutting it keeps one
+	 * of the two deltas either way, so switching gains nothing here; skip
+	 * it and leave `oid` a base, so the existing `cand_base -> oid` delta
+	 * survives with no cycle to break.
+	 */
+	base_entry = packlist_find(&to_pack, &cand_base);
+	if (base_entry && !base_entry->preferred_base && IN_PACK(base_entry) &&
+	    pack_entry_delta_base(IN_PACK(base_entry),
+				  base_entry->in_pack_offset, &base_of_base) &&
+	    oideq(&base_of_base, oid))
 		return;
 
 	oe_set_in_pack(&to_pack, entry, p);

--- a/builtin/pack-objects.c
+++ b/builtin/pack-objects.c
@@ -215,6 +215,8 @@ static timestamp_t unpack_unreachable_expiration;
 static int pack_loose_unreachable;
 static int cruft;
 static int mark_bad_deltas;
+static const char *emit_input_packs_path;
+static const char *emit_input_loose_path;
 static int shallow = 0;
 static timestamp_t cruft_expiration;
 static int local;
@@ -5259,6 +5261,68 @@ static int parse_stdin_packs_mode(const struct option *opt, const char *arg,
 	return 0;
 }
 
+static void emit_input_packs_to_file(const char *path)
+{
+	struct strbuf tmp = STRBUF_INIT;
+	struct packed_git *p;
+	FILE *fp;
+
+	strbuf_addf(&tmp, "%s.tmp", path);
+	fp = fopen(tmp.buf, "w");
+	if (!fp)
+		die_errno(_("unable to write '%s'"), tmp.buf);
+	/*
+	 * This is deliberately a conservative snapshot of every local pack,
+	 * not just packs selected by this invocation.  A geometric repack can
+	 * leave packs untouched but still include them in its replacement MIDX,
+	 * so a concurrent aggregator must exclude them too.
+	 */
+	repo_for_each_pack(the_repository, p) {
+		/* Exclude alternates */
+		if (!p->pack_local)
+			continue;
+		fprintf(fp, "%s\n", pack_basename(p));
+	}
+	if (fclose(fp))
+		die_errno(_("unable to write '%s'"), tmp.buf);
+	if (rename(tmp.buf, path))
+		die_errno(_("unable to rename '%s' to '%s'"), tmp.buf, path);
+	strbuf_release(&tmp);
+}
+
+static int emit_input_loose_cb(const struct object_id *oid,
+			       const char *path UNUSED,
+			       void *data)
+{
+	FILE *fp = data;
+	fprintf(fp, "%s\n", oid_to_hex(oid));
+	return 0;
+}
+
+static void emit_input_loose_to_file(const char *path)
+{
+	struct strbuf tmp = STRBUF_INIT;
+	FILE *fp;
+
+	strbuf_addf(&tmp, "%s.tmp", path);
+	fp = fopen(tmp.buf, "w");
+	if (!fp)
+		die_errno(_("unable to write '%s'"), tmp.buf);
+	/*
+	 * Note: for_each_loose_file_in_source() walks only the local
+	 * source (sources->next is skipped), thus excluding
+	 * alternates and matching the "p->pack_local" check in
+	 * emit_input_packs_to_file().
+	 */
+	for_each_loose_file_in_source(the_repository->objects->sources,
+				      emit_input_loose_cb, NULL, NULL, fp);
+	if (fclose(fp))
+		die_errno(_("unable to write '%s'"), tmp.buf);
+	if (rename(tmp.buf, path))
+		die_errno(_("unable to rename '%s' to '%s'"), tmp.buf, path);
+	strbuf_release(&tmp);
+}
+
 int cmd_pack_objects(int argc,
 		     const char **argv,
 		     const char *prefix,
@@ -5360,6 +5424,14 @@ int cmd_pack_objects(int argc,
 			 N_("ignore packs that have companion .keep file")),
 		OPT_STRING_LIST(0, "keep-pack", &keep_pack_list, N_("name"),
 				N_("ignore this pack")),
+		OPT_STRING(0, "emit-input-packs", &emit_input_packs_path,
+			   N_("file"),
+			   N_("write basenames of all local packs to <file> "
+			      "(plumbing, undocumented)")),
+		OPT_STRING(0, "emit-input-loose", &emit_input_loose_path,
+			   N_("file"),
+			   N_("write OIDs of input loose objects to <file> "
+			      "(plumbing, undocumented)")),
 		OPT_INTEGER(0, "compression", &cfg->pack_compression_level,
 			    N_("pack compression level")),
 		OPT_BOOL(0, "keep-true-parents", &grafts_keep_true_parents,
@@ -5618,6 +5690,11 @@ int cmd_pack_objects(int argc,
 	trace2_region_enter("pack-objects", "enumerate-objects",
 			    the_repository);
 	prepare_packing_data(the_repository, &to_pack);
+
+	if (emit_input_packs_path)
+		emit_input_packs_to_file(emit_input_packs_path);
+	if (emit_input_loose_path)
+		emit_input_loose_to_file(emit_input_loose_path);
 
 	if (progress && !cruft)
 		progress_state = start_progress(the_repository,

--- a/builtin/pack-objects.c
+++ b/builtin/pack-objects.c
@@ -44,6 +44,7 @@
 #include "pack-mtimes.h"
 #include "parse-options.h"
 #include "pkt-line.h"
+#include "path.h"
 #include "blob.h"
 #include "tree.h"
 #include "path-walk.h"
@@ -212,6 +213,7 @@ static int keep_unreachable, unpack_unreachable, include_tag;
 static timestamp_t unpack_unreachable_expiration;
 static int pack_loose_unreachable;
 static int cruft;
+static int mark_bad_deltas;
 static int shallow = 0;
 static timestamp_t cruft_expiration;
 static int local;
@@ -1469,6 +1471,23 @@ static void write_pack_file(void)
 					    nr_written, &to_pack,
 					    &pack_idx_opts, hash,
 					    &idx_tmp_name);
+
+			if (mark_bad_deltas) {
+				size_t tmpname_len = tmpname.len;
+				int fd;
+
+				strbuf_addstr(&tmpname, "baddeltas");
+				fd = xopen(tmpname.buf,
+					   O_WRONLY | O_CREAT | O_TRUNC, 0444);
+				if (close(fd))
+					die_errno(_("unable to close '%s'"),
+						  tmpname.buf);
+				if (adjust_shared_perm(the_repository,
+						       tmpname.buf))
+					die_errno(_("unable to make '%s' readable"),
+						  tmpname.buf);
+				strbuf_setlen(&tmpname, tmpname_len);
+			}
 
 			if (write_bitmap_index) {
 				size_t tmpname_len = tmpname.len;
@@ -5204,6 +5223,8 @@ int cmd_pack_objects(int argc,
 		  N_("unpack unreachable objects newer than <time>"),
 		  PARSE_OPT_OPTARG, option_parse_unpack_unreachable),
 		OPT_BOOL(0, "cruft", &cruft, N_("create a cruft pack")),
+		OPT_BOOL(0, "mark-bad-deltas", &mark_bad_deltas,
+			 N_("write a .baddeltas marker alongside the output pack(s)")),
 		OPT_CALLBACK_F(0, "cruft-expiration", NULL, N_("time"),
 		  N_("expire cruft objects older than <time>"),
 		  PARSE_OPT_OPTARG, option_parse_cruft_expiration),
@@ -5392,6 +5413,9 @@ int cmd_pack_objects(int argc,
 
 	if (!pack_to_stdout && thin)
 		die(_("--thin cannot be used to build an indexable pack"));
+
+	die_for_incompatible_opt2(mark_bad_deltas, "--mark-bad-deltas",
+				  pack_to_stdout, "--stdout");
 
 	die_for_incompatible_opt2(keep_unreachable, "--keep-unreachable",
 				  unpack_unreachable, "--unpack-unreachable");

--- a/builtin/pack-objects.c
+++ b/builtin/pack-objects.c
@@ -3829,6 +3829,13 @@ static int git_pack_config(const char *k, const char *v,
 static int stdin_packs_found_nr;
 static int stdin_packs_hints_nr;
 
+/*
+ * Whether the --stdin-packs revision walk will actually run; used to skip
+ * seeding pending commits (and its expensive per-commit object lookups) when
+ * no walk is performed.  Set in read_stdin_packs().
+ */
+static int stdin_packs_need_walk;
+
 static int add_object_entry_from_pack(const struct object_id *oid,
 				      struct packed_git *p,
 				      uint32_t pos,
@@ -3851,7 +3858,7 @@ static int add_object_entry_from_pack(const struct object_id *oid,
 	if (packed_object_info(NULL, p, ofs, &oi) < 0) {
 		die(_("could not get type of object %s in pack %s"),
 		    oid_to_hex(oid), p->pack_name);
-	} else if (type == OBJ_COMMIT) {
+	} else if (type == OBJ_COMMIT && stdin_packs_need_walk) {
 		struct rev_info *revs = _data;
 		/*
 		 * commits in included packs are used as starting points
@@ -4119,6 +4126,7 @@ static void read_stdin_packs(enum stdin_packs_mode mode, int rev_list_unpacked)
 {
 	int prev_fetch_if_missing = fetch_if_missing;
 	struct rev_info revs;
+	int need_walk;
 
 	/*
 	 * The revision walk may hit objects that are promised, only. As the
@@ -4136,7 +4144,15 @@ static void read_stdin_packs(enum stdin_packs_mode mode, int rev_list_unpacked)
 	 * That may cause us to avoid populating all of the namehash fields of
 	 * all included objects, but our goal is best-effort, since this is only
 	 * an optimization during delta selection.
+	 *
+	 * However, the walk is only needed for delta selection (which
+	 * consumes the namehash) and for STDIN_PACKS_MODE_FOLLOW (which
+	 * uses the walk to discover additional reachable objects); skip
+	 * it when neither applies.
 	 */
+	need_walk = (window && depth) || mode == STDIN_PACKS_MODE_FOLLOW;
+	stdin_packs_need_walk = need_walk;
+
 	revs.no_kept_objects = 1;
 	revs.keep_pack_cache_flags |= KEPT_PACK_IN_CORE;
 	revs.blob_objects = 1;
@@ -4159,12 +4175,14 @@ static void read_stdin_packs(enum stdin_packs_mode mode, int rev_list_unpacked)
 	if (rev_list_unpacked)
 		add_unreachable_loose_objects(&revs);
 
-	if (prepare_revision_walk(&revs))
-		die(_("revision walk setup failed"));
-	traverse_commit_list(&revs,
-			     show_commit_pack_hint,
-			     show_object_pack_hint,
-			     &mode);
+	if (need_walk) {
+		if (prepare_revision_walk(&revs))
+			die(_("revision walk setup failed"));
+		traverse_commit_list(&revs,
+				     show_commit_pack_hint,
+				     show_object_pack_hint,
+				     &mode);
+	}
 
 	release_revisions(&revs);
 

--- a/builtin/repack.c
+++ b/builtin/repack.c
@@ -4,6 +4,7 @@
 #include "builtin.h"
 #include "config.h"
 #include "environment.h"
+#include "gettext.h"
 #include "parse-options.h"
 #include "path.h"
 #include "run-command.h"
@@ -15,6 +16,10 @@
 #include "promisor-remote.h"
 #include "repack.h"
 #include "shallow.h"
+#include "dir.h"
+#include "strbuf.h"
+#include "strvec.h"
+#include "wrapper.h"
 
 #define ALL_INTO_ONE 1
 #define LOOSEN_UNREACHABLE 2
@@ -29,11 +34,13 @@ static int use_delta_islands;
 static int run_update_server_info = 1;
 static char *packdir, *packtmp_name, *packtmp;
 static int midx_must_contain_cruft = 1;
+static int aggregate_opt = -1;
 
 static const char *const git_repack_usage[] = {
 	N_("git repack [-a] [-A] [-d] [-f] [-F] [-l] [-n] [-q] [-b] [-m]\n"
 	   "[--window=<n>] [--depth=<n>] [--threads=<n>] [--keep-pack=<pack-name>]\n"
-	   "[--write-midx[=<mode>]] [--name-hash-version=<n>] [--path-walk]"),
+	   "[--write-midx[=<mode>]] [--name-hash-version=<n>] [--path-walk]\n"
+	   "[--[no-]aggregate]"),
 	NULL
 };
 
@@ -109,6 +116,10 @@ static int repack_config(const char *var, const char *value,
 								      ctx->kvi);
 		return 0;
 	}
+	if (!strcmp(var, "repack.aggregate")) {
+		aggregate_opt = git_config_bool(var, value);
+		return 0;
+	}
 	return git_default_config(var, value, ctx, cb);
 }
 
@@ -132,12 +143,383 @@ static int option_parse_write_midx(const struct option *opt, const char *arg,
 	return 0;
 }
 
+/*
+ * State for the optional `git pack-aggregate` sidecar that we
+ * launch alongside the main pack-objects when --aggregate is on.
+ */
+struct aggregate_sidecar {
+	struct child_process cmd;
+	char *tmpdir;
+	char *exclude_packs_path;
+	char *exclude_loose_path;
+	/*
+	 * Full paths of the ".keep" marker files we created in this
+	 * repack.  Cleared (and the files unlinked) after the sidecar
+	 * has been reaped, so that pack-aggregate never sees a pack
+	 * lose its marker while it is still running.
+	 */
+	struct string_list installed_keeps;
+	/*
+	 * Write end of a pipe whose read end the aggregator inherits
+	 * (passed via --parent-pipe-fd).  Closing this fd is the
+	 * orphan-detection signal: when repack exits without an
+	 * explicit stop_aggregate_sidecar(), the aggregator sees EOF
+	 * and bails out instead of running unsupervised.
+	 */
+	int parent_pipe_write_fd;
+	int started;
+};
+#define AGGREGATE_KEEP_MARKER_PREFIX "git-repack-aggregate-temporary"
+
+/*
+ * Scan packdir for stale ".keep" markers left behind by previous
+ * crashed repacks: files whose contents begin with our marker
+ * prefix and whose owning pid is no longer running.  Skip anything
+ * we cannot parse (foreign ".keep" files) or whose owner is alive.
+ */
+static void clean_stale_aggregate_keeps(const char *packdir)
+{
+	DIR *dir = opendir(packdir);
+	struct dirent *ent;
+	struct strbuf path = STRBUF_INIT;
+
+	if (!dir)
+		return;
+
+	while ((ent = readdir(dir))) {
+		const char *p;
+		char *end;
+		long pid;
+		int fd;
+		ssize_t n;
+		char buf[256];
+
+		if (!ends_with(ent->d_name, ".keep"))
+			continue;
+
+		strbuf_reset(&path);
+		strbuf_addf(&path, "%s/%s", packdir, ent->d_name);
+
+		fd = open(path.buf, O_RDONLY);
+		if (fd < 0)
+			continue;
+		n = read_in_full(fd, buf, sizeof(buf) - 1);
+		close(fd);
+		if (n <= 0)
+			continue;
+		buf[n] = '\0';
+
+		if (!skip_prefix(buf, AGGREGATE_KEEP_MARKER_PREFIX " pid=", &p))
+			continue;
+		errno = 0;
+		pid = strtol(p, &end, 10);
+		if (errno || end == p || pid <= 0)
+			continue;
+		if (*end != '\n' && *end != '\0')
+			continue;
+
+		/* Send no signal; just check existence of process */
+		if (!kill((pid_t)pid, 0))
+			continue;
+		if (errno != ESRCH)
+			continue;
+
+		if (unlink(path.buf) && errno != ENOENT)
+			warning_errno(_("could not unlink stale "
+					"aggregate .keep marker '%s'"),
+				      path.buf);
+	}
+
+	closedir(dir);
+	strbuf_release(&path);
+}
+
+/*
+ * Drop a ".keep" marker on every newly written pack so that the
+ * aggregator (which respects ".keep") cannot pick up one of the
+ * outputs from the primary repacking work.  We do this BEFORE the
+ * install loop so the marker is in place the moment
+ * generated_pack_install() renames ".idx" into view.
+ *
+ * We use O_CREAT|O_EXCL: if a ".keep" already exists for that
+ * basename (e.g. user-created, or a stale marker we failed to
+ * clean), we leave it alone and do NOT record it for cleanup --
+ * cleanup must only ever unlink markers we ourselves created.
+ */
+static void install_aggregate_keep_markers(struct aggregate_sidecar *sc,
+					   const char *packdir,
+					   const struct string_list *names)
+{
+	struct strbuf path = STRBUF_INIT;
+	struct strbuf content = STRBUF_INIT;
+	size_t i;
+
+	strbuf_addf(&content, "%s pid=%ld\n",
+		    AGGREGATE_KEEP_MARKER_PREFIX, (long)getpid());
+
+	for (i = 0; i < names->nr; i++) {
+		int fd;
+
+		strbuf_reset(&path);
+		strbuf_addf(&path, "%s/pack-%s.keep", packdir,
+			    names->items[i].string);
+
+		fd = open(path.buf, O_WRONLY | O_CREAT | O_EXCL, 0666);
+		if (fd < 0) {
+			if (errno == EEXIST)
+				continue;
+			die_errno(_("could not create aggregate "
+				    ".keep marker '%s'"), path.buf);
+		}
+		if (write_in_full(fd, content.buf, content.len) < 0)
+			die_errno(_("could not write aggregate "
+				    ".keep marker '%s'"), path.buf);
+		close(fd);
+		string_list_append(&sc->installed_keeps, path.buf);
+	}
+
+	strbuf_release(&path);
+	strbuf_release(&content);
+}
+
+/*
+ * Unlink every ".keep" marker we created earlier.  Must be called
+ * AFTER stop_aggregate_sidecar() has reaped pack-aggregate, so that
+ * the aggregator cannot see a pack lose its protective marker while
+ * it is still running.
+ */
+static void remove_aggregate_keep_markers(struct aggregate_sidecar *sc)
+{
+	size_t i;
+
+	for (i = 0; i < sc->installed_keeps.nr; i++) {
+		const char *p = sc->installed_keeps.items[i].string;
+		if (unlink(p) && errno != ENOENT)
+			warning_errno(_("could not unlink aggregate "
+					".keep marker '%s'"), p);
+	}
+	string_list_clear(&sc->installed_keeps, 0);
+}
+
+static int wait_for_emit_files(const char *packs_path,
+			       const char *loose_path,
+			       int pack_objects_out_fd)
+{
+	struct stat st;
+	int waited_ms = 0;
+	int sleep_ms = 20;
+	const int max_wait_ms = 60000;
+	struct pollfd pfd;
+
+	/*
+	 * POLLHUP is reported in revents regardless of whether it
+	 * appears in events, so we leave events==0; a hang-up on
+	 * pack-objects' stdout pipe means it has exited.  pack-objects
+	 * writes its emit files immediately after enumerating its
+	 * inputs and well before producing any output, so during this
+	 * wait there is nothing readable on the pipe to confuse us.
+	 *
+	 * We never waitpid() here: finish_pack_objects_cmd() reaps the
+	 * child later; reaping twice would be incorrect.
+	 */
+	pfd.fd = pack_objects_out_fd;
+	pfd.events = 0;
+
+	while (waited_ms < max_wait_ms) {
+		int ok_packs = (stat(packs_path, &st) == 0);
+		int ok_loose = (stat(loose_path, &st) == 0);
+		int ret;
+		if (ok_packs && ok_loose)
+			return 0;
+		pfd.revents = 0;
+		ret = poll(&pfd, 1, sleep_ms);
+		if (ret < 0 && errno != EINTR)
+			return error_errno(_("poll on pack-objects "
+					     "pipe failed"));
+		if (ret > 0 &&
+		    (pfd.revents & (POLLHUP | POLLERR | POLLNVAL)))
+			return error(_("pack-objects exited before "
+				       "emitting exclude files"));
+		waited_ms += sleep_ms;
+		if (sleep_ms < 200)
+			sleep_ms *= 2;
+	}
+	return error(_("timed out waiting for pack-objects to write "
+		       "exclude files"));
+}
+
+static int start_aggregate_sidecar(struct aggregate_sidecar *sc,
+				   int pack_objects_out_fd)
+{
+	int pp[2];
+	int flags;
+
+	if (wait_for_emit_files(sc->exclude_packs_path,
+				sc->exclude_loose_path,
+				pack_objects_out_fd))
+		return -1;
+
+	/*
+	 * Build the orphan-detection pipe: child inherits the read
+	 * end as --parent-pipe-fd; we keep the write end.  Mark our
+	 * end close-on-exec so the exec'd aggregator does not inherit
+	 * a second writer that would prevent it from seeing EOF when
+	 * we exit.
+	 */
+	if (pipe(pp))
+		return error_errno(_("could not create aggregate "
+				     "parent pipe"));
+	flags = fcntl(pp[1], F_GETFD);
+	if (flags >= 0)
+		fcntl(pp[1], F_SETFD, flags | FD_CLOEXEC);
+
+	strvec_pushl(&sc->cmd.args, "pack-aggregate", "--loop", NULL);
+	strvec_pushf(&sc->cmd.args, "--exclude-pack-file=%s",
+		     sc->exclude_packs_path);
+	strvec_pushf(&sc->cmd.args, "--exclude-loose-file=%s",
+		     sc->exclude_loose_path);
+	strvec_pushf(&sc->cmd.args, "--parent-pipe-fd=%d", pp[0]);
+	/*
+	 * Allow tests (which cannot sit through the default 60s
+	 * aggregator interval) to override --interval, --min-packs,
+	 * and --min-loose without us having to add separate
+	 * pass-through options.
+	 */
+	if (getenv("GIT_TEST_PACK_AGGREGATE_INTERVAL"))
+		strvec_pushf(&sc->cmd.args, "--interval=%s",
+			     getenv("GIT_TEST_PACK_AGGREGATE_INTERVAL"));
+	if (getenv("GIT_TEST_PACK_AGGREGATE_MIN_PACKS"))
+		strvec_pushf(&sc->cmd.args, "--min-packs=%s",
+			     getenv("GIT_TEST_PACK_AGGREGATE_MIN_PACKS"));
+	if (getenv("GIT_TEST_PACK_AGGREGATE_MIN_LOOSE"))
+		strvec_pushf(&sc->cmd.args, "--min-loose=%s",
+			     getenv("GIT_TEST_PACK_AGGREGATE_MIN_LOOSE"));
+	sc->cmd.git_cmd = 1;
+	if (start_command(&sc->cmd)) {
+		close(pp[0]);
+		close(pp[1]);
+		return error(_("could not start git pack-aggregate"));
+	}
+	/*
+	 * The aggregator now has its own copy of pp[0]; the write end
+	 * is what gives us orphan detection, and the parent's read end
+	 * is just a held-open fd.  Free it.
+	 */
+	close(pp[0]);
+	sc->parent_pipe_write_fd = pp[1];
+	sc->started = 1;
+	return 0;
+}
+
+static void stop_aggregate_sidecar(struct aggregate_sidecar *sc)
+{
+	/*
+	 * Close the parent pipe up front: if the aggregator is between
+	 * cycles it will wake from poll() and exit on its own, which
+	 * lets the SIGTERM/wait dance below complete quickly.
+	 */
+	if (sc->parent_pipe_write_fd >= 0) {
+		close(sc->parent_pipe_write_fd);
+		sc->parent_pipe_write_fd = -1;
+	}
+	if (sc->started) {
+		sc->started = 0;
+		if (sc->cmd.pid > 0) {
+			pid_t pid = sc->cmd.pid;
+			int waited_ms = 0;
+			int status;
+			pid_t r;
+
+			kill(pid, SIGTERM);
+			/*
+			 * Wait briefly for graceful exit before reaping;
+			 * pack-aggregate is expected to finish quite quickly,
+			 * so a few seconds should be plenty.
+			 */
+			while (waited_ms < 5000) {
+				r = waitpid(pid, &status, WNOHANG);
+				if (r == pid || (r < 0 && errno != EINTR))
+					break;
+				sleep_millisec(50);
+				waited_ms += 50;
+			}
+			if (r != pid) {
+				kill(pid, SIGKILL);
+				while (waitpid(pid, &status, 0) < 0 &&
+				       errno == EINTR)
+					; /* nothing */
+			}
+			/*
+			 * We never call finish_command() here, so the
+			 * normal cleanup-on-exit list still has us
+			 * registered; explicitly remove ourselves so
+			 * the cleanup handler does not try to reap us
+			 * again.
+			 */
+			sc->cmd.pid = -1;
+			child_process_clear(&sc->cmd);
+		}
+	}
+	if (sc->tmpdir) {
+		struct strbuf path = STRBUF_INIT;
+		strbuf_addstr(&path, sc->tmpdir);
+		remove_dir_recursively(&path, 0);
+		strbuf_release(&path);
+		FREE_AND_NULL(sc->tmpdir);
+	}
+	FREE_AND_NULL(sc->exclude_packs_path);
+	FREE_AND_NULL(sc->exclude_loose_path);
+
+	/*
+	 * Cleanup of the ".keep" markers we dropped on our own
+	 * outputs MUST happen after the sidecar has exited,
+	 * otherwise pack-aggregate could see a pack lose its marker
+	 * and aggregate it out from under us.
+	 */
+	remove_aggregate_keep_markers(sc);
+}
+
+/*
+ * Initialize the aggregator's tempdir and per-file paths.  This is
+ * called before pack-objects starts so the files' paths can be
+ * passed to it via --emit-input-{packs,loose}.  We also opportunistically
+ * sweep any stale ".keep" markers left behind by a previous repack
+ * that crashed; doing this once at init avoids repeated scans.
+ */
+static int init_aggregate_sidecar(struct repository *repo,
+				  struct aggregate_sidecar *sc)
+{
+	struct strbuf tmpl = STRBUF_INIT;
+	char *pdir;
+
+	pdir = mkpathdup("%s/pack", repo_get_object_directory(repo));
+	clean_stale_aggregate_keeps(pdir);
+	free(pdir);
+
+	strbuf_addf(&tmpl, "%s/pack-aggregate.XXXXXX",
+		    repo_get_object_directory(repo));
+	if (!git_mkdtemp(tmpl.buf)) {
+		error_errno(_("could not create pack-aggregate tempdir"));
+		strbuf_release(&tmpl);
+		return -1;
+	}
+	sc->tmpdir = strbuf_detach(&tmpl, NULL);
+	sc->exclude_packs_path = xstrfmt("%s/packs", sc->tmpdir);
+	sc->exclude_loose_path = xstrfmt("%s/loose", sc->tmpdir);
+	return 0;
+}
+
 int cmd_repack(int argc,
 	       const char **argv,
 	       const char *prefix,
 	       struct repository *repo)
 {
 	struct child_process cmd = CHILD_PROCESS_INIT;
+	struct aggregate_sidecar sidecar = {
+		.cmd = CHILD_PROCESS_INIT,
+		.installed_keeps = STRING_LIST_INIT_DUP,
+		.parent_pipe_write_fd = -1,
+	};
 	struct string_list_item *item;
 	struct string_list names = STRING_LIST_INIT_DUP;
 	struct existing_packs existing = EXISTING_PACKS_INIT;
@@ -232,6 +614,8 @@ int cmd_repack(int argc,
 			   N_("pack prefix to store a pack containing pruned objects")),
 		OPT_STRING(0, "filter-to", &filter_to, N_("dir"),
 			   N_("pack prefix to store a pack containing filtered out objects")),
+		OPT_BOOL(0, "aggregate", &aggregate_opt,
+			 N_("run a background pack-aggregate to roll up small packs and loose objects while this repack runs")),
 		OPT_END()
 	};
 
@@ -331,6 +715,23 @@ int cmd_repack(int argc,
 
 	show_progress = !po_args.quiet && isatty(2);
 
+	/*
+	 * If --aggregate is requested, set up a tempdir and tell the
+	 * main pack-objects to write its input pack/loose lists into
+	 * it.
+	 */
+	if (aggregate_opt > 0) {
+		if (init_aggregate_sidecar(repo, &sidecar)) {
+			/* fall through: error already reported */
+			aggregate_opt = 0;
+		} else {
+			strvec_pushf(&cmd.args, "--emit-input-packs=%s",
+				     sidecar.exclude_packs_path);
+			strvec_pushf(&cmd.args, "--emit-input-loose=%s",
+				     sidecar.exclude_loose_path);
+		}
+	}
+
 	strvec_push(&cmd.args, "--keep-true-parents");
 	for (i = 0; i < keep_pack_list.nr; i++)
 		strvec_pushf(&cmd.args, "--keep-pack=%s",
@@ -415,6 +816,37 @@ int cmd_repack(int argc,
 	ret = start_command(&cmd);
 	if (ret)
 		goto cleanup;
+
+	/*
+	 * The main pack-objects is now running.  Once it has
+	 * emitted both exclude files (which it does immediately
+	 * after enumerating its inputs and well before it finishes
+	 * writing its output), we can safely launch the aggregator
+	 * to roll up anything else that lands in objects/ in the
+	 * meantime.
+	 *
+	 * Mark our ends of the pack-objects pipes close-on-exec
+	 * first: start_command() uses plain pipe() (not
+	 * pipe2(O_CLOEXEC)), so without this the aggregator would
+	 * inherit them and pack-objects would never see EOF on stdin
+	 * (which matters for --geometric where we feed it via
+	 * cmd.in).  Test for ">0" rather than ">=0": fd 0 is the
+	 * CHILD_PROCESS_INIT default for cmd.in in the non-geometric
+	 * (no_stdin) path, which is *not* a pipe we own.
+	 */
+	if (aggregate_opt > 0) {
+		if (cmd.in > 0) {
+			int flags = fcntl(cmd.in, F_GETFD);
+			if (flags >= 0)
+				fcntl(cmd.in, F_SETFD, flags | FD_CLOEXEC);
+		}
+		if (cmd.out > 0) {
+			int flags = fcntl(cmd.out, F_GETFD);
+			if (flags >= 0)
+				fcntl(cmd.out, F_SETFD, flags | FD_CLOEXEC);
+		}
+		start_aggregate_sidecar(&sidecar, cmd.out);
+	}
 
 	if (geometry.split_factor) {
 		FILE *in = xfdopen(cmd.in, "w");
@@ -562,6 +994,9 @@ int cmd_repack(int argc,
 
 	string_list_sort(&names);
 
+	if (sidecar.started)
+		install_aggregate_keep_markers(&sidecar, packdir, &names);
+
 	odb_close(repo->objects);
 
 	/*
@@ -598,6 +1033,15 @@ int cmd_repack(int argc,
 			goto cleanup;
 	}
 
+	/*
+	 * Cruft has been written, all new packs are installed (and
+	 * ".keep"-marked), and the MIDX writer has read its explicit
+	 * include list; the remaining work is small and fast.  Stop
+	 * the pack-aggregate sidecar now, *before* odb_reprepare() or
+	 * any delete/prune step that might otherwise race it.
+	 */
+	stop_aggregate_sidecar(&sidecar);
+
 	odb_reprepare(repo->objects);
 
 	if (delete_redundant) {
@@ -633,6 +1077,7 @@ int cmd_repack(int argc,
 	}
 
 cleanup:
+	stop_aggregate_sidecar(&sidecar);
 	string_list_clear(&keep_pack_list, 0);
 	string_list_clear(&names, 1);
 	existing_packs_release(&existing);

--- a/builtin/repack.c
+++ b/builtin/repack.c
@@ -36,12 +36,14 @@ static int midx_must_contain_cruft = 1;
 static int drop_filtered;
 static int dry_run;
 static int write_bitmaps_given;
+static int aggregate_once_opt = -1;
 
 static const char *const git_repack_usage[] = {
 	N_("git repack [-a] [-A] [-d] [-f] [-F] [-l] [-n] [-q] [-b] [-m]\n"
 	   "[--window=<n>] [--depth=<n>] [--threads=<n>] [--keep-pack=<pack-name>]\n"
 	   "[--write-midx[=<mode>]] [--name-hash-version=<n>] [--path-walk]\n"
-	   "[--filter=<filter-spec>] [--drop-filtered [--dry-run]]"),
+	   "[--filter=<filter-spec>] [--drop-filtered [--dry-run]]\n"
+	   "[--[no-]aggregate-once]"),
 	NULL
 };
 
@@ -117,6 +119,10 @@ static int repack_config(const char *var, const char *value,
 								      ctx->kvi);
 		return 0;
 	}
+	if (!strcmp(var, "repack.aggregateonce")) {
+		aggregate_once_opt = git_config_bool(var, value);
+		return 0;
+	}
 	return git_default_config(var, value, ctx, cb);
 }
 
@@ -152,6 +158,29 @@ static int option_parse_write_midx(const struct option *opt, const char *arg,
 	else
 		return error(_("unknown value for %s: %s"), opt->long_name, arg);
 
+	return 0;
+}
+
+static void add_pack_aggregate_test_options(struct child_process *cmd)
+{
+	if (getenv("GIT_TEST_PACK_AGGREGATE_MIN_PACKS"))
+		strvec_pushf(&cmd->args, "--min-packs=%s",
+			     getenv("GIT_TEST_PACK_AGGREGATE_MIN_PACKS"));
+	if (getenv("GIT_TEST_PACK_AGGREGATE_MIN_LOOSE"))
+		strvec_pushf(&cmd->args, "--min-loose=%s",
+			     getenv("GIT_TEST_PACK_AGGREGATE_MIN_LOOSE"));
+}
+
+static int run_pack_aggregate_once(void)
+{
+	struct child_process cmd = CHILD_PROCESS_INIT;
+
+	strvec_pushl(&cmd.args, "pack-aggregate", "--once", NULL);
+	add_pack_aggregate_test_options(&cmd);
+	cmd.git_cmd = 1;
+
+	if (run_command(&cmd))
+		return error(_("git pack-aggregate --once failed"));
 	return 0;
 }
 
@@ -261,6 +290,8 @@ int cmd_repack(int argc,
 				N_("delete filtered out objects (requires --filter)")),
 		OPT_BOOL(0, "dry-run", &dry_run,
 				N_("only show which objects would be dropped")),
+		OPT_BOOL(0, "aggregate-once", &aggregate_once_opt,
+			 N_("run pack-aggregate once before repacking")),
 		OPT_END()
 	};
 
@@ -417,6 +448,14 @@ int cmd_repack(int argc,
 	    write_midx == REPACK_WRITE_MIDX_NONE)
 		die(_(incremental_bitmap_conflict_error));
 
+	if (geometry.split_factor && pack_everything)
+		die(_("options '%s' and '%s' cannot be used together"),
+		    "--geometric", "-A/-a");
+
+	if (filter_to && !po_args.filter_options.choice)
+		die(_("option '%s' can only be used along with '%s'"),
+		    "--filter-to", "--filter");
+
 	if (write_bitmaps && po_args.local &&
 	    odb_has_alternates(repo->objects)) {
 		/*
@@ -436,6 +475,11 @@ int cmd_repack(int argc,
 	if (config_ctx.midx_new_layer_threshold < 1)
 		die(_("invalid value for %s: %d"), "--midx-new-layer-threshold",
 		    config_ctx.midx_new_layer_threshold);
+
+	if (aggregate_once_opt > 0 && run_pack_aggregate_once()) {
+		ret = 1;
+		goto cleanup;
+	}
 
 	if (write_midx != REPACK_WRITE_MIDX_NONE && write_bitmaps) {
 		struct strbuf path = STRBUF_INIT;
@@ -458,8 +502,6 @@ int cmd_repack(int argc,
 	existing_packs_collect(&existing, &keep_pack_list);
 
 	if (geometry.split_factor) {
-		if (pack_everything)
-			die(_("options '%s' and '%s' cannot be used together"), "--geometric", "-A/-a");
 		if (write_midx == REPACK_WRITE_MIDX_INCREMENTAL) {
 			geometry.midx_layer_threshold = config_ctx.midx_new_layer_threshold;
 			geometry.midx_layer_threshold_set = true;
@@ -546,8 +588,6 @@ int cmd_repack(int argc,
 	if (po_args.filter_options.choice)
 		strvec_pushf(&cmd.args, "--filter=%s",
 			     expand_list_objects_filter_spec(&po_args.filter_options));
-	else if (filter_to)
-		die(_("option '%s' can only be used along with '%s'"), "--filter-to", "--filter");
 
 	if (geometry.split_factor)
 		cmd.in = -1;

--- a/builtin/repack.c
+++ b/builtin/repack.c
@@ -21,6 +21,7 @@
 #include "read-cache-ll.h"
 #include "wrapper.h"
 #include "dir.h"
+#include "trace2.h"
 
 #define ALL_INTO_ONE 1
 #define LOOSEN_UNREACHABLE 2
@@ -1216,6 +1217,7 @@ int cmd_repack(int argc,
 		int opts = 0;
 		bool wrote_incremental_midx = write_midx == REPACK_WRITE_MIDX_INCREMENTAL;
 
+		trace2_region_enter("repack", "pack-cleanup", repo);
 		existing_packs_remove_redundant(&existing, packdir,
 						wrote_incremental_midx);
 
@@ -1223,6 +1225,7 @@ int cmd_repack(int argc,
 			pack_geometry_remove_redundant(&geometry, &names,
 						       &existing, packdir,
 						       wrote_incremental_midx);
+		trace2_region_leave("repack", "pack-cleanup", repo);
 		if (show_progress)
 			opts |= PRUNE_PACKED_VERBOSE;
 		prune_packed_objects(opts);

--- a/builtin/repack.c
+++ b/builtin/repack.c
@@ -19,6 +19,8 @@
 #include "hex.h"
 #include "wt-status.h"
 #include "read-cache-ll.h"
+#include "wrapper.h"
+#include "dir.h"
 
 #define ALL_INTO_ONE 1
 #define LOOSEN_UNREACHABLE 2
@@ -37,13 +39,14 @@ static int drop_filtered;
 static int dry_run;
 static int write_bitmaps_given;
 static int aggregate_once_opt = -1;
+static int aggregate_loop_opt = -1;
 
 static const char *const git_repack_usage[] = {
 	N_("git repack [-a] [-A] [-d] [-f] [-F] [-l] [-n] [-q] [-b] [-m]\n"
 	   "[--window=<n>] [--depth=<n>] [--threads=<n>] [--keep-pack=<pack-name>]\n"
 	   "[--write-midx[=<mode>]] [--name-hash-version=<n>] [--path-walk]\n"
 	   "[--filter=<filter-spec>] [--drop-filtered [--dry-run]]\n"
-	   "[--[no-]aggregate-once]"),
+	   "[--[no-]aggregate-once] [--[no-]aggregate-loop]"),
 	NULL
 };
 
@@ -123,6 +126,10 @@ static int repack_config(const char *var, const char *value,
 		aggregate_once_opt = git_config_bool(var, value);
 		return 0;
 	}
+	if (!strcmp(var, "repack.aggregateloop")) {
+		aggregate_loop_opt = git_config_bool(var, value);
+		return 0;
+	}
 	return git_default_config(var, value, ctx, cb);
 }
 
@@ -161,8 +168,219 @@ static int option_parse_write_midx(const struct option *opt, const char *arg,
 	return 0;
 }
 
+struct pack_aggregate_process {
+	struct child_process cmd;
+	char *tmpdir;
+	char *exclude_packs_path;
+	char *exclude_loose_path;
+	/* Full paths of the ".keep" markers created by this repack. */
+	struct string_list installed_keeps;
+	/*
+	 * Write end of a pipe whose read end the aggregator inherits
+	 * (passed via --parent-pipe-fd).  Closing this fd is the
+	 * orphan-detection signal: when repack exits without an
+	 * explicit stop_pack_aggregate(), the aggregator sees EOF
+	 * and bails out instead of running unsupervised.
+	 */
+	int parent_pipe_write_fd;
+	int started;
+};
+#define AGGREGATE_KEEP_MARKER_PREFIX "git-repack-aggregate-temporary"
+
+/*
+ * Scan packdir for stale ".keep" markers left behind by previous
+ * crashed repacks: files whose contents begin with our marker
+ * prefix and whose owning pid is no longer running.  Skip anything
+ * we cannot parse (foreign ".keep" files) or whose owner is alive.
+ */
+static void clean_stale_aggregate_keeps(const char *packdir)
+{
+	DIR *dir = opendir(packdir);
+	struct dirent *ent;
+	struct strbuf path = STRBUF_INIT;
+
+	if (!dir)
+		return;
+
+	while ((ent = readdir(dir))) {
+		const char *p;
+		char *end;
+		long pid;
+		int fd;
+		ssize_t n;
+		char buf[256];
+
+		if (!ends_with(ent->d_name, ".keep"))
+			continue;
+
+		strbuf_reset(&path);
+		strbuf_addf(&path, "%s/%s", packdir, ent->d_name);
+
+		fd = open(path.buf, O_RDONLY);
+		if (fd < 0)
+			continue;
+		n = read_in_full(fd, buf, sizeof(buf) - 1);
+		close(fd);
+		if (n <= 0)
+			continue;
+		buf[n] = '\0';
+
+		if (!skip_prefix(buf, AGGREGATE_KEEP_MARKER_PREFIX " pid=", &p))
+			continue;
+		errno = 0;
+		pid = strtol(p, &end, 10);
+		if (errno || end == p || pid <= 0)
+			continue;
+		if (*end != '\n' && *end != '\0')
+			continue;
+
+		/* Send no signal; just check existence of process */
+		if (!kill((pid_t)pid, 0))
+			continue;
+		if (errno != ESRCH)
+			continue;
+
+		if (unlink(path.buf) && errno != ENOENT)
+			warning_errno(_("could not unlink stale "
+					"aggregate .keep marker '%s'"),
+				      path.buf);
+	}
+
+	closedir(dir);
+	strbuf_release(&path);
+}
+
+/*
+ * Drop a ".keep" marker on every newly written pack so that the
+ * aggregator (which respects ".keep") cannot pick up one of the
+ * outputs from the primary repacking work.  We do this BEFORE the
+ * install loop so the marker is in place the moment
+ * generated_pack_install() renames ".idx" into view.
+ *
+ * We use O_CREAT|O_EXCL: if a ".keep" already exists for that
+ * basename (e.g. user-created, or a stale marker we failed to
+ * clean), we leave it alone and do NOT record it for cleanup --
+ * cleanup must only ever unlink markers we ourselves created.
+ */
+static void install_aggregate_keep_markers(struct pack_aggregate_process *agg,
+					   const char *packdir,
+					   const struct string_list *names)
+{
+	struct strbuf path = STRBUF_INIT;
+	struct strbuf content = STRBUF_INIT;
+	size_t i;
+
+	strbuf_addf(&content, "%s pid=%ld\n",
+		    AGGREGATE_KEEP_MARKER_PREFIX, (long)getpid());
+
+	for (i = 0; i < names->nr; i++) {
+		int fd;
+
+		strbuf_reset(&path);
+		strbuf_addf(&path, "%s/pack-%s.keep", packdir,
+			    names->items[i].string);
+
+		fd = open(path.buf, O_WRONLY | O_CREAT | O_EXCL, 0666);
+		if (fd < 0) {
+			if (errno == EEXIST)
+				continue;
+			die_errno(_("could not create aggregate "
+				    ".keep marker '%s'"), path.buf);
+		}
+		if (write_in_full(fd, content.buf, content.len) < 0)
+			die_errno(_("could not write aggregate "
+				    ".keep marker '%s'"), path.buf);
+		close(fd);
+		string_list_append(&agg->installed_keeps, path.buf);
+	}
+
+	strbuf_release(&path);
+	strbuf_release(&content);
+}
+
+/*
+ * Unlink every ".keep" marker we created earlier.  Only call this after
+ * pack-aggregate has been reaped, or it could see a pack lose its marker
+ * while it is still running.
+ */
+static void remove_aggregate_keep_markers(struct pack_aggregate_process *agg)
+{
+	size_t i;
+
+	for (i = 0; i < agg->installed_keeps.nr; i++) {
+		const char *p = agg->installed_keeps.items[i].string;
+		if (unlink(p) && errno != ENOENT)
+			warning_errno(_("could not unlink aggregate "
+					".keep marker '%s'"), p);
+	}
+	string_list_clear(&agg->installed_keeps, 0);
+}
+
+static int wait_for_emit_files(const char *packs_path,
+			       const char *loose_path,
+			       int pack_objects_out_fd)
+{
+	struct stat st;
+	int waited_ms = 0;
+	int sleep_ms = 20;
+	const int max_wait_ms = 60000;
+	struct pollfd pfd;
+
+	/*
+	 * POLLHUP is reported in revents regardless of whether it
+	 * appears in events, so we leave events==0; a hang-up on
+	 * pack-objects' stdout pipe means it has exited.  pack-objects
+	 * writes its emit files immediately after enumerating its
+	 * inputs and well before producing any output, so during this
+	 * wait there is nothing readable on the pipe to confuse us.
+	 *
+	 * We never waitpid() here: finish_pack_objects_cmd() reaps the
+	 * child later; reaping twice would be incorrect.
+	 */
+	pfd.fd = pack_objects_out_fd;
+	pfd.events = 0;
+
+	while (waited_ms < max_wait_ms) {
+		int ok_packs = (stat(packs_path, &st) == 0);
+		int ok_loose = (stat(loose_path, &st) == 0);
+		int ret;
+		if (ok_packs && ok_loose)
+			return 0;
+		pfd.revents = 0;
+		ret = poll(&pfd, 1, sleep_ms);
+		if (ret < 0 && errno != EINTR)
+			return error_errno(_("poll on pack-objects "
+					     "pipe failed"));
+		if (ret > 0 &&
+		    (pfd.revents & (POLLHUP | POLLERR | POLLNVAL)))
+			return error(_("pack-objects exited before "
+				       "emitting exclude files"));
+		waited_ms += sleep_ms;
+		if (sleep_ms < 200)
+			sleep_ms *= 2;
+	}
+	return error(_("timed out waiting for pack-objects to write "
+		       "exclude files"));
+}
+
+static int set_cloexec_or_error(int fd, const char *description)
+{
+	int flags = fcntl(fd, F_GETFD);
+
+	if (flags < 0)
+		return error_errno(_("could not read descriptor flags for %s"),
+				   description);
+	if (fcntl(fd, F_SETFD, flags | FD_CLOEXEC) < 0)
+		return error_errno(_("could not mark %s close-on-exec"),
+				   description);
+	return 0;
+}
+
 static void add_pack_aggregate_test_options(struct child_process *cmd)
 {
+	if (getenv("GIT_TEST_PACK_AGGREGATE_INTERVAL"))
+		strvec_pushf(&cmd->args, "--interval=%s",
+			     getenv("GIT_TEST_PACK_AGGREGATE_INTERVAL"));
 	if (getenv("GIT_TEST_PACK_AGGREGATE_MIN_PACKS"))
 		strvec_pushf(&cmd->args, "--min-packs=%s",
 			     getenv("GIT_TEST_PACK_AGGREGATE_MIN_PACKS"));
@@ -184,12 +402,161 @@ static int run_pack_aggregate_once(void)
 	return 0;
 }
 
+static int start_pack_aggregate(struct pack_aggregate_process *agg,
+				int pack_objects_out_fd)
+{
+	int pp[2];
+
+	if (wait_for_emit_files(agg->exclude_packs_path,
+				agg->exclude_loose_path,
+				pack_objects_out_fd))
+		return -1;
+
+	/*
+	 * Build the orphan-detection pipe: child inherits the read
+	 * end as --parent-pipe-fd; we keep the write end.  Mark our
+	 * end close-on-exec so the exec'd aggregator does not inherit
+	 * a second writer that would prevent it from seeing EOF when
+	 * we exit.
+	 */
+	if (pipe(pp))
+		return error_errno(_("could not create aggregate "
+				     "parent pipe"));
+	if (set_cloexec_or_error(pp[1],
+				 _("aggregate parent-pipe write end"))) {
+		close(pp[0]);
+		close(pp[1]);
+		return -1;
+	}
+
+	strvec_pushl(&agg->cmd.args, "pack-aggregate", "--loop", NULL);
+	strvec_pushf(&agg->cmd.args, "--exclude-pack-file=%s",
+		     agg->exclude_packs_path);
+	strvec_pushf(&agg->cmd.args, "--exclude-loose-file=%s",
+		     agg->exclude_loose_path);
+	strvec_pushf(&agg->cmd.args, "--parent-pipe-fd=%d", pp[0]);
+	/*
+	 * Allow tests (which cannot sit through the default 60s
+	 * aggregator interval) to override --interval, --min-packs, and
+	 * --min-loose without us having to add separate pass-through
+	 * options.
+	 */
+	add_pack_aggregate_test_options(&agg->cmd);
+	agg->cmd.git_cmd = 1;
+	if (start_command(&agg->cmd)) {
+		close(pp[0]);
+		close(pp[1]);
+		return error(_("could not start git pack-aggregate"));
+	}
+	close(pp[0]);
+	agg->parent_pipe_write_fd = pp[1];
+	agg->started = 1;
+	return 0;
+}
+
+static void stop_pack_aggregate(struct pack_aggregate_process *agg)
+{
+	/*
+	 * Close the parent pipe up front: if the aggregator is between
+	 * cycles it will wake from poll() and exit on its own, which
+	 * lets the SIGTERM/wait dance below complete quickly.
+	 */
+	if (agg->parent_pipe_write_fd >= 0) {
+		close(agg->parent_pipe_write_fd);
+		agg->parent_pipe_write_fd = -1;
+	}
+	if (agg->started) {
+		agg->started = 0;
+		if (agg->cmd.pid > 0) {
+			pid_t pid = agg->cmd.pid;
+			int waited_ms = 0;
+			int status;
+			pid_t r;
+
+			kill(pid, SIGTERM);
+			/*
+			 * Wait briefly for graceful exit before reaping;
+			 * pack-aggregate is expected to finish quite quickly,
+			 * so a few seconds should be plenty.
+			 */
+			while (waited_ms < 5000) {
+				r = waitpid(pid, &status, WNOHANG);
+				if (r == pid || (r < 0 && errno != EINTR))
+					break;
+				sleep_millisec(50);
+				waited_ms += 50;
+			}
+			if (r != pid) {
+				kill(pid, SIGKILL);
+				while (waitpid(pid, &status, 0) < 0 &&
+				       errno == EINTR)
+					; /* nothing */
+			}
+			/*
+			 * We never call finish_command() here, so the
+			 * normal cleanup-on-exit list still has us
+			 * registered; explicitly remove ourselves so
+			 * the cleanup handler does not try to reap us
+			 * again.
+			 */
+			agg->cmd.pid = -1;
+			child_process_clear(&agg->cmd);
+		}
+	}
+	if (agg->tmpdir) {
+		struct strbuf path = STRBUF_INIT;
+		strbuf_addstr(&path, agg->tmpdir);
+		remove_dir_recursively(&path, 0);
+		strbuf_release(&path);
+		FREE_AND_NULL(agg->tmpdir);
+	}
+	FREE_AND_NULL(agg->exclude_packs_path);
+	FREE_AND_NULL(agg->exclude_loose_path);
+
+	remove_aggregate_keep_markers(agg);
+}
+
+/*
+ * Initialize the aggregator's tempdir and per-file paths.  This is
+ * called before pack-objects starts so the files' paths can be
+ * passed to it via --emit-input-{packs,loose}.  We also opportunistically
+ * sweep any stale ".keep" markers left behind by a previous repack
+ * that crashed; doing this once at init avoids repeated scans.
+ */
+static int init_pack_aggregate(struct repository *repo,
+			       struct pack_aggregate_process *agg)
+{
+	struct strbuf tmpl = STRBUF_INIT;
+	char *pdir;
+
+	pdir = mkpathdup("%s/pack", repo_get_object_directory(repo));
+	clean_stale_aggregate_keeps(pdir);
+	free(pdir);
+
+	strbuf_addf(&tmpl, "%s/pack-aggregate.XXXXXX",
+		    repo_get_object_directory(repo));
+	if (!mkdtemp(tmpl.buf)) {
+		error_errno(_("could not create pack-aggregate tempdir"));
+		strbuf_release(&tmpl);
+		return -1;
+	}
+	agg->tmpdir = strbuf_detach(&tmpl, NULL);
+	agg->exclude_packs_path = xstrfmt("%s/packs", agg->tmpdir);
+	agg->exclude_loose_path = xstrfmt("%s/loose", agg->tmpdir);
+	return 0;
+}
+
 int cmd_repack(int argc,
 	       const char **argv,
 	       const char *prefix,
 	       struct repository *repo)
 {
 	struct child_process cmd = CHILD_PROCESS_INIT;
+	struct pack_aggregate_process aggregate = {
+		.cmd = CHILD_PROCESS_INIT,
+		.installed_keeps = STRING_LIST_INIT_DUP,
+		.parent_pipe_write_fd = -1,
+	};
 	struct string_list_item *item;
 	struct string_list names = STRING_LIST_INIT_DUP;
 	struct existing_packs existing = EXISTING_PACKS_INIT;
@@ -292,6 +659,8 @@ int cmd_repack(int argc,
 				N_("only show which objects would be dropped")),
 		OPT_BOOL(0, "aggregate-once", &aggregate_once_opt,
 			 N_("run pack-aggregate once before repacking")),
+		OPT_BOOL(0, "aggregate-loop", &aggregate_loop_opt,
+			 N_("run pack-aggregate in the background while repacking")),
 		OPT_END()
 	};
 
@@ -514,6 +883,18 @@ int cmd_repack(int argc,
 
 	show_progress = !po_args.quiet && isatty(2);
 
+	if (aggregate_loop_opt > 0) {
+		if (init_pack_aggregate(repo, &aggregate)) {
+			/* fall through: error already reported */
+			aggregate_loop_opt = 0;
+		} else {
+			strvec_pushf(&cmd.args, "--emit-input-packs=%s",
+				     aggregate.exclude_packs_path);
+			strvec_pushf(&cmd.args, "--emit-input-loose=%s",
+				     aggregate.exclude_loose_path);
+		}
+	}
+
 	strvec_push(&cmd.args, "--keep-true-parents");
 	for (i = 0; i < keep_pack_list.nr; i++)
 		strvec_pushf(&cmd.args, "--keep-pack=%s",
@@ -597,6 +978,42 @@ int cmd_repack(int argc,
 	ret = start_command(&cmd);
 	if (ret)
 		goto cleanup;
+
+	/*
+	 * The main pack-objects is now running.  Once it has
+	 * emitted both exclude files (which it does immediately
+	 * after enumerating its inputs and well before it finishes
+	 * writing its output), we can safely launch the aggregator
+	 * to roll up anything else that lands in objects/ in the
+	 * meantime.
+	 *
+	 * Mark our ends of the pack-objects pipes close-on-exec
+	 * first: start_command() uses plain pipe() (not
+	 * pipe2(O_CLOEXEC)), so without this the aggregator would
+	 * inherit them and pack-objects would never see EOF on stdin
+	 * (which matters for --geometric where we feed it via
+	 * cmd.in).  Test for ">0" rather than ">=0": fd 0 is the
+	 * CHILD_PROCESS_INIT default for cmd.in in the non-geometric
+	 * (no_stdin) path, which is *not* a pipe we own.
+	 */
+	if (aggregate_loop_opt > 0) {
+		if ((cmd.in > 0 &&
+		     set_cloexec_or_error(cmd.in,
+					  _("main pack-objects input"))) ||
+		    (cmd.out > 0 &&
+		     set_cloexec_or_error(cmd.out,
+					  _("main pack-objects output")))) {
+			/*
+			 * pack-objects is already running and still needs its
+			 * emit-file paths, so leave pack-aggregate cleanup
+			 * until the normal cleanup path after pack-objects
+			 * exits.
+			 */
+			aggregate_loop_opt = 0;
+		} else if (start_pack_aggregate(&aggregate, cmd.out)) {
+			aggregate_loop_opt = 0;
+		}
+	}
 
 	if (geometry.split_factor) {
 		FILE *in = xfdopen(cmd.in, "w");
@@ -747,6 +1164,8 @@ int cmd_repack(int argc,
 	string_list_sort(&names);
 
 	odb_close(repo->objects);
+	if (aggregate.started)
+		install_aggregate_keep_markers(&aggregate, packdir, &names);
 
 	/*
 	 * Ok we have prepared all new packfiles.
@@ -781,6 +1200,15 @@ int cmd_repack(int argc,
 		if (ret)
 			goto cleanup;
 	}
+
+	/*
+	 * Cruft has been written, all new packs are installed (and
+	 * ".keep"-marked), and the MIDX writer has read its explicit
+	 * include list; the remaining work is small and fast.  Stop
+	 * pack-aggregate now, *before* odb_reprepare()
+	 * or any delete/prune step that might otherwise race it.
+	 */
+	stop_pack_aggregate(&aggregate);
 
 	odb_reprepare(repo->objects);
 
@@ -819,6 +1247,7 @@ int cmd_repack(int argc,
 	}
 
 cleanup:
+	stop_pack_aggregate(&aggregate);
 	string_list_clear(&keep_pack_list, 0);
 	string_list_clear(&names, 1);
 	oidset_clear(&drop_oids);

--- a/command-list.txt
+++ b/command-list.txt
@@ -148,6 +148,7 @@ git-mv                                  mainporcelain           worktree
 git-name-rev                            plumbinginterrogators
 git-notes                               mainporcelain
 git-p4                                  foreignscminterface
+git-pack-aggregate                      plumbingmanipulators
 git-pack-objects                        plumbingmanipulators
 git-pack-redundant                      plumbinginterrogators
 git-pack-refs                           ancillarymanipulators

--- a/git.c
+++ b/git.c
@@ -617,6 +617,7 @@ static struct cmd_struct commands[] = {
 	{ "mv", cmd_mv, RUN_SETUP | NEED_WORK_TREE },
 	{ "name-rev", cmd_name_rev, RUN_SETUP },
 	{ "notes", cmd_notes, RUN_SETUP },
+	{ "pack-aggregate", cmd_pack_aggregate, RUN_SETUP },
 	{ "pack-objects", cmd_pack_objects, RUN_SETUP },
 #ifndef WITH_BREAKING_CHANGES
 	{ "pack-redundant", cmd_pack_redundant, RUN_SETUP | NO_PARSEOPT | DEPRECATED },

--- a/git.c
+++ b/git.c
@@ -621,6 +621,7 @@ static struct cmd_struct commands[] = {
 	{ "mv", cmd_mv, RUN_SETUP | NEED_WORK_TREE },
 	{ "name-rev", cmd_name_rev, RUN_SETUP },
 	{ "notes", cmd_notes, RUN_SETUP },
+	{ "pack-aggregate", cmd_pack_aggregate, RUN_SETUP },
 	{ "pack-objects", cmd_pack_objects, RUN_SETUP },
 #ifndef WITH_BREAKING_CHANGES
 	{ "pack-redundant", cmd_pack_redundant, RUN_SETUP | NO_PARSEOPT | DEPRECATED },

--- a/meson.build
+++ b/meson.build
@@ -656,6 +656,7 @@ builtin_sources = [
   'builtin/mv.c',
   'builtin/name-rev.c',
   'builtin/notes.c',
+  'builtin/pack-aggregate.c',
   'builtin/pack-objects.c',
   'builtin/pack-refs.c',
   'builtin/patch-id.c',

--- a/meson.build
+++ b/meson.build
@@ -677,6 +677,7 @@ builtin_sources = [
   'builtin/mv.c',
   'builtin/name-rev.c',
   'builtin/notes.c',
+  'builtin/pack-aggregate.c',
   'builtin/pack-objects.c',
   'builtin/pack-refs.c',
   'builtin/patch-id.c',

--- a/midx.c
+++ b/midx.c
@@ -952,6 +952,24 @@ static void midx_report_pack_load(struct multi_pack_index *m,
 	}
 }
 
+/* Pin at most 256 packs, reserving 64 fds and budgeting two per pack. */
+static uint32_t midx_verify_pin_budget(void)
+{
+	uint32_t budget = 256;
+	unsigned int max_fds = get_max_fd_limit();
+
+	if (max_fds > 64) {
+		uint32_t avail = (max_fds - 64) / 2;
+		if (avail < budget)
+			budget = avail;
+	} else {
+		budget = 1;
+	}
+	if (budget < 1)
+		budget = 1;
+	return budget;
+}
+
 struct pair_pos_vs_id
 {
 	uint32_t pos;
@@ -983,6 +1001,8 @@ int verify_midx_file(struct odb_source_packed *source, unsigned flags)
 	struct repository *r = source->base.odb->repo;
 	struct pair_pos_vs_id *pairs = NULL;
 	uint32_t i;
+	uint32_t total_packs;
+	int pin_packs;
 	struct progress *progress = NULL;
 	struct multi_pack_index *m = load_multi_pack_index(source);
 	struct multi_pack_index *curr;
@@ -1007,16 +1027,29 @@ int verify_midx_file(struct odb_source_packed *source, unsigned flags)
 	if (!midx_checksum_valid(m))
 		midx_report(_("incorrect checksum"));
 
+	total_packs = m->num_packs + m->num_packs_in_base;
+
+	/* Reopening by name races with repack pack removal; avoid it when possible. */
+	pin_packs = total_packs <= midx_verify_pin_budget();
+
 	if (flags & MIDX_PROGRESS)
 		progress = start_delayed_progress(r,
 						  _("Looking for referenced packfiles"),
-						  m->num_packs + m->num_packs_in_base);
-	for (i = 0; i < m->num_packs + m->num_packs_in_base; i++) {
+						  total_packs);
+	for (i = 0; i < total_packs; i++) {
 		if (prepare_midx_pack(m, i))
 			midx_report_pack_load(m, i,
 					      "failed to load pack in position %d", i);
 
 		display_progress(progress, i + 1);
+	}
+
+	if (pin_packs) {
+		for (i = 0; i < total_packs; i++) {
+			struct packed_git *p = nth_midxed_pack(m, i);
+			if (p)
+				is_pack_valid(p);
+		}
 	}
 	stop_progress(&progress);
 
@@ -1079,7 +1112,8 @@ int verify_midx_file(struct odb_source_packed *source, unsigned flags)
 		struct pack_entry e;
 		off_t m_offset, p_offset;
 
-		if (i > 0 && pairs[i-1].pack_int_id != pairs[i].pack_int_id &&
+		if (!pin_packs &&
+		    i > 0 && pairs[i-1].pack_int_id != pairs[i].pack_int_id &&
 		    nth_midxed_pack(m, pairs[i-1].pack_int_id)) {
 			uint32_t pack_int_id = pairs[i-1].pack_int_id;
 			struct packed_git *p = nth_midxed_pack(m, pack_int_id);

--- a/midx.c
+++ b/midx.c
@@ -896,6 +896,62 @@ static void midx_report(const char *fmt, ...)
 	va_end(ap);
 }
 
+/*
+ * Set once we have blamed a verification failure on a pack that the midx
+ * references having vanished -- the signature of a concurrent repack.  The
+ * objects are not lost (they moved to the replacement pack) and a quiescent
+ * retry succeeds, so we say so rather than implying midx corruption.
+ */
+static int verify_midx_race;
+
+/*
+ * Has the ".pack" backing the midx entry at pack_int_id been removed?  A
+ * concurrent repack unlinks a redundant pack's ".idx" before its ".pack", so
+ * a missing ".pack" is the tell-tale of that removal race.
+ */
+static int midx_pack_vanished(struct multi_pack_index *m, uint32_t pack_int_id)
+{
+	struct multi_pack_index *cur = m;
+	struct strbuf path = STRBUF_INIT;
+	int vanished;
+
+	pack_int_id = midx_for_pack(&cur, pack_int_id);
+	strbuf_addf(&path, "%s/pack/%s", cur->source->base.path,
+		    cur->pack_names[pack_int_id]);
+	strbuf_strip_suffix(&path, ".idx");
+	strbuf_addstr(&path, ".pack");
+	vanished = access(path.buf, F_OK) < 0 && errno == ENOENT;
+	strbuf_release(&path);
+	return vanished;
+}
+
+/*
+ * Like midx_report(), but for a failure to load the pack for pack_int_id.  If
+ * that pack simply vanished, add a one-time hint to retry when quiescent, so a
+ * concurrent repack is not mistaken for midx corruption.
+ */
+__attribute__((format (printf, 3, 4)))
+static void midx_report_pack_load(struct multi_pack_index *m,
+				  uint32_t pack_int_id,
+				  const char *fmt, ...)
+{
+	va_list ap;
+
+	verify_midx_error = 1;
+	va_start(ap, fmt);
+	vfprintf(stderr, fmt, ap);
+	fprintf(stderr, "\n");
+	va_end(ap);
+
+	if (!verify_midx_race && midx_pack_vanished(m, pack_int_id)) {
+		verify_midx_race = 1;
+		fprintf(stderr, "%s\n",
+			_("a pack referenced by the multi-pack-index is "
+			  "missing; concurrent maintenance may have replaced "
+			  "it; retry when quiescent"));
+	}
+}
+
 struct pair_pos_vs_id
 {
 	uint32_t pos;
@@ -931,6 +987,7 @@ int verify_midx_file(struct odb_source_packed *source, unsigned flags)
 	struct multi_pack_index *m = load_multi_pack_index(source);
 	struct multi_pack_index *curr;
 	verify_midx_error = 0;
+	verify_midx_race = 0;
 
 	if (!m) {
 		int result = 0;
@@ -956,7 +1013,8 @@ int verify_midx_file(struct odb_source_packed *source, unsigned flags)
 						  m->num_packs + m->num_packs_in_base);
 	for (i = 0; i < m->num_packs + m->num_packs_in_base; i++) {
 		if (prepare_midx_pack(m, i))
-			midx_report("failed to load pack in position %d", i);
+			midx_report_pack_load(m, i,
+					      "failed to load pack in position %d", i);
 
 		display_progress(progress, i + 1);
 	}
@@ -1033,13 +1091,15 @@ int verify_midx_file(struct odb_source_packed *source, unsigned flags)
 		nth_midxed_object_oid(&oid, m, pairs[i].pos);
 
 		if (!fill_midx_entry(m, &oid, &e, NULL)) {
-			midx_report(_("failed to load pack entry for oid[%d] = %s"),
+			midx_report_pack_load(m, pairs[i].pack_int_id,
+				    _("failed to load pack entry for oid[%d] = %s"),
 				    pairs[i].pos, oid_to_hex(&oid));
 			continue;
 		}
 
 		if (open_pack_index(e.p)) {
-			midx_report(_("failed to load pack-index for packfile %s"),
+			midx_report_pack_load(m, pairs[i].pack_int_id,
+				    _("failed to load pack-index for packfile %s"),
 				    e.p->pack_name);
 			break;
 		}

--- a/odb/source-packed.c
+++ b/odb/source-packed.c
@@ -743,7 +743,8 @@ static void prepare_pack(const char *full_name, size_t full_name_len,
 	    ends_with(file_name, ".bitmap") ||
 	    ends_with(file_name, ".keep") ||
 	    ends_with(file_name, ".promisor") ||
-	    ends_with(file_name, ".mtimes"))
+	    ends_with(file_name, ".mtimes") ||
+	    ends_with(file_name, ".baddeltas"))
 		string_list_append(data->garbage, full_name);
 	else
 		report_garbage(PACKDIR_FILE_GARBAGE, full_name);

--- a/packfile.c
+++ b/packfile.c
@@ -451,7 +451,9 @@ void close_pack(struct packed_git *p)
 
 void unlink_pack_path(const char *pack_name, int force_delete)
 {
-	static const char *exts[] = {".idx", ".pack", ".rev", ".keep", ".bitmap", ".promisor", ".mtimes"};
+	static const char *exts[] = {".idx", ".pack", ".rev", ".keep",
+				     ".bitmap", ".promisor", ".mtimes",
+				     ".baddeltas"};
 	int i;
 	struct strbuf buf = STRBUF_INIT;
 	size_t plen;
@@ -807,10 +809,10 @@ struct packed_git *add_packed_git(struct repository *r, const char *path,
 		return NULL;
 
 	/*
-	 * ".promisor" is long enough to hold any suffix we're adding (and
+	 * ".baddeltas" is long enough to hold any suffix we're adding (and
 	 * the use xsnprintf double-checks that)
 	 */
-	alloc = st_add3(path_len, strlen(".promisor"), 1);
+	alloc = st_add3(path_len, strlen(".baddeltas"), 1);
 	p = alloc_packed_git(r, alloc);
 	memcpy(p->pack_name, path, path_len);
 
@@ -836,6 +838,10 @@ struct packed_git *add_packed_git(struct repository *r, const char *path,
 	xsnprintf(p->pack_name + path_len, alloc - path_len, ".mtimes");
 	if (!access(p->pack_name, F_OK))
 		p->is_cruft = 1;
+
+	xsnprintf(p->pack_name + path_len, alloc - path_len, ".baddeltas");
+	if (!access(p->pack_name, F_OK))
+		p->has_bad_deltas = 1;
 
 	xsnprintf(p->pack_name + path_len, alloc - path_len, ".pack");
 	if (stat(p->pack_name, &st) || !S_ISREG(st.st_mode)) {
@@ -1019,7 +1025,8 @@ static void prepare_pack(const char *full_name, size_t full_name_len,
 	    ends_with(file_name, ".bitmap") ||
 	    ends_with(file_name, ".keep") ||
 	    ends_with(file_name, ".promisor") ||
-	    ends_with(file_name, ".mtimes"))
+	    ends_with(file_name, ".mtimes") ||
+	    ends_with(file_name, ".baddeltas"))
 		string_list_append(data->garbage, full_name);
 	else
 		report_garbage(PACKDIR_FILE_GARBAGE, full_name);

--- a/packfile.c
+++ b/packfile.c
@@ -367,7 +367,9 @@ void close_pack(struct packed_git *p)
 
 void unlink_pack_path(const char *pack_name, int force_delete)
 {
-	static const char *exts[] = {".idx", ".pack", ".rev", ".keep", ".bitmap", ".promisor", ".mtimes"};
+	static const char *exts[] = {".idx", ".pack", ".rev", ".keep",
+				     ".bitmap", ".promisor", ".mtimes",
+				     ".baddeltas"};
 	int i;
 	struct strbuf buf = STRBUF_INIT;
 	size_t plen;
@@ -723,10 +725,10 @@ struct packed_git *add_packed_git(struct repository *r, const char *path,
 		return NULL;
 
 	/*
-	 * ".promisor" is long enough to hold any suffix we're adding (and
+	 * ".baddeltas" is long enough to hold any suffix we're adding (and
 	 * the use xsnprintf double-checks that)
 	 */
-	alloc = st_add3(path_len, strlen(".promisor"), 1);
+	alloc = st_add3(path_len, strlen(".baddeltas"), 1);
 	p = alloc_packed_git(r, alloc);
 	memcpy(p->pack_name, path, path_len);
 
@@ -752,6 +754,10 @@ struct packed_git *add_packed_git(struct repository *r, const char *path,
 	xsnprintf(p->pack_name + path_len, alloc - path_len, ".mtimes");
 	if (!access(p->pack_name, F_OK))
 		p->is_cruft = 1;
+
+	xsnprintf(p->pack_name + path_len, alloc - path_len, ".baddeltas");
+	if (!access(p->pack_name, F_OK))
+		p->has_bad_deltas = 1;
 
 	xsnprintf(p->pack_name + path_len, alloc - path_len, ".pack");
 	if (stat(p->pack_name, &st) || !S_ISREG(st.st_mode)) {

--- a/packfile.c
+++ b/packfile.c
@@ -1036,12 +1036,12 @@ off_t get_delta_base(struct packed_git *p,
  * the final object lookup), but more expensive for OFS deltas (we
  * have to load the revidx to convert the offset back into a sha1).
  */
-static int get_delta_base_oid(struct packed_git *p,
-			      struct pack_window **w_curs,
-			      off_t curpos,
-			      struct object_id *oid,
-			      enum object_type type,
-			      off_t delta_obj_offset)
+int get_delta_base_oid(struct packed_git *p,
+		       struct pack_window **w_curs,
+		       off_t curpos,
+		       struct object_id *oid,
+		       enum object_type type,
+		       off_t delta_obj_offset)
 {
 	if (type == OBJ_REF_DELTA) {
 		unsigned char *base = use_pack(p, w_curs, curpos, NULL);

--- a/packfile.c
+++ b/packfile.c
@@ -471,7 +471,7 @@ static int close_one_pack(struct repository *r)
 	return 0;
 }
 
-static unsigned int get_max_fd_limit(void)
+unsigned int get_max_fd_limit(void)
 {
 #ifdef RLIMIT_NOFILE
 	{

--- a/packfile.h
+++ b/packfile.h
@@ -33,7 +33,8 @@ struct packed_git {
 		 do_not_close:1,
 		 pack_promisor:1,
 		 multi_pack_index:1,
-		 is_cruft:1;
+		 is_cruft:1,
+		 has_bad_deltas:1;
 	unsigned char hash[GIT_MAX_RAWSZ];
 	struct revindex_entry *revindex;
 	const uint32_t *revindex_data;

--- a/packfile.h
+++ b/packfile.h
@@ -307,6 +307,9 @@ int unpack_object_header(struct packed_git *, struct pack_window **, off_t *, si
 off_t get_delta_base(struct packed_git *p, struct pack_window **w_curs,
 		     off_t *curpos, enum object_type type,
 		     off_t delta_obj_offset);
+int get_delta_base_oid(struct packed_git *p, struct pack_window **w_curs,
+		       off_t curpos, struct object_id *oid,
+		       enum object_type type, off_t delta_obj_offset);
 
 int packfile_read_object_stream(struct odb_stream **out,
 				const struct object_id *oid,

--- a/packfile.h
+++ b/packfile.h
@@ -34,7 +34,8 @@ struct packed_git {
 		 do_not_close:1,
 		 pack_promisor:1,
 		 multi_pack_index:1,
-		 is_cruft:1;
+		 is_cruft:1,
+		 has_bad_deltas:1;
 	unsigned char hash[GIT_MAX_RAWSZ];
 	struct revindex_entry *revindex;
 	const uint32_t *revindex_data;

--- a/packfile.h
+++ b/packfile.h
@@ -234,6 +234,9 @@ void close_pack_index(struct packed_git *);
 
 int close_pack_fd(struct packed_git *p);
 
+/* Return the platform's maximum number of open file descriptors. */
+unsigned int get_max_fd_limit(void);
+
 uint32_t get_pack_fanout(struct packed_git *p, uint32_t value);
 
 struct object_database;

--- a/repack-geometry.c
+++ b/repack-geometry.c
@@ -187,6 +187,58 @@ static uint32_t compute_pack_geometry_split(struct packed_git **pack, size_t pac
 	return split;
 }
 
+/*
+ * Move any packs marked with a `.baddeltas` sidecar from the kept
+ * region of `pack[]` into the rollup region.  A `.baddeltas` marker
+ * declares that the pack's existing deltas are stale (e.g. because
+ * the pack was assembled by `git pack-aggregate`, which concatenates
+ * input packs without performing a fresh delta search).  We do not
+ * want such packs to sit on the geometric ladder indefinitely:
+ * rolling them up forces the next `pack-objects` invocation to
+ * recompute deltas across their objects, while leaving any
+ * `.keep`-protected pack alone (those are filtered out by
+ * `pack_geometry_init()`).
+ *
+ * Demotion preserves the ascending sort order of the kept region so
+ * that `pack_geometry_preferred_pack()` continues to return the
+ * largest local kept pack.
+ */
+static void demote_bad_delta_packs(struct pack_geometry *geometry)
+{
+	struct packed_git **demoted, **retained;
+	uint32_t d_nr = 0, r_nr = 0, kept_nr;
+
+	if (geometry->split == geometry->pack_nr)
+		return;
+
+	kept_nr = geometry->pack_nr - geometry->split;
+	for (uint32_t k = geometry->split; k < geometry->pack_nr; k++) {
+		if (geometry->pack[k]->has_bad_deltas)
+			d_nr++;
+	}
+	if (!d_nr)
+		return;
+
+	ALLOC_ARRAY(demoted, d_nr);
+	ALLOC_ARRAY(retained, kept_nr - d_nr);
+	d_nr = 0;
+	for (uint32_t k = geometry->split; k < geometry->pack_nr; k++) {
+		if (geometry->pack[k]->has_bad_deltas)
+			demoted[d_nr++] = geometry->pack[k];
+		else
+			retained[r_nr++] = geometry->pack[k];
+	}
+
+	memcpy(&geometry->pack[geometry->split], demoted,
+	       d_nr * sizeof(*geometry->pack));
+	memcpy(&geometry->pack[geometry->split + d_nr], retained,
+	       r_nr * sizeof(*geometry->pack));
+	geometry->split += d_nr;
+
+	free(demoted);
+	free(retained);
+}
+
 void pack_geometry_split(struct pack_geometry *geometry)
 {
 	geometry->split = compute_pack_geometry_split(geometry->pack, geometry->pack_nr,
@@ -194,6 +246,7 @@ void pack_geometry_split(struct pack_geometry *geometry)
 	geometry->promisor_split = compute_pack_geometry_split(geometry->promisor_pack,
 							       geometry->promisor_pack_nr,
 							       geometry->split_factor);
+	demote_bad_delta_packs(geometry);
 	for (uint32_t i = 0; i < geometry->split; i++) {
 		struct packed_git *p = geometry->pack[i];
 		/*

--- a/repack-geometry.c
+++ b/repack-geometry.c
@@ -14,6 +14,25 @@ static uint32_t pack_geometry_weight(struct packed_git *p)
 	return p->num_objects;
 }
 
+/*
+ * True only for a durably installed "pack-<hash>" basename.  This
+ * rejects an in-flight ".tmp-<pid>-pack-<hash>" staging file written by
+ * a concurrent repack or pack-aggregate, which the object-store scan
+ * (matching any "*.idx") would otherwise feed to pack-objects.
+ */
+static int is_canonical_pack_basename(const char *base, size_t hexsz)
+{
+	const char *hex;
+	size_t i;
+
+	if (!skip_prefix(base, "pack-", &hex))
+		return 0;
+	for (i = 0; i < hexsz; i++)
+		if (!isxdigit(hex[i]))
+			return 0;
+	return !strcmp(hex + hexsz, ".pack");
+}
+
 static int pack_geometry_cmp(const void *va, const void *vb)
 {
 	uint32_t aw = pack_geometry_weight(*(struct packed_git **)va),
@@ -86,6 +105,10 @@ void pack_geometry_init(struct pack_geometry *geometry,
 				continue;
 		}
 		if (p->is_cruft)
+			continue;
+
+		if (!is_canonical_pack_basename(pack_basename(p),
+						existing->repo->hash_algo->hexsz))
 			continue;
 
 		if (p->pack_promisor) {

--- a/repack-geometry.c
+++ b/repack-geometry.c
@@ -110,6 +110,59 @@ void pack_geometry_init(struct pack_geometry *geometry,
 	strbuf_release(&buf);
 }
 
+/*
+ * Move any packs marked with a `.baddeltas` sidecar from the kept
+ * region of `pack[]` into the rollup region.  A `.baddeltas` marker
+ * declares that the pack's existing deltas are stale (e.g. because
+ * the pack was assembled by `git pack-aggregate`, which concatenates
+ * input packs without performing a fresh delta search).  We do not
+ * want such packs to sit on the geometric ladder indefinitely:
+ * rolling them up forces the next `pack-objects` invocation to
+ * recompute deltas across their objects, while leaving any
+ * `.keep`-protected pack alone (those are filtered out by
+ * `pack_geometry_init()`).
+ *
+ * Demotion preserves the ascending sort order of the kept region so
+ * that `pack_geometry_preferred_pack()` continues to return the
+ * largest local kept pack.
+ */
+static void demote_bad_delta_packs(struct pack_geometry *geometry)
+{
+	struct packed_git **demoted, **retained;
+	uint32_t d_nr = 0, r_nr = 0, kept_nr;
+	uint32_t k;
+
+	if (geometry->split == geometry->pack_nr)
+		return;
+
+	kept_nr = geometry->pack_nr - geometry->split;
+	for (k = geometry->split; k < geometry->pack_nr; k++) {
+		if (geometry->pack[k]->has_bad_deltas)
+			d_nr++;
+	}
+	if (!d_nr)
+		return;
+
+	ALLOC_ARRAY(demoted, d_nr);
+	ALLOC_ARRAY(retained, kept_nr - d_nr);
+	d_nr = 0;
+	for (k = geometry->split; k < geometry->pack_nr; k++) {
+		if (geometry->pack[k]->has_bad_deltas)
+			demoted[d_nr++] = geometry->pack[k];
+		else
+			retained[r_nr++] = geometry->pack[k];
+	}
+
+	memcpy(&geometry->pack[geometry->split], demoted,
+	       d_nr * sizeof(*geometry->pack));
+	memcpy(&geometry->pack[geometry->split + d_nr], retained,
+	       r_nr * sizeof(*geometry->pack));
+	geometry->split += d_nr;
+
+	free(demoted);
+	free(retained);
+}
+
 static uint32_t compute_pack_geometry_split(struct packed_git **pack, size_t pack_nr,
 					    int split_factor)
 {
@@ -192,6 +245,7 @@ void pack_geometry_split(struct pack_geometry *geometry)
 {
 	geometry->split = compute_pack_geometry_split(geometry->pack, geometry->pack_nr,
 						      geometry->split_factor);
+	demote_bad_delta_packs(geometry);
 	geometry->promisor_split = compute_pack_geometry_split(geometry->promisor_pack,
 							       geometry->promisor_pack_nr,
 							       geometry->split_factor);

--- a/t/meson.build
+++ b/t/meson.build
@@ -629,6 +629,7 @@ integration_tests = [
   't5333-pseudo-merge-bitmaps.sh',
   't5334-incremental-multi-pack-index.sh',
   't5335-compact-multi-pack-index.sh',
+  't5336-pack-aggregate.sh',
   't5337-pack-baddeltas.sh',
   't5351-unpack-large-objects.sh',
   't5400-send-pack.sh',

--- a/t/meson.build
+++ b/t/meson.build
@@ -629,6 +629,7 @@ integration_tests = [
   't5333-pseudo-merge-bitmaps.sh',
   't5334-incremental-multi-pack-index.sh',
   't5335-compact-multi-pack-index.sh',
+  't5337-pack-baddeltas.sh',
   't5351-unpack-large-objects.sh',
   't5400-send-pack.sh',
   't5401-update-hooks.sh',

--- a/t/meson.build
+++ b/t/meson.build
@@ -639,6 +639,7 @@ integration_tests = [
   't5333-pseudo-merge-bitmaps.sh',
   't5334-incremental-multi-pack-index.sh',
   't5335-compact-multi-pack-index.sh',
+  't5337-pack-baddeltas.sh',
   't5351-unpack-large-objects.sh',
   't5400-send-pack.sh',
   't5401-update-hooks.sh',

--- a/t/meson.build
+++ b/t/meson.build
@@ -639,6 +639,7 @@ integration_tests = [
   't5333-pseudo-merge-bitmaps.sh',
   't5334-incremental-multi-pack-index.sh',
   't5335-compact-multi-pack-index.sh',
+  't5336-pack-aggregate.sh',
   't5337-pack-baddeltas.sh',
   't5351-unpack-large-objects.sh',
   't5400-send-pack.sh',

--- a/t/t5300-pack-object.sh
+++ b/t/t5300-pack-object.sh
@@ -188,6 +188,67 @@ test_expect_success 'pack-objects with bogus arguments' '
 	test_must_fail git pack-objects --window=0 test-1 blah blah <obj-list
 '
 
+# Echo "delta" or "base" for how object $2 is stored in pack index $1.
+obj_repr () {
+	git verify-pack -v "$1" |
+	awk -v o="$2" '$1 == o {
+		if (NF >= 7 && $7 ~ /^[0-9a-f]+$/)
+			print "delta"
+		else
+			print "base"
+	}'
+}
+
+test_expect_success '--prefer-reused-deltas keeps a delta copy of a duplicated object' '
+	test_when_finished "rm -rf prefer-reused" &&
+	git init prefer-reused &&
+	(
+		cd prefer-reused &&
+
+		# O is a prefix of X (genrandom is deterministic on its
+		# seed), so O deltifies cheaply against X.
+		test-tool genrandom foo 8192 >x.bin &&
+		test-tool genrandom foo 4096 >o.bin &&
+		x=$(git hash-object -w x.bin) &&
+		o=$(git hash-object -w o.bin) &&
+
+		# One pack stores O as a plain base ...
+		echo "$o" |
+			git pack-objects --window=0 .git/objects/pack/pack >base.hash &&
+		# ... another stores O as a delta against X.
+		printf "%s\n%s\n" "$x" "$o" |
+			git pack-objects .git/objects/pack/pack >delta.hash &&
+		git prune-packed &&
+
+		base="pack-$(cat base.hash)" &&
+		delta="pack-$(cat delta.hash)" &&
+
+		# Precondition: the two packs really do disagree on how O
+		# is stored.
+		test "$(obj_repr ".git/objects/pack/$base.idx" "$o")" = base &&
+		test "$(obj_repr ".git/objects/pack/$delta.idx" "$o")" = delta &&
+
+		# Packs are enumerated newest-mtime first, so make the base
+		# pack the newer one to ensure its copy is seen first.
+		test-tool chmtime -200 ".git/objects/pack/$delta.pack" &&
+		printf "%s.pack\n%s.pack\n" "$base" "$delta" >packs.in &&
+
+		# Default: the first-seen (base) copy wins, dropping the delta.
+		git pack-objects --stdin-packs --window=0 out.default \
+			<packs.in >default.hash &&
+		test "$(obj_repr "out.default-$(cat default.hash).idx" "$o")" = base &&
+
+		# With the option, the delta copy is preferred and reused.
+		git pack-objects --stdin-packs --window=0 --prefer-reused-deltas \
+			out.prefer <packs.in >prefer.hash &&
+		test "$(obj_repr "out.prefer-$(cat prefer.hash).idx" "$o")" = delta &&
+
+		# The resulting pack must still be valid (the reused delta
+		# resolves against X, which is included).
+		git verify-pack "out.prefer-$(cat prefer.hash).idx"
+	)
+'
+
 check_unpack () {
 	local packname="$1" &&
 	local object_list="$2" &&

--- a/t/t5331-pack-objects-stdin.sh
+++ b/t/t5331-pack-objects-stdin.sh
@@ -520,4 +520,104 @@ test_expect_success '--stdin-packs with !-delimited pack without follow' '
 	)
 '
 
+test_expect_success '--stdin-packs skips rev walk when delta search is off' '
+	test_when_finished "rm -fr repo" &&
+	git init repo &&
+	(
+		cd repo &&
+
+		for c in A B C D
+		do
+			test_commit "$c" || return 1
+		done &&
+
+		A="$(echo A | git pack-objects --revs $packdir/pack)" &&
+		B="$(echo A..B | git pack-objects --revs $packdir/pack)" &&
+		C="$(echo B..C | git pack-objects --revs $packdir/pack)" &&
+		D="$(echo C..D | git pack-objects --revs $packdir/pack)" &&
+		git prune-packed &&
+
+		cat >in <<-EOF &&
+		pack-$B.pack
+		^pack-$C.pack
+		pack-$D.pack
+		EOF
+
+		# In STANDARD mode (no "=follow"), the rev walk only
+		# fills in namehash hints used during delta selection,
+		# so it is unnecessary when delta search is disabled by
+		# --window=0 or --depth=0. The trace2 counter
+		# "stdin_packs_hints" is incremented only when the walk
+		# populates a hint, so seeing a value of zero implies
+		# that the walk was skipped.
+		Pdef=$(GIT_TRACE2_EVENT="$(pwd)/walk-def.event" \
+			git pack-objects --stdin-packs $packdir/pack <in) &&
+		! grep "\"key\":\"stdin_packs_hints\",\"value\":\"0\"" walk-def.event &&
+
+		Pw0=$(GIT_TRACE2_EVENT="$(pwd)/walk-w0.event" \
+			git pack-objects --stdin-packs --window=0 $packdir/pack <in) &&
+		grep "\"key\":\"stdin_packs_hints\",\"value\":\"0\"" walk-w0.event &&
+
+		Pd0=$(GIT_TRACE2_EVENT="$(pwd)/walk-d0.event" \
+			git pack-objects --stdin-packs --depth=0 $packdir/pack <in) &&
+		grep "\"key\":\"stdin_packs_hints\",\"value\":\"0\"" walk-d0.event &&
+
+		# All three runs must produce the same object set
+		# (those in the included packs B and D, since the
+		# walk plays no role in STANDARD mode beyond hints).
+		objects_in_packs $B $D >expect &&
+		objects_in_packs $Pdef >actual &&
+		test_cmp expect actual &&
+		objects_in_packs $Pw0 >actual &&
+		test_cmp expect actual &&
+		objects_in_packs $Pd0 >actual &&
+		test_cmp expect actual
+	)
+'
+
+test_expect_success '--stdin-packs=follow walks even with delta search off' '
+	test_when_finished "rm -fr repo" &&
+	git init repo &&
+	(
+		cd repo &&
+
+		for c in A B C D
+		do
+			test_commit "$c" || return 1
+		done &&
+
+		A="$(echo A | git pack-objects --revs $packdir/pack)" &&
+		B="$(echo A..B | git pack-objects --revs $packdir/pack)" &&
+		C="$(echo B..C | git pack-objects --revs $packdir/pack)" &&
+		D="$(echo C..D | git pack-objects --revs $packdir/pack)" &&
+		git prune-packed &&
+
+		cat >in <<-EOF &&
+		pack-$B.pack
+		^pack-$C.pack
+		pack-$D.pack
+		EOF
+
+		# In FOLLOW mode, the walk also pulls in objects that
+		# live outside the included packs (here, in pack A) to
+		# close the set under reachability, so the walk must
+		# run regardless of --window/--depth.
+		objects_in_packs $A $B $D >expect &&
+
+		Pdef=$(git pack-objects --stdin-packs=follow $packdir/pack <in) &&
+		objects_in_packs $Pdef >actual &&
+		test_cmp expect actual &&
+
+		Pw0=$(git pack-objects --stdin-packs=follow --window=0 \
+			$packdir/pack <in) &&
+		objects_in_packs $Pw0 >actual &&
+		test_cmp expect actual &&
+
+		Pd0=$(git pack-objects --stdin-packs=follow --depth=0 \
+			$packdir/pack <in) &&
+		objects_in_packs $Pd0 >actual &&
+		test_cmp expect actual
+	)
+'
+
 test_done

--- a/t/t5336-pack-aggregate.sh
+++ b/t/t5336-pack-aggregate.sh
@@ -406,12 +406,17 @@ test_expect_success 'startup cleans up stale .keep markers from dead pids' '
 	)
 '
 
-test_expect_success 'startup leaves live-pid .keep markers alone' '
+test_expect_success !MINGW 'startup leaves live-pid .keep markers alone' '
 	test_when_finished "rm -fr work" &&
 	cp -R repo work &&
 	# Use the test-runner shell pid, which is reliably alive
 	# for the duration of this test.  PID 1 (init) would also
 	# work since our code treats EPERM as "alive".
+	#
+	# !MINGW: on Windows, bash $$ is a virtualized MSYS pid that
+	# does not correspond to a process kill(pid, 0) can see, so
+	# our liveness check would treat it as dead and the marker
+	# would be removed.  Skip this test there.
 	live_pid=$$ &&
 	(
 		cd work &&
@@ -427,6 +432,76 @@ test_expect_success 'startup leaves live-pid .keep markers alone' '
 			git repack -d --geometric=2 --aggregate &&
 		test_path_is_file "$live" &&
 		grep -q "pid=${live_pid}" "$live"
+	)
+'
+
+# ---- geometric .baddeltas demotion ----
+
+# Helper for the geometric tests: pack a single unique blob into its
+# own packfile.  The `tag` parameter must differ between callers so
+# that the blob contents do not collide with one another (otherwise
+# `git pack-objects --stdin-packs` would see the "rollup" objects
+# already present in the kept pack and emit nothing).
+make_unique_pack () {
+	tag=$1 &&
+	blob=$(echo "unique-${tag}-$$" | git hash-object -w --stdin) &&
+	echo "$blob" |
+	git pack-objects --window=0 .git/objects/pack/pack >/dev/null &&
+	git prune-packed
+}
+
+test_expect_success 'geometric repack demotes .baddeltas packs into rollup' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		# Build several small packs and consolidate them into
+		# one larger pack that would normally sit above the
+		# geometric split.
+		build_n_packs 8 >/dev/null &&
+		git repack -d --geometric=2 &&
+		test 1 -eq "$(count_packs)" &&
+		big=$(ls .git/objects/pack/pack-*.pack) &&
+		# Drop a .baddeltas marker on it (simulating an
+		# aggregator output).
+		>"${big%.pack}.baddeltas" &&
+		test 1 -eq "$(count_baddeltas)" &&
+		# Add small packs that are individually far smaller
+		# than the big one; ordinarily the big pack would be
+		# kept above the geometric split.
+		make_unique_pack a &&
+		make_unique_pack b &&
+		make_unique_pack c &&
+		test 4 -eq "$(count_packs)" &&
+		# With the .baddeltas demotion, the big pack is rolled
+		# up despite being above the natural split, and the
+		# resulting pack carries no .baddeltas marker.
+		git repack -d --geometric=2 &&
+		test 1 -eq "$(count_packs)" &&
+		test 0 -eq "$(count_baddeltas)" &&
+		git fsck
+	)
+'
+
+test_expect_success 'geometric repack leaves non-baddeltas packs above the split alone' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		build_n_packs 8 >/dev/null &&
+		git repack -d --geometric=2 &&
+		test 1 -eq "$(count_packs)" &&
+		# Add small packs; without any .baddeltas marker the
+		# big pack should be preserved above the split.
+		make_unique_pack a &&
+		make_unique_pack b &&
+		make_unique_pack c &&
+		test 4 -eq "$(count_packs)" &&
+		git repack -d --geometric=2 &&
+		# 1 kept big pack + 1 newly-aggregated rollup = 2.
+		test 2 -eq "$(count_packs)" &&
+		test 0 -eq "$(count_baddeltas)" &&
+		git fsck
 	)
 '
 

--- a/t/t5336-pack-aggregate.sh
+++ b/t/t5336-pack-aggregate.sh
@@ -219,4 +219,215 @@ test_expect_success 'loose then pack aggregation in one cycle' '
 	)
 '
 
+
+# ---- repack integration ----
+
+test_expect_success 'repack without --aggregate does not spawn aggregator' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		build_n_packs 3 >/dev/null &&
+		GIT_TRACE2_EVENT="$(pwd)/trace.txt" \
+			git repack -d --geometric=2 &&
+		! grep "\"pack-aggregate\"" trace.txt
+	)
+'
+
+test_expect_success 'repack --aggregate spawns and reaps pack-aggregate' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		build_n_packs 5 >/dev/null &&
+		GIT_TEST_PACK_AGGREGATE_INTERVAL=1 \
+		GIT_TEST_PACK_AGGREGATE_MIN_PACKS=10 \
+		GIT_TEST_PACK_AGGREGATE_MIN_LOOSE=10 \
+		GIT_TRACE2_EVENT="$(pwd)/trace.txt" \
+			git repack -d --geometric=2 --aggregate &&
+		grep "\"pack-aggregate\"" trace.txt &&
+		# Tempdir should be cleaned up.
+		test -z "$(ls .git/objects | grep pack-aggregate)" &&
+		git fsck
+	)
+'
+
+test_expect_success 'repack.aggregate config enables aggregator' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		build_n_packs 3 >/dev/null &&
+		GIT_TEST_PACK_AGGREGATE_INTERVAL=1 \
+		GIT_TEST_PACK_AGGREGATE_MIN_PACKS=10 \
+		GIT_TEST_PACK_AGGREGATE_MIN_LOOSE=10 \
+		GIT_TRACE2_EVENT="$(pwd)/trace.txt" \
+			git -c repack.aggregate=true \
+			repack -d --geometric=2 &&
+		grep "\"pack-aggregate\"" trace.txt
+	)
+'
+
+test_expect_success 'CLI --no-aggregate overrides repack.aggregate=true' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		build_n_packs 3 >/dev/null &&
+		GIT_TRACE2_EVENT="$(pwd)/trace.txt" \
+			git -c repack.aggregate=true \
+			repack -d --geometric=2 --no-aggregate &&
+		! grep "\"pack-aggregate\"" trace.txt
+	)
+'
+
+# ---- sidecar lifecycle / .keep marker coverage ----
+
+test_expect_success PERL 'sidecar survives through write_midx_included_packs' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		build_n_packs 5 >/dev/null &&
+		GIT_TEST_PACK_AGGREGATE_INTERVAL=1 \
+		GIT_TEST_PACK_AGGREGATE_MIN_PACKS=10 \
+		GIT_TEST_PACK_AGGREGATE_MIN_LOOSE=10 \
+		GIT_TRACE2_EVENT="$(pwd)/trace.txt" \
+			git repack -d --geometric=2 --aggregate \
+				--write-midx &&
+		# Each child subprocess writes its own trace2 "start"
+		# (with argv) and "exit" (with timestamp) events under
+		# its own session id.  Find the exit timestamp of the
+		# multi-pack-index child and the exit timestamp of the
+		# pack-aggregate child by joining via session id.
+		# We cannot rely on the parents '\''child_exit'\'' event
+		# for pack-aggregate because the sidecar teardown uses
+		# kill+waitpid directly rather than finish_command().
+		perl -ne '\''
+			my ($sid)  = /"sid":"([^"]+)"/ or next;
+			my ($time) = /"time":"([^"]+)"/;
+			if (/"event":"start"/) {
+				# Look only at the second argv element (the
+				# subcommand), not any longer argument that
+				# happens to contain "pack-aggregate" as a
+				# substring (e.g. paths under our tempdir).
+				my ($argv) = /"argv":\["[^"]*","([^"]+)"/;
+				if (defined($argv) && $argv eq "multi-pack-index") {
+					$kind{$sid} = "midx";
+				} elsif (defined($argv) && $argv eq "pack-aggregate") {
+					$kind{$sid} = "agg";
+				}
+			} elsif (/"event":"exit"/ && $kind{$sid}) {
+				$exit{$kind{$sid}} //= $time;
+			}
+			END {
+				die "missing midx exit\n" unless $exit{midx};
+				die "missing agg exit\n"  unless $exit{agg};
+				die "ordering wrong: agg=$exit{agg} midx=$exit{midx}\n"
+					unless $exit{agg} gt $exit{midx};
+			}
+		'\'' trace.txt
+	)
+'
+
+test_expect_success '--aggregate preserves pre-existing user .keep files' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		build_n_packs 5 >packs.txt &&
+		first=$(head -n 1 packs.txt) &&
+		# A user-created .keep with no marker content must
+		# survive a repack --aggregate untouched.
+		echo "I am a user keep file" \
+			>.git/objects/pack/${first}.keep &&
+		GIT_TEST_PACK_AGGREGATE_INTERVAL=1 \
+		GIT_TEST_PACK_AGGREGATE_MIN_PACKS=10 \
+		GIT_TEST_PACK_AGGREGATE_MIN_LOOSE=10 \
+			git repack -d --geometric=2 --aggregate &&
+		test_path_is_file .git/objects/pack/${first}.keep &&
+		test_path_is_file .git/objects/pack/${first}.pack &&
+		# Content untouched.
+		echo "I am a user keep file" >expect &&
+		test_cmp expect .git/objects/pack/${first}.keep
+	)
+'
+
+test_expect_success '--aggregate cleans up its own .keep markers' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		build_n_packs 5 >/dev/null &&
+		GIT_TEST_PACK_AGGREGATE_INTERVAL=1 \
+		GIT_TEST_PACK_AGGREGATE_MIN_PACKS=10 \
+		GIT_TEST_PACK_AGGREGATE_MIN_LOOSE=10 \
+			git repack -d --geometric=2 --aggregate &&
+		# No marker .keep files should remain.  Any .keep that
+		# survives must NOT carry our marker prefix.
+		for f in .git/objects/pack/*.keep
+		do
+			test -e "$f" || continue
+			! grep -q "^git-repack-aggregate-temporary " "$f" \
+				|| return 1
+		done
+	)
+'
+
+test_expect_success 'startup cleans up stale .keep markers from dead pids' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		build_n_packs 3 >packs.txt &&
+		# Spawn a short-lived subshell that writes its own pid
+		# to a file, then exits.  That pid is guaranteed dead
+		# by the time we read it.
+		sh -c "echo \$\$" >dead_pid.txt &&
+		dead_pid=$(cat dead_pid.txt) &&
+		test -n "$dead_pid" &&
+		first=$(head -n 1 packs.txt) &&
+		stale=.git/objects/pack/${first}.keep &&
+		printf "git-repack-aggregate-temporary pid=%d\n" \
+			"$dead_pid" >"$stale" &&
+		test_path_is_file "$stale" &&
+		GIT_TEST_PACK_AGGREGATE_INTERVAL=1 \
+		GIT_TEST_PACK_AGGREGATE_MIN_PACKS=10 \
+		GIT_TEST_PACK_AGGREGATE_MIN_LOOSE=10 \
+			git repack -d --geometric=2 --aggregate &&
+		# The stale marker should have been cleaned at startup;
+		# even if its pack was preserved by geometric repack,
+		# the .keep should not still carry the dead-pid marker.
+		if test -e "$stale"
+		then
+			! grep -q "^git-repack-aggregate-temporary " \
+				"$stale"
+		fi
+	)
+'
+
+test_expect_success 'startup leaves live-pid .keep markers alone' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	# Use the test-runner shell pid, which is reliably alive
+	# for the duration of this test.  PID 1 (init) would also
+	# work since our code treats EPERM as "alive".
+	live_pid=$$ &&
+	(
+		cd work &&
+		build_n_packs 3 >packs.txt &&
+		first=$(head -n 1 packs.txt) &&
+		live=.git/objects/pack/${first}.keep &&
+		printf "git-repack-aggregate-temporary pid=%d\n" \
+			"$live_pid" >"$live" &&
+		test_path_is_file "$live" &&
+		GIT_TEST_PACK_AGGREGATE_INTERVAL=1 \
+		GIT_TEST_PACK_AGGREGATE_MIN_PACKS=10 \
+		GIT_TEST_PACK_AGGREGATE_MIN_LOOSE=10 \
+			git repack -d --geometric=2 --aggregate &&
+		test_path_is_file "$live" &&
+		grep -q "pid=${live_pid}" "$live"
+	)
+'
+
 test_done

--- a/t/t5336-pack-aggregate.sh
+++ b/t/t5336-pack-aggregate.sh
@@ -1,0 +1,222 @@
+#!/bin/sh
+
+test_description='`git pack-aggregate` rolls up small packs and loose objects'
+
+. ./test-lib.sh
+
+# Build N tiny packs in objects/pack/, each containing one distinct
+# blob.  Echoes the basenames (without .pack) one per line.
+build_n_packs () {
+	n=$1 &&
+	mkdir -p .git/objects/pack &&
+	i=0 &&
+	while test $i -lt "$n"
+	do
+		blob=$(echo "content-$i-$$" | git hash-object -w --stdin) &&
+		echo "$blob" |
+		git pack-objects --window=0 .git/objects/pack/pack \
+			>pack_hash &&
+		hash=$(cat pack_hash) &&
+		test -n "$hash" &&
+		test_path_is_file .git/objects/pack/pack-${hash}.pack &&
+		git prune-packed &&
+		echo "pack-$hash" &&
+		i=$((i + 1)) || return 1
+	done
+}
+
+# Create N loose objects in the repository.  Echoes the OIDs one per
+# line.
+build_n_loose () {
+	n=$1 &&
+	i=0 &&
+	while test $i -lt "$n"
+	do
+		echo "loose-$i-$$" | git hash-object -w --stdin &&
+		i=$((i + 1)) || return 1
+	done
+}
+
+count_packs () {
+	ls .git/objects/pack/pack-*.pack 2>/dev/null | wc -l
+}
+
+count_baddeltas () {
+	ls .git/objects/pack/pack-*.baddeltas 2>/dev/null | wc -l
+}
+
+count_loose () {
+	find .git/objects \
+		-type f \
+		-name '[0-9a-f]*' \
+		-not -path '.git/objects/pack/*' \
+		-not -path '.git/objects/info/*' |
+	wc -l
+}
+
+test_expect_success 'setup an empty repo' '
+	git init repo
+'
+
+test_expect_success '--once requires either --once or --loop' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		test_must_fail git pack-aggregate 2>err &&
+		grep "exactly one of --once or --loop" err
+	)
+'
+
+test_expect_success '--once below --min-packs is a no-op for packs' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		build_n_packs 3 >/dev/null &&
+		test 3 -eq "$(count_packs)" &&
+		git pack-aggregate --once --min-loose=1000 &&
+		test 3 -eq "$(count_packs)" &&
+		test 0 -eq "$(count_baddeltas)"
+	)
+'
+
+test_expect_success '--once aggregates above --min-packs' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		build_n_packs 5 >packs.txt &&
+		test 5 -eq "$(count_packs)" &&
+		git pack-aggregate --once \
+			--min-loose=1000 --min-packs=5 &&
+		test 1 -eq "$(count_packs)" &&
+		test 1 -eq "$(count_baddeltas)" &&
+		git fsck
+	)
+'
+
+test_expect_success '--exclude-pack-file protects listed packs' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		build_n_packs 6 >packs.txt &&
+		head -n 2 packs.txt >exclude.txt &&
+		git pack-aggregate --once \
+			--min-loose=1000 --min-packs=4 \
+			--exclude-pack-file=exclude.txt &&
+		while read name
+		do
+			test_path_is_file \
+				.git/objects/pack/${name}.pack || return 1
+		done <exclude.txt &&
+		# 2 excluded + 1 aggregate = 3 packs total.
+		test 3 -eq "$(count_packs)" &&
+		test 1 -eq "$(count_baddeltas)" &&
+		git fsck
+	)
+'
+
+test_expect_success 'sidecar-marked packs are skipped' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		build_n_packs 6 >packs.txt &&
+		first=$(head -n 1 packs.txt) &&
+		>.git/objects/pack/${first}.keep &&
+		git pack-aggregate --once \
+			--min-loose=1000 --min-packs=4 &&
+		test_path_is_file .git/objects/pack/${first}.pack &&
+		test_path_is_file .git/objects/pack/${first}.keep &&
+		# 1 kept + 1 aggregate = 2 packs total.
+		test 2 -eq "$(count_packs)" &&
+		git fsck
+	)
+'
+
+test_expect_success 'aggregate re-rolls up .baddeltas packs' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		build_n_packs 5 >/dev/null &&
+		git pack-aggregate --once \
+			--min-loose=1000 --min-packs=5 &&
+		test 1 -eq "$(count_packs)" &&
+		test 1 -eq "$(count_baddeltas)" &&
+		# Now add more small packs and aggregate again.  The
+		# previous .baddeltas pack should NOT be protected (we
+		# want to keep rolling them up).
+		build_n_packs 4 >/dev/null &&
+		test 5 -eq "$(count_packs)" &&
+		git pack-aggregate --once \
+			--min-loose=1000 --min-packs=5 &&
+		test 1 -eq "$(count_packs)" &&
+		test 1 -eq "$(count_baddeltas)" &&
+		git fsck
+	)
+'
+
+test_expect_success 'aggregates loose objects above --min-loose' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		build_n_loose 5 >/dev/null &&
+		test 5 -eq "$(count_loose)" &&
+		git pack-aggregate --once \
+			--min-loose=1 --min-packs=1000 &&
+		test 0 -eq "$(count_loose)" &&
+		test 1 -eq "$(count_packs)" &&
+		test 1 -eq "$(count_baddeltas)" &&
+		git fsck
+	)
+'
+
+test_expect_success '--exclude-loose-file protects listed loose objects' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		build_n_loose 5 >loose.txt &&
+		head -n 2 loose.txt >exclude.txt &&
+		git pack-aggregate --once \
+			--min-loose=1 --min-packs=1000 \
+			--exclude-loose-file=exclude.txt &&
+		while read oid
+		do
+			dir=$(echo "$oid" | cut -c1-2) &&
+			rest=$(echo "$oid" | cut -c3-) &&
+			test_path_is_file \
+				.git/objects/${dir}/${rest} || return 1
+		done <exclude.txt &&
+		test 2 -eq "$(count_loose)" &&
+		test 1 -eq "$(count_packs)" &&
+		git fsck
+	)
+'
+
+test_expect_success 'loose then pack aggregation in one cycle' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		build_n_loose 5 >/dev/null &&
+		build_n_packs 5 >/dev/null &&
+		test 5 -eq "$(count_loose)" &&
+		test 5 -eq "$(count_packs)" &&
+		git pack-aggregate --once \
+			--min-loose=1 --min-packs=5 &&
+		# Step 1 creates one pack from the loose objects, then
+		# step 2 sweeps that pack plus the five existing ones
+		# into a single aggregate.
+		test 0 -eq "$(count_loose)" &&
+		test 1 -eq "$(count_packs)" &&
+		test 1 -eq "$(count_baddeltas)" &&
+		git fsck
+	)
+'
+
+test_done

--- a/t/t5336-pack-aggregate.sh
+++ b/t/t5336-pack-aggregate.sh
@@ -1,0 +1,177 @@
+#!/bin/sh
+
+test_description='`git pack-aggregate` rolls up small packs and loose objects'
+
+. ./test-lib.sh
+
+# Build N tiny packs in objects/pack/, each containing one distinct
+# blob.  Echoes the basenames (without .pack) one per line.
+build_n_packs () {
+	n=$1 &&
+	mkdir -p .git/objects/pack &&
+	i=0 &&
+	while test $i -lt "$n"
+	do
+		blob=$(echo "content-$i-$$" | git hash-object -w --stdin) &&
+		echo "$blob" |
+		git pack-objects --window=0 .git/objects/pack/pack \
+			>pack_hash &&
+		hash=$(cat pack_hash) &&
+		test -n "$hash" &&
+		test_path_is_file .git/objects/pack/pack-${hash}.pack &&
+		git prune-packed &&
+		echo "pack-$hash" &&
+		i=$((i + 1)) || return 1
+	done
+}
+
+# Create N loose objects in the repository.  Echoes the OIDs one per
+# line.
+build_n_loose () {
+	n=$1 &&
+	i=0 &&
+	while test $i -lt "$n"
+	do
+		echo "loose-$i-$$" | git hash-object -w --stdin &&
+		i=$((i + 1)) || return 1
+	done
+}
+
+count_packs () {
+	ls .git/objects/pack/pack-*.pack 2>/dev/null | wc -l
+}
+
+count_baddeltas () {
+	ls .git/objects/pack/pack-*.baddeltas 2>/dev/null | wc -l
+}
+
+count_loose () {
+	find .git/objects \
+		-type f \
+		-name '[0-9a-f]*' \
+		-not -path '.git/objects/pack/*' \
+		-not -path '.git/objects/info/*' |
+	wc -l
+}
+
+test_expect_success 'setup an empty repo' '
+	git init repo
+'
+
+test_expect_success '--once is required' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		test_must_fail git pack-aggregate 2>err &&
+		grep -- "--once is required" err
+	)
+'
+
+test_expect_success '--once below --min-packs is a no-op for packs' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		build_n_packs 3 >/dev/null &&
+		test 3 -eq "$(count_packs)" &&
+		git pack-aggregate --once --min-loose=1000 &&
+		test 3 -eq "$(count_packs)" &&
+		test 0 -eq "$(count_baddeltas)"
+	)
+'
+
+test_expect_success '--once aggregates above --min-packs' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		build_n_packs 5 >packs.txt &&
+		test 5 -eq "$(count_packs)" &&
+		git pack-aggregate --once \
+			--min-loose=1000 --min-packs=5 &&
+		test 1 -eq "$(count_packs)" &&
+		test 1 -eq "$(count_baddeltas)" &&
+		git fsck
+	)
+'
+
+test_expect_success 'sidecar-marked packs are skipped' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		build_n_packs 6 >packs.txt &&
+		first=$(head -n 1 packs.txt) &&
+		>.git/objects/pack/${first}.keep &&
+		git pack-aggregate --once \
+			--min-loose=1000 --min-packs=4 &&
+		test_path_is_file .git/objects/pack/${first}.pack &&
+		test_path_is_file .git/objects/pack/${first}.keep &&
+		# 1 kept + 1 aggregate = 2 packs total.
+		test 2 -eq "$(count_packs)" &&
+		git fsck
+	)
+'
+
+test_expect_success 'aggregate re-rolls up .baddeltas packs' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		build_n_packs 5 >/dev/null &&
+		git pack-aggregate --once \
+			--min-loose=1000 --min-packs=5 &&
+		test 1 -eq "$(count_packs)" &&
+		test 1 -eq "$(count_baddeltas)" &&
+		# Now add more small packs and aggregate again.  The
+		# previous .baddeltas pack should NOT be protected (we
+		# want to keep rolling them up).
+		build_n_packs 4 >/dev/null &&
+		test 5 -eq "$(count_packs)" &&
+		git pack-aggregate --once \
+			--min-loose=1000 --min-packs=5 &&
+		test 1 -eq "$(count_packs)" &&
+		test 1 -eq "$(count_baddeltas)" &&
+		git fsck
+	)
+'
+
+test_expect_success 'aggregates loose objects above --min-loose' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		build_n_loose 5 >/dev/null &&
+		test 5 -eq "$(count_loose)" &&
+		git pack-aggregate --once \
+			--min-loose=1 --min-packs=1000 &&
+		test 0 -eq "$(count_loose)" &&
+		test 1 -eq "$(count_packs)" &&
+		test 1 -eq "$(count_baddeltas)" &&
+		git fsck
+	)
+'
+
+test_expect_success 'loose then pack aggregation in one cycle' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		build_n_loose 5 >/dev/null &&
+		build_n_packs 5 >/dev/null &&
+		test 5 -eq "$(count_loose)" &&
+		test 5 -eq "$(count_packs)" &&
+		git pack-aggregate --once \
+			--min-loose=1 --min-packs=5 &&
+		# Step 1 creates one pack from the loose objects, then
+		# step 2 sweeps that pack plus the five existing ones
+		# into a single aggregate.
+		test 0 -eq "$(count_loose)" &&
+		test 1 -eq "$(count_packs)" &&
+		test 1 -eq "$(count_baddeltas)" &&
+		git fsck
+	)
+'
+
+test_done

--- a/t/t5336-pack-aggregate.sh
+++ b/t/t5336-pack-aggregate.sh
@@ -37,6 +37,26 @@ build_n_loose () {
 	done
 }
 
+# Build a single pack containing N distinct blobs.  Echoes the pack
+# basename (without .pack).
+build_big_pack () {
+	n=$1 &&
+	mkdir -p .git/objects/pack &&
+	i=0 &&
+	while test $i -lt "$n"
+	do
+		echo "big-$i-$$" | git hash-object -w --stdin &&
+		i=$((i + 1)) || return 1
+	done >big_oids &&
+	git pack-objects --window=0 .git/objects/pack/pack \
+		<big_oids >big_hash &&
+	hash=$(cat big_hash) &&
+	test -n "$hash" &&
+	test_path_is_file .git/objects/pack/pack-${hash}.pack &&
+	git prune-packed &&
+	echo "pack-$hash"
+}
+
 count_packs () {
 	ls .git/objects/pack/pack-*.pack 2>/dev/null | wc -l
 }
@@ -111,6 +131,78 @@ test_expect_success 'sidecar-marked packs are skipped' '
 		# 1 kept + 1 aggregate = 2 packs total.
 		test 2 -eq "$(count_packs)" &&
 		git fsck
+	)
+'
+
+test_expect_success '--max-objects skips packs above the object-count limit' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		big=$(build_big_pack 20) &&
+		build_n_packs 5 >/dev/null &&
+		test 6 -eq "$(count_packs)" &&
+		# The big pack (20 objects) is above the cap; the five
+		# single-object packs are below it and get rolled up.
+		git pack-aggregate --once \
+			--min-loose=1000 --min-packs=1 --max-objects=10 &&
+		test_path_is_file .git/objects/pack/${big}.pack &&
+		# 1 preserved big pack + 1 aggregate = 2 packs total.
+		test 2 -eq "$(count_packs)" &&
+		test 1 -eq "$(count_baddeltas)" &&
+		git fsck
+	)
+'
+
+test_expect_success '--max-objects=0 disables the object-count limit' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		big=$(build_big_pack 20) &&
+		build_n_packs 5 >/dev/null &&
+		test 6 -eq "$(count_packs)" &&
+		# With no cap, the big pack is aggregated along with the
+		# small ones into a single pack.
+		git pack-aggregate --once \
+			--min-loose=1000 --min-packs=1 --max-objects=0 &&
+		test_path_is_missing .git/objects/pack/${big}.pack &&
+		test 1 -eq "$(count_packs)" &&
+		git fsck
+	)
+'
+
+test_expect_success 'pack.aggregateMaxObjects supplies the default limit' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		big=$(build_big_pack 20) &&
+		build_n_packs 5 >/dev/null &&
+		test 6 -eq "$(count_packs)" &&
+		git -c pack.aggregateMaxObjects=10 pack-aggregate --once \
+			--min-loose=1000 --min-packs=1 &&
+		test_path_is_file .git/objects/pack/${big}.pack &&
+		test 2 -eq "$(count_packs)" &&
+		# An explicit --max-objects still overrides the config.
+		big2=$(build_big_pack 20) &&
+		git -c pack.aggregateMaxObjects=10 pack-aggregate --once \
+			--min-loose=1000 --min-packs=1 --max-objects=0 &&
+		test_path_is_missing .git/objects/pack/${big2}.pack &&
+		test 1 -eq "$(count_packs)" &&
+		git fsck
+	)
+'
+
+test_expect_success 'pack.aggregateMaxObjects rejects negative values' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		build_n_packs 5 >/dev/null &&
+		test_must_fail git -c pack.aggregateMaxObjects=-1 \
+			pack-aggregate --once --min-packs=5 2>err &&
+		grep "cannot be negative" err
 	)
 '
 

--- a/t/t5336-pack-aggregate.sh
+++ b/t/t5336-pack-aggregate.sh
@@ -596,6 +596,7 @@ test_expect_success 'repack --aggregate-once runs pack-aggregate once' '
 		GIT_TRACE2_EVENT="$(pwd)/trace.txt" \
 			git repack -d --geometric=2 --aggregate-once &&
 		grep "\"argv\":.*\"pack-aggregate\",\"--once\"" trace.txt &&
+		! grep "\"argv\":.*\"pack-aggregate\",\"--loop\"" trace.txt &&
 		git fsck
 	)
 '
@@ -630,22 +631,60 @@ test_expect_success 'repack --aggregate-once handles an existing MIDX' '
 	)
 '
 
-test_expect_success 'repack aggregation config enables once mode' '
+test_expect_success 'repack --aggregate-loop spawns and reaps pack-aggregate' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		build_n_packs 5 >/dev/null &&
+		GIT_TEST_PACK_AGGREGATE_INTERVAL=1 \
+		GIT_TEST_PACK_AGGREGATE_MIN_PACKS=10 \
+		GIT_TEST_PACK_AGGREGATE_MIN_LOOSE=10 \
+		GIT_TRACE2_EVENT="$(pwd)/trace.txt" \
+			git repack -d --geometric=2 --aggregate-loop &&
+		grep "\"argv\":.*\"pack-aggregate\",\"--loop\"" trace.txt &&
+		# Tempdir should be cleaned up.
+		test -z "$(ls .git/objects | grep pack-aggregate)" &&
+		git fsck
+	)
+'
+
+test_expect_success 'repack can enable both aggregation modes' '
 	test_when_finished "rm -fr work" &&
 	cp -R repo work &&
 	(
 		cd work &&
 		build_n_packs 3 >/dev/null &&
+		GIT_TEST_PACK_AGGREGATE_INTERVAL=1 \
+		GIT_TEST_PACK_AGGREGATE_MIN_PACKS=10 \
+		GIT_TEST_PACK_AGGREGATE_MIN_LOOSE=10 \
+		GIT_TRACE2_EVENT="$(pwd)/trace.txt" \
+			git repack -d --geometric=2 \
+				--aggregate-once --aggregate-loop &&
+		grep "\"argv\":.*\"pack-aggregate\",\"--once\"" trace.txt &&
+		grep "\"argv\":.*\"pack-aggregate\",\"--loop\"" trace.txt
+	)
+'
+
+test_expect_success 'repack aggregation config enables both modes' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		build_n_packs 3 >/dev/null &&
+		GIT_TEST_PACK_AGGREGATE_INTERVAL=1 \
 		GIT_TEST_PACK_AGGREGATE_MIN_PACKS=10 \
 		GIT_TEST_PACK_AGGREGATE_MIN_LOOSE=10 \
 		GIT_TRACE2_EVENT="$(pwd)/trace.txt" \
 			git -c repack.aggregateOnce=true \
+			-c repack.aggregateLoop=true \
 			repack -d --geometric=2 &&
-		grep "\"argv\":.*\"pack-aggregate\",\"--once\"" trace.txt
+		grep "\"argv\":.*\"pack-aggregate\",\"--once\"" trace.txt &&
+		grep "\"argv\":.*\"pack-aggregate\",\"--loop\"" trace.txt
 	)
 '
 
-test_expect_success 'CLI can disable configured once aggregation' '
+test_expect_success 'CLI can disable configured aggregation modes' '
 	test_when_finished "rm -fr work" &&
 	cp -R repo work &&
 	(
@@ -653,8 +692,166 @@ test_expect_success 'CLI can disable configured once aggregation' '
 		build_n_packs 3 >/dev/null &&
 		GIT_TRACE2_EVENT="$(pwd)/trace.txt" \
 			git -c repack.aggregateOnce=true \
-			repack -d --geometric=2 --no-aggregate-once &&
+			-c repack.aggregateLoop=true \
+			repack -d --geometric=2 \
+				--no-aggregate-once --no-aggregate-loop &&
 		! grep "\"pack-aggregate\"" trace.txt
+	)
+'
+
+# ---- pack-aggregate lifecycle / .keep marker coverage ----
+
+test_expect_success PERL 'pack-aggregate survives through MIDX bitmap write' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		test_commit base &&
+		build_n_packs 5 >/dev/null &&
+		GIT_TEST_PACK_AGGREGATE_INTERVAL=1 \
+		GIT_TEST_PACK_AGGREGATE_MIN_PACKS=10 \
+		GIT_TEST_PACK_AGGREGATE_MIN_LOOSE=10 \
+		GIT_TRACE2_EVENT="$(pwd)/trace.txt" \
+			git repack -d --geometric=2 --aggregate-loop \
+				--write-midx --write-bitmap-index &&
+		test_path_is_file \
+			.git/objects/pack/multi-pack-index-*.bitmap &&
+		git rev-list --test-bitmap HEAD &&
+		# Each child subprocess writes its own trace2 "start"
+		# (with argv) and "exit" (with timestamp) events under
+		# its own session id.  Find the exit timestamp of the
+		# multi-pack-index child and the exit timestamp of the
+		# pack-aggregate child by joining via session id.
+		# We cannot rely on the parents '\''child_exit'\'' event
+		# for pack-aggregate because its teardown uses
+		# kill+waitpid directly rather than finish_command().
+		perl -ne '\''
+			my ($sid)  = /"sid":"([^"]+)"/ or next;
+			my ($time) = /"time":"([^"]+)"/;
+			if (/"event":"start"/) {
+				# Look only at the second argv element (the
+				# subcommand), not any longer argument that
+				# happens to contain "pack-aggregate" as a
+				# substring (e.g. paths under our tempdir).
+				my ($argv) = /"argv":\["[^"]*","([^"]+)"/;
+				if (defined($argv) && $argv eq "multi-pack-index") {
+					$kind{$sid} = "midx";
+				} elsif (defined($argv) && $argv eq "pack-aggregate") {
+					$kind{$sid} = "agg";
+				}
+			} elsif (/"event":"exit"/ && $kind{$sid}) {
+				$exit{$kind{$sid}} //= $time;
+			}
+			END {
+				die "missing midx exit\n" unless $exit{midx};
+				die "missing agg exit\n"  unless $exit{agg};
+				die "ordering wrong: agg=$exit{agg} midx=$exit{midx}\n"
+					unless $exit{agg} gt $exit{midx};
+			}
+		'\'' trace.txt
+	)
+'
+
+test_expect_success '--aggregate-loop preserves pre-existing user .keep files' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		build_n_packs 5 >packs.txt &&
+		first=$(head -n 1 packs.txt) &&
+		# A user-created .keep with no marker content must
+		# survive a repack --aggregate-loop untouched.
+		echo "I am a user keep file" >expect &&
+		cp expect .git/objects/pack/${first}.keep &&
+		GIT_TEST_PACK_AGGREGATE_INTERVAL=1 \
+		GIT_TEST_PACK_AGGREGATE_MIN_PACKS=10 \
+		GIT_TEST_PACK_AGGREGATE_MIN_LOOSE=10 \
+			git repack -d --geometric=2 --aggregate-loop &&
+		test_path_is_file .git/objects/pack/${first}.keep &&
+		test_path_is_file .git/objects/pack/${first}.pack &&
+		test_cmp expect .git/objects/pack/${first}.keep
+	)
+'
+
+test_expect_success '--aggregate-loop cleans up its own .keep markers' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		build_n_packs 5 >/dev/null &&
+		GIT_TEST_PACK_AGGREGATE_INTERVAL=1 \
+		GIT_TEST_PACK_AGGREGATE_MIN_PACKS=10 \
+		GIT_TEST_PACK_AGGREGATE_MIN_LOOSE=10 \
+			git repack -d --geometric=2 --aggregate-loop &&
+		# No marker .keep files should remain.  Any .keep that
+		# survives must NOT carry our marker prefix.
+		for f in .git/objects/pack/*.keep
+		do
+			test -e "$f" || continue
+			! grep -q "^git-repack-aggregate-temporary " "$f" \
+				|| return 1
+		done
+	)
+'
+
+test_expect_success 'startup cleans up stale .keep markers from dead pids' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		build_n_packs 3 >packs.txt &&
+		# Spawn a short-lived subshell that writes its own pid
+		# to a file, then exits.  That pid is guaranteed dead
+		# by the time we read it.
+		sh -c "echo \$\$" >dead_pid.txt &&
+		dead_pid=$(cat dead_pid.txt) &&
+		test -n "$dead_pid" &&
+		first=$(head -n 1 packs.txt) &&
+		stale=.git/objects/pack/${first}.keep &&
+		printf "git-repack-aggregate-temporary pid=%d\n" \
+			"$dead_pid" >"$stale" &&
+		test_path_is_file "$stale" &&
+		GIT_TEST_PACK_AGGREGATE_INTERVAL=1 \
+		GIT_TEST_PACK_AGGREGATE_MIN_PACKS=10 \
+		GIT_TEST_PACK_AGGREGATE_MIN_LOOSE=10 \
+			git repack -d --geometric=2 --aggregate-loop &&
+		# The stale marker should have been cleaned at startup;
+		# even if its pack was preserved by geometric repack,
+		# the .keep should not still carry the dead-pid marker.
+		if test -e "$stale"
+		then
+			! grep -q "^git-repack-aggregate-temporary " \
+				"$stale"
+		fi
+	)
+'
+
+test_expect_success !MINGW 'startup leaves live-pid .keep markers alone' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	# Use the test-runner shell pid, which is reliably alive
+	# for the duration of this test.  PID 1 (init) would also
+	# work since our code treats EPERM as "alive".
+	#
+	# !MINGW: on Windows, bash $$ is a virtualized MSYS pid that
+	# does not correspond to a process kill(pid, 0) can see, so
+	# our liveness check would treat it as dead and the marker
+	# would be removed.  Skip this test there.
+	live_pid=$$ &&
+	(
+		cd work &&
+		build_n_packs 3 >packs.txt &&
+		first=$(head -n 1 packs.txt) &&
+		live=.git/objects/pack/${first}.keep &&
+		printf "git-repack-aggregate-temporary pid=%d\n" \
+			"$live_pid" >"$live" &&
+		test_path_is_file "$live" &&
+		GIT_TEST_PACK_AGGREGATE_INTERVAL=1 \
+		GIT_TEST_PACK_AGGREGATE_MIN_PACKS=10 \
+		GIT_TEST_PACK_AGGREGATE_MIN_LOOSE=10 \
+			git repack -d --geometric=2 --aggregate-loop &&
+		test_path_is_file "$live" &&
+		grep -q "pid=${live_pid}" "$live"
 	)
 '
 

--- a/t/t5336-pack-aggregate.sh
+++ b/t/t5336-pack-aggregate.sh
@@ -78,13 +78,13 @@ test_expect_success 'setup an empty repo' '
 	git init repo
 '
 
-test_expect_success '--once is required' '
+test_expect_success '--once requires either --once or --loop' '
 	test_when_finished "rm -fr work" &&
 	cp -R repo work &&
 	(
 		cd work &&
 		test_must_fail git pack-aggregate 2>err &&
-		grep -- "--once is required" err
+		grep "exactly one of --once or --loop" err
 	)
 '
 
@@ -111,6 +111,28 @@ test_expect_success '--once aggregates above --min-packs' '
 		git pack-aggregate --once \
 			--min-loose=1000 --min-packs=5 &&
 		test 1 -eq "$(count_packs)" &&
+		test 1 -eq "$(count_baddeltas)" &&
+		git fsck
+	)
+'
+
+test_expect_success '--exclude-pack-file protects listed packs' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		build_n_packs 6 >packs.txt &&
+		head -n 2 packs.txt >exclude.txt &&
+		git pack-aggregate --once \
+			--min-loose=1000 --min-packs=4 \
+			--exclude-pack-file=exclude.txt &&
+		while read name
+		do
+			test_path_is_file \
+				.git/objects/pack/${name}.pack || return 1
+		done <exclude.txt &&
+		# 2 excluded + 1 aggregate = 3 packs total.
+		test 3 -eq "$(count_packs)" &&
 		test 1 -eq "$(count_baddeltas)" &&
 		git fsck
 	)
@@ -431,6 +453,29 @@ test_expect_success 'aggregates loose objects above --min-loose' '
 		test 0 -eq "$(count_loose)" &&
 		test 1 -eq "$(count_packs)" &&
 		test 1 -eq "$(count_baddeltas)" &&
+		git fsck
+	)
+'
+
+test_expect_success '--exclude-loose-file protects listed loose objects' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		build_n_loose 5 >loose.txt &&
+		head -n 2 loose.txt >exclude.txt &&
+		git pack-aggregate --once \
+			--min-loose=1 --min-packs=1000 \
+			--exclude-loose-file=exclude.txt &&
+		while read oid
+		do
+			dir=$(echo "$oid" | cut -c1-2) &&
+			rest=$(echo "$oid" | cut -c3-) &&
+			test_path_is_file \
+				.git/objects/${dir}/${rest} || return 1
+		done <exclude.txt &&
+		test 2 -eq "$(count_loose)" &&
+		test 1 -eq "$(count_packs)" &&
 		git fsck
 	)
 '

--- a/t/t5336-pack-aggregate.sh
+++ b/t/t5336-pack-aggregate.sh
@@ -855,4 +855,39 @@ test_expect_success !MINGW 'startup leaves live-pid .keep markers alone' '
 	)
 '
 
+test_expect_success 'pack-aggregate ignores in-flight .tmp-* packs' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		build_n_packs 5 >packs.txt &&
+		# Simulate a concurrent repack or pack-aggregate that has
+		# fully written its output but not yet renamed it into
+		# place: stage one pack under a ".tmp-<pid>-pack-<hash>"
+		# name.  The object-store scan enumerates any "*.idx", so
+		# this in-flight pack becomes visible to get_all_packs();
+		# the aggregator must never treat it as a candidate, and in
+		# particular must not delete it out from under its owner.
+		victim=$(head -n 1 packs.txt) &&
+		for e in pack idx rev
+		do
+			from=.git/objects/pack/${victim}.$e &&
+			if test -f "$from"
+			then
+				mv "$from" \
+				   .git/objects/pack/.tmp-1234-${victim}.$e ||
+				return 1
+			fi
+		done &&
+		git pack-aggregate --once --min-loose=1000 --min-packs=4 &&
+		# The staged temp pack is left untouched ...
+		test_path_is_file .git/objects/pack/.tmp-1234-${victim}.pack &&
+		test_path_is_file .git/objects/pack/.tmp-1234-${victim}.idx &&
+		# ... and only the four canonical packs were rolled into a
+		# single aggregate.
+		test 1 -eq "$(count_packs)" &&
+		git fsck
+	)
+'
+
 test_done

--- a/t/t5336-pack-aggregate.sh
+++ b/t/t5336-pack-aggregate.sh
@@ -526,4 +526,91 @@ test_expect_success 'geometric repack leaves non-baddeltas packs above the split
 	)
 '
 
+# ---- repack integration ----
+
+test_expect_success 'repack does not aggregate by default' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		build_n_packs 3 >/dev/null &&
+		GIT_TRACE2_EVENT="$(pwd)/trace.txt" \
+			git repack -d --geometric=2 &&
+		! grep "\"pack-aggregate\"" trace.txt
+	)
+'
+
+test_expect_success 'repack --aggregate-once runs pack-aggregate once' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		build_n_packs 3 >/dev/null &&
+		GIT_TEST_PACK_AGGREGATE_MIN_PACKS=10 \
+		GIT_TEST_PACK_AGGREGATE_MIN_LOOSE=10 \
+		GIT_TRACE2_EVENT="$(pwd)/trace.txt" \
+			git repack -d --geometric=2 --aggregate-once &&
+		grep "\"argv\":.*\"pack-aggregate\",\"--once\"" trace.txt &&
+		git fsck
+	)
+'
+
+test_expect_success 'repack stops when --aggregate-once fails' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		build_n_packs 3 >/dev/null &&
+		test_env GIT_TEST_PACK_AGGREGATE_MIN_PACKS=-1 \
+			GIT_TRACE2_EVENT="$(pwd)/trace.txt" \
+			test_must_fail git repack -d --geometric=2 \
+				--aggregate-once 2>err &&
+		grep "\-\-min-packs must be at least 1" err &&
+		! grep "\"argv\":.*\"pack-objects\"" trace.txt
+	)
+'
+
+test_expect_success 'repack --aggregate-once handles an existing MIDX' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		build_n_packs 5 >/dev/null &&
+		git multi-pack-index write &&
+		GIT_TEST_PACK_AGGREGATE_MIN_PACKS=5 \
+		GIT_TEST_PACK_AGGREGATE_MIN_LOOSE=10 \
+			git repack -d --geometric=2 \
+				--aggregate-once --write-midx &&
+		git fsck
+	)
+'
+
+test_expect_success 'repack aggregation config enables once mode' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		build_n_packs 3 >/dev/null &&
+		GIT_TEST_PACK_AGGREGATE_MIN_PACKS=10 \
+		GIT_TEST_PACK_AGGREGATE_MIN_LOOSE=10 \
+		GIT_TRACE2_EVENT="$(pwd)/trace.txt" \
+			git -c repack.aggregateOnce=true \
+			repack -d --geometric=2 &&
+		grep "\"argv\":.*\"pack-aggregate\",\"--once\"" trace.txt
+	)
+'
+
+test_expect_success 'CLI can disable configured once aggregation' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		build_n_packs 3 >/dev/null &&
+		GIT_TRACE2_EVENT="$(pwd)/trace.txt" \
+			git -c repack.aggregateOnce=true \
+			repack -d --geometric=2 --no-aggregate-once &&
+		! grep "\"pack-aggregate\"" trace.txt
+	)
+'
+
 test_done

--- a/t/t5336-pack-aggregate.sh
+++ b/t/t5336-pack-aggregate.sh
@@ -174,4 +174,74 @@ test_expect_success 'loose then pack aggregation in one cycle' '
 	)
 '
 
+# ---- geometric .baddeltas demotion ----
+
+# Helper for the geometric tests: pack a single unique blob into its
+# own packfile.  The `tag` parameter must differ between callers so
+# that the blob contents do not collide with one another (otherwise
+# `git pack-objects --stdin-packs` would see the "rollup" objects
+# already present in the kept pack and emit nothing).
+make_unique_pack () {
+	tag=$1 &&
+	blob=$(echo "unique-${tag}-$$" | git hash-object -w --stdin) &&
+	echo "$blob" |
+	git pack-objects --window=0 .git/objects/pack/pack >/dev/null &&
+	git prune-packed
+}
+
+test_expect_success 'geometric repack demotes .baddeltas packs into rollup' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		# Build several small packs and consolidate them into
+		# one larger pack that would normally sit above the
+		# geometric split.
+		build_n_packs 8 >/dev/null &&
+		git repack -d --geometric=2 &&
+		test 1 -eq "$(count_packs)" &&
+		big=$(ls .git/objects/pack/pack-*.pack) &&
+		# Drop a .baddeltas marker on it (simulating an
+		# aggregator output).
+		>"${big%.pack}.baddeltas" &&
+		test 1 -eq "$(count_baddeltas)" &&
+		# Add small packs that are individually far smaller
+		# than the big one; ordinarily the big pack would be
+		# kept above the geometric split.
+		make_unique_pack a &&
+		make_unique_pack b &&
+		make_unique_pack c &&
+		test 4 -eq "$(count_packs)" &&
+		# With the .baddeltas demotion, the big pack is rolled
+		# up despite being above the natural split, and the
+		# resulting pack carries no .baddeltas marker.
+		git repack -d --geometric=2 &&
+		test 1 -eq "$(count_packs)" &&
+		test 0 -eq "$(count_baddeltas)" &&
+		git fsck
+	)
+'
+
+test_expect_success 'geometric repack leaves non-baddeltas packs above the split alone' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		build_n_packs 8 >/dev/null &&
+		git repack -d --geometric=2 &&
+		test 1 -eq "$(count_packs)" &&
+		# Add small packs; without any .baddeltas marker the
+		# big pack should be preserved above the split.
+		make_unique_pack a &&
+		make_unique_pack b &&
+		make_unique_pack c &&
+		test 4 -eq "$(count_packs)" &&
+		git repack -d --geometric=2 &&
+		# 1 kept big pack + 1 newly-aggregated rollup = 2.
+		test 2 -eq "$(count_packs)" &&
+		test 0 -eq "$(count_baddeltas)" &&
+		git fsck
+	)
+'
+
 test_done

--- a/t/t5336-pack-aggregate.sh
+++ b/t/t5336-pack-aggregate.sh
@@ -206,6 +206,113 @@ test_expect_success 'pack.aggregateMaxObjects rejects negative values' '
 	)
 '
 
+test_expect_success '--max-loose-objects splits the cycle-start backlog' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		build_n_loose 10 >/dev/null &&
+		git pack-aggregate --once --min-loose=1 --min-packs=1000 \
+			--max-loose-objects=4 &&
+		test 0 -eq "$(count_loose)" &&
+		test 3 -eq "$(count_packs)" &&
+		test 3 -eq "$(count_baddeltas)" &&
+		git fsck
+	)
+'
+
+test_expect_success '--min-loose can exceed --max-loose-objects' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		build_n_loose 6 >/dev/null &&
+		git pack-aggregate --once --min-loose=5 --min-packs=1000 \
+			--max-loose-objects=2 &&
+		test 0 -eq "$(count_loose)" &&
+		test 3 -eq "$(count_packs)" &&
+		git fsck
+	)
+'
+
+test_expect_success 'multiple loose tranches avoid same-cycle reaggregation' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		build_n_loose 10 >/dev/null &&
+		build_n_packs 5 >/dev/null &&
+		git pack-aggregate --once --min-loose=1 --min-packs=1 \
+			--max-loose-objects=4 &&
+		# The five original packs are aggregated, while the three
+		# loose-rollup packs remain separate until a later cycle.
+		test 0 -eq "$(count_loose)" &&
+		test 4 -eq "$(count_packs)" &&
+		test 4 -eq "$(count_baddeltas)" &&
+		git fsck
+	)
+'
+
+test_expect_success 'loose objects newer than the cycle cutoff are deferred' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		build_n_loose 5 >oids &&
+		deferred=$(tail -n 1 oids) &&
+		deferred_path=.git/objects/$(echo "$deferred" | cut -c1-2)/$(echo "$deferred" | cut -c3-) &&
+		test-tool chmtime +60 "$deferred_path" &&
+		git pack-aggregate --once --min-loose=1 --min-packs=1000 \
+			--max-loose-objects=2 &&
+		test 1 -eq "$(count_loose)" &&
+		test_path_is_file "$deferred_path" &&
+		test-tool chmtime -60 "$deferred_path" &&
+		git pack-aggregate --once --min-loose=1 --min-packs=1000 \
+			--max-loose-objects=2 &&
+		test 0 -eq "$(count_loose)" &&
+		git fsck
+	)
+'
+
+test_expect_success '--max-loose-objects=0 disables tranche splitting' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		build_n_loose 10 >/dev/null &&
+		git pack-aggregate --once --min-loose=1 --min-packs=1000 \
+			--max-loose-objects=0 &&
+		test 0 -eq "$(count_loose)" &&
+		test 1 -eq "$(count_packs)" &&
+		git fsck
+	)
+'
+
+test_expect_success 'pack.aggregateMaxLooseObjects supplies the default limit' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		build_n_loose 10 >/dev/null &&
+		git -c pack.aggregateMaxLooseObjects=4 pack-aggregate --once \
+			--min-loose=1 --min-packs=1000 &&
+		test 0 -eq "$(count_loose)" &&
+		test 3 -eq "$(count_packs)" &&
+		git fsck
+	)
+'
+
+test_expect_success 'pack.aggregateMaxLooseObjects rejects negative values' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		test_must_fail git -c pack.aggregateMaxLooseObjects=-1 \
+			pack-aggregate --once 2>err &&
+		grep "cannot be negative" err
+	)
+'
+
 test_expect_success 'aggregate re-rolls up .baddeltas packs' '
 	test_when_finished "rm -fr work" &&
 	cp -R repo work &&

--- a/t/t5336-pack-aggregate.sh
+++ b/t/t5336-pack-aggregate.sh
@@ -313,6 +313,89 @@ test_expect_success 'pack.aggregateMaxLooseObjects rejects negative values' '
 	)
 '
 
+test_expect_success '--max-packs splits candidates into several output packs' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		build_n_packs 10 >/dev/null &&
+		test 10 -eq "$(count_packs)" &&
+		git cat-file --batch-all-objects --batch-check >before &&
+		# 10 candidates, at most 4 per output pack: ceil(10/4)=3
+		# batches of sizes 4, 4, 2 => 3 output packs, with no
+		# objects lost across the batch boundaries.
+		git pack-aggregate --once \
+			--min-loose=1000 --min-packs=1 --max-packs=4 &&
+		test 3 -eq "$(count_packs)" &&
+		test 3 -eq "$(count_baddeltas)" &&
+		git cat-file --batch-all-objects --batch-check >after &&
+		test_cmp before after &&
+		git fsck
+	)
+'
+
+test_expect_success '--max-packs above the candidate count yields one pack' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		build_n_packs 5 >/dev/null &&
+		test 5 -eq "$(count_packs)" &&
+		git pack-aggregate --once \
+			--min-loose=1000 --min-packs=1 --max-packs=100 &&
+		test 1 -eq "$(count_packs)" &&
+		test 1 -eq "$(count_baddeltas)" &&
+		git fsck
+	)
+'
+
+test_expect_success '--max-packs=0 folds everything into one pack' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		build_n_packs 10 >/dev/null &&
+		test 10 -eq "$(count_packs)" &&
+		git pack-aggregate --once \
+			--min-loose=1000 --min-packs=1 --max-packs=0 &&
+		test 1 -eq "$(count_packs)" &&
+		git fsck
+	)
+'
+
+test_expect_success 'pack.aggregateMaxPacks supplies the default limit' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		build_n_packs 10 >/dev/null &&
+		test 10 -eq "$(count_packs)" &&
+		git -c pack.aggregateMaxPacks=4 pack-aggregate --once \
+			--min-loose=1000 --min-packs=1 &&
+		test 3 -eq "$(count_packs)" &&
+		# An explicit --max-packs=0 still overrides the config,
+		# folding the current packs back into a single one.
+		build_n_packs 6 >/dev/null &&
+		test 9 -eq "$(count_packs)" &&
+		git -c pack.aggregateMaxPacks=4 pack-aggregate --once \
+			--min-loose=1000 --min-packs=1 --max-packs=0 &&
+		test 1 -eq "$(count_packs)" &&
+		git fsck
+	)
+'
+
+test_expect_success 'pack.aggregateMaxPacks rejects negative values' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		build_n_packs 5 >/dev/null &&
+		test_must_fail git -c pack.aggregateMaxPacks=-1 \
+			pack-aggregate --once --min-packs=5 2>err &&
+		grep "cannot be negative" err
+	)
+'
+
 test_expect_success 'aggregate re-rolls up .baddeltas packs' '
 	test_when_finished "rm -fr work" &&
 	cp -R repo work &&

--- a/t/t5337-pack-baddeltas.sh
+++ b/t/t5337-pack-baddeltas.sh
@@ -121,4 +121,37 @@ test_expect_success '.baddeltas is removed by git repack -d' '
 	)
 '
 
+test_expect_success 'pack-objects --mark-bad-deltas writes .baddeltas' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		A=$(git hash-object -w a) &&
+		B=$(git hash-object -w b) &&
+		printf "%s\n%s\n" "$A" "$B" |
+			git pack-objects --window=0 --mark-bad-deltas \
+				.git/objects/pack/pack >/dev/null &&
+		pack=$(basename "$(ls .git/objects/pack/pack-*.pack)") &&
+		test_path_is_file .git/objects/pack/${pack%.pack}.baddeltas &&
+		test 0 -eq "$(count_deltas .git/objects/pack/${pack%.pack}.idx)" &&
+		git prune-packed &&
+
+		out_pack=$(repack_blobs) &&
+		test 1 -le "$(count_deltas .git/objects/pack/${out_pack%.pack}.idx)"
+	)
+'
+
+test_expect_success 'pack-objects --mark-bad-deltas is incompatible with --stdout' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		A=$(git hash-object -w a) &&
+		printf "%s\n" "$A" >in &&
+		test_must_fail git pack-objects --mark-bad-deltas --stdout \
+			<in >/dev/null 2>err &&
+		test_grep "cannot be used together" err
+	)
+'
+
 test_done

--- a/t/t5337-pack-baddeltas.sh
+++ b/t/t5337-pack-baddeltas.sh
@@ -1,0 +1,124 @@
+#!/bin/sh
+
+test_description='`.baddeltas` sidecar disables the same-pack try_delta() skip'
+
+. ./test-lib.sh
+
+# Two similar but distinct blobs.  The contents are deliberately large
+# enough and similar enough that a real delta search will find a useful
+# delta between them.
+generate_blobs () {
+	{
+		printf "header\n" &&
+		i=0 &&
+		while test $i -lt 200
+		do
+			printf "line %d padding-padding-padding-padding\n" $i &&
+			i=$((i + 1)) || return 1
+		done
+	} >a &&
+	{
+		printf "header\n" &&
+		i=0 &&
+		while test $i -lt 200
+		do
+			printf "line %d padding-padding-padding-padding\n" $i &&
+			i=$((i + 1)) || return 1
+		done &&
+		printf "tail-line\n"
+	} >b
+}
+
+# Build a pack from the two blobs without doing any delta search, and
+# echo the basename of the resulting .pack file (the last "pack-*.pack"
+# in objects/pack).
+build_input_pack () {
+	A=$(git hash-object -w a) &&
+	B=$(git hash-object -w b) &&
+	printf "%s\n%s\n" "$A" "$B" |
+	git pack-objects --window=0 .git/objects/pack/pack >/dev/null &&
+	git prune-packed &&
+	basename "$(ls -t .git/objects/pack/pack-*.pack | head -1)"
+}
+
+# Count delta entries in a pack idx.  "git verify-pack -v" prints one
+# line per object with 5 fields for non-delta entries (oid, type, size,
+# size-in-pack, offset) and 7 fields for delta entries (... depth
+# base-oid).
+count_deltas () {
+	git verify-pack -v "$1" |
+	awk 'NF == 7 { n++ } END { print n + 0 }'
+}
+
+# Repack just the two blobs from the existing pack into a fresh pack
+# with prefix "out".  Echo the basename of the resulting .pack file.
+repack_blobs () {
+	A=$(git hash-object a) &&
+	B=$(git hash-object b) &&
+	rm -f .git/objects/pack/out-*.pack \
+	      .git/objects/pack/out-*.idx \
+	      .git/objects/pack/out-*.rev &&
+	printf "%s\n%s\n" "$A" "$B" |
+	git pack-objects .git/objects/pack/out >/dev/null &&
+	basename "$(ls .git/objects/pack/out-*.pack)"
+}
+
+test_expect_success 'set up two similar blobs' '
+	git init repo &&
+	(
+		cd repo &&
+		generate_blobs
+	)
+'
+
+test_expect_success 'without .baddeltas, same-pack pair is skipped' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		input_pack=$(build_input_pack) &&
+		test 0 -eq "$(count_deltas .git/objects/pack/${input_pack%.pack}.idx)" &&
+		out_pack=$(repack_blobs) &&
+		test 0 -eq "$(count_deltas .git/objects/pack/${out_pack%.pack}.idx)"
+	)
+'
+
+test_expect_success 'with .baddeltas, same-pack pair gets reconsidered' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		input_pack=$(build_input_pack) &&
+		test 0 -eq "$(count_deltas .git/objects/pack/${input_pack%.pack}.idx)" &&
+		>.git/objects/pack/${input_pack%.pack}.baddeltas &&
+		out_pack=$(repack_blobs) &&
+		test 1 -le "$(count_deltas .git/objects/pack/${out_pack%.pack}.idx)"
+	)
+'
+
+test_expect_success '.baddeltas does not trigger garbage warnings' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		input_pack=$(build_input_pack) &&
+		>.git/objects/pack/${input_pack%.pack}.baddeltas &&
+		git count-objects -v 2>warnings &&
+		! grep -i garbage warnings
+	)
+'
+
+test_expect_success '.baddeltas is removed by git repack -d' '
+	test_when_finished "rm -fr work" &&
+	cp -R repo work &&
+	(
+		cd work &&
+		input_pack=$(build_input_pack) &&
+		>.git/objects/pack/${input_pack%.pack}.baddeltas &&
+		git repack -ad &&
+		test_path_is_missing .git/objects/pack/${input_pack%.pack}.baddeltas &&
+		test_path_is_missing .git/objects/pack/$input_pack
+	)
+'
+
+test_done

--- a/t/t7703-repack-geometric.sh
+++ b/t/t7703-repack-geometric.sh
@@ -541,4 +541,52 @@ test_expect_success 'geometric repack works with promisor packs' '
 	)
 '
 
+test_expect_success 'geometric repack ignores in-flight .tmp-* packs' '
+	git init geometric-tmp &&
+	test_when_finished "rm -fr geometric-tmp" &&
+	(
+		cd geometric-tmp &&
+
+		# Build several packs whose sizes do not already form a
+		# geometric progression, so that a --geometric=2 repack
+		# would roll the smaller ones together.
+		for i in 1 2 3 4 5 6
+		do
+			n=$((i * 3)) &&
+			j=0 &&
+			while test $j -lt $n
+			do
+				echo "obj-$i-$j" | git hash-object -w --stdin &&
+				j=$((j + 1)) || return 1
+			done |
+			git pack-objects --window=0 $packdir/pack \
+				>/dev/null || return 1
+		done &&
+		git prune-packed &&
+
+		# Stage the smallest pack under an in-flight
+		# ".tmp-<pid>-pack-<hash>" name, as a concurrent repack or
+		# pack-aggregate would before renaming it into place.  The
+		# geometric roll-up must not select it as pack-objects input
+		# (it may vanish under us mid-read), and with -d it must not
+		# delete it either.
+		victim=$(ls -S $packdir/pack-*.pack | tail -n 1) &&
+		vb=$(basename "$victim" .pack) &&
+		for e in pack idx rev
+		do
+			from=$packdir/${vb}.$e &&
+			if test -f "$from"
+			then
+				mv "$from" $packdir/.tmp-1234-${vb}.$e ||
+				return 1
+			fi
+		done &&
+
+		git repack --geometric 2 -d &&
+
+		test_path_is_file $packdir/.tmp-1234-${vb}.pack &&
+		test_path_is_file $packdir/.tmp-1234-${vb}.idx
+	)
+'
+
 test_done


### PR DESCRIPTION
During the time between when a repack starts and when it completes,
large repositories can gain thousands of packfiles and tens of thousands
of loose objects that are not part of that repack.  Not only does this
mean that the repository immediately needs maintenance again, but git
operations slow down dramatically during the repack -- sometimes to the
point that the service is effectively considered offline.

This series proposes a simple (optional, off by default) solution:

  * Doing maintenance during maintenance.

or, more specifically:

  * Doing (cheap mere aggregation) maintenance (of new objects and packs)
    during (far more thorough) maintenance (of older objects and packs).

=== Concerns/Objection ===

The description above probably raises several serious concerns; let me
attempt to address them (feedback on whether I've missed any, or
insufficiently addressed some very welcome):


Objection 1: What does "cheap mere aggregation" mean?

It means omitting all of the following:
  * delta compression or even delta searching
  * reachability checks, and anything related to them
    * commit-graph updates
    * bitmap generation
    * cruft pack generation or updates
  * multi-pack index creation or updates


Objection 2: Aggregating packs without delta searches causes bad deltas

Yes, but this series adds a .baddeltas marker file (similar to .keep,
.mtimes, .bitmap, .promisor that already exist) to notify future
pack-objects invocations that two objects within that pack should be
checked for deltas, so the effect does not persist.

(On the flip side, see Trade-off 1)


Objection 3: Repack or its subprocess can fail if packfiles disappear

repack calls pack-objects, which enumerates the existing packs, and
only repacks those (or a subset of those if doing a geometric repack),
and then writes a new pack.  The remainder of repack (e.g. multi-pack
index creation, bitmap generation) -- at least up until the
odb_reprepare() call immediately before deleting redundant packs --
only works on this subset of packs.  Thus, if we have pack-objects
tell us the packs it is working on and we avoid touching any packs:

  * in an existing multi-pack-index
  * in the list of packs that repack's pack-objects is working on
  * that is written by repack's pack-objects process
  * that are covered by other sidecars (mainly '.keep' and '.mtimes', but
    we throw in '.promisor' and '.bitmap' for good measure)

Then we should be safe; this does require modifying pack-objects to:
  * let us know exactly what packs it is working on
  * create its new pack with a (temporary, see below) .keep file

(We also have pack-objects notify us which loose objects exist at that
time, even though that is not needed for correctness, but does allow
us to generally avoid putting a loose object into two new packs.)


Objection 4: The .keep created by pack-objects might persist

It is removed at the end of the repack process.

Further, if for some reason the repack process is killed or dies, the
.keep file contains a marker making it clear the keep was meant to be
temporary and has the corresponding PID of the repack process, meaning
that if that PID no longer exists, the .keep file can be cleaned up.
See also the next point.


Objection 5: Will this "cheap" maintenance actually be cheap?

There's an unnecessary reachability walk today which makes this kind
of "cheap" maintenance somewhat expensive.  Patch 3 removes it and
makes a typical case 500x faster and take 50x less memory.

That's fast enough that I not only run "cheap" maintenance during
"real" maintenance, I also run a "cheap" maintenance step before "real"
maintenance.  The reasons for this inserted preparatory step are:
  * it allows other git operations to be faster while waiting for
    the "real" maintenance to complete
  * it reduces the number of packfiles and loose objects that need
    to be tracked for exclusion
  * the preparatory step can look for leftover ".keep" files from a
    previous repack process that died early and remove them

=== Important tradeoffs ===


Trade-off 1: need to repeat some delta checks

Two objects being in the same pack that aren't a delta against each
other usually means a previous process has checked and determined
those two objects are not a good delta.  Any such objects placed into
a .baddeltas pack will lose that information and we'll have to
re-check for deltas.


Trade-off 2: mtime delay for expiring objects

When we repack loose objects into a (non-cruft) pack, that effectively
updates their mtime when they could have been ready to expire.  If
these objects are unreachable, then the "real" maintenance's
reachability check will determine that and either unpack these objects
or move them to a cruft pack.  Either way, they'll be stamped with the
pack's mtime they were removed from.  For large repositories where we
essentially continuously run maintenance all day long, this can only
add a delay equal to how long a maintenance run takes and is thus
considered inconsequential.


=== Series overview ===


  Patch 1: Add support for a ".baddeltas" marker for packs, in try_delta()
  Patch 2: Support --mark-bad-deltas option in pack-objects
  Patch 3: Accelerate pack-objects when delta search is off
  Patch 4: Add --emit-input-{packs,loose} plumbing options to pack-objects

    This patch is critical, because we need to know what packs the
    regular repacking will be working with so we avoid them.

    Trying to enumerate the packs outside of repack/pack-objects risks a
    race with newly pushed packs, and in large repositories which push
    multiple times per second, losing that race is quite likely.

  Patch 5: New pack-aggregate builtin for cheap object/pack aggregation
  Patch 6: Allow repack to spawn pack-aggregate while doing regular repacking
