### PR TITLE
fetch: skip fsmonitor initialization

### DIFF
--- a/builtin/fetch.c
+++ b/builtin/fetch.c
@@ -2649,6 +2649,7 @@ int cmd_fetch(int argc,
 	if (the_repository->gitdir) {
 		prepare_repo_settings(the_repository);
 		the_repository->settings.command_requires_full_index = 0;
+		the_repository->settings.command_requires_fsmonitor = 0;
 	}
 
 	argc = parse_options(argc, argv, prefix,

--- a/fsmonitor.c
+++ b/fsmonitor.c
@@ -792,7 +792,8 @@ void remove_fsmonitor(struct index_state *istate)
 void tweak_fsmonitor(struct index_state *istate)
 {
 	unsigned int i;
-	int fsmonitor_enabled = (fsm_settings__get_mode(istate->repo)
+	int fsmonitor_enabled = (istate->repo->settings.command_requires_fsmonitor &&
+				 fsm_settings__get_mode(istate->repo)
 				 > FSMONITOR_MODE_DISABLED);
 
 	if (istate->fsmonitor_dirty) {

--- a/repo-settings.c
+++ b/repo-settings.c
@@ -138,6 +138,7 @@ void prepare_repo_settings(struct repository *r)
 	 * removed.
 	 */
 	r->settings.command_requires_full_index = 1;
+	r->settings.command_requires_fsmonitor = 1;
 
 	if (!repo_config_get_ulong(r, "core.deltabasecachelimit", &ulongval))
 		r->settings.delta_base_cache_limit = ulongval;

--- a/repo-settings.h
+++ b/repo-settings.h
@@ -25,6 +25,7 @@ struct repo_settings {
 	int gc_write_commit_graph;
 	int fetch_write_commit_graph;
 	int command_requires_full_index;
+	int command_requires_fsmonitor;
 	int sparse_index;
 	int pack_read_reverse_index;
 	int pack_use_bitmap_boundary_traversal;

--- a/t/t7519-status-fsmonitor.sh
+++ b/t/t7519-status-fsmonitor.sh
@@ -477,4 +477,25 @@ test_expect_success 'status succeeds with sparse index' '
 	)
 '
 
+test_expect_success "fetch does not activate fsmonitor" '
+	test_when_finished "rm -rf fsm-repo fsm-upstream" &&
+
+	git init fsm-upstream &&
+	test_commit -C fsm-upstream initial &&
+
+	git clone fsm-upstream fsm-repo &&
+	test_hook -C fsm-repo fsmonitor-test <<-\EOF &&
+	printf "last_update_token\0"
+	EOF
+	git -C fsm-repo config core.fsmonitor .git/hooks/fsmonitor-test &&
+
+	GIT_TRACE2_EVENT="$(pwd)/trace2-status.txt" \
+		git -C fsm-repo status &&
+	test_region fsm_hook query trace2-status.txt &&
+
+	GIT_TRACE2_EVENT="$(pwd)/trace2-fetch.txt" \
+		git -C fsm-repo fetch origin &&
+	test_region ! fsm_hook query trace2-fetch.txt
+'
+
 test_done


### PR DESCRIPTION
When fetching in a repository with fsmonitor enabled, submodule
recursion triggers config_from_gitmodules() which reads the index.
Reading the index activates fsmonitor via tweak_fsmonitor() in
post_read_index_from(), causing an unnecessary daemon query. On
repositories where inotify watches are exhausted and the daemon
falls back to a full filesystem scan, this adds several seconds
to every fetch.

This patch introduces command_requires_fsmonitor (analogous to
command_requires_full_index) and sets it to 0 in cmd_fetch.

Benchmark results (mean of 15 runs, Linux, built-in fsmonitor
daemon):

  git.git (~7k files, healthy daemon):
    before: 3.3s  after: 3.3s  (no change, network-dominated)

  Large repo (~500k files, exhausted inotify watches):
    before: 9.1s  after: 2.6s  (3.5x faster)

Skipping fsmonitor is never harmful for operations that do not
examine the working tree.

An alternative considered was preventing the index read from
activating fsmonitor in the first place, but tweak_fsmonitor()
is called unconditionally from post_read_index_from() after every
index read -- that is the right design for commands like status,
diff, and add that need fsmonitor as soon as the index is loaded.
The other options (making config_from_gitmodules() avoid the index
read, or adding a "read index without side effects" API) would be
larger changes for the same result. The command_requires_fsmonitor
flag is the least invasive approach and follows the established
pattern.

cc: Jeff Hostetler <jeffhostetler@github.com>
