### PR TITLE
Improve diagnostic output for trace2 data assertions

### DIFF
--- a/t/t3500-cherry.sh
+++ b/t/t3500-cherry.sh
@@ -92,7 +92,7 @@ test_expect_success 'cherry in partial clone does bulk prefetch' '
 
 		grep "child_start.*fetch.negotiationAlgorithm" trace.output >fetches &&
 		test_line_count = 1 fetches &&
-		test_trace2_data promisor fetch_count 4 <trace.output &&
+		test_trace2_data_singular promisor fetch_count 4 <trace.output &&
 
 		# A second invocation should not refetch any blobs, since
 		# the prefetch is expected to filter out OIDs that are

--- a/t/t5332-multi-pack-reuse.sh
+++ b/t/t5332-multi-pack-reuse.sh
@@ -18,11 +18,11 @@ objdir=.git/objects
 packdir=$objdir/pack
 
 test_pack_reused () {
-	test_trace2_data pack-objects pack-reused "$1"
+	test_trace2_data_singular pack-objects pack-reused "$1"
 }
 
 test_packs_reused () {
-	test_trace2_data pack-objects packs-reused "$1"
+	test_trace2_data_singular pack-objects packs-reused "$1"
 }
 
 

--- a/t/t5333-pseudo-merge-bitmaps.sh
+++ b/t/t5333-pseudo-merge-bitmaps.sh
@@ -15,15 +15,15 @@ test_pseudo_merge_commits () {
 }
 
 test_pseudo_merges_satisfied () {
-	test_trace2_data bitmap pseudo_merges_satisfied "$1"
+	test_trace2_data_singular bitmap pseudo_merges_satisfied "$1"
 }
 
 test_pseudo_merges_cascades () {
-	test_trace2_data bitmap pseudo_merges_cascades "$1"
+	test_trace2_data_singular bitmap pseudo_merges_cascades "$1"
 }
 
 test_pseudo_merges_reused () {
-	test_trace2_data pack-bitmap-write building_bitmaps_pseudo_merge_reused "$1"
+	test_trace2_data_singular pack-bitmap-write building_bitmaps_pseudo_merge_reused "$1"
 }
 
 tag_everything () {

--- a/t/t5620-backfill.sh
+++ b/t/t5620-backfill.sh
@@ -116,7 +116,7 @@ test_expect_success 'do partial clone 1, backfill gets all objects' '
 		-C backfill1 backfill &&
 
 	# We should have engaged the partial clone machinery
-	test_trace2_data promisor fetch_count 48 <backfill-file-trace &&
+	test_trace2_data_singular promisor fetch_count 48 <backfill-file-trace &&
 
 	# No more missing objects!
 	git -C backfill1 rev-list --quiet --objects --missing=print HEAD >revs2 &&
@@ -160,8 +160,8 @@ test_expect_success 'backfill --sparse' '
 	# older versions of the four files at tip.
 	GIT_TRACE2_EVENT="$(pwd)/sparse-trace1" git \
 		-C backfill3 backfill --sparse &&
-	test_trace2_data promisor fetch_count 4 <sparse-trace1 &&
-	test_trace2_data path-walk paths 5 <sparse-trace1 &&
+	test_trace2_data_singular promisor fetch_count 4 <sparse-trace1 &&
+	test_trace2_data_singular path-walk paths 5 <sparse-trace1 &&
 	git -C backfill3 rev-list --quiet --objects --missing=print HEAD >missing &&
 	test_line_count = 40 missing &&
 
@@ -172,8 +172,8 @@ test_expect_success 'backfill --sparse' '
 	git -C backfill3 sparse-checkout set d &&
 	GIT_TRACE2_EVENT="$(pwd)/sparse-trace2" git \
 		-C backfill3 backfill --sparse &&
-	test_trace2_data promisor fetch_count 8 <sparse-trace2 &&
-	test_trace2_data path-walk paths 15 <sparse-trace2 &&
+	test_trace2_data_singular promisor fetch_count 8 <sparse-trace2 &&
+	test_trace2_data_singular path-walk paths 15 <sparse-trace2 &&
 	git -C backfill3 rev-list --quiet --objects --missing=print HEAD >missing &&
 	test_line_count = 24 missing &&
 
@@ -194,8 +194,8 @@ test_expect_success 'backfill auto-detects sparse-checkout from config' '
 	GIT_TRACE2_EVENT="$(pwd)/auto-sparse-trace" git \
 		-C backfill-auto-sparse backfill &&
 
-	test_trace2_data promisor fetch_count 4 <auto-sparse-trace &&
-	test_trace2_data path-walk paths 5 <auto-sparse-trace
+	test_trace2_data_singular promisor fetch_count 4 <auto-sparse-trace &&
+	test_trace2_data_singular path-walk paths 5 <auto-sparse-trace
 '
 
 test_expect_success 'backfill --sparse without cone mode (positive)' '
@@ -218,10 +218,10 @@ test_expect_success 'backfill --sparse without cone mode (positive)' '
 
 	GIT_TRACE2_EVENT="$(pwd)/no-cone-trace1" git \
 		-C backfill4 backfill --sparse &&
-	test_trace2_data promisor fetch_count 6 <no-cone-trace1 &&
+	test_trace2_data_singular promisor fetch_count 6 <no-cone-trace1 &&
 
 	# This walk needed to visit all directories to search for these paths.
-	test_trace2_data path-walk paths 12 <no-cone-trace1 &&
+	test_trace2_data_singular path-walk paths 12 <no-cone-trace1 &&
 	git -C backfill4 rev-list --quiet --objects --missing=print HEAD >missing &&
 	test_line_count = 36 missing
 '
@@ -246,11 +246,11 @@ test_expect_success 'backfill --sparse without cone mode (negative)' '
 
 	GIT_TRACE2_EVENT="$(pwd)/no-cone-trace2" git \
 		-C backfill5 backfill --sparse &&
-	test_trace2_data promisor fetch_count 18 <no-cone-trace2 &&
+	test_trace2_data_singular promisor fetch_count 18 <no-cone-trace2 &&
 
 	# This walk needed to visit all directories to search for these paths, plus
 	# 12 extra "file.?.txt" paths than the previous test.
-	test_trace2_data path-walk paths 24 <no-cone-trace2 &&
+	test_trace2_data_singular path-walk paths 24 <no-cone-trace2 &&
 	git -C backfill5 rev-list --quiet --objects --missing=print HEAD >missing &&
 	test_line_count = 12 missing
 '
@@ -268,7 +268,7 @@ test_expect_success 'backfill with revision range' '
 	GIT_TRACE2_EVENT="$(pwd)/backfill-trace" git -C backfill-revs backfill HEAD~2..HEAD &&
 
 	# 36 objects downloaded, 12 still missing
-	test_trace2_data promisor fetch_count 36 <backfill-trace &&
+	test_trace2_data_singular promisor fetch_count 36 <backfill-trace &&
 	git -C backfill-revs rev-list --quiet --objects --missing=print HEAD >missing &&
 	test_line_count = 12 missing
 '
@@ -288,10 +288,10 @@ test_expect_success 'backfill with revisions over stdin' '
 	^HEAD~2
 	EOF
 
-	GIT_TRACE2_EVENT="$(pwd)/backfill-trace" git -C backfill-revs backfill --stdin <in &&
+	GIT_TRACE2_EVENT="$(pwd)/backfill-stdin-trace" git -C backfill-revs backfill --stdin <in &&
 
 	# 36 objects downloaded, 12 still missing
-	test_trace2_data promisor fetch_count 36 <backfill-trace &&
+	test_trace2_data_singular promisor fetch_count 36 <backfill-stdin-trace &&
 	git -C backfill-revs rev-list --quiet --objects --missing=print HEAD >missing &&
 	test_line_count = 12 missing
 '
@@ -523,7 +523,7 @@ test_expect_success 'backfilling over HTTP succeeds' '
 		-C backfill-http backfill &&
 
 	# We should have engaged the partial clone machinery
-	test_trace2_data promisor fetch_count 48 <backfill-http-trace &&
+	test_trace2_data_singular promisor fetch_count 48 <backfill-http-trace &&
 
 	# Confirm all objects are present, none missing.
 	git -C backfill-http rev-list --objects --all >rev-list-out &&

--- a/t/t7810-grep.sh
+++ b/t/t7810-grep.sh
@@ -1964,8 +1964,8 @@ test_expect_success 'grep of revision in partial clone batches prefetch and hono
 
 	# Exactly the two a/*.txt blobs should have been requested, and
 	# the server packed those two objects in the response.
-	test_trace2_data promisor fetch_count 2 <grep-trace-pathspec &&
-	test_trace2_data pack-objects written 2 <grep-trace-pathspec &&
+	test_trace2_data_singular promisor fetch_count 2 <grep-trace-pathspec &&
+	test_trace2_data_singular pack-objects written 2 <grep-trace-pathspec &&
 
 	# b/matches.md should still be missing locally.
 	git -C grep-partial rev-list --quiet --objects \
@@ -1979,8 +1979,8 @@ test_expect_success 'grep of revision in partial clone batches prefetch and hono
 		git -C grep-partial grep -c "needle" HEAD >result &&
 
 	test_line_count = 2 result &&
-	test_trace2_data promisor fetch_count 1 <grep-trace-all &&
-	test_trace2_data pack-objects written 1 <grep-trace-all &&
+	test_trace2_data_singular promisor fetch_count 1 <grep-trace-all &&
+	test_trace2_data_singular pack-objects written 1 <grep-trace-all &&
 
 	# Everything is local now.
 	git -C grep-partial rev-list --quiet --objects \

--- a/t/test-lib-functions.sh
+++ b/t/test-lib-functions.sh
@@ -1996,6 +1996,41 @@ test_trace2_data () {
 	grep -e '"category":"'"$1"'","key":"'"$2"'","value":"'"$3"'"'
 }
 
+# Check that the given trace2 data event has the expected value and
+# appears exactly once.  Produces a diagnostic on failure.
+#
+#	test_trace2_data_singular <category> <key> <value>
+test_trace2_data_singular () {
+	local category="$1" key="$2" expect_val="$3"
+	local kv_pattern='"category":"'"$category"'","key":"'"$key"'","value":"\([^"]*\)"'
+	local actual
+
+	actual=$(sed -n "s|.*${kv_pattern}.*|\1|p") &&
+
+	if test -z "$actual"
+	then
+		echo >&4 "error: trace2 data '$category/$key' not found"
+		return 1
+	fi &&
+
+	case "$actual" in
+	*"
+"*)
+		echo >&4 "error: trace2 data '$category/$key' has multiple entries, expected 1"
+		printf '%s\n' "$actual" | sed 's/^/  actual:   /' >&4
+		return 1
+		;;
+	esac &&
+
+	if test "$actual" != "$expect_val"
+	then
+		echo >&4 "error: trace2 data '$category/$key'"
+		echo >&4 "  expected: $expect_val"
+		echo >&4 "  actual:   $actual"
+		return 1
+	fi
+}
+
 # Given a GIT_TRACE2_EVENT log over stdin, writes to stdout a list of URLs
 # sent to git-remote-https child processes.
 test_remote_https_urls() {


### PR DESCRIPTION
While working on trace2 instrumentation for merge-base computation,
I found it tricky to fix up expected values when assertions failed --
test_trace2_data is a bare grep that silently returns a non-zero
exit code, giving no indication of what went wrong.

This series adds test_trace2_data_singular, a more informative
variant that verifies the event appears exactly once and reports
clear diagnostics on failure (key not found, multiple entries, or
value mismatch), then migrates all applicable call sites to use it.

The migration also exposed a latent trace file collision in t5620
where two tests wrote to the same file and GIT_TRACE2_EVENT
silently appended, which is fixed in the second patch.

Before (value mismatch, with -v):

```
$ test_trace2_data status count/changed 999 <trace2.txt
$ echo $?
1
(no output)
```

After:

```
$ test_trace2_data_singular status count/changed 999 <trace2.txt
error: trace2 data 'status/count/changed'
  expected: 999
  actual:   0
```

cc: Patrick Steinhardt <ps@pks.im>