### PR TITLE
ci(dockerized): reduce the PID limit for private repositories

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -420,7 +420,9 @@ jobs:
       CI_JOB_IMAGE: ${{matrix.vector.image}}
       CUSTOM_PATH: /custom
     runs-on: ubuntu-latest
-    container: ${{matrix.vector.image}}
+    container:
+      image: ${{ matrix.vector.image }}
+      options: ${{ github.repository_visibility == 'private' && '--pids-limit 16384 --ulimit nproc=16384:16384 --ulimit nofile=32768:32768' || '' }}
     steps:
     - name: prepare libc6 for actions
       if: matrix.vector.jobname == 'linux32'


### PR DESCRIPTION
I needed to craft this patch while developing fixes for vulnerabilities which eventually were published as Git for Windows v2.53.0(3).

Changes since v1:
- Reworded the commit message's title to reflect the actual intent.