### PR TITLE
commit-graph: fix topo_levels slab propagation regression

### DIFF
--- a/commit-graph.c
+++ b/commit-graph.c
@@ -2610,7 +2610,7 @@ int write_commit_graph(struct odb_source *source,
 
 	g = prepare_commit_graph(ctx.r);
 	for (struct commit_graph *chain = g; chain; chain = chain->base_graph)
-		g->topo_levels = &topo_levels;
+		chain->topo_levels = &topo_levels;
 
 	if (flags & COMMIT_GRAPH_WRITE_BLOOM_FILTERS)
 		ctx.changed_paths = 1;

--- a/commit-graph.c
+++ b/commit-graph.c
@@ -1653,6 +1653,7 @@ static void compute_reachable_generation_numbers(
 {
 	int i;
 	struct commit_list *list = NULL;
+	intmax_t steps = 0;
 
 	for (i = 0; i < info->commits->nr; i++) {
 		struct commit *c = info->commits->items[i];
@@ -1671,6 +1672,7 @@ static void compute_reachable_generation_numbers(
 			int all_parents_computed = 1;
 			timestamp_t max_gen = 0;
 
+			steps++;
 			for (parent = current->parents; parent; parent = parent->next) {
 				repo_parse_commit(info->r, parent->item);
 				gen = info->get_generation(parent->item, info->data);
@@ -1694,6 +1696,9 @@ static void compute_reachable_generation_numbers(
 			}
 		}
 	}
+
+	trace2_data_intmax("commit-graph", info->r,
+			   "generation-dfs-steps", steps);
 }
 
 static timestamp_t get_topo_level(struct commit *c, void *data)

--- a/t/t5324-split-commit-graph.sh
+++ b/t/t5324-split-commit-graph.sh
@@ -718,6 +718,30 @@ test_expect_success 'write generation data chunk when commit-graph chain is repl
 	)
 '
 
+test_expect_failure 'incremental write reads topo levels from all layers' '
+	git init topo-from-lower &&
+	(
+		cd topo-from-lower &&
+
+		for i in $(test_seq 5)
+		do
+			test_commit base-$i || return 1
+		done &&
+		git commit-graph write --reachable &&
+
+		test_commit extra &&
+		git commit-graph write --reachable --split=no-merge &&
+
+		git checkout base-3 &&
+		test_commit new-branch &&
+
+		GIT_TRACE2_EVENT="$(pwd)/trace.txt" \
+			git commit-graph write --reachable --split=no-merge &&
+
+		test_trace2_data commit-graph generation-dfs-steps 1 <trace.txt
+	)
+'
+
 test_expect_success 'temporary graph layer is discarded upon failure' '
 	git init layer-discard &&
 	(

--- a/t/t5324-split-commit-graph.sh
+++ b/t/t5324-split-commit-graph.sh
@@ -718,7 +718,7 @@ test_expect_success 'write generation data chunk when commit-graph chain is repl
 	)
 '
 
-test_expect_failure 'incremental write reads topo levels from all layers' '
+test_expect_success 'incremental write reads topo levels from all layers' '
 	git init topo-from-lower &&
 	(
 		cd topo-from-lower &&


### PR DESCRIPTION
When fetch.writeCommitGraph is enabled (or git maintenance runs
after fetch), an incremental commit-graph write computes generation
numbers for the newly added commits.  For commits already in the
graph, their topo levels should be read from the existing layers,
making the DFS proportional to the number of new commits.

199d452758 (commit-graph: return the prepared commit graph from
`prepare_commit_graph()`, 2025-09-04), part of the
ps/commit-graph-via-source series [1], refactored the loop that
propagates the topo_levels slab to each layer of the commit-graph
chain.  The original code used a single variable that advanced
through the chain:

    while (g) {
        g->topo_levels = &topo_levels;
        g = g->base_graph;
    }

The refactored code introduced a separate iteration variable but
did not update the loop body to match:

    for (struct commit_graph *chain = g; chain; chain = chain->base_graph)
        g->topo_levels = &topo_levels;

This always assigns to the topmost layer instead of the current
one.  Commits from lower layers appear to have no generation
numbers, so the DFS re-walks the entire ancestry.

On a repo with a multi-layer split commit-graph, an incremental
commit-graph write triggered by `git fetch` drops from
~3.5 seconds to ~0.2 seconds after the fix.

[1] https://lore.kernel.org/git/aMNTELw0Wk8jWoPc@nand.local/T/#mb55b5f0e1ccf82d969ac1d8144c56ecf87b833e8

Changes since v1:

 - Fixed wrong commit title and date in the reference
   (Junio, Taylor).
 - use test_expect_failure with the correct
   assertion instead of a # BUG comment (Taylor).
 - Simplified commit messages.

cc: Taylor Blau <me@ttaylorr.com>
cc: Kristofer Karlsson <krka@spotify.com>
cc: Patrick Steinhardt <ps@pks.im>
cc: Taylor Blau <ttaylorr@openai.com>