### PR TITLE
osxkeychain: fix build with Rust

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4074,7 +4074,7 @@ contrib/libgit-sys/libgitpub.a: $(LIBGIT_HIDDEN_EXPORT)
 
 contrib/credential/osxkeychain/git-credential-osxkeychain: contrib/credential/osxkeychain/git-credential-osxkeychain.o $(LIB_FILE) GIT-LDFLAGS
 	$(QUIET_LINK)$(CC) $(ALL_CFLAGS) -o $@ $(ALL_LDFLAGS) \
-		$(filter %.o,$^) $(LIB_FILE) $(EXTLIBS) -framework Security -framework CoreFoundation
+		$(filter %.o,$^) $(LIBS) -framework Security -framework CoreFoundation
 
 contrib/credential/osxkeychain/git-credential-osxkeychain.o: contrib/credential/osxkeychain/git-credential-osxkeychain.c GIT-CFLAGS
 	$(QUIET_LINK)$(CC) -o $@ -c $(dep_args) $(compdb_args) $(ALL_CFLAGS) $(EXTRA_CPPFLAGS) $<


### PR DESCRIPTION
I ran into this when trying to build Microsoft Git v2.55.0-rc0. This seems to be similar in spirit to https://lore.kernel.org/git/pull.2288.git.git.1778001976709.gitgitgadget@gmail.com/ but the latter seems not to have gained traction. This build failure is a hard regression in v2.55.0, though.

cc: Patrick Steinhardt <ps@pks.im>