### PR TITLE
worktree add: shouldn't dwim if -b or -B is given

### DIFF
--- a/builtin/worktree.c
+++ b/builtin/worktree.c
@@ -897,6 +897,9 @@ static int add(int ac, const char **av, const char *prefix,
 
 		/* DWIM: Infer --orphan when repo has no refs. */
 		opts.orphan = (!s) && dwim_orphan(&opts, !!opt_track, 1);
+	} else if (ac == 2 && new_branch) {
+		if (!strcmp(branch, "HEAD"))
+			can_use_local_refs(&opts);
 	} else if (ac == 2) {
 		struct object_id oid;
 		struct commit *commit;

--- a/t/t2400-worktree-add.sh
+++ b/t/t2400-worktree-add.sh
@@ -621,6 +621,16 @@ test_expect_success '"add" <path> <branch> dwims' '
 	)
 '
 
+test_expect_success '"add" <path> <branch> does not dwim with -b' '
+	test_when_finished rm -rf repo_upstream repo_dwim wt &&
+	setup_remote_repo repo_upstream repo_dwim &&
+	(
+		cd repo_dwim &&
+		test_must_fail git worktree add -b branch ../wt foo 2>actual &&
+		test_grep "^fatal: invalid reference: foo" actual
+	)
+'
+
 test_expect_success '"add" <path> <branch> dwims with checkout.defaultRemote' '
 	test_when_finished rm -rf repo_upstream repo_dwim foo &&
 	setup_remote_repo repo_upstream repo_dwim &&


### PR DESCRIPTION
CC: Jacob Abel <jacobabel@nullpo.dev>
cc: Yoichi Nakayama <yoichi.nakayama@gmail.com>