### PR TITLE
completion: zsh: support completion after "git -C <path>"

### DIFF
--- a/contrib/completion/git-completion.zsh
+++ b/contrib/completion/git-completion.zsh
@@ -227,6 +227,7 @@ __git_zsh_main ()
 		'(-p --paginate --no-pager)'{-p,--paginate}'[pipe all output into ''less'']' \
 		'(-p --paginate)--no-pager[do not pipe git output into a pager]' \
 		'--git-dir=-[set the path to the repository]: :_directories' \
+		'*-C[run as if git was started in <path>]: :_directories' \
 		'--bare[treat the repository as a bare repository]' \
 		'(- :)--version[prints the git suite version]' \
 		'--exec-path=-[path to where your core git programs are installed]:: :_directories' \
@@ -251,7 +252,29 @@ __git_zsh_main ()
 		done
 		;;
 	(arg)
-		local command="${words[1]}" __git_dir __git_cmd_idx=1
+		local command="${words[1]}" __git_dir __git_cmd_idx
+		local -a __git_C_args
+		local -i i=2
+
+		while (( i <= $#orig_words )); do
+			case ${orig_words[i]} in
+			-C)
+				__git_C_args+=(-C ${orig_words[i+1]})
+				(( i++ ))
+				;;
+			-c|--git-dir|--work-tree|--namespace)
+				(( i++ ))
+				;;
+			-*)
+				;;
+			*)
+				break
+				;;
+			esac
+			(( i++ ))
+		done
+
+		__git_cmd_idx=$(( i - 1 ))
 
 		if (( $+opt_args[--bare] )); then
 			__git_dir='.'


### PR DESCRIPTION
  * The command is now located by walking the global options in front of it,
    mirroring the loop at the beginning of `__git_main` in
    `git-completion.bash`, instead of skipping only leading `-C` options. This
    also fixes argument completion after other global options, e.g.
    `git -p checkout <TAB>`.
  * The log message uses the present tense for the pre-image and notes that the
    argument of a `-C` is completed without regard for the `-C` options before
    it.

  cc: Ben Knoble <ben.knoble@gmail.com>
  cc: Junio C Hamano <gitster@pobox.com>

cc: "Lutz Lengemann" <lutz@lengemann.net>
cc: "D. Ben Knoble" <ben.knoble@gmail.com>