### PR TITLE
worktree: Fix out of bounds read that causes data loss and reject invalid empty input in worktree add

### DIFF
--- a/builtin/worktree.c
+++ b/builtin/worktree.c
@@ -496,6 +496,8 @@ static int add_worktree(const char *path, const char *refname,
 		die(_("invalid reference: %s"), refname);
 
 	name = worktree_basename(path, &len);
+	if (!len)
+		die(_("the empty string is not a valid worktree"));
 	strbuf_add(&sb, name, path + len - name);
 	sanitize_refname_component(sb.buf, &sb_name);
 	if (!sb_name.len)

--- a/builtin/worktree.c
+++ b/builtin/worktree.c
@@ -297,17 +297,21 @@ static void remove_junk_on_signal(int signo)
 static const char *worktree_basename(const char *path, int *olen)
 {
 	const char *name;
-	int len;
+	int len, len2;
 
-	len = strlen(path);
+	len2 = len = strlen(path);
 	while (len && is_dir_sep(path[len - 1]))
 		len--;
 
-	for (name = path + len - 1; name > path; name--)
-		if (is_dir_sep(*name)) {
-			name++;
-			break;
-		}
+	if(len) {
+		for (name = path + len - 1; name > path; name--)
+			if (is_dir_sep(*name)) {
+				name++;
+				break;
+			}
+	}
+	else
+		name = path + len2;
 
 	*olen = len;
 	return name;


### PR DESCRIPTION
Passing an empty string to `git worktree add` (typically via an unset variable, e.g. `git worktree add "$UNSET_VAR" -b tb origin/main`) can result in `BUG: How come '' becomes empty after sanitization?` but it can also have worse consequences: recursively deleting the current working directory, including `.git`. The inconsistent behaviour is caused by `worktree_basename` reading unrelated bytes from the memory before `path` and passing that back to `add_worktree`, which can circumvent the check for the `BUG` call. 

CC: Marc Branchaud <marcnarc@xiplink.com>
CC: Nguyễn Thái Ngọc Duy <pclouds@gmail.com>
CC: Eric Sunshine <sunshine@sunshineco.com>
cc: René Scharfe <l.s.r@web.de>