### PR TITLE
revision: fix --no-walk path filtering regression

### DIFF
--- a/revision.c
+++ b/revision.c
@@ -4419,6 +4419,7 @@ static struct commit *get_revision_1(struct rev_info *revs)
 
 		switch (mode) {
 		case REV_WALK_REFLOG:
+		case REV_WALK_NO_WALK:
 			try_to_simplify_commit(revs, commit);
 			break;
 		case REV_WALK_TOPO:
@@ -4432,7 +4433,6 @@ static struct commit *get_revision_1(struct rev_info *revs)
 					    oid_to_hex(&commit->object.oid));
 			}
 			break;
-		case REV_WALK_NO_WALK:
 		case REV_WALK_LIMITED:
 			break;
 		}

--- a/t/t6017-rev-list-stdin.sh
+++ b/t/t6017-rev-list-stdin.sh
@@ -148,4 +148,22 @@ test_expect_success '--not via stdin does not influence revisions from command l
 	test_cmp expect actual
 '
 
+test_expect_success '--no-walk filters by path (single commit, match)' '
+	git rev-parse side-1 >expect &&
+	git rev-list --no-walk side-1 -- file-1 >actual &&
+	test_cmp expect actual
+'
+
+test_expect_success '--no-walk filters by path (single commit, no match)' '
+	git rev-list --no-walk side-2 -- file-1 >actual &&
+	test_must_be_empty actual
+'
+
+test_expect_success '--no-walk with pathspec exclusion' '
+	git rev-parse side-3 side-2 >expect &&
+	git rev-parse side-1 side-2 side-3 >input &&
+	git rev-list --stdin --no-walk -- ":!file-1" <input >actual &&
+	test_cmp expect actual
+'
+
 test_done


### PR DESCRIPTION
Fix for a regression reported by Peter Colberg [1] where
`git rev-list --no-walk <commit> -- <path>` ignores path arguments
since dd4bc01c0a.

Verified against linux.git with the exact example from the report:

```
git rev-list --topo-order v7.0..v7.1 -- drivers/gpu/drm/ |
git rev-list --stdin --no-walk=unsorted -- ':!drivers/gpu/drm/'
```

Without fix: 2026 commits (all pass through unfiltered)
With fix: 146 commits (correctly filtered)

[1] https://lore.kernel.org/git/CAL71e4NjDTHbKR8z7pSrPpzDrX19JOTR04sArm7P=m5ivqkskA@mail.gmail.com/T/#u

CC: Peter Colberg <pcolberg@redhat.com>