### PR TITLE
git-gui: ignore broken-pipe error when closing cat-file pipe

### DIFF
--- a/lib/commit.tcl
+++ b/lib/commit.tcl
@@ -386,7 +386,9 @@ proc commit_committree {fd_wt curHEAD msg_p} {
 		set fd_ot [git_read [list cat-file commit $PARENT]]
 		fconfigure $fd_ot -encoding iso8859-1
 		set old_tree [gets $fd_ot]
-		close $fd_ot
+		# Ignore a failure at close time: on Windows the child may
+		# die writing the unread tail of the commit object.
+		catch {close $fd_ot}
 
 		if {[string equal -length 5 {tree } $old_tree]
 			&& [string length $old_tree] == [expr {$hashlength + 5}]} {


### PR DESCRIPTION
Changes since v1:

- Wrap the [close] in [catch] instead of draining the pipe with
  [read], as suggested by Johannes Sixt.
- Use the full name in the Author and Signed-off-by fields.

Reproduction (Windows, official MinGW-based Git for Windows 2.52):

1. Create a parent commit whose commit object is larger than the pipe
   buffer (~8 KiB):

       git commit --allow-empty -m "$(yes 'padding line' | head -c 12000)"

2. In git-gui, stage a small change and make a normal commit (click
   "Commit", not "Amend Last Commit").

3. Without the patch, the commit fails with "child process exited
   abnormally" and nothing is committed. Parent objects up to
   ~6.5 KiB succeed; ~9 KiB and larger fail 10 out of 10 times.

Note: amending does not trigger the bug -- the "git cat-file commit
$PARENT" pipe in question is only opened for normal commits
(commit_type eq {normal}); the amend path reads the parent through a
different call that drains the pipe to EOF. The bug also does not
reproduce with builds linked against the MSYS2/Cygwin runtime (which
emulate SIGPIPE); it requires a native MinGW build such as the
official Git for Windows.

cc: Johannes Sixt <j6t@kdbg.org>