### PR TITLE
t2021: move directory-to-file checkout test out of t0050

### DIFF
--- a/t/t0050-filesystem.sh
+++ b/t/t0050-filesystem.sh
@@ -117,24 +117,4 @@ $test_unicode 'merge (silent unicode normalization)' '
 	git merge topic
 '
 
-test_expect_success CASE_INSENSITIVE_FS 'checkout with no pathspec and a case insensitive fs' '
-	git init repo &&
-	(
-		cd repo &&
-
-		>Gitweb &&
-		git add Gitweb &&
-		git commit -m "add Gitweb" &&
-
-		git checkout --orphan todo &&
-		git reset --hard &&
-		mkdir -p gitweb/subdir &&
-		>gitweb/subdir/file &&
-		git add gitweb &&
-		git commit -m "add gitweb/subdir/file" &&
-
-		git checkout main
-	)
-'
-
 test_done

--- a/t/t2021-checkout-overwrite.sh
+++ b/t/t2021-checkout-overwrite.sh
@@ -79,4 +79,27 @@ test_expect_success 'checkout --overwrite-ignore should succeed if only ignored 
 	test_path_is_file some_dir
 '
 
+test_expect_success 'checkout switching to a tracked file replaces a tracked directory' '
+	git init -b main dir-to-file &&
+	(
+		cd dir-to-file &&
+
+		>Gitweb &&
+		git add Gitweb &&
+		git commit -m "add Gitweb" &&
+
+		git checkout --orphan todo &&
+		git reset --hard &&
+		mkdir -p gitweb/subdir &&
+		>gitweb/subdir/file &&
+		git add gitweb &&
+		git commit -m "add gitweb/subdir/file" &&
+
+		git checkout main &&
+
+		test_path_is_file Gitweb &&
+		test_path_is_missing gitweb/subdir/file
+	)
+'
+
 test_done


### PR DESCRIPTION
This addresses https://github.com/gitgitgadget/git/issues/429.

The test `'checkout with no pathspec and a case insensitive fs'` in t0050 was added as a minimal reproduction of a segfault. Its author reviewed it afterwards and listed what was wrong with it:

  https://lore.kernel.org/git/20191007180409.GD11529@szeder.dev/

This patch acts on three of those points.

**Dropping `CASE_INSENSITIVE_FS`.** The segfault needed a case insensitive filesystem, but the command sequence does not. I checked this rather than assuming it: with the prerequisite removed the test passes on ext4, so as it stood the prerequisite was only stopping it from running on most systems.

**Moving it to t2021.** t0050 collects filesystem capability tests. What this actually exercises is checkout replacing a tracked directory with a tracked file across a branch switch, and t2021 (`checkout must not overwrite an untracked objects`) is where that behaviour is already covered.

**Checking the result.** The test previously ended at `git checkout main`, so it passed as long as checkout exited successfully and would not have noticed the wrong contents being left behind. It now asserts the end state I observed by running the sequence: `Gitweb` present as a file, and the `gitweb` directory gone.

One detail worth flagging for review: t2021 does not set `GIT_TEST_DEFAULT_INITIAL_BRANCH_NAME` the way t0050 does, so the repository is created with an explicit `git init -b main`. Adding the variable to t2021 would have changed the environment for the tests already in the script, which seemed worse than being explicit in the one test that needs it.

I have left the fourth point from that message alone — why the extra subdirectory was needed to trigger the segfault. I could not determine it, and guessing at it in the commit message seemed worse than not raising it.

Both scripts pass: t0050 12/12, t2021 10/10.
