### PR TITLE
win32: ensure that `localtime_r()` is declared even in i686 builds

### DIFF
--- a/compat/posix.h
+++ b/compat/posix.h
@@ -56,7 +56,7 @@
 # define UNUSED
 #endif
 
-#ifdef __MINGW64__
+#if defined(__MINGW32__) || defined(__MINGW64__)
 #define _POSIX_C_SOURCE 1
 #elif defined(__sun__)
  /*


### PR DESCRIPTION
Git for Windows plans on reducing the scope of its i686 support after v2.55.0 even further, therefore this patch (which I had forgotten about) needs to be in that version.

cc: Patrick Steinhardt <ps@pks.im>