### PR TITLE
builtin: move prepare_repo_settings() past parse_options()

### DIFF
--- a/builtin/checkout.c
+++ b/builtin/checkout.c
@@ -1880,10 +1880,6 @@ static int checkout_main(int argc, const char **argv, const char *prefix,
 	opts->show_progress = -1;
 
 	repo_config(the_repository, git_checkout_config, opts);
-	if (the_repository->gitdir) {
-		prepare_repo_settings(the_repository);
-		the_repository->settings.command_requires_full_index = 0;
-	}
 
 	opts->track = BRANCH_TRACK_UNSPECIFIED;
 
@@ -1894,6 +1890,9 @@ static int checkout_main(int argc, const char **argv, const char *prefix,
 
 	argc = parse_options(argc, argv, prefix, options,
 			     usagestr, parseopt_flags);
+
+	prepare_repo_settings(the_repository);
+	the_repository->settings.command_requires_full_index = 0;
 
 	if (opts->patch_context < -1)
 		die(_("'%s' cannot be negative"), "--unified");

--- a/builtin/fetch.c
+++ b/builtin/fetch.c
@@ -2646,13 +2646,12 @@ int cmd_fetch(int argc,
 	}
 
 	repo_config(the_repository, git_fetch_config, &config);
-	if (the_repository->gitdir) {
-		prepare_repo_settings(the_repository);
-		the_repository->settings.command_requires_full_index = 0;
-	}
 
 	argc = parse_options(argc, argv, prefix,
 			     builtin_fetch_options, builtin_fetch_usage, 0);
+
+	prepare_repo_settings(the_repository);
+	the_repository->settings.command_requires_full_index = 0;
 
 	if (recurse_submodules_cli != RECURSE_SUBMODULES_DEFAULT)
 		config.recurse_submodules = recurse_submodules_cli;
@@ -2890,7 +2889,6 @@ int cmd_fetch(int argc,
 	if (negotiate_only)
 		goto cleanup;
 
-	prepare_repo_settings(the_repository);
 	if (fetch_write_commit_graph > 0 ||
 	    (fetch_write_commit_graph < 0 &&
 	     the_repository->settings.fetch_write_commit_graph)) {

--- a/builtin/log.c
+++ b/builtin/log.c
@@ -674,11 +674,6 @@ int cmd_show(int argc,
 	init_diff_ui_defaults();
 	repo_config(the_repository, git_log_config, &cfg);
 
-	if (the_repository->gitdir) {
-		prepare_repo_settings(the_repository);
-		the_repository->settings.command_requires_full_index = 0;
-	}
-
 	memset(&match_all, 0, sizeof(match_all));
 	repo_init_revisions(the_repository, &rev, prefix);
 	repo_config(the_repository, grep_config, &rev.grep_filter);
@@ -692,6 +687,9 @@ int cmd_show(int argc,
 	opt.def = "HEAD";
 	opt.tweak = show_setup_revisions_tweak;
 	cmd_log_init(argc, argv, prefix, &rev, &opt, &cfg);
+
+	prepare_repo_settings(the_repository);
+	the_repository->settings.command_requires_full_index = 0;
 
 	if (!rev.no_walk) {
 		ret = cmd_log_walk(&rev);

--- a/builtin/pull.c
+++ b/builtin/pull.c
@@ -1016,12 +1016,11 @@ int cmd_pull(int argc,
 		set_reflog_message(argc, argv);
 
 	repo_config(the_repository, git_pull_config, NULL);
-	if (the_repository->gitdir) {
-		prepare_repo_settings(the_repository);
-		the_repository->settings.command_requires_full_index = 0;
-	}
 
 	argc = parse_options(argc, argv, prefix, pull_options, pull_usage, 0);
+
+	prepare_repo_settings(the_repository);
+	the_repository->settings.command_requires_full_index = 0;
 	if (opt_autostash == -1)
 		opt_autostash = config_pull_autostash;
 


### PR DESCRIPTION
Several commands call `prepare_repo_settings()` before `parse_options()`.
The git dispatcher demotes `RUN_SETUP` to `RUN_SETUP_GENTLY` when
the user passes `-h`, so the repository may not be initialized at the
point these calls are reached.  The `if (the_repository->gitdir)` guards
that were added to work around this are unnecessary once the calls are
moved after `parse_options()`, since `-h` is handled during option
parsing and never reaches the later code.

Move the calls in checkout, fetch, pull, and show to just after their
`parse_options()` call, and drop the now-unnecessary guards.

In fetch, this also removes a second `prepare_repo_settings()` call
that appeared later in the function.  Since `prepare_repo_settings()`
is idempotent (it returns early when settings are already initialized),
the second call was a no-op.

cc: gitgitgadget