### PR TITLE
history: close COMMIT_EDITMSG before launching the editor

### DIFF
--- a/builtin/history.c
+++ b/builtin/history.c
@@ -74,6 +74,14 @@ static int fill_commit_message(struct repository *repo,
 	wt_status_collect_free_buffers(&s);
 	string_list_clear_func(&s.change, change_data_free);
 
+	/*
+	 * Close the handle before launching the editor: on Windows an open
+	 * handle would prevent the editor from replacing the file (e.g.
+	 * BusyBox' `ash` cannot overwrite a file that another process keeps
+	 * open), and leaving it open leaks the descriptor everywhere else.
+	 */
+	fclose(s.fp);
+
 	strbuf_reset(out);
 	if (launch_editor(path, out, NULL)) {
 		fprintf(stderr, _("Aborting commit as launching the editor failed.\n"));


### PR DESCRIPTION
I noticed this problem while trying to whip MinGit-BusyBox into a better shape during the -rc phase. Technically, this is not a fix for  a regression during the v2.55.0 period, but I figured it'd be better to send it now anyway than to forget about sending it after v2.55.0 is released.

Cc: Patrick Steinhardt <ps@pks.im>