### PR TITLE
t1402: test forbidden characters in refnames

### DIFF
--- a/t/t1402-check-ref-format.sh
+++ b/t/t1402-check-ref-format.sh
@@ -49,16 +49,19 @@ invalid_ref 'foo/./bar'
 invalid_ref 'foo/bar/.'
 invalid_ref '.refs/foo'
 invalid_ref 'refs/heads/foo.'
-invalid_ref 'heads/foo..bar'
-invalid_ref 'heads/foo?bar'
+for c in '?' '~' '^' ':' '*' '[' ' ' '\' '..'
+do
+	invalid_ref "heads/foo${c}bar"
+done
 valid_ref 'foo./bar'
 invalid_ref 'heads/foo.lock'
 invalid_ref 'heads///foo.lock'
 invalid_ref 'foo.lock/bar'
 invalid_ref 'foo.lock///bar'
 valid_ref 'heads/foo@bar'
+valid_ref 'refs/@'
+invalid_ref '@' --allow-onelevel
 invalid_ref 'heads/v@{ation'
-invalid_ref 'heads/foo\bar'
 invalid_ref "$(printf 'heads/foo\t')"
 invalid_ref "$(printf 'heads/foo\177')"
 valid_ref "$(printf 'heads/fu\303\237')"


### PR DESCRIPTION
git-check-ref-format(1) documents the characters that a refname may not contain (space, tilde, caret, colon, question-mark, asterisk, open-bracket) and the rule that it may not be the single character "@".  t1402 only exercised a few of these directly.

This adds the remaining forbidden characters in embedded form, and checks that "@" alone is rejected even with --allow-onelevel, where "@" is otherwise a valid refname component (as "refs/@" confirms).

Test-only; documents existing behaviour, in the spirit of 919eb8ace (t1402: check for refs ending with a dot).

cc: Patrick Steinhardt <ps@pks.im>